### PR TITLE
feat: Add ring buffer migration and enhanced monitoring features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ A simple but powerful eBPF-based diagnostic tool for Kubernetes applications.
 
 ## Features
 
-- **Network Connection Monitoring**: Tracks TCP connection latency and errors
+- **Network Connection Monitoring**: Tracks TCP IPv4/IPv6 connection latency and errors
 - **TCP RTT Analysis**: Detects RTT spikes and retry patterns
+- **File System Monitoring**: Tracks read, write, and fsync operations with latency analysis
+- **CPU/Scheduling Tracking**: Monitors thread blocking and CPU scheduling events
+- **DNS Tracking**: Monitors DNS lookups
 - **CPU Usage per Process**: Shows CPU consumption by process
-- **File System Monitoring**: Identifies slow disk operations
 - **Process Activity Analysis**: Shows which processes are generating events
 - **Diagnose Mode**: Collects events for a specified duration and generates a comprehensive summary report
 
@@ -55,15 +57,18 @@ make build-setup
 The diagnose mode generates a comprehensive report including:
 
 - **Summary Statistics**: Total events, events per second, collection period
+- **DNS Statistics**: DNS lookup latency, errors, top targets
 - **TCP Statistics**: RTT analysis, spikes detection, send/receive operations
-- **Connection Statistics**: Connection latency, failures, error breakdown, top targets
+- **Connection Statistics**: IPv4/IPv6 connection latency, failures, error breakdown, top targets
+- **File System Statistics**: Read, write, and fsync operation latency, slow operations
+- **CPU Statistics**: Thread blocking times and scheduling events
 - **CPU Usage by Process**: CPU percentage per process
-- **File System Statistics**: Write and fsync operation latency, slow operations
 - **Process Activity**: Top active processes by event count
 - **Activity Timeline**: Event distribution over time
 - **Activity Bursts**: Detection of burst periods
 - **Connection Patterns**: Analysis of connection behavior
 - **Network I/O Patterns**: Send/receive ratios and throughput analysis
+- **Potential Issues**: Automatic detection of high error rates and performance problems
 
 ## Running without sudo
 

--- a/bpf/vmlinux.h
+++ b/bpf/vmlinux.h
@@ -55,36 +55,27 @@ struct pt_regs {
     unsigned long ss;
 };
 
-#define PT_REGS_PARM1(x) ((x)->di)
-#define PT_REGS_PARM2(x) ((x)->si)
-#define PT_REGS_PARM3(x) ((x)->dx)
-#define PT_REGS_PARM4(x) ((x)->cx)
-#define PT_REGS_PARM5(x) ((x)->r8)
-#define PT_REGS_PARM6(x) ((x)->r9)
-#define PT_REGS_RC(x) ((x)->ax)
-#define PT_REGS_SP(x) ((x)->sp)
-#define PT_REGS_IP(x) ((x)->ip)
-
-struct in_addr {
-    __be32 s_addr;
+struct path {
+    struct dentry *dentry;
+    struct vfsmount *mnt;
 };
 
-struct sockaddr_in {
-    __u16 sin_family;
-    __be16 sin_port;
-    struct in_addr sin_addr;
-};
-
-struct sockaddr {
-    __u16 sa_family;
-    char sa_data[14];
-};
-
-struct sock {};
 struct file {};
 struct dentry {};
 struct qstr {
     const char *name;
 };
 
+struct in_addr {
+    u32 s_addr;
+};
+
+struct sockaddr_in {
+    u16 sin_family;
+    u16 sin_port;
+    struct in_addr sin_addr;
+    char sin_zero[8];
+};
+
 #endif /* __VMLINUX_H__ */
+

--- a/internal/diagnose/cpu_profiling.go
+++ b/internal/diagnose/cpu_profiling.go
@@ -8,34 +8,34 @@ import (
 )
 
 func (d *Diagnostician) generateCPUUsageReport(duration time.Duration) string {
-	
+
 	pidActivity := d.analyzeProcessActivity()
 	if len(pidActivity) == 0 {
 		return d.generateCPUUsageFromProc(duration)
 	}
-	
+
 	totalActivity := 0
 	for _, info := range pidActivity {
 		totalActivity += info.count
 	}
-	
+
 	if totalActivity == 0 {
 		return d.generateCPUUsageFromProc(duration)
 	}
-	
+
 	var report string
 	report += fmt.Sprintf("CPU Usage by Process:\n")
-	
+
 	totalDurationNS := uint64(duration.Nanoseconds())
 	totalCPUPercent := 0.0
-	
+
 	sort.Slice(pidActivity, func(i, j int) bool {
 		return pidActivity[i].count > pidActivity[j].count
 	})
-	
+
 	var podProcesses []pidInfo
 	var kernelProcesses []pidInfo
-	
+
 	for _, info := range pidActivity {
 		if isKernelThread(info.pid, info.name) {
 			kernelProcesses = append(kernelProcesses, info)
@@ -43,7 +43,7 @@ func (d *Diagnostician) generateCPUUsageReport(duration time.Duration) string {
 			podProcesses = append(podProcesses, info)
 		}
 	}
-	
+
 	podCPUPercent := 0.0
 	if len(podProcesses) > 0 {
 		report += fmt.Sprintf("  Pod Processes:\n")
@@ -51,36 +51,36 @@ func (d *Diagnostician) generateCPUUsageReport(duration time.Duration) string {
 			if i >= 10 {
 				break
 			}
-			
+
 			cpuTimeNS := uint64(float64(totalDurationNS) * info.percentage / 100.0)
 			cpuPercent := info.percentage
 			cpuTimeSec := float64(cpuTimeNS) / 1e9
 			durationSec := duration.Seconds()
-			
+
 			report += fmt.Sprintf("    PID %d (%s):      %5.1f%% CPU (%.2fs / %.2fs)\n",
 				info.pid, info.name, cpuPercent, cpuTimeSec, durationSec)
-			
+
 			podCPUPercent += cpuPercent
 		}
 		report += "\n"
 	}
-	
+
 	if len(kernelProcesses) > 0 {
 		kernelCPUPercent := 0.0
 		report += fmt.Sprintf("  System/Kernel Processes:\n")
 		for i, info := range kernelProcesses {
-			if i >= 5 { 
+			if i >= 5 {
 				break
 			}
-			
+
 			cpuTimeNS := uint64(float64(totalDurationNS) * info.percentage / 100.0)
 			cpuPercent := info.percentage
 			cpuTimeSec := float64(cpuTimeNS) / 1e9
 			durationSec := duration.Seconds()
-			
+
 			report += fmt.Sprintf("    PID %d (%s):      %5.1f%% CPU (%.2fs / %.2fs)\n",
 				info.pid, info.name, cpuPercent, cpuTimeSec, durationSec)
-			
+
 			kernelCPUPercent += cpuPercent
 		}
 		if len(kernelProcesses) > 5 {
@@ -91,17 +91,17 @@ func (d *Diagnostician) generateCPUUsageReport(duration time.Duration) string {
 	} else {
 		totalCPUPercent = podCPUPercent
 	}
-	
+
 	report += fmt.Sprintf("\n  Total CPU usage: %.1f%% (%.2fs / %.2fs)\n",
 		totalCPUPercent, totalCPUPercent*duration.Seconds()/100.0, duration.Seconds())
 	report += fmt.Sprintf("  Idle time: %.1f%% (%.2fs / %.2fs)\n\n",
 		100.0-totalCPUPercent, (100.0-totalCPUPercent)*duration.Seconds()/100.0, duration.Seconds())
-	
+
 	return report
 }
 
 func isKernelThread(pid uint32, name string) bool {
-	
+
 	kernelPrefixes := []string{
 		"kworker",
 		"irq/",
@@ -118,25 +118,25 @@ func isKernelThread(pid uint32, name string) bool {
 		"dmcrypt",
 		"kcryptd",
 	}
-	
+
 	nameLower := strings.ToLower(name)
 	for _, prefix := range kernelPrefixes {
 		if strings.HasPrefix(nameLower, prefix) {
 			return true
 		}
 	}
-	
+
 	if strings.HasPrefix(name, "[") && strings.HasSuffix(name, "]") {
 		return true
 	}
-	
+
 	return false
 }
 
 func (d *Diagnostician) generateCPUUsageFromProc(duration time.Duration) string {
 	var report string
 	report += fmt.Sprintf("CPU Usage by Process:\n")
-	report += fmt.Sprintf("  ⚠ No CPU events collected during diagnostic period.\n")
+	report += fmt.Sprintf("  No CPU events collected during diagnostic period.\n")
 	report += fmt.Sprintf("  This may indicate:\n")
 	report += fmt.Sprintf("    - Pod is idle or sleeping\n")
 	report += fmt.Sprintf("    - eBPF probes not attached correctly\n")

--- a/internal/ebpf/loader.go
+++ b/internal/ebpf/loader.go
@@ -16,10 +16,5 @@ func loadPodtrace() (*ebpf.CollectionSpec, error) {
 		}
 	}
 
-	if eventsMap, ok := spec.Maps["events"]; ok {
-		if eventsMap.Type == ebpf.RingBuf {
-		}
-	}
-
 	return spec, nil
 }

--- a/internal/ebpf/tracer.go
+++ b/internal/ebpf/tracer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/ringbuf"
 	"github.com/cilium/ebpf/rlimit"
 	"golang.org/x/sys/unix"
 
@@ -22,7 +22,7 @@ import (
 type Tracer struct {
 	collection *ebpf.Collection
 	links      []link.Link
-	reader     *perf.Reader
+	reader     *ringbuf.Reader
 	cgroupPath string
 }
 
@@ -55,7 +55,7 @@ func NewTracer() (*Tracer, error) {
 			fmt.Fprintf(os.Stderr, "Warning: failed to remove memlock limit: %v\n", err)
 		}
 	}
-	
+
 	spec, err := loadPodtrace()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load eBPF spec: %w", err)
@@ -72,13 +72,13 @@ func NewTracer() (*Tracer, error) {
 		return nil, fmt.Errorf("failed to attach probes: %w", err)
 	}
 
-	rd, err := perf.NewReader(coll.Maps["events"], 64*1024)
+	rd, err := ringbuf.NewReader(coll.Maps["events"])
 	if err != nil {
 		for _, l := range links {
 			l.Close()
 		}
 		coll.Close()
-		return nil, fmt.Errorf("failed to open perf event reader: %w", err)
+		return nil, fmt.Errorf("failed to open ring buffer reader: %w", err)
 	}
 
 	return &Tracer{
@@ -111,22 +111,22 @@ func (t *Tracer) isPIDInCgroup(pid uint32) bool {
 	if pidCgroupPath == "" {
 		return false
 	}
-	
+
 	normalizedTarget := normalizeCgroupPath(t.cgroupPath)
 	normalizedPID := normalizeCgroupPath(pidCgroupPath)
-	
+
 	if normalizedPID == normalizedTarget {
 		return true
 	}
-	
+
 	if strings.HasPrefix(normalizedPID, normalizedTarget+"/") {
 		return true
 	}
-	
+
 	if strings.HasPrefix(normalizedTarget, normalizedPID+"/") {
 		return true
 	}
-	
+
 	return false
 }
 
@@ -145,7 +145,7 @@ func extractCgroupPathFromProc(cgroupContent string) string {
 	if strings.HasPrefix(cgroupContent, "0::") {
 		return strings.TrimPrefix(cgroupContent, "0::")
 	}
-	
+
 	lines := strings.Split(cgroupContent, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
@@ -162,26 +162,21 @@ func extractCgroupPathFromProc(cgroupContent string) string {
 
 // Start begins collecting events and sends them to the event channel
 func (t *Tracer) Start(eventChan chan<- *events.Event) error {
-		go func() {
+	go func() {
 		for {
 			record, err := t.reader.Read()
 			if err != nil {
 				if err.Error() != "" && strings.Contains(err.Error(), "closed") {
 					return
 				}
-				fmt.Fprintf(os.Stderr, "Error reading perf buffer: %v\n", err)
-				continue
-			}
-
-			if record.LostSamples > 0 {
-				fmt.Fprintf(os.Stderr, "Lost %d samples\n", record.LostSamples)
+				fmt.Fprintf(os.Stderr, "Error reading ring buffer: %v\n", err)
 				continue
 			}
 
 			event := parseEvent(record.RawSample)
 			if event != nil {
 				event.ProcessName = getProcessNameQuick(event.PID)
-				
+
 				if t.isPIDInCgroup(event.PID) {
 					eventChan <- event
 				}
@@ -244,16 +239,20 @@ func attachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 	var links []link.Link
 
 	probes := map[string]string{
-		"kprobe_tcp_connect":     "tcp_v4_connect",
-		"kretprobe_tcp_connect":  "tcp_v4_connect",
-		"kprobe_tcp_sendmsg":     "tcp_sendmsg",
-		"kretprobe_tcp_sendmsg":  "tcp_sendmsg",
-		"kprobe_tcp_recvmsg":     "tcp_recvmsg",
-		"kretprobe_tcp_recvmsg":  "tcp_recvmsg",
-		"kprobe_vfs_write":       "vfs_write",
-		"kretprobe_vfs_write":    "vfs_write",
-		"kprobe_vfs_fsync":       "vfs_fsync",
-		"kretprobe_vfs_fsync":    "vfs_fsync",
+		"kprobe_tcp_connect":       "tcp_v4_connect",
+		"kretprobe_tcp_connect":    "tcp_v4_connect",
+		"kprobe_tcp_v6_connect":    "tcp_v6_connect",
+		"kretprobe_tcp_v6_connect": "tcp_v6_connect",
+		"kprobe_tcp_sendmsg":       "tcp_sendmsg",
+		"kretprobe_tcp_sendmsg":    "tcp_sendmsg",
+		"kprobe_tcp_recvmsg":       "tcp_recvmsg",
+		"kretprobe_tcp_recvmsg":    "tcp_recvmsg",
+		"kprobe_vfs_write":         "vfs_write",
+		"kretprobe_vfs_write":      "vfs_write",
+		"kprobe_vfs_read":          "vfs_read",
+		"kretprobe_vfs_read":       "vfs_read",
+		"kprobe_vfs_fsync":         "vfs_fsync",
+		"kretprobe_vfs_fsync":      "vfs_fsync",
 	}
 
 	for progName, symbol := range probes {
@@ -281,7 +280,64 @@ func attachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 		links = append(links, l)
 	}
 
+	if tracepointProg := coll.Programs["tracepoint_sched_switch"]; tracepointProg != nil {
+		tp, err := link.Tracepoint("sched", "sched_switch", tracepointProg, nil)
+		if err != nil {
+			if !strings.Contains(err.Error(), "permission denied") {
+				fmt.Fprintf(os.Stderr, "Note: CPU/scheduling tracking unavailable: %v\n", err)
+			}
+		} else {
+			links = append(links, tp)
+		}
+	}
+
+	libcPath := findLibcPath()
+	if libcPath != "" {
+		uprobe, err := link.OpenExecutable(libcPath)
+		if err == nil {
+			if uprobeProg := coll.Programs["uprobe_getaddrinfo"]; uprobeProg != nil {
+				l, err := uprobe.Uprobe("getaddrinfo", uprobeProg, nil)
+				if err == nil {
+					links = append(links, l)
+				} else {
+					fmt.Fprintf(os.Stderr, "Note: DNS tracking (uprobe) unavailable: %v\n", err)
+				}
+			}
+			if uretprobeProg := coll.Programs["uretprobe_getaddrinfo"]; uretprobeProg != nil {
+				l, err := uprobe.Uretprobe("getaddrinfo", uretprobeProg, nil)
+				if err == nil {
+					links = append(links, l)
+				} else {
+					fmt.Fprintf(os.Stderr, "Note: DNS tracking (uretprobe) unavailable: %v\n", err)
+				}
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Note: DNS tracking unavailable (libc not found)\n")
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Note: DNS tracking unavailable (libc path not found)\n")
+	}
+
 	return links, nil
+}
+
+func findLibcPath() string {
+	libcPaths := []string{
+		"/lib/x86_64-linux-gnu/libc.so.6",
+		"/lib64/libc.so.6",
+		"/lib/libc.so.6",
+		"/usr/lib/x86_64-linux-gnu/libc.so.6",
+		"/usr/lib64/libc.so.6",
+		"/usr/lib/libc.so.6",
+	}
+
+	for _, path := range libcPaths {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path
+		}
+	}
+
+	return ""
 }
 
 var processNameCache = make(map[uint32]string)
@@ -296,7 +352,7 @@ func getProcessNameQuick(pid uint32) string {
 	processNameCacheMutex.Unlock()
 
 	name := ""
-	
+
 	cmdlinePath := fmt.Sprintf("/proc/%d/cmdline", pid)
 	if cmdline, err := os.ReadFile(cmdlinePath); err == nil {
 		parts := strings.Split(string(cmdline), "\x00")
@@ -307,7 +363,7 @@ func getProcessNameQuick(pid uint32) string {
 			}
 		}
 	}
-	
+
 	if name == "" {
 		statPath := fmt.Sprintf("/proc/%d/stat", pid)
 		if data, err := os.ReadFile(statPath); err == nil {
@@ -319,18 +375,18 @@ func getProcessNameQuick(pid uint32) string {
 			}
 		}
 	}
-	
+
 	if name == "" {
 		commPath := fmt.Sprintf("/proc/%d/comm", pid)
 		if data, err := os.ReadFile(commPath); err == nil {
 			name = strings.TrimSpace(string(data))
 		}
 	}
-	
+
 	processNameCacheMutex.Lock()
 	processNameCache[pid] = name
 	processNameCacheMutex.Unlock()
-	
+
 	return name
 }
 

--- a/scripts/build-and-setup.sh
+++ b/scripts/build-and-setup.sh
@@ -23,14 +23,14 @@ set_capabilities() {
 	echo "Setting capabilities..."
 	if sudo ./scripts/setup-capabilities.sh; then
 		echo ""
-		echo "✓ Build and setup complete!"
+		echo "Build and setup complete!"
 		echo ""
 		echo "You can now run podtrace:"
 		echo "  ./bin/podtrace -n <namespace> <pod-name>"
 	else
 		echo ""
-		echo "⚠ Build succeeded but failed to set capabilities."
-		echo "  Run manually: sudo ./scripts/setup-capabilities.sh"
+		echo "Build succeeded but failed to set capabilities."
+		echo "Run manually: sudo ./scripts/setup-capabilities.sh"
 		exit 1
 	fi
 }

--- a/test/README.md
+++ b/test/README.md
@@ -44,3 +44,6 @@ Run all tests automatically:
 - `setup-test-pods.sh` - Script to create test environment
 - `cleanup-test-pods.sh` - Script to clean up test environment
 - `run-tests.sh` - Automated test runner
+- `quick-test.sh` - Quick test script
+- `test-debug.sh` - Debug test script
+- `test-cpu-usage.sh` - CPU usage test script


### PR DESCRIPTION
# Add ring buffer migration and enhanced monitoring features

## Summary

This PR migrates podtrace from perf buffers to ring buffers and adds several new monitoring features including file read operations, IPv6 support, CPU scheduling tracking, and DNS tracking.

## Changes

### Core Infrastructure

- **Migrate from perf buffer to ring buffer**: Replaced `BPF_MAP_TYPE_PERF_EVENT_ARRAY` with `BPF_MAP_TYPE_RINGBUF` for better performance and lower overhead
  - Updated BPF code to use `bpf_ringbuf_output()` instead of `bpf_perf_event_output()`
  - Updated Go code to use `ringbuf.NewReader()` for event consumption

### New Features

- **File read operations tracking**: Added `kprobe/vfs_read` and `kretprobe/vfs_read` to track file read operations alongside writes and fsync
  - Integrated into File System Statistics with latency analysis
  - Tracks read operations >1ms threshold

- **IPv6 support**: Added `kprobe/tcp_v6_connect` and `kretprobe/tcp_v6_connect` for IPv6 connection tracking
  - Implemented `format_ipv6_port()` helper function for IPv6 address formatting
  - IPv6 addresses displayed in standard format (e.g., `[::1]:8080`)

- **CPU/Scheduling tracking**: Added `sched_switch` tracepoint support for thread blocking analysis
  - Tracks thread blocking times >1ms threshold
  - Integrated into CPU Statistics in diagnostic reports
  - Gracefully handles permission denied errors in container environments

- **DNS tracking**: Implemented DNS lookup tracking via uprobes on `getaddrinfo` in libc
  - Added `uprobe/getaddrinfo` and `uretprobe/getaddrinfo` BPF programs
  - Captures hostname, latency, and error codes
  - Integrated into DNS Statistics in diagnostic reports
  - Gracefully handles cases where uprobes cannot attach (container environments)

## Technical Details

### BPF Changes

- Added new event types: `EVENT_READ`, `EVENT_SCHED_SWITCH`
- Added new BPF maps: `dns_targets` for DNS hostname storage
- Added new probe attachments: `vfs_read`, `tcp_v6_connect`, `sched_switch`, `getaddrinfo`
- Removed file path extraction code and related maps

### Go Changes

- Updated `internal/ebpf/tracer.go` for ring buffer and new probe attachments
- Updated `internal/events/events.go` to handle new event types
- Updated `internal/diagnose/diagnose.go` for new statistics and removed slow FS detection
- Removed unused `cgroupPath` field from `Diagnostician`

## Breaking Changes

None. All changes are backward compatible with existing functionality.

## Documentation

- Updated main README.md with all new features
- Updated test/README.md to reflect current test scripts
- Removed references to removed features