### PR TITLE
fix: Replace bpf_d_path with inode-based path resolution for cross-kernel compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ BINARY = bin/podtrace
 # For Go < 1.21, user needs to upgrade Go manually
 export GOTOOLCHAIN=auto
 
-ENABLE_FILE_PATH_TRACKING ?= 0
-BPF_CFLAGS = -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3 -DENABLE_FILE_PATH_TRACKING=$(ENABLE_FILE_PATH_TRACKING)
+BPF_CFLAGS = -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3
 
 all: check-go build
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A simple but powerful eBPF-based diagnostic tool for Kubernetes applications. Pr
 
 ### File System Monitoring
 - **File Operations**: Tracks read, write, and fsync operations with latency analysis
-- **File Path Tracking**: Captures full file paths for filesystem operations
+- **File Path Tracking**: Captures full file paths using multi-strategy resolution (inode-based correlation with `open()` events)
 - **I/O Bandwidth**: Monitors bytes transferred for file read/write operations
 - **Throughput Analysis**: Calculates average throughput and peak transfer rates
 

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -41,8 +41,8 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
-	__type(value, char[MAX_STRING_LEN]);
-} file_paths SEC(".maps");
+	__type(value, u64);
+} file_inodes SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -62,7 +62,7 @@ The eBPF programs run in the kernel and trace system calls and kernel events. Th
 - **events.h**: Event types and structures
 - **helpers.h**: Helper functions
 - **network.c**: Network probes (TCP, UDP, DNS, HTTP, TCP retransmissions, network errors)
-- **filesystem.c**: Filesystem probes (with optional file path tracking)
+- **filesystem.c**: Filesystem probes with inode-based path resolution
 - **cpu.c**: CPU/scheduling probes and lock contention tracking
 - **memory.c**: Memory probes
 - **syscalls.c**: System call probes (execve, fork, open, close)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -62,20 +62,6 @@ This will:
 - Compile the eBPF program (`bpf/podtrace.bpf.c`) to `bpf/podtrace.bpf.o`
 - Build the Go binary to `bin/podtrace`
 
-**Optional: Enable File Path Tracking**
-
-File path tracking is disabled by default because it requires the `bpf_d_path` helper function (kernel 5.6+). If your kernel supports it, you can enable it:
-
-```bash
-make ENABLE_FILE_PATH_TRACKING=1
-
-# Or set it permanently in Makefile
-# Change: ENABLE_FILE_PATH_TRACKING ?= 0
-# To:     ENABLE_FILE_PATH_TRACKING ?= 1
-```
-
-**Note**: If you enable file path tracking but your kernel doesn't support `bpf_d_path`, podtrace will fail to load with an error about "unknown func bpf_d_path". In this case, rebuild with `ENABLE_FILE_PATH_TRACKING=0` (the default).
-
 ### 4. Set Capabilities (Optional)
 
 To run without `sudo`, set the required capabilities:
@@ -136,10 +122,15 @@ You should see usage information.
 - DNS tracking requires libc to be found
 - The tool will work without DNS tracking
 
-**Error: "unknown func bpf_d_path"**
-- This occurs when file path tracking is enabled but the kernel doesn't support `bpf_d_path`
-- Rebuild with `ENABLE_FILE_PATH_TRACKING=0` (the default)
-- File path tracking requires kernel 5.6+ with `bpf_d_path` helper support
+**File Path Resolution Issues:**
+- If paths show as `ino:DEV/INO` instead of actual paths, this means inode extraction returned 0
+- This is expected if `vmlinux.h` is incomplete or missing
+- To enable full path resolution, generate a complete `vmlinux.h`:
+  ```bash
+  bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h
+  make build
+  ```
+- Path tracking still works via `open()` events even without inode extraction
 
 ## Running in Kubernetes
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -113,7 +113,7 @@ The diagnose report includes:
 - Read, write, and fsync operation counts
 - Operation latencies (avg, max, percentiles)
 - Slow operations (>10ms)
-- Top accessed files (if file path tracking is enabled)
+- Top accessed files (file paths captured from `open()` events)
 - I/O bandwidth metrics (total bytes, average bytes, throughput)
 
 ### CPU Statistics
@@ -186,7 +186,7 @@ Look for:
 
 Check:
 - File System Statistics for slow operations
-- Top accessed files (if file path tracking is enabled)
+- Top accessed files (file paths captured from `open()` events)
 - Read/write latency percentiles
 - I/O bandwidth and throughput metrics
 
@@ -227,7 +227,7 @@ Review:
 
 - Only traces the first container in a pod
 - Requires kernel 5.8+ with BTF support
-- File path tracking requires kernel 5.6+ with `bpf_d_path` support (disabled by default)
+- File path tracking uses inode-based correlation and works on all kernels (5.8+)
 - DNS tracking may be unavailable if libc path cannot be determined
 - CPU scheduling tracking requires tracepoint permissions
 - Stack trace symbol resolution requires `addr2line` tool and debug symbols

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	EventChannelBufferSize = getIntEnvOrDefault("PODTRACE_EVENT_BUFFER_SIZE", 100)
+	EventChannelBufferSize = getIntEnvOrDefault("PODTRACE_EVENT_BUFFER_SIZE", 10000)
 	CacheMaxSize           = getIntEnvOrDefault("PODTRACE_CACHE_MAX_SIZE", MaxProcessCacheSize)
 	CacheTTLSeconds        = getIntEnvOrDefault("PODTRACE_CACHE_TTL_SECONDS", DefaultCacheTTLSeconds)
 	ErrorBackoffEnabled    = getEnvOrDefault("PODTRACE_ERROR_BACKOFF_ENABLED", "true") == "true"

--- a/internal/ebpf/pathresolver/pathresolver.go
+++ b/internal/ebpf/pathresolver/pathresolver.go
@@ -1,0 +1,259 @@
+package pathresolver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+type cachedPath struct {
+	path      string
+	timestamp time.Time
+}
+
+type Resolver struct {
+	mu           sync.RWMutex
+	cache        map[string]string
+	inodeToPath  map[string]*cachedPath
+	pidFdToPath  map[uint32]map[uint32]*cachedPath
+	pidFdToInode map[uint32]map[uint32]string
+	maxChecks    int
+	cacheTTL     time.Duration
+}
+
+func New() *Resolver {
+	ttl := time.Duration(config.CacheTTLSeconds) * time.Second
+	maxChecks := getIntEnvOrDefault("PODTRACE_PATH_MAX_FD_CHECKS", 100)
+	return &Resolver{
+		cache:        make(map[string]string),
+		inodeToPath:  make(map[string]*cachedPath),
+		pidFdToPath:  make(map[uint32]map[uint32]*cachedPath),
+		pidFdToInode: make(map[uint32]map[uint32]string),
+		maxChecks:    maxChecks,
+		cacheTTL:     ttl,
+	}
+}
+
+func getIntEnvOrDefault(key string, defaultValue int) int {
+	if val := os.Getenv(key); val != "" {
+		if intVal, err := strconv.Atoi(val); err == nil {
+			return intVal
+		}
+	}
+	return defaultValue
+}
+
+func (r *Resolver) ResolvePath(pid uint32, target string) string {
+	if target == "" || !strings.HasPrefix(target, "ino:") {
+		return target
+	}
+
+	parts := strings.SplitN(target[4:], "/", 2)
+	if len(parts) != 2 {
+		return target
+	}
+
+	ino, err1 := strconv.ParseUint(parts[0], 10, 32)
+	dev, err2 := strconv.ParseUint(parts[1], 10, 32)
+	if err1 != nil || err2 != nil {
+		return target
+	}
+
+	r.mu.RLock()
+	if cached, ok := r.inodeToPath[target]; ok {
+		if time.Since(cached.timestamp) < r.cacheTTL {
+			r.mu.RUnlock()
+			return cached.path
+		}
+	}
+	r.mu.RUnlock()
+
+	cacheKey := fmt.Sprintf("%d:%d:%d", pid, ino, dev)
+	r.mu.RLock()
+	if cached, ok := r.cache[cacheKey]; ok {
+		r.mu.RUnlock()
+		return cached
+	}
+	r.mu.RUnlock()
+
+	path := r.resolveInode(pid, uint32(ino), uint32(dev))
+	if path != "" {
+		r.mu.Lock()
+		r.cache[cacheKey] = path
+		r.inodeToPath[target] = &cachedPath{
+			path:      path,
+			timestamp: time.Now(),
+		}
+		r.mu.Unlock()
+		return path
+	}
+
+	return target
+}
+
+func (r *Resolver) RecordOpen(pid uint32, fd uint32, path string, ino, dev uint32) {
+	if path == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	inodeKey := fmt.Sprintf("ino:%d/%d", ino, dev)
+	r.inodeToPath[inodeKey] = &cachedPath{
+		path:      path,
+		timestamp: time.Now(),
+	}
+
+	if r.pidFdToPath[pid] == nil {
+		r.pidFdToPath[pid] = make(map[uint32]*cachedPath)
+	}
+	r.pidFdToPath[pid][fd] = &cachedPath{
+		path:      path,
+		timestamp: time.Now(),
+	}
+
+	if r.pidFdToInode[pid] == nil {
+		r.pidFdToInode[pid] = make(map[uint32]string)
+	}
+	r.pidFdToInode[pid][fd] = inodeKey
+}
+
+func (r *Resolver) RecordOpenByFD(pid uint32, fd uint32, path string) {
+	if path == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.pidFdToPath[pid] == nil {
+		r.pidFdToPath[pid] = make(map[uint32]*cachedPath)
+	}
+	r.pidFdToPath[pid][fd] = &cachedPath{
+		path:      path,
+		timestamp: time.Now(),
+	}
+}
+
+func (r *Resolver) CorrelateFDWithInode(pid uint32, fd uint32, ino, dev uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.pidFdToPath[pid] == nil {
+		return
+	}
+
+	cached, ok := r.pidFdToPath[pid][fd]
+	if !ok {
+		return
+	}
+
+	if time.Since(cached.timestamp) > 5*time.Second {
+		return
+	}
+
+	inodeKey := fmt.Sprintf("ino:%d/%d", ino, dev)
+	r.inodeToPath[inodeKey] = &cachedPath{
+		path:      cached.path,
+		timestamp: time.Now(),
+	}
+
+	if r.pidFdToInode[pid] == nil {
+		r.pidFdToInode[pid] = make(map[uint32]string)
+	}
+	r.pidFdToInode[pid][fd] = inodeKey
+}
+
+func (r *Resolver) isProcessAlive(pid uint32) bool {
+	_, err := os.Stat(fmt.Sprintf("%s/%d", config.ProcBasePath, pid))
+	return err == nil
+}
+
+func (r *Resolver) resolveInode(pid uint32, ino, dev uint32) string {
+	if !r.isProcessAlive(pid) {
+		return ""
+	}
+
+	fdDir := fmt.Sprintf("%s/%d/fd", config.ProcBasePath, pid)
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return ""
+	}
+
+	checked := 0
+
+	for _, entry := range entries {
+		if checked >= r.maxChecks {
+			break
+		}
+
+		_, err := strconv.ParseUint(entry.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+
+		checked++
+
+		fdPath := filepath.Join(fdDir, entry.Name())
+		linkPath, err := os.Readlink(fdPath)
+		if err != nil {
+			continue
+		}
+
+		if !filepath.IsAbs(linkPath) {
+			linkPath = filepath.Join(fdDir, linkPath)
+		}
+
+		var stat syscall.Stat_t
+		if err := syscall.Stat(linkPath, &stat); err != nil {
+			continue
+		}
+
+		if stat.Ino == uint64(ino) && stat.Dev == uint64(dev) {
+			return linkPath
+		}
+	}
+
+	return ""
+}
+
+func (r *Resolver) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = make(map[string]string)
+	r.inodeToPath = make(map[string]*cachedPath)
+	r.pidFdToPath = make(map[uint32]map[uint32]*cachedPath)
+	r.pidFdToInode = make(map[uint32]map[uint32]string)
+}
+
+func (r *Resolver) CleanupExpired() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	for key, cached := range r.inodeToPath {
+		if now.Sub(cached.timestamp) > r.cacheTTL {
+			delete(r.inodeToPath, key)
+		}
+	}
+
+	for pid, fdMap := range r.pidFdToPath {
+		for fd, cached := range fdMap {
+			if now.Sub(cached.timestamp) > r.cacheTTL {
+				delete(fdMap, fd)
+			}
+		}
+		if len(fdMap) == 0 {
+			delete(r.pidFdToPath, pid)
+			delete(r.pidFdToInode, pid)
+		}
+	}
+}

--- a/internal/ebpf/pathresolver/pathresolver_test.go
+++ b/internal/ebpf/pathresolver/pathresolver_test.go
@@ -1,0 +1,326 @@
+package pathresolver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func TestResolvePath(t *testing.T) {
+	resolver := New()
+
+	tests := []struct {
+		name     string
+		pid      uint32
+		target   string
+		expected string
+	}{
+		{
+			name:     "empty target",
+			pid:      1234,
+			target:   "",
+			expected: "",
+		},
+		{
+			name:     "non-inode target",
+			pid:      1234,
+			target:   "/path/to/file",
+			expected: "/path/to/file",
+		},
+		{
+			name:     "invalid inode format",
+			pid:      1234,
+			target:   "ino:invalid",
+			expected: "ino:invalid",
+		},
+		{
+			name:     "inode format without slash",
+			pid:      1234,
+			target:   "ino:12345",
+			expected: "ino:12345",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolver.ResolvePath(tt.pid, tt.target)
+			if result != tt.expected {
+				t.Errorf("ResolvePath(%d, %q) = %q, want %q", tt.pid, tt.target, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveInode(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	resolver := New()
+	pid := uint32(os.Getpid())
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "testfile")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	var stat syscall.Stat_t
+	if err := syscall.Stat(testFile, &stat); err != nil {
+		t.Fatalf("Failed to stat test file: %v", err)
+	}
+
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	path := resolver.resolveInode(pid, uint32(stat.Ino), uint32(stat.Dev))
+	if path == "" {
+		t.Log("Path resolution returned empty (may not work in test environment)")
+		return
+	}
+
+	if path != testFile {
+		t.Errorf("resolveInode() = %q, want %q", path, testFile)
+	}
+}
+
+func TestResolvePathCaching(t *testing.T) {
+	resolver := New()
+	pid := uint32(1234)
+	target := "ino:12345/67890"
+
+	result1 := resolver.ResolvePath(pid, target)
+	result2 := resolver.ResolvePath(pid, target)
+
+	if result1 != result2 {
+		t.Errorf("Cached result differs: first=%q, second=%q", result1, result2)
+	}
+}
+
+func TestClear(t *testing.T) {
+	resolver := New()
+
+	resolver.mu.Lock()
+	resolver.cache["test:1:2"] = "/test/path"
+	resolver.inodeToPath["ino:1/2"] = &cachedPath{path: "/test/path", timestamp: time.Now()}
+	resolver.mu.Unlock()
+
+	resolver.Clear()
+
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+	if len(resolver.cache) != 0 {
+		t.Error("Cache should be empty after Clear()")
+	}
+	if len(resolver.inodeToPath) != 0 {
+		t.Error("InodeToPath should be empty after Clear()")
+	}
+}
+
+func TestRecordOpen(t *testing.T) {
+	resolver := New()
+	pid := uint32(1234)
+	fd := uint32(5)
+	path := "/test/path"
+	ino := uint32(100)
+	dev := uint32(200)
+
+	resolver.RecordOpen(pid, fd, path, ino, dev)
+
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+
+	inodeKey := "ino:100/200"
+	if cached, ok := resolver.inodeToPath[inodeKey]; !ok || cached.path != path {
+		t.Errorf("RecordOpen() failed to store inode mapping: got %v", resolver.inodeToPath[inodeKey])
+	}
+
+	if resolver.pidFdToPath[pid] == nil {
+		t.Error("RecordOpen() failed to initialize pidFdToPath")
+	} else if cached, ok := resolver.pidFdToPath[pid][fd]; !ok || cached.path != path {
+		t.Errorf("RecordOpen() failed to store FD mapping: got %v", resolver.pidFdToPath[pid][fd])
+	}
+}
+
+func TestRecordOpenByFD(t *testing.T) {
+	resolver := New()
+	pid := uint32(1234)
+	fd := uint32(5)
+	path := "/test/path"
+
+	resolver.RecordOpenByFD(pid, fd, path)
+
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+
+	if resolver.pidFdToPath[pid] == nil {
+		t.Error("RecordOpenByFD() failed to initialize pidFdToPath")
+	} else if cached, ok := resolver.pidFdToPath[pid][fd]; !ok || cached.path != path {
+		t.Errorf("RecordOpenByFD() failed to store FD mapping: got %v", resolver.pidFdToPath[pid][fd])
+	}
+}
+
+func TestCorrelateFDWithInode(t *testing.T) {
+	resolver := New()
+	pid := uint32(1234)
+	fd := uint32(5)
+	path := "/test/path"
+	ino := uint32(100)
+	dev := uint32(200)
+
+	resolver.RecordOpenByFD(pid, fd, path)
+	time.Sleep(10 * time.Millisecond)
+	resolver.CorrelateFDWithInode(pid, fd, ino, dev)
+
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+
+	inodeKey := "ino:100/200"
+	if cached, ok := resolver.inodeToPath[inodeKey]; !ok || cached.path != path {
+		t.Errorf("CorrelateFDWithInode() failed to correlate: got %v", resolver.inodeToPath[inodeKey])
+	}
+}
+
+func TestResolvePathWithInodeCache(t *testing.T) {
+	resolver := New()
+	pid := uint32(1234)
+	fd := uint32(5)
+	path := "/test/path"
+	ino := uint32(100)
+	dev := uint32(200)
+
+	resolver.RecordOpen(pid, fd, path, ino, dev)
+
+	target := "ino:100/200"
+	result := resolver.ResolvePath(pid, target)
+
+	if result != path {
+		t.Errorf("ResolvePath() with inode cache = %q, want %q", result, path)
+	}
+}
+
+func TestCleanupExpired(t *testing.T) {
+	resolver := New()
+	resolver.cacheTTL = 10 * time.Millisecond
+
+	pid := uint32(1234)
+	fd := uint32(5)
+	path := "/test/path"
+	ino := uint32(100)
+	dev := uint32(200)
+
+	resolver.RecordOpen(pid, fd, path, ino, dev)
+
+	time.Sleep(20 * time.Millisecond)
+
+	resolver.CleanupExpired()
+
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+
+	inodeKey := "ino:100/200"
+	if _, ok := resolver.inodeToPath[inodeKey]; ok {
+		t.Error("CleanupExpired() should have removed expired entries")
+	}
+}
+
+func TestIsProcessAlive(t *testing.T) {
+	resolver := New()
+
+	alive := resolver.isProcessAlive(uint32(os.Getpid()))
+	if !alive {
+		t.Error("Current process should be alive")
+	}
+
+	alive = resolver.isProcessAlive(99999999)
+	if alive {
+		t.Error("Non-existent PID should not be alive")
+	}
+}
+
+func TestResolveInode_ProcessNotAlive(t *testing.T) {
+	resolver := New()
+	path := resolver.resolveInode(99999999, 100, 200)
+	if path != "" {
+		t.Errorf("resolveInode() for non-existent process should return empty, got %q", path)
+	}
+}
+
+func TestResolveInode_InvalidFDDir(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	resolver := New()
+	origProcBase := config.ProcBasePath
+	config.SetProcBasePath("/nonexistent/proc")
+	defer func() { config.SetProcBasePath(origProcBase) }()
+
+	path := resolver.resolveInode(uint32(os.Getpid()), 100, 200)
+	if path != "" {
+		t.Errorf("resolveInode() with invalid proc base should return empty, got %q", path)
+	}
+}
+
+func TestResolveInode_NonNumericFD(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	resolver := New()
+	pid := uint32(os.Getpid())
+
+	tmpDir := t.TempDir()
+	origProcBase := config.ProcBasePath
+	config.SetProcBasePath(tmpDir)
+	defer func() { config.SetProcBasePath(origProcBase) }()
+
+	procDir := filepath.Join(tmpDir, fmt.Sprintf("%d", pid))
+	fdDir := filepath.Join(procDir, "fd")
+	_ = os.MkdirAll(fdDir, 0755)
+
+	_ = os.WriteFile(filepath.Join(fdDir, "not-a-number"), []byte(""), 0644)
+
+	path := resolver.resolveInode(pid, 100, 200)
+	if path != "" {
+		t.Logf("resolveInode() returned %q (may be expected)", path)
+	}
+}
+
+func TestResolveInode_MaxChecks(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	resolver := New()
+	resolver.maxChecks = 2
+
+	pid := uint32(os.Getpid())
+	tmpDir := t.TempDir()
+	origProcBase := config.ProcBasePath
+	config.SetProcBasePath(tmpDir)
+	defer func() { config.SetProcBasePath(origProcBase) }()
+
+	procDir := filepath.Join(tmpDir, fmt.Sprintf("%d", pid))
+	fdDir := filepath.Join(procDir, "fd")
+	_ = os.MkdirAll(fdDir, 0755)
+
+	for i := 0; i < 5; i++ {
+		_ = os.WriteFile(filepath.Join(fdDir, fmt.Sprintf("%d", i)), []byte(""), 0644)
+	}
+
+	path := resolver.resolveInode(pid, 100, 200)
+	if path != "" {
+		t.Logf("resolveInode() returned %q (may be expected)", path)
+	}
+}

--- a/internal/ebpf/tracer/tracer_test.go
+++ b/internal/ebpf/tracer/tracer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -569,7 +570,7 @@ func TestTracer_SetContainerID_MultipleCalls(t *testing.T) {
 
 	err1 := tracer.SetContainerID("container-1")
 	err2 := tracer.SetContainerID("container-2")
-	
+
 	if err1 == nil && err2 == nil {
 		if tracer.containerID != "container-2" {
 			t.Errorf("Expected containerID 'container-2', got %q", tracer.containerID)
@@ -788,7 +789,6 @@ func TestTracer_Start_StackNrZero(t *testing.T) {
 		t.Error("Expected n to be 0")
 	}
 }
-
 
 func TestTracer_GetProcessNameQuick_CmdlineNoSlash(t *testing.T) {
 	tempDir := t.TempDir()
@@ -1263,3 +1263,94 @@ func TestTracer_GetProcessNameQuick_CmdlineRootPath(t *testing.T) {
 	}
 }
 
+func TestTracer_ExtractInodeFromFD(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	tracer := &Tracer{}
+	pid := uint32(os.Getpid())
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "testfile")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	fd := uint32(f.Fd())
+	ino, dev := tracer.extractInodeFromFD(pid, fd)
+
+	if ino == 0 || dev == 0 {
+		t.Logf("extractInodeFromFD() returned ino=%d, dev=%d (may not work in test environment)", ino, dev)
+	}
+}
+
+func TestTracer_ExtractInodeFromFD_InvalidPID(t *testing.T) {
+	tracer := &Tracer{}
+	ino, dev := tracer.extractInodeFromFD(99999999, 0)
+	if ino != 0 || dev != 0 {
+		t.Errorf("extractInodeFromFD() for invalid PID should return 0,0, got %d,%d", ino, dev)
+	}
+}
+
+func TestTracer_FindFDForInode(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping test that requires root access to read /proc")
+	}
+
+	tracer := &Tracer{}
+	pid := uint32(os.Getpid())
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "testfile")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	var stat syscall.Stat_t
+	if err := syscall.Stat(testFile, &stat); err != nil {
+		t.Fatalf("Failed to stat test file: %v", err)
+	}
+
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	fd := tracer.findFDForInode(pid, uint32(stat.Ino), uint32(stat.Dev))
+	if fd == 0 {
+		t.Log("findFDForInode() returned 0 (may not work in test environment)")
+	}
+}
+
+func TestTracer_FindFDForInode_InvalidPID(t *testing.T) {
+	tracer := &Tracer{}
+	fd := tracer.findFDForInode(99999999, 100, 200)
+	if fd != 0 {
+		t.Errorf("findFDForInode() for invalid PID should return 0, got %d", fd)
+	}
+}
+
+func TestTracer_FindFDForInode_InvalidFDDir(t *testing.T) {
+	tempDir := t.TempDir()
+	origProcBase := config.ProcBasePath
+	config.SetProcBasePath(tempDir)
+	defer func() { config.SetProcBasePath(origProcBase) }()
+
+	tracer := &Tracer{}
+	fd := tracer.findFDForInode(uint32(os.Getpid()), 100, 200)
+	if fd != 0 {
+		t.Errorf("findFDForInode() with invalid proc base should return 0, got %d", fd)
+	}
+}


### PR DESCRIPTION
This PR fixes the critical issue where `bpf_d_path` was incorrectly used in `kprobe` programs and replaces it with a robust multi-strategy path resolution approach.
