### PR TITLE
feat: Add file path tracking and I/O bandwidth metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ BINARY = bin/podtrace
 # For Go < 1.21, user needs to upgrade Go manually
 export GOTOOLCHAIN=auto
 
-BPF_CFLAGS = -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3
+ENABLE_FILE_PATH_TRACKING ?= 0
+BPF_CFLAGS = -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3 -DENABLE_FILE_PATH_TRACKING=$(ENABLE_FILE_PATH_TRACKING)
 
 all: check-go build
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A simple but powerful eBPF-based diagnostic tool for Kubernetes applications. Pr
 
 ### File System Monitoring
 - **File Operations**: Tracks read, write, and fsync operations with latency analysis
+- **File Path Tracking**: Captures full file paths for filesystem operations (optional, requires kernel 5.6+ with `bpf_d_path` support)
 - **I/O Bandwidth**: Monitors bytes transferred for file read/write operations
 - **Throughput Analysis**: Calculates average throughput and peak transfer rates
 
@@ -149,6 +150,8 @@ All metrics are exported per process and per event type:
 | `podtrace_dns_latency_seconds_histogram` | Distribution of DNS query latencies             |
 | `podtrace_fs_latency_seconds_gauge`      | Latest file system operation latency            |
 | `podtrace_fs_latency_seconds_histogram`  | Distribution of file system operation latencies |
+| `podtrace_network_bytes_total`           | Total bytes transferred over network (TCP/UDP)  |
+| `podtrace_filesystem_bytes_total`       | Total bytes transferred via filesystem ops      |
 | `podtrace_cpu_block_seconds_gauge`       | Latest CPU block time                           |
 | `podtrace_cpu_block_seconds_histogram`   | Distribution of CPU block times                 |
 

--- a/bpf/vmlinux.h
+++ b/bpf/vmlinux.h
@@ -60,8 +60,12 @@ struct path {
     struct vfsmount *mnt;
 };
 
-struct file {};
+struct file {
+    struct path f_path;
+};
+
 struct dentry {};
+struct vfsmount {};
 struct qstr {
     const char *name;
 };

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -62,7 +62,7 @@ The eBPF programs run in the kernel and trace system calls and kernel events. Th
 - **events.h**: Event types and structures
 - **helpers.h**: Helper functions
 - **network.c**: Network probes (TCP, UDP, DNS, HTTP)
-- **filesystem.c**: Filesystem probes
+- **filesystem.c**: Filesystem probes (with optional file path tracking)
 - **cpu.c**: CPU/scheduling probes
 - **memory.c**: Memory probes
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -62,6 +62,20 @@ This will:
 - Compile the eBPF program (`bpf/podtrace.bpf.c`) to `bpf/podtrace.bpf.o`
 - Build the Go binary to `bin/podtrace`
 
+**Optional: Enable File Path Tracking**
+
+File path tracking is disabled by default because it requires the `bpf_d_path` helper function (kernel 5.6+). If your kernel supports it, you can enable it:
+
+```bash
+make ENABLE_FILE_PATH_TRACKING=1
+
+# Or set it permanently in Makefile
+# Change: ENABLE_FILE_PATH_TRACKING ?= 0
+# To:     ENABLE_FILE_PATH_TRACKING ?= 1
+```
+
+**Note**: If you enable file path tracking but your kernel doesn't support `bpf_d_path`, podtrace will fail to load with an error about "unknown func bpf_d_path". In this case, rebuild with `ENABLE_FILE_PATH_TRACKING=0` (the default).
+
 ### 4. Set Capabilities (Optional)
 
 To run without `sudo`, set the required capabilities:
@@ -121,6 +135,11 @@ You should see usage information.
 - This is a warning, not an error
 - DNS tracking requires libc to be found
 - The tool will work without DNS tracking
+
+**Error: "unknown func bpf_d_path"**
+- This occurs when file path tracking is enabled but the kernel doesn't support `bpf_d_path`
+- Rebuild with `ENABLE_FILE_PATH_TRACKING=0` (the default)
+- File path tracking requires kernel 5.6+ with `bpf_d_path` helper support
 
 ## Running in Kubernetes
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -154,6 +154,7 @@ The dashboard includes:
 - **Connection Latency**: TCP connection latencies
 - **DNS Latency**: DNS lookup latencies
 - **File System Latency**: FS operation latencies
+- **I/O Bandwidth**: Network and filesystem throughput metrics
 - **CPU Block Time**: Thread blocking durations
 - **Per-Process Metrics**: Breakdown by process name
 
@@ -193,6 +194,46 @@ sum(rate(podtrace_fs_latency_seconds_count[5m])) by (type, process_name)
 histogram_quantile(0.99,
   rate(podtrace_cpu_block_seconds_histogram_bucket[5m])
 )
+```
+
+### I/O Bandwidth Metrics
+
+**`podtrace_network_bytes_total`** (Counter)
+- Description: Total bytes transferred over network (TCP/UDP send/receive)
+- Labels: `type`, `process_name`, `direction` (send or recv)
+- Use with `rate()` to get bytes/second
+
+**`podtrace_filesystem_bytes_total`** (Counter)
+- Description: Total bytes transferred via filesystem operations (read/write)
+- Labels: `type`, `process_name`, `operation` (read or write)
+- Use with `rate()` to get bytes/second
+
+### I/O Bandwidth Query Examples
+
+#### Network Throughput (bytes/second)
+
+```promql
+# Total network throughput
+sum(rate(podtrace_network_bytes_total[5m])) by (direction)
+
+# Network throughput by process
+sum(rate(podtrace_network_bytes_total[5m])) by (process_name, direction)
+
+# TCP send throughput
+sum(rate(podtrace_network_bytes_total{direction="send"}[5m])) by (process_name)
+```
+
+#### Filesystem Throughput (bytes/second)
+
+```promql
+# Total filesystem throughput
+sum(rate(podtrace_filesystem_bytes_total[5m])) by (operation)
+
+# Filesystem throughput by process
+sum(rate(podtrace_filesystem_bytes_total[5m])) by (process_name, operation)
+
+# Write throughput
+sum(rate(podtrace_filesystem_bytes_total{operation="write"}[5m])) by (process_name)
 ```
 
 ## Security

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -88,7 +88,8 @@ The diagnose report includes:
 - Read, write, and fsync operation counts
 - Operation latencies (avg, max, percentiles)
 - Slow operations (>10ms)
-- Top accessed files
+- Top accessed files (if file path tracking is enabled)
+- I/O bandwidth metrics (total bytes, average bytes, throughput)
 
 ### CPU Statistics
 - Thread switch count
@@ -144,8 +145,9 @@ Look for:
 
 Check:
 - File System Statistics for slow operations
-- Top accessed files
+- Top accessed files (if file path tracking is enabled)
 - Read/write latency percentiles
+- I/O bandwidth and throughput metrics
 
 ### Monitor CPU Scheduling
 
@@ -184,6 +186,7 @@ Review:
 
 - Only traces the first container in a pod
 - Requires kernel 5.8+ with BTF support
+- File path tracking requires kernel 5.6+ with `bpf_d_path` support (disabled by default)
 - DNS tracking may be unavailable if libc path cannot be determined
 - CPU scheduling tracking requires tracepoint permissions
 


### PR DESCRIPTION
# Add File Path Tracking and I/O Bandwidth Metrics

This PR implements two major features that were previously incomplete in podtrace:

## Features

### 1. File Path Tracking

**Problem**: File paths were not being captured for filesystem operations, showing only generic "file" labels.

**Solution**: 
- Implemented file path extraction using the `bpf_d_path` helper function
- Extracts full file paths from `struct file` for read/write/fsync operations
- Made optional via build flag to support kernels without `bpf_d_path` support

**Implementation Details**:
- Uses `BPF_CORE_READ` to safely access `file->f_path`
- Calls `bpf_d_path` to convert kernel path structure to string
- Stores paths in BPF map for retrieval in kretprobe handlers
- Gracefully handles errors and missing helper support

**Build Configuration**:
```bash
# Default (disabled) - works on all kernels
make

# Enable if kernel supports bpf_d_path (kernel 5.6+)
make ENABLE_FILE_PATH_TRACKING=1
```

### 2. I/O Bandwidth & Throughput Metrics

**Problem**: While bytes were being tracked per operation, there were no dedicated Prometheus metrics for calculating throughput (bytes/second).

**Solution**:
- Added `podtrace_network_bytes_total` counter for TCP/UDP send/receive
- Added `podtrace_filesystem_bytes_total` counter for read/write operations
- Metrics support `rate()` queries for throughput calculations
- Only exports metrics when bytes > 0 to reduce noise

**Usage Examples**:
```promql
# Network throughput (bytes/second)
rate(podtrace_network_bytes_total[5m])

# Filesystem write throughput
rate(podtrace_filesystem_bytes_total{operation="write"}[5m])
```

## Changes

### BPF Code
- `bpf/filesystem.c`: File path extraction implementation

### Go Code
- `internal/metricsexporter/promexporter.go`: 
  - Added bandwidth counter metrics
  - Added export functions for network and filesystem bandwidth
  - Updated event handler to export bandwidth metrics

### Build System
- `Makefile`: Added `ENABLE_FILE_PATH_TRACKING` build flag (default: 0)

## Metrics Added

| Metric | Type | Description |
|--------|------|-------------|
| `podtrace_network_bytes_total` | Counter | Total bytes transferred over network (TCP/UDP) |
| `podtrace_filesystem_bytes_total` | Counter | Total bytes transferred via filesystem operations |

## Configuration

File path tracking is **disabled by default** to ensure compatibility with all kernels. To enable:

```bash
make ENABLE_FILE_PATH_TRACKING=1
```

**Note**: Requires kernel 5.6+ with `bpf_d_path` helper support. If enabled on an unsupported kernel, the program will fail to load with an error about "unknown func bpf_d_path".