### PR TITLE
fix: Code hardening

### DIFF
--- a/bpf/cpu.c
+++ b/bpf/cpu.c
@@ -33,9 +33,10 @@ int tracepoint_sched_switch(void *ctx) {
 			u64 block_time = calc_latency(*block_start);
 			if (block_time > 1000000) {
 				struct event *e = get_event_buf();
-    if (!e) {
-    	return 0;
-    }
+				if (!e) {
+					bpf_map_delete_elem(&start_times, &key);
+					return 0;
+				}
 				e->timestamp = timestamp;
 				e->pid = prev_pid;
 				e->type = EVENT_SCHED_SWITCH;
@@ -108,9 +109,10 @@ int kretprobe_do_futex(struct pt_regs *ctx) {
 	}
 	long ret = PT_REGS_RC(ctx);
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_LOCK_CONTENTION;
@@ -183,9 +185,10 @@ int uretprobe_pthread_mutex_lock(struct pt_regs *ctx) {
 	}
 	long ret = PT_REGS_RC(ctx);
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_LOCK_CONTENTION;

--- a/bpf/filesystem.c
+++ b/bpf/filesystem.c
@@ -103,9 +103,10 @@ int kretprobe_vfs_read(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_READ;
@@ -151,9 +152,10 @@ int kretprobe_vfs_write(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_WRITE;
@@ -212,9 +214,10 @@ int kretprobe_vfs_fsync(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_FSYNC;

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -178,9 +178,10 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_TCP_SEND;
@@ -231,9 +232,10 @@ int kretprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_TCP_RECV;
@@ -287,9 +289,10 @@ int uretprobe_getaddrinfo(struct pt_regs *ctx) {
 	u64 latency = calc_latency(*start_ts);
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_DNS;
@@ -462,9 +465,10 @@ int kretprobe_udp_sendmsg(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_UDP_SEND;
@@ -508,9 +512,10 @@ int kretprobe_udp_recvmsg(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_UDP_RECV;
@@ -555,9 +560,10 @@ int uretprobe_http_request(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_HTTP_REQ;
@@ -607,9 +613,10 @@ int uretprobe_http_response(struct pt_regs *ctx) {
 	}
 	
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_HTTP_RESP;
@@ -659,9 +666,10 @@ int uretprobe_PQexec(struct pt_regs *ctx) {
 	}
 	u64 latency = calc_latency(*start_ts);
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_DB_QUERY;
@@ -717,9 +725,10 @@ int uretprobe_mysql_real_query(struct pt_regs *ctx) {
 	}
 	u64 latency = calc_latency(*start_ts);
 	struct event *e = get_event_buf();
- if (!e) {
- 	return 0;
- }
+	if (!e) {
+		bpf_map_delete_elem(&start_times, &key);
+		return 0;
+	}
 	e->timestamp = bpf_ktime_get_ns();
 	e->pid = pid;
 	e->type = EVENT_DB_QUERY;

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -565,7 +565,12 @@ func (d *Diagnostician) generateStackTraceSection() string {
 	}
 	r := &resolver{cache: make(map[string]string)}
 	stackMap := make(map[string]*stackSummary)
+	const maxEventsForStacks = 10000
+	processed := 0
 	for _, e := range d.events {
+		if processed >= maxEventsForStacks {
+			break
+		}
 		if e == nil {
 			continue
 		}
@@ -575,6 +580,7 @@ func (d *Diagnostician) generateStackTraceSection() string {
 		if e.LatencyNS < uint64(1000000) && e.Type != events.EventLockContention && e.Type != events.EventDBQuery {
 			continue
 		}
+		processed++
 		top := e.Stack[0]
 		frame := resolve(r, e.PID, top)
 		if frame == "" {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -10,6 +10,16 @@ func sanitizeString(s string) string {
 	return strings.ReplaceAll(s, "%", "%%")
 }
 
+func truncateString(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}
+
 type EventType uint32
 
 const (
@@ -94,16 +104,17 @@ func (e *Event) TypeString() string {
 
 func (e *Event) FormatMessage() string {
 	latencyMs := float64(e.LatencyNS) / 1e6
+	const maxTargetLen = 256
 
 	switch e.Type {
 	case EventDNS:
 		if e.Error != 0 {
-			return fmt.Sprintf("[DNS] lookup %s failed: error %d", sanitizeString(e.Target), e.Error)
+			return fmt.Sprintf("[DNS] lookup %s failed: error %d", sanitizeString(truncateString(e.Target, maxTargetLen)), e.Error)
 		}
-		return fmt.Sprintf("[DNS] lookup %s took %.2fms", sanitizeString(e.Target), latencyMs)
+		return fmt.Sprintf("[DNS] lookup %s took %.2fms", sanitizeString(truncateString(e.Target, maxTargetLen)), latencyMs)
 
 	case EventConnect:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -168,14 +179,14 @@ func (e *Event) FormatMessage() string {
 		return ""
 
 	case EventHTTPReq:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
 		return fmt.Sprintf("[HTTP] request to %s took %.2fms", sanitizeString(target), latencyMs)
 
 	case EventHTTPResp:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -187,7 +198,7 @@ func (e *Event) FormatMessage() string {
 
 	case EventTCPState:
 		stateStr := TCPStateString(e.TCPState)
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -197,7 +208,7 @@ func (e *Event) FormatMessage() string {
 		return fmt.Sprintf("[MEM] Page fault (error: %d)", e.Error)
 
 	case EventOOMKill:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -205,7 +216,7 @@ func (e *Event) FormatMessage() string {
 		return fmt.Sprintf("[MEM] OOM kill: %s (%.2f MB)", sanitizeString(target), memMB)
 
 	case EventWrite:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -216,7 +227,7 @@ func (e *Event) FormatMessage() string {
 		return msg
 
 	case EventRead:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -227,7 +238,7 @@ func (e *Event) FormatMessage() string {
 		return msg
 
 	case EventFsync:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "file"
 		}
@@ -237,35 +248,35 @@ func (e *Event) FormatMessage() string {
 		return fmt.Sprintf("[CPU] thread blocked %.2fms", latencyMs)
 
 	case EventLockContention:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "lock"
 		}
 		return fmt.Sprintf("[LOCK] contention on %s (%.2fms)", sanitizeString(target), latencyMs)
 
 	case EventTCPRetrans:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
 		return fmt.Sprintf("[NET] TCP retransmission detected for %s", sanitizeString(target))
 
 	case EventNetDevError:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "iface"
 		}
 		return fmt.Sprintf("[NET] network device errors on %s (error=%d)", sanitizeString(target), e.Error)
 
 	case EventDBQuery:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "query"
 		}
 		return fmt.Sprintf("[DB] query pattern %s took %.2fms", sanitizeString(target), latencyMs)
 
 	case EventExec:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -275,14 +286,14 @@ func (e *Event) FormatMessage() string {
 		return fmt.Sprintf("[PROC] execve %s took %.2fms", sanitizeString(target), latencyMs)
 
 	case EventFork:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "child"
 		}
 		return fmt.Sprintf("[PROC] fork created pid %d (%s)", e.PID, sanitizeString(target))
 
 	case EventOpen:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "file"
 		}
@@ -330,16 +341,17 @@ func TCPStateString(state uint32) string {
 
 func (e *Event) FormatRealtimeMessage() string {
 	latencyMs := float64(e.LatencyNS) / 1e6
+	const maxTargetLen = 256
 
 	switch e.Type {
 	case EventDNS:
 		if e.Error != 0 {
-			return fmt.Sprintf("[DNS] lookup %s failed: error %d", sanitizeString(e.Target), e.Error)
+			return fmt.Sprintf("[DNS] lookup %s failed: error %d", sanitizeString(truncateString(e.Target, maxTargetLen)), e.Error)
 		}
-		return fmt.Sprintf("[DNS] lookup %s took %.2fms", sanitizeString(e.Target), latencyMs)
+		return fmt.Sprintf("[DNS] lookup %s took %.2fms", sanitizeString(truncateString(e.Target, maxTargetLen)), latencyMs)
 
 	case EventConnect:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -376,7 +388,7 @@ func (e *Event) FormatRealtimeMessage() string {
 
 	case EventTCPState:
 		stateStr := TCPStateString(e.TCPState)
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -386,7 +398,7 @@ func (e *Event) FormatRealtimeMessage() string {
 		return fmt.Sprintf("[MEM] Page fault (error: %d)", e.Error)
 
 	case EventOOMKill:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -394,7 +406,7 @@ func (e *Event) FormatRealtimeMessage() string {
 		return fmt.Sprintf("[MEM] OOM kill: %s (%.2f MB)", sanitizeString(target), memMB)
 
 	case EventWrite:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -405,7 +417,7 @@ func (e *Event) FormatRealtimeMessage() string {
 		return msg
 
 	case EventRead:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" || target == "?" {
 			target = "file"
 		}
@@ -416,7 +428,7 @@ func (e *Event) FormatRealtimeMessage() string {
 		return msg
 
 	case EventFsync:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "file"
 		}
@@ -426,35 +438,35 @@ func (e *Event) FormatRealtimeMessage() string {
 		return fmt.Sprintf("[CPU] thread blocked %.2fms", latencyMs)
 
 	case EventLockContention:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "lock"
 		}
 		return fmt.Sprintf("[LOCK] contention on %s (%.2fms)", sanitizeString(target), latencyMs)
 
 	case EventTCPRetrans:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
 		return fmt.Sprintf("[NET] TCP retransmission for %s", sanitizeString(target))
 
 	case EventNetDevError:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "iface"
 		}
 		return fmt.Sprintf("[NET] network device errors on %s (error=%d)", sanitizeString(target), e.Error)
 
 	case EventDBQuery:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "query"
 		}
 		return fmt.Sprintf("[DB] query pattern %s took %.2fms", sanitizeString(target), latencyMs)
 
 	case EventExec:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "unknown"
 		}
@@ -464,14 +476,14 @@ func (e *Event) FormatRealtimeMessage() string {
 		return fmt.Sprintf("[PROC] execve %s took %.2fms", sanitizeString(target), latencyMs)
 
 	case EventFork:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "child"
 		}
 		return fmt.Sprintf("[PROC] fork created pid %d (%s)", e.PID, sanitizeString(target))
 
 	case EventOpen:
-		target := e.Target
+		target := truncateString(e.Target, maxTargetLen)
 		if target == "" {
 			target = "file"
 		}

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,6 +143,8 @@ func findCgroupPath(containerID string) (string, error) {
 		filepath.Join(cgroupBase, "user.slice"),
 	}
 
+	var errFound = errors.New("podtrace: cgroup found")
+
 	for _, basePath := range paths {
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
 			continue
@@ -156,7 +159,7 @@ func findCgroupPath(containerID string) (string, error) {
 			if strings.Contains(path, containerID) || (len(containerID) >= 12 && strings.Contains(path, containerID[:12])) {
 				foundPath = path
 				found = true
-				return fmt.Errorf("found")
+				return errFound
 			}
 			return nil
 		})


### PR DESCRIPTION
- Fix eBPF map leaks by ensuring cleanup on all error paths
- Replace magic constants with struct-based calculations
- Reject non-loopback metrics addresses by default
- Improve cgroup discovery robustness
- Add performance limits for stack trace processing
- Add string truncation for long event targets