### PR TITLE
feat: Add structured logging with zap and internal metrics tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,10 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
+go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ const (
 	DefaultMetricsPort        = 3000
 	DefaultMetricsHost        = "127.0.0.1"
 	DefaultRingBufferSizeKB   = 2048
+	DefaultLogLevel           = "info"
 )
 
 const (

--- a/internal/ebpf/filter/filter.go
+++ b/internal/ebpf/filter/filter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/metricsexporter"
 	"github.com/podtrace/podtrace/internal/validation"
 )
 
@@ -40,9 +41,11 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	f.pidCacheMu.RLock()
 	if cached, ok := f.pidCache[pid]; ok {
 		f.pidCacheMu.RUnlock()
+		metricsexporter.RecordPIDCacheHit()
 		return cached
 	}
 	f.pidCacheMu.RUnlock()
+	metricsexporter.RecordPIDCacheMiss()
 
 	cgroupFile := fmt.Sprintf("%s/%d/cgroup", config.ProcBasePath, pid)
 	if len(cgroupFile) > config.MaxCgroupFilePathLength {

--- a/internal/ebpf/process_cache.go
+++ b/internal/ebpf/process_cache.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/metricsexporter"
 	"github.com/podtrace/podtrace/internal/validation"
 )
 
@@ -23,9 +24,11 @@ func getProcessNameQuick(pid uint32) string {
 	processNameCacheMutex.RLock()
 	if name, ok := processNameCache[pid]; ok {
 		processNameCacheMutex.RUnlock()
+		metricsexporter.RecordProcessCacheHit()
 		return name
 	}
 	processNameCacheMutex.RUnlock()
+	metricsexporter.RecordProcessCacheMiss()
 
 	name := ""
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,89 @@
+package logger
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+var (
+	log         *zap.Logger
+	atomicLevel zap.AtomicLevel
+)
+
+func init() {
+	level := getLogLevel()
+	atomicLevel = zap.NewAtomicLevelAt(level)
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
+
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderConfig),
+		zapcore.AddSync(os.Stderr),
+		atomicLevel,
+	)
+
+	log = zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+}
+
+func getLogLevel() zapcore.Level {
+	levelStr := os.Getenv("PODTRACE_LOG_LEVEL")
+	if levelStr == "" {
+		levelStr = config.DefaultLogLevel
+	}
+	return parseLogLevel(levelStr)
+}
+
+func Debug(msg string, fields ...zap.Field) {
+	log.Debug(msg, fields...)
+}
+
+func Info(msg string, fields ...zap.Field) {
+	log.Info(msg, fields...)
+}
+
+func Warn(msg string, fields ...zap.Field) {
+	log.Warn(msg, fields...)
+}
+
+func Error(msg string, fields ...zap.Field) {
+	log.Error(msg, fields...)
+}
+
+func Fatal(msg string, fields ...zap.Field) {
+	log.Fatal(msg, fields...)
+}
+
+func Logger() *zap.Logger {
+	return log
+}
+
+func Sync() {
+	_ = log.Sync()
+}
+
+func SetLevel(levelStr string) {
+	level := parseLogLevel(levelStr)
+	atomicLevel.SetLevel(level)
+}
+
+func parseLogLevel(levelStr string) zapcore.Level {
+	switch levelStr {
+	case "debug":
+		return zapcore.DebugLevel
+	case "info":
+		return zapcore.InfoLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	case "fatal":
+		return zapcore.FatalLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}


### PR DESCRIPTION
Replace fmt.Printf with structured logging using zap and add internal metrics tracking.

## Changes

### Structured Logging
- Replaced all fmt.Printf calls with structured logging using zap
- Added configurable log levels via `--log-level` CLI flag and `PODTRACE_LOG_LEVEL` environment variable
- Supports debug, info, warn, error, and fatal log levels
- CLI flag takes precedence over environment variable

### Internal Metrics
Added Prometheus metrics for observability:
- **Ring buffer drops**: `podtrace_ring_buffer_drops_total` - tracks events dropped due to ring buffer errors
- **Cache performance**: 
  - `podtrace_process_cache_hits_total` / `podtrace_process_cache_misses_total`
  - `podtrace_pid_cache_hits_total` / `podtrace_pid_cache_misses_total`
- **Event processing latency**: `podtrace_event_processing_latency_seconds` - histogram tracking time from ring buffer read to event channel send
- **Error rates by type**: `podtrace_errors_total` - counter with labels for event_type and error_code

All metrics are exposed through the existing Prometheus metrics endpoint when `--metrics` flag is enabled.