### PR TITLE
fix: DaemonSet no-events and systemd cgroup driver

### DIFF
--- a/.github/workflows/ebpf-build.yml
+++ b/.github/workflows/ebpf-build.yml
@@ -45,8 +45,11 @@ jobs:
         run: |
           echo "Generating vmlinux.h from BTF..."
           if [ -f /sys/kernel/btf/vmlinux ]; then
-            bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h
-            echo "vmlinux.h generated successfully"
+            if bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h 2>/dev/null; then
+              echo "vmlinux.h generated successfully"
+            else
+              echo "Warning: bpftool failed or not available for this kernel, using placeholder vmlinux.h"
+            fi
           else
             echo "Warning: /sys/kernel/btf/vmlinux not found, using placeholder vmlinux.h"
           fi
@@ -60,21 +63,15 @@ jobs:
       - name: Compile eBPF program
         run: |
           echo "Compiling podtrace.bpf.c..."
-          if [ -f /sys/kernel/btf/vmlinux ]; then
-            clang -O2 -g \
-              -target bpf \
-              -D__TARGET_ARCH_x86 \
-              -DPODTRACE_VMLINUX_FROM_BTF \
-              -I./bpf \
-              -c bpf/podtrace.bpf.c \
-              -o bpf/podtrace.bpf.o
+          if [ -f bpf/vmlinux.h ] && [ -s bpf/vmlinux.h ]; then
+            VMLINUX_SIZE=$(stat -c%s bpf/vmlinux.h 2>/dev/null || echo 0)
+            if [ "$VMLINUX_SIZE" -gt 50000 ]; then
+              clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -DPODTRACE_VMLINUX_FROM_BTF -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+            else
+              clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+            fi
           else
-            clang -O2 -g \
-              -target bpf \
-              -D__TARGET_ARCH_x86 \
-              -I./bpf \
-              -c bpf/podtrace.bpf.c \
-              -o bpf/podtrace.bpf.o
+            clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
           fi
 
       - name: Build Go binary

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,8 +48,11 @@ jobs:
         run: |
           echo "Generating vmlinux.h from BTF..."
           if [ -f /sys/kernel/btf/vmlinux ]; then
-            bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h
-            echo "vmlinux.h generated successfully"
+            if bpftool btf dump file /sys/kernel/btf/vmlinux format c > bpf/vmlinux.h 2>/dev/null; then
+              echo "vmlinux.h generated successfully"
+            else
+              echo "Warning: bpftool failed or not available for this kernel, using placeholder vmlinux.h"
+            fi
           else
             echo "Warning: /sys/kernel/btf/vmlinux not found, using placeholder vmlinux.h"
           fi
@@ -64,21 +67,15 @@ jobs:
         if: matrix.language == 'cpp'
         run: |
           echo "Compiling podtrace.bpf.c..."
-          if [ -f /sys/kernel/btf/vmlinux ]; then
-            clang -O2 -g \
-              -target bpf \
-              -D__TARGET_ARCH_x86 \
-              -DPODTRACE_VMLINUX_FROM_BTF \
-              -I./bpf \
-              -c bpf/podtrace.bpf.c \
-              -o bpf/podtrace.bpf.o
+          if [ -f bpf/vmlinux.h ] && [ -s bpf/vmlinux.h ]; then
+            VMLINUX_SIZE=$(stat -c%s bpf/vmlinux.h 2>/dev/null || echo 0)
+            if [ "$VMLINUX_SIZE" -gt 50000 ]; then
+              clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -DPODTRACE_VMLINUX_FROM_BTF -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+            else
+              clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+            fi
           else
-            clang -O2 -g \
-              -target bpf \
-              -D__TARGET_ARCH_x86 \
-              -I./bpf \
-              -c bpf/podtrace.bpf.c \
-              -o bpf/podtrace.bpf.o
+            clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -I./bpf -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
           fi
 
       - name: Analyze

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ else
   BPF_ARCH_DEFINE = -D__TARGET_ARCH_x86
 endif
 
-BPF_CFLAGS = -O2 -g -target bpf $(BPF_ARCH_DEFINE) -mcpu=$(BPF_MCPU)
+LIBBPF_INCLUDE ?= /usr/include
+BPF_CFLAGS = -O2 -g -target bpf $(BPF_ARCH_DEFINE) -mcpu=$(BPF_MCPU) -I$(LIBBPF_INCLUDE)
 
 all: check-go build
 

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -14,6 +14,18 @@ typedef unsigned int __u32;
 typedef int __s32;
 typedef unsigned long long __u64;
 typedef long long __s64;
+typedef __u16 __be16;
+typedef __u32 __be32;
+typedef __u64 __be64;
+typedef __u32 __wsum;
+typedef __s8 s8;
+typedef __u8 u8;
+typedef __s16 s16;
+typedef __u16 u16;
+typedef __s32 s32;
+typedef __u32 u32;
+typedef __s64 s64;
+typedef __u64 u64;
 #endif
 
 #include <bpf/bpf_helpers.h>

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -28,6 +28,16 @@ typedef __s64 s64;
 typedef __u64 u64;
 #endif
 
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+struct dentry;
+struct path {
+	struct dentry *dentry;
+};
+struct file {
+	struct path f_path;
+};
+#endif
+
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -4,6 +4,18 @@
 #define PODTRACE_COMMON_H
 
 #include "vmlinux.h"
+
+#ifndef __u8
+typedef unsigned char __u8;
+typedef signed char __s8;
+typedef unsigned short __u16;
+typedef short __s16;
+typedef unsigned int __u32;
+typedef int __s32;
+typedef unsigned long long __u64;
+typedef long long __s64;
+#endif
+
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -34,27 +34,27 @@ typedef __u64 u64;
 
 #ifndef PODTRACE_VMLINUX_FROM_BTF
 struct pt_regs {
-	long unsigned int r15;
-	long unsigned int r14;
-	long unsigned int r13;
-	long unsigned int r12;
-	long unsigned int bp;
-	long unsigned int bx;
-	long unsigned int r11;
-	long unsigned int r10;
-	long unsigned int r9;
-	long unsigned int r8;
-	long unsigned int ax;
-	long unsigned int cx;
-	long unsigned int dx;
-	long unsigned int si;
-	long unsigned int di;
-	long unsigned int orig_ax;
-	long unsigned int ip;
-	long unsigned int cs;
-	long unsigned int flags;
-	long unsigned int sp;
-	long unsigned int ss;
+	unsigned long r15;
+	unsigned long r14;
+	unsigned long r13;
+	unsigned long r12;
+	unsigned long rbp;
+	unsigned long rbx;
+	unsigned long r11;
+	unsigned long r10;
+	unsigned long r9;
+	unsigned long r8;
+	unsigned long rax;
+	unsigned long rcx;
+	unsigned long rdx;
+	unsigned long rsi;
+	unsigned long rdi;
+	unsigned long orig_ax;
+	unsigned long ip;
+	unsigned long cs;
+	unsigned long flags;
+	unsigned long sp;
+	unsigned long ss;
 };
 
 struct sockaddr_in {

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -28,16 +28,6 @@ typedef __s64 s64;
 typedef __u64 u64;
 #endif
 
-#ifdef PODTRACE_VMLINUX_FROM_BTF
-struct dentry;
-struct path {
-	struct dentry *dentry;
-};
-struct file {
-	struct path f_path;
-};
-#endif
-
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -7,7 +7,7 @@
 - **Linux Kernel**: 5.8+ with BTF support
 - **Go**: 1.24+
 - **Kubernetes**: Access to a Kubernetes cluster
-- **Build Tools**: `clang` and `llc` (LLVM toolchain)
+- **Build Tools**: `clang` and `llc` (LLVM toolchain), **libbpf headers** (e.g. `libbpf-dev` on Debian/Ubuntu)
 
 ### Check Kernel Support
 
@@ -44,6 +44,15 @@ cd podtrace
 ```
 
 ### 2. Install Dependencies
+
+**System packages (Debian/Ubuntu):**
+
+```bash
+sudo apt update
+sudo apt install -y clang llvm build-essential libbpf-dev
+```
+
+**Go modules:**
 
 ```bash
 make deps
@@ -92,6 +101,9 @@ You should see usage information.
 
 ### Build Errors
 
+**Error: "bpf/bpf_helpers.h file not found" (or similar libbpf header)**
+- Install libbpf headers: `sudo apt install libbpf-dev` (Debian/Ubuntu). The Makefile adds `/usr/include` so that `<bpf/bpf_helpers.h>` is found; you can override with `make LIBBPF_INCLUDE=/path/to/include` if your headers are elsewhere.
+
 **Error: "failed to load eBPF program"**
 - Ensure kernel version is 5.8+
 - Check BTF support: `ls /sys/kernel/btf/vmlinux`
@@ -116,6 +128,7 @@ You should see usage information.
 - Ensure the pod is running
 - Check container runtime (Docker, containerd, CRI-O)
 - Verify cgroup v2 support
+- **Kubelet with `--cgroup-driver=systemd` (e.g. Ubuntu/Debian):** Podtrace automatically looks for container cgroups under both the default cgroup root and `/sys/fs/cgroup/systemd/`. No configuration is required. If you use a custom cgroup root via `PODTRACE_CGROUP_BASE`, ensure it is the host’s cgroup root (e.g. when running in a DaemonSet, mount the host’s `/sys/fs/cgroup` and set `PODTRACE_CGROUP_BASE` to that mount).
 
 **Error: "DNS tracking unavailable"**
 - This is a warning, not an error
@@ -135,9 +148,90 @@ You should see usage information.
 
 ## Running in Kubernetes
 
-### As a Pod
+### As a DaemonSet (recommended)
 
-You can run Podtrace as a DaemonSet or Job in your cluster:
+When Podtrace runs **inside a container** (DaemonSet or Job), it must see the **host’s** cgroup tree, process tree, and (for CRI-based resolution) the container runtime socket. Otherwise you get “no events collected” because:
+
+1. **Cgroup resolution** uses `PODTRACE_CGROUP_BASE` (default `/sys/fs/cgroup`). In a container that is the **container’s** cgroup, not the target pod’s, so the target pod’s cgroup path does not exist and resolution can fail or be wrong.
+2. **Event filtering** either uses a kernel cgroup ID (derived from the cgroup path) or a userspace check that reads `/proc/<pid>/cgroup` via `PODTRACE_PROC_BASE`. In a container, default `/proc` is the **container’s** `/proc`; PIDs from the target pod are not visible there, so every event is filtered out and no events are collected.
+3. **CRI resolution** (containerd/crio) looks for sockets under `/run/containerd/containerd.sock` etc.; those exist on the host, not in the container, unless you mount and set `PODTRACE_CRI_ENDPOINT`.
+
+Use the following pattern so the DaemonSet pod sees the host’s cgroups, proc, and (optionally) CRI socket, and point Podtrace at them with environment variables:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: podtrace
+spec:
+  selector:
+    matchLabels:
+      app: podtrace
+  template:
+    metadata:
+      labels:
+        app: podtrace
+    spec:
+      hostPID: true          # optional but recommended so PIDs match host
+      hostNetwork: false     # set true only if you need it
+      containers:
+      - name: podtrace
+        image: your-registry/podtrace:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          # Example: trace a specific pod for 30s then exit
+          ./podtrace -n default my-app-pod --diagnose 30s
+          # Or keep running and trace interactively (depends on your entrypoint)
+          exec ./podtrace -n default my-app-pod
+        env:
+        # Point at host mount paths so resolution and filtering see the target pod
+        - name: PODTRACE_CGROUP_BASE
+          value: /host/sys/fs/cgroup
+        - name: PODTRACE_PROC_BASE
+          value: /host/proc
+        # If you use CRI for pod→cgroup resolution, mount runtime socket and set:
+        # - name: PODTRACE_CRI_ENDPOINT
+        #   value: unix:///host/run/containerd/containerd.sock
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+            - BPF
+          privileged: false
+        volumeMounts:
+        - name: host-cgroup
+          mountPath: /host/sys/fs/cgroup
+          readOnly: true
+        - name: host-proc
+          mountPath: /host/proc
+          readOnly: true
+        # Optional: for CRI resolution (containerd example)
+        # - name: host-run
+        #   mountPath: /host/run
+        #   readOnly: true
+      volumes:
+      - name: host-cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: host-proc
+        hostPath:
+          path: /proc
+          type: Directory
+      # - name: host-run
+      #   hostPath:
+      #     path: /run
+      #     type: Directory
+```
+
+- **PODTRACE_CGROUP_BASE**: Must be the **host** cgroup root (e.g. `/host/sys/fs/cgroup`). Required so that pod→cgroup resolution finds the target pod’s cgroup and (on cgroup v2) so the tracer can set the in-kernel cgroup filter.
+- **PODTRACE_PROC_BASE**: Must be the **host** `/proc` (e.g. `/host/proc`). Required for userspace cgroup filtering (cgroup v1 or when kernel cgroup ID is not used) so that `/proc/<pid>/cgroup` exists for the target pod’s PIDs.
+- **PODTRACE_CRI_ENDPOINT**: Set to the path where you mount the host’s runtime socket (e.g. `unix:///host/run/containerd/containerd.sock`) if you want CRI-based resolution. Otherwise resolution falls back to scanning the host cgroup and proc (which only works if `PODTRACE_CGROUP_BASE` and `PODTRACE_PROC_BASE` point at the host).
+
+### As a Pod (simple example)
+
+You can also run Podtrace as a single Pod with the same host mounts and env vars as above:
 
 ```yaml
 apiVersion: v1
@@ -148,28 +242,45 @@ spec:
   containers:
   - name: podtrace
     image: your-registry/podtrace:latest
+    env:
+    - name: PODTRACE_CGROUP_BASE
+      value: /host/sys/fs/cgroup
+    - name: PODTRACE_PROC_BASE
+      value: /host/proc
     securityContext:
       capabilities:
         add:
         - SYS_ADMIN
         - BPF
     volumeMounts:
-    - name: sys
-      mountPath: /sys
-    - name: proc
-      mountPath: /proc
+    - name: host-cgroup
+      mountPath: /host/sys/fs/cgroup
+      readOnly: true
+    - name: host-proc
+      mountPath: /host/proc
+      readOnly: true
   volumes:
-  - name: sys
+  - name: host-cgroup
     hostPath:
-      path: /sys
-  - name: proc
+      path: /sys/fs/cgroup
+      type: Directory
+  - name: host-proc
     hostPath:
       path: /proc
+      type: Directory
 ```
+
+### Cgroup driver (systemd vs cgroupfs)
+
+Podtrace works with both kubelet cgroup drivers:
+
+- **`--cgroup-driver=cgroupfs`**: Container cgroups are under the default hierarchy (e.g. `/sys/fs/cgroup/kubepods.slice/...`).
+- **`--cgroup-driver=systemd`** (common on Ubuntu/Debian): Container cgroups are under the systemd hierarchy (e.g. `/sys/fs/cgroup/systemd/kubepods.slice/...`).
+
+Podtrace tries both the default cgroup root and `/sys/fs/cgroup/systemd` when resolving pod cgroup paths, so no extra configuration is needed for systemd-driven nodes. If your node uses a different layout, set `PODTRACE_CGROUP_BASE` to the host’s cgroup root (and, when running in a container, mount that path into the pod).
 
 ### Required Permissions
 
-- Access to `/sys/fs/cgroup` (for cgroup filtering)
-- Access to `/proc` (for process information)
-- Kubernetes API access (for pod resolution)
-- eBPF capabilities (SYS_ADMIN, BPF)
+- **Host cgroup and proc** mounted and `PODTRACE_CGROUP_BASE` / `PODTRACE_PROC_BASE` set (see above); otherwise you get no events when running in a container.
+- Kubernetes API access (for pod resolution).
+- eBPF capabilities: `SYS_ADMIN`, `BPF`.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -251,6 +251,7 @@ Review:
 - Verify the pod is running and active
 - Check that the application is making system calls
 - Ensure cgroup path was found correctly
+- **When running as a DaemonSet/container:** Podtrace must see the **host’s** cgroup and process filesystems and (for CRI) the container runtime socket. Otherwise resolution or event filtering uses the container’s own `/sys/fs/cgroup` and `/proc`, so either resolution fails or every event is filtered out. See [Running as a DaemonSet](#running-as-a-daemonset) in the installation doc and set `PODTRACE_CGROUP_BASE`, `PODTRACE_PROC_BASE`, and (if using CRI) `PODTRACE_CRI_ENDPOINT` to the host mount points.
 
 **High CPU usage:**
 - This is normal for high-event-rate applications

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -333,6 +333,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						zap.String("cgroup_path", t.cgroupPath),
 						zap.Duration("elapsed", elapsed),
 						zap.Int("links_attached", len(t.links)))
+					logger.Warn("If running in a container (e.g. DaemonSet), ensure host /sys/fs/cgroup and /proc are mounted and PODTRACE_CGROUP_BASE / PODTRACE_PROC_BASE point at them; see installation doc 'Running as a DaemonSet'")
 				} else if eventsCollected == 0 && eventsParsed > 0 && elapsed > 10*time.Second {
 					logger.Warn("Events parsed but none collected - filtering may be too strict",
 						zap.Int64("events_parsed", eventsParsed),
@@ -341,6 +342,11 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						zap.String("cgroup_path", t.cgroupPath),
 						zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter),
 						zap.Duration("elapsed", elapsed))
+					if t.useUserspaceCgroupFilter {
+						logger.Warn("Running in a container (e.g. DaemonSet)? Set PODTRACE_CGROUP_BASE and PODTRACE_PROC_BASE to the host's cgroup and proc mount paths so the target pod's cgroup is visible and filtering can match events",
+							zap.String("cgroup_base", config.CgroupBasePath),
+							zap.String("proc_base", config.ProcBasePath))
+					}
 				}
 			}
 		}

--- a/scripts/build-and-setup.sh
+++ b/scripts/build-and-setup.sh
@@ -5,10 +5,30 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+check_deps() {
+	local missing=()
+	command -v clang >/dev/null 2>&1 || missing+=(clang)
+	command -v go >/dev/null 2>&1 || missing+=(go)
+	if [[ ! -f /usr/include/bpf/bpf_helpers.h ]] && [[ ! -f "${LIBBPF_INCLUDE:-/usr/include}/bpf/bpf_helpers.h" ]]; then
+		missing+=(libbpf-dev)
+	fi
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		echo "Error: Missing required build tools or headers: ${missing[*]}"
+		echo ""
+		echo "On Debian/Ubuntu install with:"
+		echo "  sudo apt update"
+		echo "  sudo apt install -y clang llvm build-essential libbpf-dev"
+		echo "  # Go: use go.mod version or install from https://go.dev/dl/"
+		echo ""
+		exit 1
+	fi
+}
+
 build_podtrace() {
 	echo "Building podtrace..."
 	cd "${ROOT_DIR}"
 
+	check_deps
 	make clean
 	make build
 


### PR DESCRIPTION
# DaemonSet "no events collected" and systemd cgroup driver support

## Summary

This PR fixes two issues:

1. **DaemonSet / in-container runs** – Podtrace runs but reports "no events collected" when deployed as a DaemonSet (or any container).
2. **Systemd cgroup driver** – On nodes where kubelet uses `--cgroup-driver=systemd`, container cgroups live under `/sys/fs/cgroup/systemd/` and were not found, so tracing failed.

## Changes

### DaemonSet / "no events collected"

- **Docs**
  - **installation.md**: Rewrote "Running in Kubernetes" with a full DaemonSet example: host mounts for `/sys/fs/cgroup` and `/proc` (and optional CRI socket), and env vars `PODTRACE_CGROUP_BASE`, `PODTRACE_PROC_BASE`, `PODTRACE_CRI_ENDPOINT`. Added a simpler "As a Pod" example and clarified required permissions.
  - **usage.md**: Under "No events collected", added a bullet explaining that when running as a DaemonSet/container, host cgroup and proc must be mounted and the above env vars set, with a pointer to the installation doc.
- **Tracer**
  - When the log message "Events parsed but none collected" is emitted and userspace cgroup filter is in use, add a warning that in a container (e.g. DaemonSet) you should set `PODTRACE_CGROUP_BASE` and `PODTRACE_PROC_BASE` to the host’s cgroup and proc mount paths.
  - When "No events parsed from ring buffer" is logged, add a short hint about mounting host cgroup/proc and setting those env vars when running in a container.

### Systemd cgroup driver

- **internal/kubernetes/pod.go**
  - **`cgroupRootCandidates()`**: Returns a list of cgroup roots to try: `config.CgroupBasePath` and, if it exists, `config.CgroupBasePath + "/systemd"`, so both default and systemd hierarchy are considered.
  - **`resolveCgroupPathCRI`**: For the path returned by CRI, builds a full path for each candidate root and uses the first that exists on disk.
  - **`findCgroupPathV1` / `findCgroupPathV2`**: Base paths for scanning (e.g. `kubepods.slice`) are built from each candidate root so containers under `.../systemd/kubepods.slice/...` are found.
  - **`findCgroupPathFromProc`**: When building a full path from `/proc/<pid>/cgroup`, tries each candidate root so paths under the systemd hierarchy resolve.
- **internal/kubernetes/pod_test.go**
  - **`TestFindCgroupPath_SystemdDriver`**: Ensures a cgroup under `.../systemd/kubepods.slice/...` is found.
- **Docs**
  - **installation.md**: Troubleshooting for "cgroup path not found" now mentions `--cgroup-driver=systemd` and that Podtrace looks under both the default root and `/sys/fs/cgroup/systemd`. New subsection **"Cgroup driver (systemd vs cgroupfs)"** explains support for both drivers and optional `PODTRACE_CGROUP_BASE`.

## Testing

- `go test ./internal/kubernetes/... -run TestFindCgroupPath` (includes `TestFindCgroupPath_SystemdDriver`).
- Manually: run Podtrace against a pod on a node with `--cgroup-driver=systemd` and confirm cgroup resolution and event collection; run as DaemonSet with host cgroup/proc mounted and env set and confirm events are collected.