### PR TITLE
feat: implement Podtrace operator with TracerConfig, PodTrace, and PodTraceSession reconcilers plus exporter-bundle sync and kind e2e smoke

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -22,11 +22,12 @@ on:
       - "Makefile"
       - ".github/workflows/go-ci.yml"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
       matrix:
         go-version: [1.25]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: manual
 
       - name: Install build dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build clean test check-go test-unit test-integration test-bench coverage \
-        generate manifests clientset envtest docker-build helm-lint helm-template operator-tools
+        generate manifests clientset envtest docker-build helm-lint helm-template operator-tools \
+        e2e-kind e2e-kind-cleanup
 
 CLANG ?= clang
 LLC ?= llc
@@ -247,6 +248,16 @@ envtest:
 
 helm-lint:
 	helm lint deploy/charts/podtrace
+
+# e2e-kind runs the Phase-2 smoke script against whatever kind cluster
+# the user's KUBECONFIG currently points at. The script is idempotent;
+# re-running it upgrades an existing release in place.
+e2e-kind:
+	test/e2e/kind-smoke.sh
+
+# e2e-kind-cleanup tears down the e2e release and sample namespace.
+e2e-kind-cleanup:
+	test/e2e/kind-smoke.sh cleanup
 
 helm-template:
 	helm template podtrace deploy/charts/podtrace

--- a/cmd/podtrace/operator.go
+++ b/cmd/podtrace/operator.go
@@ -1,12 +1,18 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/podtrace/podtrace/internal/operator"
 )
 
-// operatorOptions holds flags for `podtrace operator`.
+// operatorOptions holds flags for `podtrace operator`. Defaults mirror
+// operator.DefaultOptions(); the two layers are kept in sync by the
+// toOperatorOptions translation below, so the Cobra surface remains the
+// single source of truth for flag names.
 type operatorOptions struct {
 	systemNamespace      string
 	metricsAddr          string
@@ -35,7 +41,11 @@ The operator runs unprivileged. Only the agent DaemonSet and per-session
 Jobs require privileged pods, and they live in the podtrace-system
 namespace.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("operator mode is not available in this release")
+			// ctrl.SetupSignalHandler returns a ctx that cancels on
+			// SIGTERM/SIGINT. It is also process-singleton, so we wire
+			// it once here rather than pushing into internal/operator.
+			ctx := ctrl.SetupSignalHandler()
+			return operator.Run(ctx, toOperatorOptions(opts))
 		},
 	}
 
@@ -51,8 +61,35 @@ namespace.`,
 		"Namespace holding the leader-election lease")
 	cmd.Flags().IntVar(&opts.webhookPort, "webhook-port", 9443,
 		"Port the validating webhook server listens on")
-	cmd.Flags().StringVar(&opts.webhookCertDir, "webhook-cert-dir", "/var/run/podtrace/tls",
-		"Directory containing tls.crt and tls.key for the webhook server")
+	cmd.Flags().StringVar(&opts.webhookCertDir, "webhook-cert-dir", "",
+		"Directory containing tls.crt and tls.key for the webhook server (empty disables the webhook)")
 
 	return cmd
+}
+
+// toOperatorOptions is the sole translation point between the CLI flag
+// struct and the operator package's Options struct. Keeping the CLI
+// layer thin here lets internal/operator be a reusable library.
+func toOperatorOptions(c *operatorOptions) operator.Options {
+	// NODE_NAME / POD_NAMESPACE leak through for leader-elect-namespace
+	// when the user wants "wherever this pod runs"; this first iteration
+	// keeps the flag explicit.
+	leaderNS := c.leaderElectNamespace
+	if leaderNS == "" {
+		leaderNS = c.systemNamespace
+	}
+	// If POD_NAMESPACE is set (common in in-cluster deployments) and the
+	// user did not override leader-elect-namespace, prefer the pod's own NS.
+	if envNS, ok := os.LookupEnv("POD_NAMESPACE"); ok && c.leaderElectNamespace == "podtrace-system" {
+		leaderNS = envNS
+	}
+	return operator.Options{
+		SystemNamespace:         c.systemNamespace,
+		MetricsBindAddress:      c.metricsAddr,
+		HealthBindAddress:       c.healthAddr,
+		LeaderElection:          c.leaderElect,
+		LeaderElectionNamespace: leaderNS,
+		WebhookPort:             c.webhookPort,
+		WebhookCertDir:          c.webhookCertDir,
+	}
 }

--- a/cmd/podtrace/operator_test.go
+++ b/cmd/podtrace/operator_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -22,17 +21,55 @@ func TestNewOperatorCmd_Metadata(t *testing.T) {
 			t.Errorf("missing flag %q", f)
 		}
 	}
+
+	// RunE must be wired; we cannot execute it in a unit test because it
+	// starts a real manager that needs a kubeconfig. End-to-end coverage
+	// lives in envtest (internal/operator/*_test.go) and the kind-cluster
+	// smoke script under test/e2e/.
+	if cmd.RunE == nil {
+		t.Error("RunE is nil — operator subcommand is not wired")
+	}
 }
 
-func TestNewOperatorCmd_NotImplemented(t *testing.T) {
+func TestNewOperatorCmd_FlagsMapCleanlyToOptions(t *testing.T) {
 	cmd := newOperatorCmd()
-	err := cmd.RunE(cmd, nil)
-	if err == nil {
-		t.Fatal("expected error from operator command")
+	// Override a couple of flags to non-default values and confirm they
+	// propagate through toOperatorOptions. Keeps the CLI↔library contract
+	// honest without booting a manager.
+	if err := cmd.Flags().Set("system-namespace", "custom-ns"); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "not available") {
-		t.Errorf("error does not indicate unavailability: %q", err.Error())
+	if err := cmd.Flags().Set("leader-elect", "false"); err != nil {
+		t.Fatal(err)
 	}
+	if err := cmd.Flags().Set("webhook-port", "10443"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The options struct is owned privately by newOperatorCmd's closure;
+	// we re-derive it via the same translation helper the RunE uses.
+	opts := &operatorOptions{}
+	opts.systemNamespace = cmd.Flag("system-namespace").Value.String()
+	opts.leaderElectNamespace = cmd.Flag("leader-elect-namespace").Value.String()
+	opts.metricsAddr = cmd.Flag("metrics-addr").Value.String()
+	opts.healthAddr = cmd.Flag("health-addr").Value.String()
+	opts.webhookCertDir = cmd.Flag("webhook-cert-dir").Value.String()
+	// bools/ints need typed getters
+	opts.leaderElect, _ = cmd.Flags().GetBool("leader-elect")
+	opts.webhookPort, _ = cmd.Flags().GetInt("webhook-port")
+
+	runtimeOpts := toOperatorOptions(opts)
+	if runtimeOpts.SystemNamespace != "custom-ns" {
+		t.Errorf("SystemNamespace=%q want custom-ns", runtimeOpts.SystemNamespace)
+	}
+	if runtimeOpts.LeaderElection {
+		t.Error("LeaderElection should be false after override")
+	}
+	if runtimeOpts.WebhookPort != 10443 {
+		t.Errorf("WebhookPort=%d want 10443", runtimeOpts.WebhookPort)
+	}
+	// The toOperatorOptions return type is operator.Options by
+	// declaration; no further runtime assertion needed.
 }
 
 func TestNewOperatorCmd_LeaderElectDefault(t *testing.T) {
@@ -56,5 +93,15 @@ func TestNewOperatorCmd_WebhookPortDefault(t *testing.T) {
 	// Helm template's assumed service port.
 	if v != 9443 {
 		t.Errorf("webhook-port default=%d, want 9443", v)
+	}
+}
+
+func TestNewOperatorCmd_WebhookCertDirDefault(t *testing.T) {
+	cmd := newOperatorCmd()
+	v, _ := cmd.Flags().GetString("webhook-cert-dir")
+	// Default empty — operator runs without the webhook server unless the
+	// operator pod is given a cert directory (via cert-manager or similar).
+	if v != "" {
+		t.Errorf("webhook-cert-dir default=%q want empty", v)
 	}
 }

--- a/deploy/charts/podtrace/templates/operator-certificate.yaml
+++ b/deploy/charts/podtrace/templates/operator-certificate.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.operator.enabled .Values.webhook.enabled (eq .Values.webhook.certSource "cert-manager") }}
+---
+# cert-manager Certificate that issues the TLS material for the
+# ValidatingWebhookConfiguration. The validating-webhook template's
+# `cert-manager.io/inject-ca-from` annotation references THIS
+# Certificate by name; keep the two in sync.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "podtrace.fullname" . }}-serving-cert
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  # DNS names match the webhook Service so TLS verification succeeds
+  # when the apiserver calls the webhook.
+  dnsNames:
+    - {{ include "podtrace.fullname" . }}-webhook.{{ include "podtrace.systemNamespace" . }}.svc
+    - {{ include "podtrace.fullname" . }}-webhook.{{ include "podtrace.systemNamespace" . }}.svc.cluster.local
+  # The Secret is mounted by the operator Deployment at
+  # /tmp/k8s-webhook-server/serving-certs (see operator-deployment.yaml).
+  secretName: {{ include "podtrace.fullname" . }}-webhook-tls
+  issuerRef:
+    name: {{ .Values.webhook.certManager.issuerRef.name }}
+    kind: {{ .Values.webhook.certManager.issuerRef.kind }}
+{{- end }}

--- a/deploy/charts/podtrace/templates/operator-deployment.yaml
+++ b/deploy/charts/podtrace/templates/operator-deployment.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.operator.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  replicas: {{ .Values.operator.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "podtrace.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: operator
+  template:
+    metadata:
+      labels:
+        {{- include "podtrace.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: operator
+      {{- with .Values.operator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "podtrace.fullname" . }}-operator
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: operator
+          image: {{ include "podtrace.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - operator
+            - --system-namespace={{ include "podtrace.systemNamespace" . }}
+            - --leader-elect={{ .Values.operator.leaderElect }}
+            - --leader-elect-namespace={{ include "podtrace.systemNamespace" . }}
+            - --metrics-addr=:8080
+            - --health-addr=:8081
+            {{- if .Values.webhook.enabled }}
+            - --webhook-port={{ .Values.webhook.port }}
+            - --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+            {{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.operator.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            {{- if .Values.webhook.enabled }}
+            - name: webhook
+              containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.operator.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          {{- if .Values.webhook.enabled }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+          {{- end }}
+      {{- if .Values.webhook.enabled }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "podtrace.fullname" . }}-webhook-tls
+            defaultMode: 420
+      {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/podtrace/templates/operator-rbac.yaml
+++ b/deploy/charts/podtrace/templates/operator-rbac.yaml
@@ -1,0 +1,76 @@
+{{- if and .Values.operator.enabled .Values.rbac.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+---
+# ClusterRole for the operator. These permissions must match what the
+# reconcilers actually need — kept manually in sync with the kubebuilder
+# rbac markers in internal/operator/*_controller.go.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+rules:
+  # podtrace.io CRDs
+  - apiGroups: ["podtrace.io"]
+    resources: ["tracerconfigs", "podtraces", "podtracesessions", "exporterconfigs"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["podtrace.io"]
+    resources: ["tracerconfigs/status", "podtraces/status", "podtracesessions/status", "exporterconfigs/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["podtrace.io"]
+    resources: ["tracerconfigs/finalizers", "podtraces/finalizers", "podtracesessions/finalizers"]
+    verbs: ["update"]
+  # Owned workload resources
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Pod lookup (selector → node resolution in PodTraceSessionReconciler)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # System-namespace infrastructure: SAs, bundles (ConfigMap+Secret)
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Agent RBAC managed by TracerConfigReconciler
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Events surface on operator errors
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # Leader election lease
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "podtrace.fullname" . }}-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "podtrace.fullname" . }}-operator
+    namespace: {{ include "podtrace.systemNamespace" . }}
+{{- end }}

--- a/deploy/charts/podtrace/templates/operator-service.yaml
+++ b/deploy/charts/podtrace/templates/operator-service.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.operator.enabled }}
+---
+# Metrics service — Prometheus ServiceMonitor target.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator-metrics
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "podtrace.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+{{- if .Values.webhook.enabled }}
+---
+# Webhook service — referenced by the ValidatingWebhookConfiguration's
+# clientConfig.service block. Name matches podtrace.fullname-webhook so
+# the webhook template's service lookup lands here.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "podtrace.fullname" . }}-webhook
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: webhook
+      protocol: TCP
+  selector:
+    {{- include "podtrace.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+{{- end }}
+{{- end }}

--- a/internal/operator/exporter_bundle.go
+++ b/internal/operator/exporter_bundle.go
@@ -1,0 +1,110 @@
+package operator
+
+import (
+	"fmt"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// renderBundlePayload converts an ExporterConfig's typed spec into the
+// ConfigMap data and (optionally) a credential-Secret reference that
+// the operator will copy into systemNS as part of the bundle.
+//
+// Bundle schema (ConfigMap.data):
+//
+//	type                 = otlp | jaeger | zipkin | splunk | datadog
+//	endpoint             = full URL or host:port (exporter-specific)
+//	protocol             = http | grpc (OTLP only)
+//	insecure             = "true" | "false" (OTLP only)
+//	site                 = datadoghq.com | datadoghq.eu (DataDog only)
+//	sample_percent       = decimal string (optional)
+//	headers.<name>       = literal value (OTLP only)
+//	header_secret_keys   = space-separated list of ConfigMap keys that
+//	                       reference the companion Secret (OTLP only)
+//
+// The second return value, if non-nil, names the user-namespace Secret
+// key the operator should load for the bundle's companion credential
+// Secret. Exporters without credentials (Jaeger, Zipkin, credential-less
+// OTLP) return nil here.
+func renderBundlePayload(ec *podtracev1alpha1.ExporterConfig) (map[string]string, *podtracev1alpha1.SecretKeySelector, error) {
+	data := map[string]string{
+		"type": string(ec.Spec.Type),
+	}
+	if ec.Spec.SamplePercent != nil {
+		data["sample_percent"] = itoa(int(*ec.Spec.SamplePercent))
+	}
+
+	switch ec.Spec.Type {
+	case podtracev1alpha1.ExporterTypeOTLP:
+		if ec.Spec.OTLP == nil {
+			return nil, nil, fmt.Errorf("spec.otlp is required when type=otlp")
+		}
+		data["endpoint"] = ec.Spec.OTLP.Endpoint
+		if ec.Spec.OTLP.Protocol != "" {
+			data["protocol"] = string(ec.Spec.OTLP.Protocol)
+		} else {
+			data["protocol"] = string(podtracev1alpha1.OTLPProtocolHTTP)
+		}
+		data["insecure"] = boolString(ec.Spec.OTLP.Insecure)
+		for _, h := range ec.Spec.OTLP.Headers {
+			// Literal-valued headers go straight into the ConfigMap.
+			// Secret-valued headers are deferred to the credential path;
+			// this first iteration supports exactly one Secret-valued
+			// header (the most common pattern — an Authorization bearer).
+			if h.ValueFrom != nil {
+				// Use the first Secret-backed header as THE credential,
+				// exposed in the companion Secret under key "credential".
+				// Multi-Secret support is tracked as a future enhancement.
+				sk := h.ValueFrom.DeepCopy()
+				data["header_secret_name"] = h.Name
+				return data, sk, nil
+			}
+			data["headers."+h.Name] = h.Value
+		}
+		return data, nil, nil
+
+	case podtracev1alpha1.ExporterTypeJaeger:
+		if ec.Spec.Jaeger == nil {
+			return nil, nil, fmt.Errorf("spec.jaeger is required when type=jaeger")
+		}
+		data["endpoint"] = ec.Spec.Jaeger.Endpoint
+		return data, nil, nil
+
+	case podtracev1alpha1.ExporterTypeZipkin:
+		if ec.Spec.Zipkin == nil {
+			return nil, nil, fmt.Errorf("spec.zipkin is required when type=zipkin")
+		}
+		data["endpoint"] = ec.Spec.Zipkin.Endpoint
+		return data, nil, nil
+
+	case podtracev1alpha1.ExporterTypeSplunk:
+		if ec.Spec.Splunk == nil {
+			return nil, nil, fmt.Errorf("spec.splunk is required when type=splunk")
+		}
+		data["endpoint"] = ec.Spec.Splunk.Endpoint
+		ref := ec.Spec.Splunk.TokenSecretRef
+		return data, &ref, nil
+
+	case podtracev1alpha1.ExporterTypeDataDog:
+		if ec.Spec.DataDog == nil {
+			return nil, nil, fmt.Errorf("spec.datadog is required when type=datadog")
+		}
+		if ec.Spec.DataDog.Site != "" {
+			data["site"] = ec.Spec.DataDog.Site
+		} else {
+			data["site"] = "datadoghq.com"
+		}
+		ref := ec.Spec.DataDog.APIKeySecretRef
+		return data, &ref, nil
+
+	default:
+		return nil, nil, fmt.Errorf("unsupported exporter type %q", ec.Spec.Type)
+	}
+}
+
+func boolString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/operator/exporter_bundle_test.go
+++ b/internal/operator/exporter_bundle_test.go
@@ -1,0 +1,173 @@
+package operator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func ec(name string, spec podtracev1alpha1.ExporterConfigSpec) *podtracev1alpha1.ExporterConfig {
+	return &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID("u-" + name)},
+		Spec:       spec,
+	}
+}
+
+func TestRenderBundlePayload_OTLP_LiteralHeaders(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("otlp-lit", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeOTLP,
+		OTLP: &podtracev1alpha1.OTLPExporter{
+			Endpoint: "otel:4318",
+			Protocol: podtracev1alpha1.OTLPProtocolGRPC,
+			Insecure: true,
+			Headers: []podtracev1alpha1.OTLPHeader{
+				{Name: "X-Tenant", Value: "team-a"},
+				{Name: "X-Env", Value: "prod"},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret != nil {
+		t.Errorf("OTLP without ValueFrom must not produce a credential Secret ref")
+	}
+	for k, v := range map[string]string{
+		"type":             "otlp",
+		"endpoint":         "otel:4318",
+		"protocol":         "grpc",
+		"insecure":         "true",
+		"headers.X-Tenant": "team-a",
+		"headers.X-Env":    "prod",
+	} {
+		if data[k] != v {
+			t.Errorf("data[%q]=%q want %q", k, data[k], v)
+		}
+	}
+}
+
+func TestRenderBundlePayload_OTLP_SecretBackedHeader(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("otlp-sec", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeOTLP,
+		OTLP: &podtracev1alpha1.OTLPExporter{
+			Endpoint: "otel:4318",
+			Headers: []podtracev1alpha1.OTLPHeader{
+				{Name: "Authorization", ValueFrom: &podtracev1alpha1.SecretKeySelector{
+					Name: "auth", Key: "token",
+				}},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil || secret.Name != "auth" || secret.Key != "token" {
+		t.Fatalf("expected credential ref auth/token, got %+v", secret)
+	}
+	if data["header_secret_name"] != "Authorization" {
+		t.Errorf("header_secret_name=%q want Authorization", data["header_secret_name"])
+	}
+	if data["protocol"] != "http" {
+		t.Errorf("protocol defaulted wrong: %q", data["protocol"])
+	}
+}
+
+func TestRenderBundlePayload_Jaeger_NoCredentials(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("j", podtracev1alpha1.ExporterConfigSpec{
+		Type:   podtracev1alpha1.ExporterTypeJaeger,
+		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://jaeger:14268"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret != nil {
+		t.Error("Jaeger has no credentials; Secret ref must be nil")
+	}
+	if data["endpoint"] != "http://jaeger:14268" || data["type"] != "jaeger" {
+		t.Errorf("payload wrong: %v", data)
+	}
+}
+
+func TestRenderBundlePayload_Zipkin(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("z", podtracev1alpha1.ExporterConfigSpec{
+		Type:   podtracev1alpha1.ExporterTypeZipkin,
+		Zipkin: &podtracev1alpha1.ZipkinExporter{Endpoint: "http://zipkin:9411/api/v2/spans"},
+	}))
+	if err != nil || secret != nil || data["type"] != "zipkin" {
+		t.Fatalf("zipkin payload: err=%v secret=%v data=%v", err, secret, data)
+	}
+}
+
+func TestRenderBundlePayload_Splunk_RequiresTokenSecret(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("s", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeSplunk,
+		Splunk: &podtracev1alpha1.SplunkExporter{
+			Endpoint:       "https://splunk:8088",
+			TokenSecretRef: podtracev1alpha1.SecretKeySelector{Name: "hec", Key: "token"},
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil || secret.Name != "hec" {
+		t.Fatalf("expected HEC credential ref, got %+v", secret)
+	}
+	if data["endpoint"] != "https://splunk:8088" {
+		t.Errorf("splunk endpoint lost: %v", data)
+	}
+}
+
+func TestRenderBundlePayload_DataDog_DefaultSite(t *testing.T) {
+	data, secret, err := renderBundlePayload(ec("d", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeDataDog,
+		DataDog: &podtracev1alpha1.DataDogExporter{
+			APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api"},
+		},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil || secret.Name != "dd" {
+		t.Fatalf("expected DataDog credential ref, got %+v", secret)
+	}
+	if data["site"] != "datadoghq.com" {
+		t.Errorf("default site should be datadoghq.com, got %q", data["site"])
+	}
+}
+
+func TestRenderBundlePayload_ErrorOnMissingVariant(t *testing.T) {
+	_, _, err := renderBundlePayload(ec("broken", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeOTLP,
+		// no OTLP block populated
+	}))
+	if err == nil {
+		t.Fatal("expected error when spec.otlp is nil for type=otlp")
+	}
+}
+
+func TestRenderBundlePayload_UnknownType(t *testing.T) {
+	_, _, err := renderBundlePayload(ec("xxx", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterType("made-up"),
+	}))
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestRenderBundlePayload_SamplePercent(t *testing.T) {
+	pct := int32(25)
+	data, _, err := renderBundlePayload(ec("s", podtracev1alpha1.ExporterConfigSpec{
+		Type:          podtracev1alpha1.ExporterTypeJaeger,
+		Jaeger:        &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
+		SamplePercent: &pct,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data["sample_percent"] != "25" {
+		t.Errorf("sample_percent=%q want 25", data["sample_percent"])
+	}
+}

--- a/internal/operator/finalizer.go
+++ b/internal/operator/finalizer.go
@@ -1,0 +1,84 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// FinalizerCleanup is the single finalizer name used by the operator for
+// cross-namespace cleanup of resources a namespaced CR cannot own via
+// ownerReferences. Kubernetes forbids a namespaced owner in namespace A
+// from owning any object in namespace B, so we fall back to:
+//
+//  1. Put the child in podtrace-system, with labels naming the owning CR.
+//  2. Add this finalizer to the CR at first reconcile.
+//  3. On CR deletion, list children by label and delete them before
+//     clearing the finalizer.
+//
+// This is the standard pattern in Prometheus Operator, cert-manager, etc.
+const FinalizerCleanup = "podtrace.io/cleanup"
+
+// ensureFinalizer adds FinalizerCleanup to the object if it is not
+// already present. Returns true when the finalizer was added and the
+// caller should update the object.
+func ensureFinalizer(obj client.Object) bool {
+	return controllerutil.AddFinalizer(obj, FinalizerCleanup)
+}
+
+// removeFinalizer removes FinalizerCleanup from the object. Returns
+// true when removal changed the object.
+func removeFinalizer(obj client.Object) bool {
+	return controllerutil.RemoveFinalizer(obj, FinalizerCleanup)
+}
+
+// cleanupPodTraceChildren deletes the bundle ConfigMap + Secret this
+// PodTrace owns across namespaces. Called on CR deletion.
+func cleanupPodTraceChildren(ctx context.Context, c client.Client, pt *podtracev1alpha1.PodTrace, systemNS string) error {
+	bundleName := ExporterBundleName(pt.UID)
+	// Delete ConfigMap + Secret with matching name. Ignore NotFound so
+	// repeated cleanups are idempotent.
+	for _, obj := range []client.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: bundleName, Namespace: systemNS}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: bundleName, Namespace: systemNS}},
+	} {
+		if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete %T %s/%s: %w", obj, systemNS, bundleName, err)
+		}
+	}
+	return nil
+}
+
+// cleanupPodTraceSessionChildren deletes the per-node Jobs this
+// PodTraceSession owns across namespaces. Called on CR deletion.
+func cleanupPodTraceSessionChildren(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) error {
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, client.InNamespace(systemNS), client.MatchingLabels{
+		LabelManagedBy:   ManagedByValue,
+		LabelComponent:   ComponentSession,
+		LabelSessionName: s.Name,
+		LabelSessionNS:   s.Namespace,
+	}); err != nil {
+		return fmt.Errorf("list session Jobs: %w", err)
+	}
+	policy := metav1.DeletePropagationBackground
+	for i := range jobs.Items {
+		j := &jobs.Items[i]
+		if j.UID == types.UID("") {
+			continue
+		}
+		if err := c.Delete(ctx, j, &client.DeleteOptions{PropagationPolicy: &policy}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete Job %s/%s: %w", j.Namespace, j.Name, err)
+		}
+	}
+	return nil
+}

--- a/internal/operator/helpers.go
+++ b/internal/operator/helpers.go
@@ -1,0 +1,55 @@
+package operator
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// defaultControllerOptions centralises tuning knobs applied to every
+// reconciler in the operator. Reconciliation is single-writer per CR
+// (MaxConcurrentReconciles=1) — the CRs are few, and concurrent
+// reconciliation of the same object would race on status patches.
+func defaultControllerOptions() controller.Options {
+	return controller.Options{
+		MaxConcurrentReconciles: 1,
+	}
+}
+
+// mergeLabels returns dst with src's entries overlaid. nil-safe: either
+// argument may be nil.
+func mergeLabels(dst, src map[string]string) map[string]string {
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// upsertCondition replaces the entry in conds with the same Type as
+// newCond, or appends newCond if no such entry exists. It preserves the
+// original LastTransitionTime when Status is unchanged — the standard
+// Kubernetes-condition invariant.
+func upsertCondition(conds []metav1.Condition, newCond metav1.Condition) []metav1.Condition {
+	for i, c := range conds {
+		if c.Type != newCond.Type {
+			continue
+		}
+		if c.Status == newCond.Status {
+			newCond.LastTransitionTime = c.LastTransitionTime
+		}
+		conds[i] = newCond
+		return conds
+	}
+	return append(conds, newCond)
+}
+
+// conditionStatusFromBool maps a boolean to metav1.ConditionTrue/False.
+// Extracted so readers do not have to parse a ternary at every call site.
+func conditionStatusFromBool(ok bool) metav1.ConditionStatus {
+	if ok {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
+}

--- a/internal/operator/helpers_test.go
+++ b/internal/operator/helpers_test.go
@@ -1,0 +1,89 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpsertCondition_AppendsNewType(t *testing.T) {
+	now := metav1.Now()
+	conds := upsertCondition(nil, metav1.Condition{
+		Type:               ConditionReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ok",
+		LastTransitionTime: now,
+	})
+	if len(conds) != 1 || conds[0].Type != ConditionReady {
+		t.Fatalf("unexpected conds: %+v", conds)
+	}
+}
+
+func TestUpsertCondition_UpdatesSameType(t *testing.T) {
+	oldTime := metav1.NewTime(time.Now().Add(-time.Hour))
+	conds := []metav1.Condition{{
+		Type:               ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             "old",
+		LastTransitionTime: oldTime,
+	}}
+	newer := metav1.Condition{
+		Type:               ConditionReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "new",
+		LastTransitionTime: metav1.Now(),
+	}
+	conds = upsertCondition(conds, newer)
+	if len(conds) != 1 {
+		t.Fatalf("upsert grew the slice: %+v", conds)
+	}
+	if conds[0].Reason != "new" || conds[0].Status != metav1.ConditionTrue {
+		t.Errorf("condition not updated: %+v", conds[0])
+	}
+}
+
+func TestUpsertCondition_PreservesTransitionWhenStatusUnchanged(t *testing.T) {
+	// Kubernetes-condition invariant: LastTransitionTime only changes
+	// when Status changes. A reconcile that re-reports the same Status
+	// must not bump the timestamp — consumers use that timestamp as a
+	// "how long has this been true" signal.
+	oldTime := metav1.NewTime(time.Now().Add(-time.Hour))
+	conds := []metav1.Condition{{
+		Type:               ConditionReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "previous",
+		LastTransitionTime: oldTime,
+	}}
+	same := metav1.Condition{
+		Type:               ConditionReady,
+		Status:             metav1.ConditionTrue, // unchanged
+		Reason:             "refreshed",
+		LastTransitionTime: metav1.Now(),
+	}
+	conds = upsertCondition(conds, same)
+	if !conds[0].LastTransitionTime.Equal(&oldTime) {
+		t.Errorf("LastTransitionTime changed despite same Status: %v → %v",
+			oldTime, conds[0].LastTransitionTime)
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	got := mergeLabels(nil, map[string]string{"a": "1"})
+	if got["a"] != "1" {
+		t.Errorf("merge into nil failed: %v", got)
+	}
+	got = mergeLabels(map[string]string{"a": "1", "b": "2"}, map[string]string{"b": "new", "c": "3"})
+	if got["a"] != "1" || got["b"] != "new" || got["c"] != "3" {
+		t.Errorf("merge wrong: %v", got)
+	}
+}
+
+func TestConditionStatusFromBool(t *testing.T) {
+	if conditionStatusFromBool(true) != metav1.ConditionTrue {
+		t.Error("true should map to ConditionTrue")
+	}
+	if conditionStatusFromBool(false) != metav1.ConditionFalse {
+		t.Error("false should map to ConditionFalse")
+	}
+}

--- a/internal/operator/naming.go
+++ b/internal/operator/naming.go
@@ -1,0 +1,159 @@
+// Package operator implements the podtrace Kubernetes operator's control
+// plane: three reconcilers that watch TracerConfig, PodTrace, and
+// PodTraceSession CRs and drive the corresponding infrastructure.
+//
+// Naming and label conventions are centralised here so every reconciler
+// produces the same resource names and selectors — agents and tests
+// depend on these being stable.
+package operator
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Label keys. "podtrace.io/managed-by=podtrace-operator" is the single
+// source of truth for "this object is owned by the operator" — used for
+// bulk cleanup and for informer filters.
+const (
+	LabelManagedBy      = "podtrace.io/managed-by"
+	LabelComponent      = "podtrace.io/component"
+	LabelTracerConfig   = "podtrace.io/tracer-config"
+	LabelPodTraceName   = "podtrace.io/podtrace"
+	LabelPodTraceNS     = "podtrace.io/podtrace-namespace"
+	LabelSessionName    = "podtrace.io/session"
+	LabelSessionNS      = "podtrace.io/session-namespace"
+	LabelExporterConfig = "podtrace.io/exporter-config"
+	LabelNodeName       = "podtrace.io/node"
+
+	ManagedByValue = "podtrace-operator"
+
+	ComponentAgent   = "agent"
+	ComponentSession = "session"
+	ComponentBundle  = "exporter-bundle"
+)
+
+// Condition types reported on CR .status.conditions.
+const (
+	ConditionReady      = "Ready"
+	ConditionReconciled = "Reconciled"
+	ConditionDegraded   = "Degraded"
+	ConditionPaused     = "Paused"
+)
+
+// AgentDaemonSetName is the fixed DaemonSet name created by
+// TracerConfigReconciler. Agents discover each other and the operator
+// discovers them by this name — do not derive per-TracerConfig names.
+func AgentDaemonSetName() string { return "podtrace-agent" }
+
+// AgentServiceAccountName is the ServiceAccount the agent DaemonSet runs as.
+func AgentServiceAccountName() string { return "podtrace-agent" }
+
+// AgentClusterRoleName is the ClusterRole granting the agent read access to
+// PodTrace CRs cluster-wide and status-patch on the same.
+func AgentClusterRoleName() string { return "podtrace-agent" }
+
+// AgentClusterRoleBindingName binds AgentClusterRoleName to AgentServiceAccountName.
+func AgentClusterRoleBindingName() string { return "podtrace-agent" }
+
+// OperatorWebhookServiceName is the Service fronting the webhook server
+// inside the operator Deployment. Referenced by the
+// ValidatingWebhookConfiguration rendered by the Helm chart.
+func OperatorWebhookServiceName() string { return "podtrace-webhook" }
+
+// SessionJobName returns the deterministic Job name for a PodTraceSession
+// on a specific node. Keeping it deterministic makes
+// PodTraceSessionReconciler's fan-out idempotent — re-reconciling never
+// produces a second Job on the same node.
+//
+// Format: pts-<session-uid>-<node-hash>, truncated to 63 chars. Using
+// the session UID (not name) is mandatory because session names collide
+// across namespaces but UIDs never do.
+func SessionJobName(sessionUID types.UID, nodeName string) string {
+	raw := fmt.Sprintf("pts-%s-%s", shortUID(sessionUID), sanitiseDNS(nodeName))
+	if len(raw) > 63 {
+		raw = raw[:63]
+	}
+	return raw
+}
+
+// ExporterBundleName returns the ConfigMap/Secret name maintained by the
+// operator in the system namespace for an ExporterConfig. Agents read
+// these bundles instead of the original Secrets so their RBAC stays
+// scoped to podtrace-system only.
+//
+// Format: pt-bundle-<exporterconfig-uid>. Namespace is always
+// TracerConfig.spec.systemNamespace (default "podtrace-system").
+func ExporterBundleName(exporterUID types.UID) string {
+	return "pt-bundle-" + shortUID(exporterUID)
+}
+
+// BundleAnnotationSourceRef is an annotation the operator puts on every
+// bundle ConfigMap/Secret pointing back at the ExporterConfig that owns
+// it (namespace/name). Used for audit and for reverse lookup when the
+// ExporterConfig is deleted.
+const BundleAnnotationSourceRef = "podtrace.io/exporterconfig-ref"
+
+// ManagedObjectMeta returns the common ObjectMeta applied to every
+// operator-managed resource (DaemonSet, Job, RBAC, Service, bundles).
+// Callers augment with owner refs and optional extra labels.
+func ManagedObjectMeta(name, namespace, component string, extraLabels map[string]string) metav1.ObjectMeta {
+	labels := map[string]string{
+		LabelManagedBy: ManagedByValue,
+		LabelComponent: component,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    labels,
+	}
+}
+
+// shortUID returns the first 12 characters of a UID string — enough to
+// stay collision-resistant within a cluster while keeping derived names
+// inside Kubernetes' 63-character limit.
+func shortUID(uid types.UID) string {
+	s := string(uid)
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}
+
+// sanitiseDNS replaces characters that are not valid in DNS-1123 labels
+// with '-'. Node names can legally contain characters like '.' which
+// Kubernetes rejects in object names.
+func sanitiseDNS(in string) string {
+	b := make([]byte, 0, len(in))
+	for _, r := range in {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b = append(b, byte(r))
+		case r >= '0' && r <= '9':
+			b = append(b, byte(r))
+		case r == '-':
+			b = append(b, '-')
+		case r >= 'A' && r <= 'Z':
+			b = append(b, byte(r+('a'-'A')))
+		default:
+			b = append(b, '-')
+		}
+	}
+	// Trim leading/trailing '-' — DNS-1123 forbids them at label ends.
+	start, end := 0, len(b)
+	for start < end && b[start] == '-' {
+		start++
+	}
+	for end > start && b[end-1] == '-' {
+		end--
+	}
+	if start == end {
+		return "node"
+	}
+	return string(b[start:end])
+}

--- a/internal/operator/naming_test.go
+++ b/internal/operator/naming_test.go
@@ -1,0 +1,127 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestSessionJobName_Properties locks in the Job-name contract the
+// reconciler relies on for fan-out idempotency:
+//
+//  1. Same (sessionUID, node) → same Job name on every call.
+//  2. Different (sessionUID, node) pairs → different Job names.
+//  3. Output is a valid DNS-1123 label (len <= 63, starts and ends with
+//     [a-z0-9], only [a-z0-9-] in between).
+//  4. Weird node names (dots, colons, uppercase) do not leak into the
+//     result.
+func TestSessionJobName_Properties(t *testing.T) {
+	cases := []struct {
+		name    string
+		uid     types.UID
+		node    string
+		mustHave string
+	}{
+		{"simple", "abcdef1234567890", "ip-10-0-1-4", "pts-abcdef123456"},
+		{"dotted-fqdn", "abcdef1234567890", "node-1.prod.example.com", "pts-abcdef123456"},
+		{"uppercase", "abcdef1234567890", "Node-Upper", "pts-abcdef123456"},
+		{"short-uid", "ab12", "node-a", "pts-ab12"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			name1 := SessionJobName(tc.uid, tc.node)
+			name2 := SessionJobName(tc.uid, tc.node)
+			if name1 != name2 {
+				t.Fatalf("non-deterministic: %q vs %q", name1, name2)
+			}
+			if !strings.HasPrefix(name1, tc.mustHave) {
+				t.Errorf("expected prefix %q, got %q", tc.mustHave, name1)
+			}
+			if len(name1) > 63 {
+				t.Errorf("exceeds DNS-1123 length: %d chars", len(name1))
+			}
+			if !isDNS1123Label(name1) {
+				t.Errorf("not a valid DNS-1123 label: %q", name1)
+			}
+		})
+	}
+
+	// Distinct (uid, node) pairs must produce distinct names.
+	a := SessionJobName("uid-aaa", "node-a")
+	b := SessionJobName("uid-aaa", "node-b")
+	c := SessionJobName("uid-bbb", "node-a")
+	if a == b || a == c || b == c {
+		t.Errorf("collision: %s %s %s", a, b, c)
+	}
+}
+
+func TestExporterBundleName_Properties(t *testing.T) {
+	n := ExporterBundleName("abcdef12345678")
+	if !strings.HasPrefix(n, "pt-bundle-") {
+		t.Errorf("missing prefix: %q", n)
+	}
+	if len(n) > 63 {
+		t.Errorf("exceeds DNS-1123 length: %d chars", len(n))
+	}
+	if !isDNS1123Label(n) {
+		t.Errorf("not a valid DNS-1123 label: %q", n)
+	}
+	if ExporterBundleName("aaa") == ExporterBundleName("bbb") {
+		t.Error("distinct UIDs collided")
+	}
+}
+
+func TestSanitiseDNS(t *testing.T) {
+	cases := map[string]string{
+		"node-a":                "node-a",
+		"Node-Upper":            "node-upper",
+		"node.fqdn.example.com": "node-fqdn-example-com",
+		"----trim-dashes----":   "trim-dashes",
+		"":                      "node", // fallback for empty
+		"!!!":                   "node",
+	}
+	for in, want := range cases {
+		if got := sanitiseDNS(in); got != want {
+			t.Errorf("sanitiseDNS(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestManagedObjectMeta_LabelsMerged(t *testing.T) {
+	m := ManagedObjectMeta("foo", "ns", ComponentAgent, map[string]string{
+		"extra": "yes",
+	})
+	if m.Name != "foo" || m.Namespace != "ns" {
+		t.Errorf("name/namespace wrong: %+v", m)
+	}
+	if m.Labels[LabelManagedBy] != ManagedByValue {
+		t.Error("managed-by label missing")
+	}
+	if m.Labels[LabelComponent] != ComponentAgent {
+		t.Error("component label missing")
+	}
+	if m.Labels["extra"] != "yes" {
+		t.Error("extra label missing")
+	}
+}
+
+// isDNS1123Label is a small local check mirroring k8s DNS-1123 label rules.
+// Keeping it here avoids pulling k8s.io/apimachinery/pkg/util/validation
+// into this test file.
+func isDNS1123Label(s string) bool {
+	if s == "" || len(s) > 63 {
+		return false
+	}
+	for i, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		case c == '-' && i != 0 && i != len(s)-1:
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -1,0 +1,264 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// PodTraceReconciler is a thin orchestrator for continuous PodTrace CRs:
+//
+//   - Verifies the referenced ExporterConfig exists and is ready.
+//   - Maintains an "exporter bundle" in the system namespace: a
+//     ConfigMap with endpoint/config data plus a paired Secret carrying
+//     resolved credential material. Agents read the bundle instead of
+//     walking back to the user-namespace Secret, which keeps agent RBAC
+//     scoped to systemNS for Secrets.
+//   - Aggregates status.conditions from the per-node status entries
+//     written directly by agents. It does NOT touch status.nodeStatus —
+//     that array is agent-owned and patched via merge.
+//
+// The agent is not in the hot path: status rollup runs on the standard
+// reconcile cadence, not per-event.
+type PodTraceReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	SystemNamespace string
+}
+
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtraces,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtraces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtraces/finalizers,verbs=update
+// +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch;create;update;patch;delete
+
+func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("podtrace", req.String())
+
+	var pt podtracev1alpha1.PodTrace
+	if err := r.Get(ctx, req.NamespacedName, &pt); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get PodTrace: %w", err)
+	}
+
+	// Deletion path: tear down cross-namespace children first, then
+	// release the finalizer so the apiserver actually removes the CR.
+	if !pt.DeletionTimestamp.IsZero() {
+		if err := cleanupPodTraceChildren(ctx, r.Client, &pt, r.SystemNamespace); err != nil {
+			return ctrl.Result{}, err
+		}
+		if removeFinalizer(&pt) {
+			if err := r.Update(ctx, &pt); err != nil {
+				return ctrl.Result{}, fmt.Errorf("clear finalizer: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+	if ensureFinalizer(&pt) {
+		if err := r.Update(ctx, &pt); err != nil {
+			return ctrl.Result{}, fmt.Errorf("set finalizer: %w", err)
+		}
+		// Re-queue; the Update mutated the object and we want a fresh
+		// Get before running the rest of the reconcile.
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if pt.Spec.Paused {
+		r.setCondition(&pt, ConditionPaused, metav1.ConditionTrue, "Paused", "spec.paused=true")
+		r.setCondition(&pt, ConditionReady, metav1.ConditionFalse, "Paused", "tracing is paused")
+		return ctrl.Result{}, r.Status().Update(ctx, &pt)
+	}
+	r.setCondition(&pt, ConditionPaused, metav1.ConditionFalse, "NotPaused", "")
+
+	// Resolve the exporter. Its readiness gates bundle sync.
+	var ec podtracev1alpha1.ExporterConfig
+	ecKey := types.NamespacedName{Namespace: pt.Namespace, Name: pt.Spec.ExporterRef.Name}
+	if err := r.Get(ctx, ecKey, &ec); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "ExporterNotFound",
+				fmt.Sprintf("ExporterConfig %s not found", ecKey))
+			r.setCondition(&pt, ConditionReady, metav1.ConditionFalse, "ExporterNotFound", "")
+			_ = r.Status().Update(ctx, &pt)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
+	}
+
+	if err := r.syncExporterBundle(ctx, &pt, &ec); err != nil {
+		logger.Error(err, "sync exporter bundle")
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
+		_ = r.Status().Update(ctx, &pt)
+		return ctrl.Result{}, err
+	}
+	r.setCondition(&pt, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
+
+	// matchedPods and ready-rollup are conservative when there are no
+	// per-node reports yet (first reconcile). Agents patch status.nodeStatus
+	// every ~30s (StatusReportInterval), after which this rollup is accurate.
+	pt.Status.MatchedPods = countReadyPods(pt.Status.NodeStatus)
+	allReady := len(pt.Status.NodeStatus) > 0 && allNodesReady(pt.Status.NodeStatus)
+	r.setCondition(&pt, ConditionReady, conditionStatusFromBool(allReady), "AgentsReady",
+		fmt.Sprintf("%d node(s) reporting", len(pt.Status.NodeStatus)))
+	r.setCondition(&pt, ConditionReconciled, metav1.ConditionTrue, "Reconciled", "exporter bundle up to date")
+	pt.Status.ObservedGeneration = pt.Generation
+
+	if err := r.Status().Update(ctx, &pt); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *PodTraceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// No Owns() here: bundles live in a different namespace than the
+	// PodTrace, so Kubernetes rejects ownerReferences. Cleanup goes
+	// through FinalizerCleanup; see finalizer.go.
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("podtrace").
+		For(&podtracev1alpha1.PodTrace{}).
+		WithOptions(defaultControllerOptions()).
+		Complete(r)
+}
+
+// syncExporterBundle creates / updates the per-PodTrace ConfigMap+Secret
+// in the system namespace. The ConfigMap carries endpoint metadata that
+// agents use to construct the exporter; the Secret carries the resolved
+// credential material (copied from user-namespace Secrets at sync time).
+//
+// One bundle per PodTrace simplifies the agent-side view: an agent looks
+// up "the bundle for PodTrace X" and that is the ground truth for
+// everything needed to export its events.
+func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig) error {
+	systemNS := r.SystemNamespace
+	name := ExporterBundleName(pt.UID)
+
+	payload, credSecretRef, err := renderBundlePayload(ec)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: ManagedObjectMeta(name, systemNS, ComponentBundle, map[string]string{
+			LabelPodTraceName:   pt.Name,
+			LabelPodTraceNS:     pt.Namespace,
+			LabelExporterConfig: ec.Name,
+		}),
+	}
+	// No ownerReference: Kubernetes forbids a namespaced owner (PodTrace)
+	// from owning a child in a different namespace. Finalizer + label-
+	// based cleanup handles deletion — see finalizer.go.
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
+		cm.Labels = mergeLabels(cm.Labels, map[string]string{
+			LabelManagedBy:      ManagedByValue,
+			LabelComponent:      ComponentBundle,
+			LabelPodTraceName:   pt.Name,
+			LabelPodTraceNS:     pt.Namespace,
+			LabelExporterConfig: ec.Name,
+		})
+		cm.Annotations = mergeLabels(cm.Annotations, map[string]string{
+			BundleAnnotationSourceRef: ec.Namespace + "/" + ec.Name,
+		})
+		cm.Data = payload
+		return nil
+	}); err != nil {
+		return fmt.Errorf("bundle ConfigMap: %w", err)
+	}
+
+	// Only create a companion Secret when the exporter actually references
+	// one. Exporters without credentials (e.g. plain Jaeger/Zipkin) get a
+	// ConfigMap-only bundle.
+	if credSecretRef != nil {
+		credData, err := r.loadCredentialSecret(ctx, ec.Namespace, *credSecretRef)
+		if err != nil {
+			return fmt.Errorf("load credential Secret: %w", err)
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: ManagedObjectMeta(name, systemNS, ComponentBundle, map[string]string{
+				LabelPodTraceName:   pt.Name,
+				LabelPodTraceNS:     pt.Namespace,
+				LabelExporterConfig: ec.Name,
+			}),
+		}
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+			secret.Labels = mergeLabels(secret.Labels, map[string]string{
+				LabelManagedBy:      ManagedByValue,
+				LabelComponent:      ComponentBundle,
+				LabelPodTraceName:   pt.Name,
+				LabelPodTraceNS:     pt.Namespace,
+				LabelExporterConfig: ec.Name,
+			})
+			secret.Annotations = mergeLabels(secret.Annotations, map[string]string{
+				BundleAnnotationSourceRef: ec.Namespace + "/" + ec.Name,
+			})
+			secret.Type = corev1.SecretTypeOpaque
+			secret.Data = credData
+			return nil
+		}); err != nil {
+			return fmt.Errorf("bundle Secret: %w", err)
+		}
+	}
+	return nil
+}
+
+// loadCredentialSecret reads a SecretKeySelector from the ExporterConfig's
+// namespace and returns just the one key the exporter referenced, keyed
+// under a deterministic name (always "credential") so agents never have
+// to re-parse the SecretKeySelector.
+func (r *PodTraceReconciler) loadCredentialSecret(ctx context.Context, namespace string, ref podtracev1alpha1.SecretKeySelector) (map[string][]byte, error) {
+	var src corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref.Name}, &src); err != nil {
+		return nil, fmt.Errorf("get Secret %s/%s: %w", namespace, ref.Name, err)
+	}
+	val, ok := src.Data[ref.Key]
+	if !ok {
+		return nil, fmt.Errorf("secret %s/%s has no key %q", namespace, ref.Name, ref.Key)
+	}
+	return map[string][]byte{"credential": val}, nil
+}
+
+// setCondition, scoped to PodTrace status.
+func (r *PodTraceReconciler) setCondition(pt *podtracev1alpha1.PodTrace, condType string, status metav1.ConditionStatus, reason, message string) {
+	pt.Status.Conditions = upsertCondition(pt.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: pt.Generation,
+	})
+}
+
+func allNodesReady(ns []podtracev1alpha1.PodTraceNodeStatus) bool {
+	for _, n := range ns {
+		if !n.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+// countReadyPods sums activeCgroups across all per-node reports as a
+// proxy for matchedPods. cgroups and pods are 1:1 under the current
+// target-resolution rules.
+func countReadyPods(ns []podtracev1alpha1.PodTraceNodeStatus) int32 {
+	total := int32(0)
+	for _, n := range ns {
+		total += n.ActiveCgroups
+	}
+	return total
+}

--- a/internal/operator/podtrace_controller_test.go
+++ b/internal/operator/podtrace_controller_test.go
@@ -1,0 +1,210 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TestPodTraceReconciler_EnvtestBundleSync_OTLPLiteral asserts the happy
+// path for a credential-less OTLP exporter: a ConfigMap lands in the
+// system namespace with correct data, no companion Secret.
+func TestPodTraceReconciler_EnvtestBundleSync_OTLPLiteral(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	if err := c.Create(ctx, ec); err != nil {
+		t.Fatal(err)
+	}
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "trace", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	bundleName := ExporterBundleName(pt.UID)
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var cm corev1.ConfigMap
+			return c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &cm)
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	var cm corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &cm); err != nil {
+		t.Fatalf("bundle ConfigMap missing: %v", err)
+	}
+	if cm.Data["type"] != "otlp" || cm.Data["endpoint"] != "otel:4318" {
+		t.Errorf("bundle data wrong: %+v", cm.Data)
+	}
+	// Credential-less exporter → no companion Secret.
+	var secret corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &secret)
+	if err == nil {
+		t.Error("companion Secret should not exist for credential-less OTLP")
+	}
+}
+
+// TestPodTraceReconciler_EnvtestBundleSync_SecretCredentials covers the
+// DataDog path: operator must read the user-namespace Secret, copy its
+// key into the system-namespace bundle Secret, and leave the original
+// Secret untouched.
+func TestPodTraceReconciler_EnvtestBundleSync_SecretCredentials(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := c.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-key", Namespace: ns},
+		Data:       map[string][]byte{"api": []byte("super-secret-token")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeDataDog,
+			DataDog: &podtracev1alpha1.DataDogExporter{
+				Site: "datadoghq.eu",
+				APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd-key", Key: "api"},
+			},
+		},
+	}
+	if err := c.Create(ctx, ec); err != nil {
+		t.Fatal(err)
+	}
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-trace", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "dd"},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	bundleName := ExporterBundleName(pt.UID)
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var s corev1.Secret
+			return c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &s)
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	var bundle corev1.Secret
+	if err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &bundle); err != nil {
+		t.Fatalf("bundle Secret missing: %v", err)
+	}
+	if string(bundle.Data["credential"]) != "super-secret-token" {
+		t.Errorf("bundle credential not copied: %q", bundle.Data["credential"])
+	}
+
+	var cm corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &cm); err != nil {
+		t.Fatalf("bundle ConfigMap missing: %v", err)
+	}
+	if cm.Data["site"] != "datadoghq.eu" {
+		t.Errorf("site not carried in bundle: %+v", cm.Data)
+	}
+}
+
+// TestPodTraceReconciler_EnvtestExporterRefMissing exercises the
+// fail-closed path: when the referenced ExporterConfig does not exist,
+// the reconciler must set Degraded=True with a clear reason instead of
+// erroring out.
+func TestPodTraceReconciler_EnvtestExporterRefMissing(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "does-not-exist"},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+
+	// Loop-reconcile past the finalizer-add Requeue until Degraded shows up.
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var got podtracev1alpha1.PodTrace
+			if err := c.Get(ctx, types.NamespacedName{Name: pt.Name, Namespace: ns}, &got); err != nil {
+				return err
+			}
+			if !conditionIs(got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue) {
+				return fmt.Errorf("Degraded not yet True: %+v", got.Status.Conditions)
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(ctx, types.NamespacedName{Name: pt.Name, Namespace: ns}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !conditionIs(got.Status.Conditions, ConditionReady, metav1.ConditionFalse) {
+		t.Errorf("expected Ready=False, got %+v", got.Status.Conditions)
+	}
+}
+
+func conditionIs(conds []metav1.Condition, condType string, want metav1.ConditionStatus) bool {
+	for _, c := range conds {
+		if c.Type == condType {
+			return c.Status == want
+		}
+	}
+	return false
+}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -1,0 +1,379 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// PodTraceSessionReconciler turns a PodTraceSession CR into one Job per
+// node hosting at least one matched pod. Jobs invoke the existing
+// `podtrace --diagnose <duration>` CLI, so sessions work today without
+// the Phase-3 agent being present.
+//
+// The reconcile loop is intentionally one-shot: once Jobs exist we only
+// roll up their status. The only mutating action after initial fan-out
+// is TTL-driven cleanup.
+type PodTraceSessionReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	SystemNamespace string
+}
+
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtracesessions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtracesessions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=podtracesessions/finalizers,verbs=update
+// +kubebuilder:rbac:groups=podtrace.io,resources=tracerconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+
+// Reconcile fans a PodTraceSession out into per-node Jobs, then rolls
+// Job status back into PodTraceSession.status.
+func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("podtracesession", req.String())
+
+	var session podtracev1alpha1.PodTraceSession
+	if err := r.Get(ctx, req.NamespacedName, &session); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get PodTraceSession: %w", err)
+	}
+
+	// Deletion path: clean up cross-namespace Jobs, then release the finalizer.
+	if !session.DeletionTimestamp.IsZero() {
+		if err := cleanupPodTraceSessionChildren(ctx, r.Client, &session, r.SystemNamespace); err != nil {
+			return ctrl.Result{}, err
+		}
+		if removeFinalizer(&session) {
+			if err := r.Update(ctx, &session); err != nil {
+				return ctrl.Result{}, fmt.Errorf("clear finalizer: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+	if ensureFinalizer(&session) {
+		if err := r.Update(ctx, &session); err != nil {
+			return ctrl.Result{}, fmt.Errorf("set finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Terminal phases are sticky. TTL-driven cleanup runs below, but we
+	// do not re-fan out a session that has already produced Jobs.
+	if session.Status.Phase == podtracev1alpha1.SessionPhaseCompleted ||
+		session.Status.Phase == podtracev1alpha1.SessionPhaseFailed {
+		return r.reconcileTerminalSession(ctx, &session)
+	}
+
+	targetNodes, err := r.resolveTargetNodes(ctx, &session)
+	if err != nil {
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ResolveTargets", err.Error())
+		_ = r.Status().Update(ctx, &session)
+		return ctrl.Result{}, err
+	}
+	if len(targetNodes) == 0 {
+		logger.Info("no matched pods; session stays Pending until pods appear")
+		session.Status.Phase = podtracev1alpha1.SessionPhasePending
+		r.setCondition(&session, ConditionReconciled, metav1.ConditionTrue, "NoMatchedPods", "selector matched zero pods")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, r.Status().Update(ctx, &session)
+	}
+
+	tc := r.resolveTracerConfig(ctx)
+	cap := effectiveMaxConcurrentSessionsPerNode(tc)
+
+	if cap > 0 {
+		exceeded, err := r.nodesAtCapacity(ctx, targetNodes, cap, session.Namespace, session.Name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if len(exceeded) > 0 {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "NodeCapacity",
+				fmt.Sprintf("nodes at max concurrency (%d): %v", cap, exceeded))
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		}
+	}
+
+	jobs, err := r.ensureJobs(ctx, &session, tc, targetNodes)
+	if err != nil {
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "EnsureJobs", err.Error())
+		_ = r.Status().Update(ctx, &session)
+		return ctrl.Result{}, err
+	}
+
+	// Refresh status from Job conditions. summarizeSessionJobs also decides
+	// whether the session has reached a terminal phase.
+	session.Status.Jobs = makeSessionJobRefs(jobs)
+	session.Status.Phase = computeSessionPhase(jobs)
+	session.Status.ObservedGeneration = session.Generation
+	if session.Status.StartTime == nil && anyJobStarted(jobs) {
+		now := metav1.Now()
+		session.Status.StartTime = &now
+	}
+	if isTerminal(session.Status.Phase) && session.Status.CompletionTime == nil {
+		now := metav1.Now()
+		session.Status.CompletionTime = &now
+	}
+	r.setCondition(&session, ConditionReconciled, metav1.ConditionTrue, "Reconciled",
+		fmt.Sprintf("%d Job(s) on %d node(s)", len(jobs), len(targetNodes)))
+	r.setCondition(&session, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
+
+	if err := r.Status().Update(ctx, &session); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
+	}
+
+	// Re-queue while the session is still running so status reflects Job
+	// progress without waiting on a default 10h informer re-list.
+	if !isTerminal(session.Status.Phase) {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *PodTraceSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("podtracesession").
+		For(&podtracev1alpha1.PodTraceSession{}).
+		WithOptions(defaultControllerOptions()).
+		Complete(r)
+}
+
+// resolveTargetNodes expands spec.selector / spec.podRefs into the set of
+// node names hosting at least one matched pod. Deterministic ordering
+// (sorted) so reconcile is idempotent under flaky informer caches.
+func (r *PodTraceSessionReconciler) resolveTargetNodes(ctx context.Context, s *podtracev1alpha1.PodTraceSession) ([]string, error) {
+	nodes := map[string]struct{}{}
+
+	if s.Spec.Selector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(s.Spec.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid selector: %w", err)
+		}
+		var list corev1.PodList
+		listOpts := &client.ListOptions{
+			LabelSelector: sel,
+			Namespace:     s.Namespace,
+		}
+		if s.Spec.NamespaceSelector != nil {
+			// namespaced scope stays session.Namespace only for now;
+			// cross-namespace selector is Phase-3+ territory because it
+			// requires watching Namespaces.
+			listOpts.Namespace = ""
+		}
+		if err := r.List(ctx, &list, listOpts); err != nil {
+			return nil, fmt.Errorf("list pods for selector: %w", err)
+		}
+		for _, p := range list.Items {
+			if p.Spec.NodeName != "" && isPodEligible(&p) {
+				nodes[p.Spec.NodeName] = struct{}{}
+			}
+		}
+	}
+
+	for _, ref := range s.Spec.PodRefs {
+		ns := ref.Namespace
+		if ns == "" {
+			ns = s.Namespace
+		}
+		var pod corev1.Pod
+		if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("get pod %s/%s: %w", ns, ref.Name, err)
+		}
+		if pod.Spec.NodeName != "" && isPodEligible(&pod) {
+			nodes[pod.Spec.NodeName] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(nodes))
+	for n := range nodes {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// isPodEligible filters out pods the tracer cannot attach to: those in
+// Pending (no pid/cgroup yet) or already terminated.
+func isPodEligible(p *corev1.Pod) bool {
+	switch p.Status.Phase {
+	case corev1.PodRunning:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveTracerConfig returns the "default" TracerConfig when present,
+// otherwise nil. A missing TracerConfig is not fatal for session
+// reconciliation — defaults are applied — it only means certain caps
+// (like MaxConcurrentSessionsPerNode) do not apply.
+func (r *PodTraceSessionReconciler) resolveTracerConfig(ctx context.Context) *podtracev1alpha1.TracerConfig {
+	var tc podtracev1alpha1.TracerConfig
+	if err := r.Get(ctx, types.NamespacedName{Name: "default"}, &tc); err != nil {
+		return nil
+	}
+	return &tc
+}
+
+// nodesAtCapacity returns the subset of the candidate node list whose
+// current active-session Job count is >= cap. "Active" excludes the
+// session currently being reconciled (its own Jobs don't count against
+// its own cap). Self-identity is (selfNS, selfName), which is unique
+// cluster-wide for PodTraceSession resources.
+func (r *PodTraceSessionReconciler) nodesAtCapacity(ctx context.Context, candidates []string, cap int32, selfNS, selfName string) ([]string, error) {
+	var allJobs batchv1.JobList
+	if err := r.List(ctx, &allJobs, client.MatchingLabels{
+		LabelManagedBy: ManagedByValue,
+		LabelComponent: ComponentSession,
+	}); err != nil {
+		return nil, fmt.Errorf("list session Jobs: %w", err)
+	}
+
+	counts := map[string]int32{}
+	for _, j := range allJobs.Items {
+		if j.Status.Succeeded > 0 || j.Status.Failed > 0 {
+			continue
+		}
+		if j.Labels[LabelSessionName] == selfName && j.Labels[LabelSessionNS] == selfNS {
+			continue
+		}
+		node, ok := j.Labels[LabelNodeName]
+		if !ok {
+			continue
+		}
+		counts[node]++
+	}
+
+	var over []string
+	for _, n := range candidates {
+		if counts[n] >= cap {
+			over = append(over, n)
+		}
+	}
+	return over, nil
+}
+
+// effectiveMaxConcurrentSessionsPerNode returns the cap from TracerConfig
+// or a sensible default (0 = no cap) when no TracerConfig exists.
+func effectiveMaxConcurrentSessionsPerNode(tc *podtracev1alpha1.TracerConfig) int32 {
+	if tc == nil {
+		return 0
+	}
+	return tc.Spec.MaxConcurrentSessionsPerNode
+}
+
+// ensureJobs creates-or-updates one Job per target node, owner-ref'd to
+// the session. Returns all Jobs currently owned by the session (not just
+// those created this call) so Reconcile can roll up status.
+func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, nodes []string) ([]batchv1.Job, error) {
+	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
+
+	for _, node := range nodes {
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SessionJobName(s.UID, node),
+				Namespace: systemNS,
+			},
+		}
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, job, func() error {
+			job.Labels = mergeLabels(job.Labels, map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: s.Name,
+				LabelSessionNS:   s.Namespace,
+				LabelNodeName:    node,
+			})
+			// Spec is immutable after Job creation apart from specific fields;
+			// controllerutil.CreateOrUpdate will call us with the existing
+			// object, so we only set Spec when it is the zero value (fresh create).
+			if job.Spec.Template.Spec.Containers == nil {
+				job.Spec = buildSessionJobSpec(s, tc, node)
+			}
+			// No ownerReference: the PodTraceSession lives in the user
+			// namespace but its Jobs live in podtrace-system. Cleanup goes
+			// through FinalizerCleanup; see finalizer.go.
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("ensure Job for node %s: %w", node, err)
+		}
+	}
+
+	var owned batchv1.JobList
+	if err := r.List(ctx, &owned, client.InNamespace(systemNS), client.MatchingLabels{
+		LabelManagedBy:   ManagedByValue,
+		LabelComponent:   ComponentSession,
+		LabelSessionName: s.Name,
+		LabelSessionNS:   s.Namespace,
+	}); err != nil {
+		return nil, fmt.Errorf("list owned Jobs: %w", err)
+	}
+	return owned.Items, nil
+}
+
+// reconcileTerminalSession handles TTL-driven cleanup only. Terminal
+// sessions are not re-fanned-out; we just check if their TTL has
+// elapsed and delete the CR.
+func (r *PodTraceSessionReconciler) reconcileTerminalSession(ctx context.Context, s *podtracev1alpha1.PodTraceSession) (ctrl.Result, error) {
+	ttl := sessionTTL(s)
+	if ttl == 0 || s.Status.CompletionTime == nil {
+		return ctrl.Result{}, nil
+	}
+	deadline := s.Status.CompletionTime.Add(time.Duration(ttl) * time.Second)
+	if time.Now().Before(deadline) {
+		return ctrl.Result{RequeueAfter: time.Until(deadline)}, nil
+	}
+	if err := r.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("delete expired session: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func sessionTTL(s *podtracev1alpha1.PodTraceSession) int32 {
+	if s.Spec.TTLSecondsAfterFinished != nil {
+		return *s.Spec.TTLSecondsAfterFinished
+	}
+	return 300
+}
+
+// setCondition mirrors TracerConfigReconciler.setCondition; duplicated
+// rather than generic so the two reconcilers can evolve independently.
+func (r *PodTraceSessionReconciler) setCondition(s *podtracev1alpha1.PodTraceSession, condType string, status metav1.ConditionStatus, reason, message string) {
+	s.Status.Conditions = upsertCondition(s.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: s.Generation,
+	})
+}
+
+func systemNamespaceForSession(tc *podtracev1alpha1.TracerConfig, fallback string) string {
+	if tc != nil && tc.Spec.SystemNamespace != "" {
+		return tc.Spec.SystemNamespace
+	}
+	return fallback
+}
+

--- a/internal/operator/podtracesession_controller_test.go
+++ b/internal/operator/podtracesession_controller_test.go
@@ -1,0 +1,194 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// createPodOnNode creates a Running Pod on the given node in the given ns.
+// envtest has no kubelet, so we manually set spec.nodeName and
+// status.phase=Running. That's enough for the reconciler's selector +
+// node-resolution path.
+func createPodOnNode(t *testing.T, c client.Client, namespace, name, node string, labels map[string]string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+		},
+	}
+	if err := c.Create(ctx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	if err := c.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("status update pod: %v", err)
+	}
+}
+
+func TestPodTraceSessionReconciler_EnvtestFanOutByNode(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ensureDefaultTracerConfig(t, c)
+
+	// Pods on two distinct nodes matching app=api.
+	createPodOnNode(t, c, ns, "api-a", "node-a", map[string]string{"app": "api"})
+	createPodOnNode(t, c, ns, "api-b", "node-b", map[string]string{"app": "api"})
+	// Decoy pod that must NOT be included.
+	createPodOnNode(t, c, ns, "other", "node-a", map[string]string{"app": "other"})
+
+	session := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Duration:    metav1.Duration{Duration: 30 * time.Second},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		},
+	}
+	if err := c.Create(ctx, session); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var list batchv1.JobList
+			if err := c.List(ctx, &list, client.InNamespace(systemNS), client.MatchingLabels{
+				LabelSessionName: session.Name,
+				LabelSessionNS:   ns,
+			}); err != nil {
+				return err
+			}
+			if len(list.Items) != 2 {
+				return errf("have %d jobs, want 2", len(list.Items))
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: session.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	// Jobs must be pinned to the right nodes via nodeSelector.
+	var list batchv1.JobList
+	if err := c.List(ctx, &list, client.InNamespace(systemNS), client.MatchingLabels{
+		LabelSessionName: session.Name,
+		LabelSessionNS:   ns,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]bool{}
+	for _, j := range list.Items {
+		if j.Labels[LabelNodeName] == "" {
+			t.Errorf("Job %q missing node label: %+v", j.Name, j.Labels)
+		}
+		nodes[j.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"]] = true
+	}
+	if !nodes["node-a"] || !nodes["node-b"] {
+		t.Errorf("Jobs not pinned to expected nodes: %v", nodes)
+	}
+}
+
+func TestPodTraceSessionReconciler_EnvtestStatusReflectsJobCompletion(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ensureDefaultTracerConfig(t, c)
+	createPodOnNode(t, c, ns, "only", "node-x", map[string]string{"app": "one"})
+	session := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-diag", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "one"}},
+			Duration:    metav1.Duration{Duration: 10 * time.Second},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		},
+	}
+	if err := c.Create(ctx, session); err != nil {
+		t.Fatal(err)
+	}
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+
+	// Reconcile until the Job appears. The first Reconcile call only
+	// adds the finalizer and returns Requeue=true; the Job is created on
+	// the next pass. reconcileUntil makes this transparent.
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var jobs batchv1.JobList
+			if err := c.List(ctx, &jobs, client.InNamespace(systemNS), client.MatchingLabels{
+				LabelSessionName: session.Name,
+			}); err != nil {
+				return err
+			}
+			if len(jobs.Items) != 1 {
+				return errf("have %d jobs, want 1", len(jobs.Items))
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: session.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	// Force the one Job to Succeeded.
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, client.InNamespace(systemNS), client.MatchingLabels{
+		LabelSessionName: session.Name,
+	}); err != nil || len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 Job, got %d (err=%v)", len(jobs.Items), err)
+	}
+	j := &jobs.Items[0]
+	j.Status.Succeeded = 1
+	now := metav1.Now()
+	j.Status.CompletionTime = &now
+	if err := c.Status().Update(ctx, j); err != nil {
+		t.Fatalf("status update job: %v", err)
+	}
+
+	// Reconcile again; session should now be Completed.
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var got podtracev1alpha1.PodTraceSession
+			if err := c.Get(ctx, types.NamespacedName{Name: session.Name, Namespace: ns}, &got); err != nil {
+				return err
+			}
+			if got.Status.Phase != podtracev1alpha1.SessionPhaseCompleted {
+				return errf("phase=%q want Completed", got.Status.Phase)
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: session.Name, Namespace: ns}})
+			return err
+		},
+	)
+}
+
+// errf is a shorthand for fmt.Errorf used inside reconcileUntil predicates.
+func errf(format string, a ...any) error {
+	return fmt.Errorf(format, a...)
+}

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -1,0 +1,274 @@
+package operator
+
+import (
+	"strconv"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// buildSessionJobSpec renders the Job spec for one node's slice of a
+// PodTraceSession. The Job invokes the existing `podtrace` CLI with
+// `--diagnose <duration>` so it works today without the Phase-3 agent
+// being present.
+//
+// Each Job is pinned to its node via nodeSelector on kubernetes.io/hostname,
+// because DaemonSet-style NodeAffinity would be overkill for a one-shot.
+func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, node string) batchv1.JobSpec {
+	completions := int32(1)
+	parallelism := int32(1)
+
+	backoffLimit := int32(0)
+	ttlSeconds := int32(300)
+	deadlineOffset := int32(30)
+	if tc != nil {
+		if tc.Spec.Session.BackoffLimit != nil {
+			backoffLimit = *tc.Spec.Session.BackoffLimit
+		}
+		if tc.Spec.Session.TTLSecondsAfterFinished != nil {
+			ttlSeconds = *tc.Spec.Session.TTLSecondsAfterFinished
+		}
+		if tc.Spec.Session.ActiveDeadlineSecondsOffset > 0 {
+			deadlineOffset = tc.Spec.Session.ActiveDeadlineSecondsOffset
+		}
+	}
+
+	activeDeadline := int64(s.Spec.Duration.Seconds()) + int64(deadlineOffset)
+
+	imagePullPolicy := corev1.PullIfNotPresent
+	image := ""
+	var pullSecrets []corev1.LocalObjectReference
+	var resources corev1.ResourceRequirements
+	if tc != nil {
+		image = tc.Spec.Image
+		if tc.Spec.ImagePullPolicy != "" {
+			imagePullPolicy = tc.Spec.ImagePullPolicy
+		}
+		pullSecrets = tc.Spec.ImagePullSecrets
+		resources = tc.Spec.Session.Resources
+	}
+
+	priv := true
+	runAsRoot := int64(0)
+
+	args := buildDiagnoseArgs(s)
+
+	return batchv1.JobSpec{
+		Completions:             &completions,
+		Parallelism:             &parallelism,
+		BackoffLimit:            &backoffLimit,
+		TTLSecondsAfterFinished: &ttlSeconds,
+		ActiveDeadlineSeconds:   &activeDeadline,
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					LabelManagedBy:   ManagedByValue,
+					LabelComponent:   ComponentSession,
+					LabelSessionName: s.Name,
+					LabelSessionNS:   s.Namespace,
+					LabelNodeName:    node,
+				},
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy:      corev1.RestartPolicyNever,
+				ServiceAccountName: AgentServiceAccountName(),
+				NodeSelector: map[string]string{
+					"kubernetes.io/hostname": node,
+				},
+				HostPID:           true,
+				ImagePullSecrets:  pullSecrets,
+				Tolerations:       tolerationsFrom(tc),
+				PriorityClassName: priorityClassNameFrom(tc),
+				Containers: []corev1.Container{{
+					Name:            "podtrace",
+					Image:           image,
+					ImagePullPolicy: imagePullPolicy,
+					Args:            args,
+					Env: []corev1.EnvVar{
+						{
+							Name: "NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+							},
+						},
+					},
+					Resources: resources,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &priv,
+						RunAsUser:  &runAsRoot,
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN"},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "bpf", MountPath: "/sys/fs/bpf", MountPropagation: mountPropagationHostToContainer()},
+						{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
+						{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
+						{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+					},
+				}},
+				Volumes: []corev1.Volume{
+					{Name: "bpf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf"}}},
+					{Name: "btf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/btf/vmlinux"}}},
+					{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+					{Name: "cgroup", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/cgroup"}}},
+				},
+			},
+		},
+	}
+}
+
+// buildDiagnoseArgs produces the `podtrace` CLI args that a session Job
+// executes. The Job is pinned to one node, so we additionally pre-filter
+// the selector/podRefs to that node at --pods time — but this first
+// iteration trusts the top-level selector and lets the binary resolve
+// pods itself.
+func buildDiagnoseArgs(s *podtracev1alpha1.PodTraceSession) []string {
+	args := []string{
+		"--diagnose", s.Spec.Duration.Duration.String(),
+	}
+	if s.Spec.ContainerName != "" {
+		args = append(args, "--container", s.Spec.ContainerName)
+	}
+	if len(s.Spec.Filters) > 0 {
+		vals := make([]string, 0, len(s.Spec.Filters))
+		for _, f := range s.Spec.Filters {
+			vals = append(vals, string(f))
+		}
+		args = append(args, "--filter", strings.Join(vals, ","))
+	}
+	if s.Spec.SamplePercent != nil {
+		args = append(args, "--tracing-sample-rate", strconv.FormatFloat(float64(*s.Spec.SamplePercent)/100.0, 'f', 2, 64))
+	}
+
+	// Selector → podtrace's --pod-selector flag. PodRefs → --pods.
+	// Webhook guarantees exactly one of the two is set.
+	if s.Spec.Selector != nil {
+		args = append(args, "--pod-selector", labelSelectorToFlag(s.Spec.Selector))
+		args = append(args, "--all-in-namespace", "--namespace", s.Namespace)
+	}
+	if len(s.Spec.PodRefs) > 0 {
+		refs := make([]string, 0, len(s.Spec.PodRefs))
+		for _, r := range s.Spec.PodRefs {
+			if r.Namespace != "" {
+				refs = append(refs, r.Namespace+"/"+r.Name)
+			} else {
+				refs = append(refs, s.Namespace+"/"+r.Name)
+			}
+		}
+		args = append(args, "--pods", strings.Join(refs, ","))
+	}
+	return args
+}
+
+func labelSelectorToFlag(s *metav1.LabelSelector) string {
+	parts := make([]string, 0, len(s.MatchLabels))
+	for k, v := range s.MatchLabels {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func tolerationsFrom(tc *podtracev1alpha1.TracerConfig) []corev1.Toleration {
+	if tc == nil {
+		return nil
+	}
+	return tc.Spec.Tolerations
+}
+
+func priorityClassNameFrom(tc *podtracev1alpha1.TracerConfig) string {
+	if tc == nil {
+		return ""
+	}
+	return tc.Spec.Agent.PriorityClassName
+}
+
+// makeSessionJobRefs rolls up a list of child Jobs into the slim status
+// representation carried on PodTraceSession.
+func makeSessionJobRefs(jobs []batchv1.Job) []podtracev1alpha1.SessionJobRef {
+	refs := make([]podtracev1alpha1.SessionJobRef, 0, len(jobs))
+	for _, j := range jobs {
+		node := j.Labels[LabelNodeName]
+		ref := podtracev1alpha1.SessionJobRef{
+			Node:      node,
+			Name:      j.Name,
+			Completed: j.Status.Succeeded > 0 || j.Status.Failed >= jobBackoffLimit(&j)+1,
+		}
+		if j.Status.StartTime != nil {
+			ref.StartTime = j.Status.StartTime
+		}
+		if j.Status.CompletionTime != nil {
+			ref.CompletionTime = j.Status.CompletionTime
+		}
+		if j.Status.Failed > 0 && j.Status.Succeeded == 0 {
+			ref.Message = "Job failed"
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func jobBackoffLimit(j *batchv1.Job) int32 {
+	if j.Spec.BackoffLimit != nil {
+		return *j.Spec.BackoffLimit
+	}
+	return 6 // Kubernetes default
+}
+
+// computeSessionPhase maps Job statuses to a SessionPhase.
+//
+//   - All succeeded         → Completed
+//   - Any failed past limit → Failed
+//   - Any running           → Running
+//   - Otherwise             → Pending
+func computeSessionPhase(jobs []batchv1.Job) podtracev1alpha1.SessionPhase {
+	if len(jobs) == 0 {
+		return podtracev1alpha1.SessionPhasePending
+	}
+	allSucceeded := true
+	anyRunning := false
+	anyFailedFatal := false
+	for i := range jobs {
+		j := &jobs[i]
+		succeeded := j.Status.Succeeded > 0
+		failed := j.Status.Failed > jobBackoffLimit(j)
+		running := j.Status.Active > 0
+
+		if !succeeded {
+			allSucceeded = false
+		}
+		if failed {
+			anyFailedFatal = true
+		}
+		if running {
+			anyRunning = true
+		}
+	}
+	switch {
+	case allSucceeded:
+		return podtracev1alpha1.SessionPhaseCompleted
+	case anyFailedFatal:
+		return podtracev1alpha1.SessionPhaseFailed
+	case anyRunning:
+		return podtracev1alpha1.SessionPhaseRunning
+	default:
+		return podtracev1alpha1.SessionPhasePending
+	}
+}
+
+func isTerminal(p podtracev1alpha1.SessionPhase) bool {
+	return p == podtracev1alpha1.SessionPhaseCompleted || p == podtracev1alpha1.SessionPhaseFailed
+}
+
+func anyJobStarted(jobs []batchv1.Job) bool {
+	for _, j := range jobs {
+		if j.Status.StartTime != nil || j.Status.Active > 0 || j.Status.Succeeded > 0 || j.Status.Failed > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -1,0 +1,206 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func newSession(mod func(*podtracev1alpha1.PodTraceSession)) *podtracev1alpha1.PodTraceSession {
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "diag",
+			Namespace: "default",
+			UID:       "u-sess",
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Duration: metav1.Duration{Duration: 5 * time.Minute},
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		},
+	}
+	if mod != nil {
+		mod(s)
+	}
+	return s
+}
+
+func TestBuildDiagnoseArgs_SelectorPath(t *testing.T) {
+	args := buildDiagnoseArgs(newSession(nil))
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--diagnose 5m0s") {
+		t.Errorf("missing --diagnose: %v", args)
+	}
+	if !strings.Contains(joined, "--pod-selector app=api") {
+		t.Errorf("missing --pod-selector: %v", args)
+	}
+	if !strings.Contains(joined, "--all-in-namespace") {
+		t.Errorf("missing --all-in-namespace: %v", args)
+	}
+	if !strings.Contains(joined, "--namespace default") {
+		t.Errorf("missing --namespace default: %v", args)
+	}
+}
+
+func TestBuildDiagnoseArgs_PodRefsPath(t *testing.T) {
+	s := newSession(func(s *podtracev1alpha1.PodTraceSession) {
+		s.Spec.Selector = nil
+		s.Spec.PodRefs = []podtracev1alpha1.PodRef{
+			{Name: "pod-a"},                      // falls back to s.Namespace
+			{Namespace: "team-b", Name: "pod-b"}, // explicit ns
+		}
+	})
+	args := buildDiagnoseArgs(s)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--pods default/pod-a,team-b/pod-b") {
+		t.Errorf("pods flag wrong: %v", args)
+	}
+	if strings.Contains(joined, "--pod-selector") {
+		t.Errorf("selector flag must not be present on podRefs path: %v", args)
+	}
+}
+
+func TestBuildDiagnoseArgs_FiltersAndSample(t *testing.T) {
+	pct := int32(50)
+	s := newSession(func(s *podtracev1alpha1.PodTraceSession) {
+		s.Spec.Filters = []podtracev1alpha1.EventFilter{
+			podtracev1alpha1.FilterDNS,
+			podtracev1alpha1.FilterNet,
+		}
+		s.Spec.SamplePercent = &pct
+		s.Spec.ContainerName = "api"
+	})
+	args := buildDiagnoseArgs(s)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--filter dns,net") {
+		t.Errorf("filter flag wrong: %v", args)
+	}
+	if !strings.Contains(joined, "--container api") {
+		t.Errorf("container flag missing: %v", args)
+	}
+	if !strings.Contains(joined, "--tracing-sample-rate 0.50") {
+		t.Errorf("sample-rate wrong: %v", args)
+	}
+}
+
+func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
+	ttl := int32(600)
+	backoff := int32(0)
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image: "ghcr.io/podtrace/podtrace:test",
+			Session: podtracev1alpha1.SessionRuntimeSpec{
+				TTLSecondsAfterFinished:     &ttl,
+				BackoffLimit:                &backoff,
+				ActiveDeadlineSecondsOffset: 45,
+			},
+		},
+	}
+	spec := buildSessionJobSpec(newSession(nil), tc, "node-a")
+
+	if spec.BackoffLimit == nil || *spec.BackoffLimit != 0 {
+		t.Errorf("backoffLimit: %v", spec.BackoffLimit)
+	}
+	if spec.TTLSecondsAfterFinished == nil || *spec.TTLSecondsAfterFinished != 600 {
+		t.Errorf("TTL: %v", spec.TTLSecondsAfterFinished)
+	}
+	// 5m + 45s = 345s
+	if spec.ActiveDeadlineSeconds == nil || *spec.ActiveDeadlineSeconds != 345 {
+		t.Errorf("activeDeadlineSeconds=%v want 345", spec.ActiveDeadlineSeconds)
+	}
+	// Pinned to the right node
+	if spec.Template.Spec.NodeSelector["kubernetes.io/hostname"] != "node-a" {
+		t.Errorf("nodeSelector wrong: %v", spec.Template.Spec.NodeSelector)
+	}
+	if spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("restartPolicy=%v want Never", spec.Template.Spec.RestartPolicy)
+	}
+	// Image propagated
+	if spec.Template.Spec.Containers[0].Image != "ghcr.io/podtrace/podtrace:test" {
+		t.Errorf("image: %q", spec.Template.Spec.Containers[0].Image)
+	}
+}
+
+func TestComputeSessionPhase_Transitions(t *testing.T) {
+	succeededJob := batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}
+	failedJob := batchv1.Job{Status: batchv1.JobStatus{Failed: 7 /*> default backoffLimit 6*/}}
+	runningJob := batchv1.Job{Status: batchv1.JobStatus{Active: 1}}
+	pendingJob := batchv1.Job{}
+
+	cases := []struct {
+		name string
+		jobs []batchv1.Job
+		want podtracev1alpha1.SessionPhase
+	}{
+		{"empty-pending", nil, podtracev1alpha1.SessionPhasePending},
+		{"all-succeeded", []batchv1.Job{succeededJob, succeededJob}, podtracev1alpha1.SessionPhaseCompleted},
+		{"any-fatal-failed", []batchv1.Job{succeededJob, failedJob}, podtracev1alpha1.SessionPhaseFailed},
+		{"any-running", []batchv1.Job{pendingJob, runningJob}, podtracev1alpha1.SessionPhaseRunning},
+		{"pending-only", []batchv1.Job{pendingJob, pendingJob}, podtracev1alpha1.SessionPhasePending},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := computeSessionPhase(tc.jobs); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMakeSessionJobRefs_CompletionMarker(t *testing.T) {
+	jobs := []batchv1.Job{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pts-u-sess-node-a",
+			Labels: map[string]string{LabelNodeName: "node-a"},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "pts-u-sess-node-b",
+			Labels: map[string]string{LabelNodeName: "node-b"},
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}}
+	refs := makeSessionJobRefs(jobs)
+	if len(refs) != 2 {
+		t.Fatalf("len=%d want 2", len(refs))
+	}
+	if !refs[0].Completed || refs[1].Completed {
+		t.Errorf("completion flags wrong: %+v", refs)
+	}
+}
+
+func TestAnyJobStarted(t *testing.T) {
+	start := metav1.Now()
+	if anyJobStarted([]batchv1.Job{{}, {}}) {
+		t.Error("no started jobs should return false")
+	}
+	if !anyJobStarted([]batchv1.Job{{Status: batchv1.JobStatus{StartTime: &start}}}) {
+		t.Error("StartTime set should return true")
+	}
+	if !anyJobStarted([]batchv1.Job{{Status: batchv1.JobStatus{Active: 1}}}) {
+		t.Error("Active pod should return true")
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	if !isTerminal(podtracev1alpha1.SessionPhaseCompleted) {
+		t.Error("Completed should be terminal")
+	}
+	if !isTerminal(podtracev1alpha1.SessionPhaseFailed) {
+		t.Error("Failed should be terminal")
+	}
+	if isTerminal(podtracev1alpha1.SessionPhaseRunning) {
+		t.Error("Running must not be terminal")
+	}
+	if isTerminal(podtracev1alpha1.SessionPhasePending) {
+		t.Error("Pending must not be terminal")
+	}
+}

--- a/internal/operator/reconcilers.go
+++ b/internal/operator/reconcilers.go
@@ -1,0 +1,42 @@
+package operator
+
+import (
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// registerReconcilers wires all three reconcilers onto the manager.
+// Order does not matter — the manager starts them in parallel — but we
+// construct them in dependency order (TracerConfig first, then Session,
+// then PodTrace) so a stack trace points at the failing one.
+func registerReconcilers(mgr ctrl.Manager, opts Options) error {
+	tcr := &TracerConfigReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: opts.SystemNamespace,
+	}
+	if err := tcr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("TracerConfigReconciler: %w", err)
+	}
+
+	ptsr := &PodTraceSessionReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: opts.SystemNamespace,
+	}
+	if err := ptsr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("PodTraceSessionReconciler: %w", err)
+	}
+
+	ptr := &PodTraceReconciler{
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: opts.SystemNamespace,
+	}
+	if err := ptr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("PodTraceReconciler: %w", err)
+	}
+
+	return nil
+}

--- a/internal/operator/runtime.go
+++ b/internal/operator/runtime.go
@@ -1,0 +1,178 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// Options configure a single operator run. All addresses default to
+// loopback so unit tests can bring the manager up without opening public
+// ports; production callers override via the CLI flags in
+// cmd/podtrace/operator.go.
+type Options struct {
+	// SystemNamespace is the namespace in which the operator creates
+	// the agent DaemonSet, agent RBAC, per-session Jobs, and resolved
+	// exporter bundles. Must be a PSA-privileged namespace.
+	SystemNamespace string
+
+	// MetricsBindAddress (host:port) for controller-runtime's Prometheus
+	// metrics endpoint. Empty disables the server.
+	MetricsBindAddress string
+
+	// HealthBindAddress (host:port) for /healthz and /readyz. Empty
+	// disables the server.
+	HealthBindAddress string
+
+	// LeaderElection enables HA-safe single-writer reconciliation. Always
+	// on in production; tests disable it because the envtest harness
+	// tears the manager down too fast for a lease renewal.
+	LeaderElection          bool
+	LeaderElectionNamespace string
+	LeaderElectionID        string
+
+	// WebhookPort / WebhookCertDir wire the admission webhook server.
+	// When WebhookCertDir is empty, the webhook server is not started —
+	// useful when running the operator behind an external cert flow.
+	WebhookPort    int
+	WebhookCertDir string
+
+	// SyncPeriod bounds how often controller-runtime re-lists informer
+	// caches. Zero leaves the library default (10h).
+	SyncPeriod time.Duration
+
+	// GracefulShutdownTimeout caps how long Run will block after ctx is
+	// cancelled. Zero leaves the library default.
+	GracefulShutdownTimeout time.Duration
+}
+
+// DefaultOptions returns production-sensible defaults. Callers typically
+// start from these and override only what the CLI flags customised.
+func DefaultOptions() Options {
+	return Options{
+		SystemNamespace:         "podtrace-system",
+		MetricsBindAddress:      ":8080",
+		HealthBindAddress:       ":8081",
+		LeaderElection:          true,
+		LeaderElectionNamespace: "podtrace-system",
+		LeaderElectionID:        "podtrace-operator.podtrace.io",
+		WebhookPort:             9443,
+		WebhookCertDir:          "/var/run/podtrace/tls",
+	}
+}
+
+// NewScheme returns a scheme with both client-go's default types and
+// the podtrace v1alpha1 API group registered. Exposed so tests can
+// share one scheme across envtest harnesses.
+func NewScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		return nil, fmt.Errorf("clientgo scheme: %w", err)
+	}
+	if err := podtracev1alpha1.AddToScheme(s); err != nil {
+		return nil, fmt.Errorf("podtrace scheme: %w", err)
+	}
+	return s, nil
+}
+
+// Run boots a controller-runtime manager, wires all three reconcilers and
+// the validating webhook, and blocks until ctx is cancelled. Returns the
+// first terminal error, or nil on clean shutdown.
+//
+// The shape mirrors what `cmd/podtrace operator` wants: one function
+// call that owns the whole control-plane lifetime.
+func Run(ctx context.Context, opts Options) error {
+	if opts.SystemNamespace == "" {
+		return errors.New("operator: SystemNamespace is required")
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
+
+	scheme, err := NewScheme()
+	if err != nil {
+		return err
+	}
+
+	managerOpts := ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: opts.MetricsBindAddress,
+		},
+		HealthProbeBindAddress:  opts.HealthBindAddress,
+		LeaderElection:          opts.LeaderElection,
+		LeaderElectionID:        leaderElectionID(opts),
+		LeaderElectionNamespace: opts.LeaderElectionNamespace,
+	}
+	if opts.GracefulShutdownTimeout > 0 {
+		managerOpts.GracefulShutdownTimeout = &opts.GracefulShutdownTimeout
+	}
+	if opts.WebhookCertDir != "" {
+		managerOpts.WebhookServer = webhook.NewServer(webhook.Options{
+			Port:    opts.WebhookPort,
+			CertDir: opts.WebhookCertDir,
+		})
+	}
+	if opts.SyncPeriod > 0 {
+		managerOpts.Cache.SyncPeriod = &opts.SyncPeriod
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOpts)
+	if err != nil {
+		return fmt.Errorf("build manager: %w", err)
+	}
+
+	if err := registerReconcilers(mgr, opts); err != nil {
+		return fmt.Errorf("register reconcilers: %w", err)
+	}
+
+	if opts.WebhookCertDir != "" {
+		if err := registerWebhooks(mgr); err != nil {
+			return fmt.Errorf("register webhooks: %w", err)
+		}
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("add healthz: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("add readyz: %w", err)
+	}
+
+	utilruntime.Must(nil) // keep utilruntime import referenced without panicking
+	return mgr.Start(ctx)
+}
+
+func leaderElectionID(opts Options) string {
+	if opts.LeaderElectionID != "" {
+		return opts.LeaderElectionID
+	}
+	return "podtrace-operator.podtrace.io"
+}
+
+// registerWebhooks wires the three validating webhooks onto the manager.
+// Each Setup* function declares a +kubebuilder:webhook marker so the
+// paths match the Helm-rendered ValidatingWebhookConfiguration.
+func registerWebhooks(mgr ctrl.Manager) error {
+	if err := podtracev1alpha1.SetupPodTraceWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("podtrace webhook: %w", err)
+	}
+	if err := podtracev1alpha1.SetupPodTraceSessionWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("podtracesession webhook: %w", err)
+	}
+	if err := podtracev1alpha1.SetupExporterConfigWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("exporterconfig webhook: %w", err)
+	}
+	return nil
+}

--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -1,0 +1,267 @@
+//go:build envtest
+// +build envtest
+
+// Envtest harness for the operator package.
+//
+// One *testing.M-shared envtest.Environment is brought up for the whole
+// suite so that every reconciler test reuses one kube-apiserver + etcd.
+// Tests are isolated by unique namespace per subtest, never by env
+// teardown — envtest.Start is the expensive bit (~5s).
+//
+// Run with:
+//
+//   make envtest-operator
+//
+// or directly:
+//
+//   KUBEBUILDER_ASSETS=$(setup-envtest use 1.30.x -p path) \
+//     go test -tags=envtest -timeout 300s ./internal/operator/...
+
+package operator
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+var (
+	testEnvOnce sync.Once
+	testEnv     *envtest.Environment
+	testScheme  *runtime.Scheme
+	testClient  client.Client
+	testCfgLock sync.Mutex
+)
+
+// setupSharedEnvtest brings up the apiserver+etcd exactly once per
+// `go test` invocation. Subsequent calls are no-ops. On failure the
+// first call returns the error and subsequent calls observe it via
+// testClient==nil → t.Skip.
+func setupSharedEnvtest(t *testing.T) (*runtime.Scheme, client.Client, string) {
+	t.Helper()
+	testCfgLock.Lock()
+	defer testCfgLock.Unlock()
+
+	testEnvOnce.Do(func() {
+		log.SetLogger(zap.New(zap.WriteTo(io.Discard)))
+
+		crdPath := locateCRDPath(t)
+		if _, err := os.Stat(crdPath); err != nil {
+			t.Skipf("CRDs not found at %s: %v", crdPath, err)
+			return
+		}
+
+		env := &envtest.Environment{
+			CRDDirectoryPaths:     []string{crdPath},
+			ErrorIfCRDPathMissing: true,
+		}
+		cfg, err := env.Start()
+		if err != nil {
+			t.Skipf("envtest.Start failed (likely missing KUBEBUILDER_ASSETS): %v", err)
+			return
+		}
+
+		sch, err := NewScheme()
+		if err != nil {
+			t.Fatalf("NewScheme: %v", err)
+		}
+
+		c, err := client.New(cfg, client.Options{Scheme: sch})
+		if err != nil {
+			t.Fatalf("client.New: %v", err)
+		}
+
+		testEnv = env
+		testScheme = sch
+		testClient = c
+	})
+
+	if testClient == nil {
+		t.SkipNow()
+	}
+
+	// Each test gets its own namespace so test resources do not collide
+	// when run with -parallel. Namespaces are not cleaned up — envtest
+	// tear-down at process exit handles it.
+	ns := freshNamespace(t)
+	return testScheme, testClient, ns
+}
+
+// freshNamespace creates a unique namespace and returns its name.
+func freshNamespace(t *testing.T) string {
+	t.Helper()
+	name := strings.ToLower(sanitiseDNS(t.Name())) + "-ns"
+	// sanitiseDNS keeps names DNS-1123 safe; collapse to <=63 chars.
+	if len(name) > 60 {
+		name = name[:60]
+	}
+	nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := testClient.Create(ctx, nsObj); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create namespace %q: %v", name, err)
+	}
+	return name
+}
+
+// ensureSystemNamespace creates podtrace-system once if it does not yet exist.
+// Reconcilers write bundles here; tests share the same namespace.
+//
+// Safe to share across tests for bundle reconcilers because bundle names
+// incorporate PodTrace UIDs, which are unique across tests. TracerConfig
+// tests must use ensureDedicatedSystemNamespace instead, because the
+// agent DaemonSet and RBAC names are fixed-singleton.
+func ensureSystemNamespace(t *testing.T, c client.Client) string {
+	t.Helper()
+	const name = "podtrace-system"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	return name
+}
+
+// ensureDedicatedSystemNamespace creates a test-owned system namespace
+// of the form "podtrace-system-<suffix>". Use this for TracerConfig
+// envtests, which contend for the singleton agent DaemonSet + RBAC
+// names — each TracerConfig under test must live in its own system NS
+// or reconciliation will fight over owner references.
+func ensureDedicatedSystemNamespace(t *testing.T, c client.Client, suffix string) string {
+	t.Helper()
+	name := "podtrace-system-" + sanitiseDNS(suffix)
+	if len(name) > 60 {
+		name = name[:60]
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	return name
+}
+
+// ensureDefaultTracerConfig upserts the cluster-wide "default" TracerConfig.
+// Session reconcile reads it to source the Job container image. Without
+// it, Job pods fail apiserver admission for empty image. Idempotent:
+// tests that need it can call unconditionally.
+func ensureDefaultTracerConfig(t *testing.T, c client.Client) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image: "ghcr.io/podtrace/podtrace:test",
+		},
+	}
+	err := c.Create(ctx, tc)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create default TracerConfig: %v", err)
+	}
+}
+
+// locateCRDPath reuses the stripHelmDirectives technique from the
+// api/v1alpha1 envtest — the CRD YAMLs under deploy/charts/podtrace are
+// wrapped with `{{- if .Values.crds.install }}` which plain YAML loaders
+// reject. We materialize a cleaned copy in a tempdir at test time.
+func locateCRDPath(t *testing.T) string {
+	t.Helper()
+	repoRoot := findRepoRoot(t)
+	src := filepath.Join(repoRoot, "deploy", "charts", "podtrace", "templates", "crds")
+	dst := t.TempDir()
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", src, err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		cleaned := stripHelmDirectives(string(raw))
+		if err := os.WriteFile(filepath.Join(dst, e.Name()), []byte(cleaned), 0o644); err != nil {
+			t.Fatalf("write cleaned CRD: %v", err)
+		}
+	}
+	return dst
+}
+
+func stripHelmDirectives(in string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(in, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "{{-") || strings.HasPrefix(trimmed, "{{") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate go.mod from %s", dir)
+	return ""
+}
+
+// reconcileUntil drives a single reconcile iteration repeatedly until
+// `want` returns nil or the deadline passes. Tests use this instead of
+// wiring a full manager — reconcilers take a ctrl.Request so direct
+// invocation is simple and deterministic.
+func reconcileUntil(t *testing.T, deadline time.Duration, want func() error, reconcile func() error) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for {
+		if err := reconcile(); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if err := want(); err == nil {
+			return
+		}
+		if time.Now().After(end) {
+			if err := want(); err != nil {
+				t.Fatalf("condition not met within %s: %v", deadline, err)
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/operator/tracerconfig_controller.go
+++ b/internal/operator/tracerconfig_controller.go
@@ -1,0 +1,256 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TracerConfigReconciler owns the cluster-wide agent infrastructure:
+// the agent DaemonSet, its ServiceAccount, and the ClusterRole/Binding
+// that grants agents the minimum RBAC to do their job.
+//
+// Only a single TracerConfig object named "default" is reconciled in
+// this first iteration; other names are accepted but the DaemonSet
+// always lives under AgentDaemonSetName() in SystemNamespace so the
+// agent-side discovery path stays simple.
+type TracerConfigReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	SystemNamespace string
+}
+
+// +kubebuilder:rbac:groups=podtrace.io,resources=tracerconfigs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=tracerconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=podtrace.io,resources=tracerconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile ensures the agent DaemonSet and its RBAC match spec.
+// Idempotent; re-queues on transient API errors.
+func (r *TracerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("tracerconfig", req.Name)
+
+	var tc podtracev1alpha1.TracerConfig
+	if err := r.Get(ctx, req.NamespacedName, &tc); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Resource deleted; owner refs on the DaemonSet + RBAC clean
+			// themselves up. Nothing to do here.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get TracerConfig: %w", err)
+	}
+
+	systemNS := r.systemNamespaceFor(&tc)
+
+	if err := r.ensureAgentRBAC(ctx, &tc, systemNS); err != nil {
+		logger.Error(err, "ensure agent RBAC")
+		r.setCondition(&tc, ConditionDegraded, metav1.ConditionTrue, "RBACError", err.Error())
+		_ = r.Status().Update(ctx, &tc)
+		return ctrl.Result{}, err
+	}
+
+	ds, err := r.ensureAgentDaemonSet(ctx, &tc, systemNS)
+	if err != nil {
+		logger.Error(err, "ensure agent DaemonSet")
+		r.setCondition(&tc, ConditionDegraded, metav1.ConditionTrue, "DaemonSetError", err.Error())
+		_ = r.Status().Update(ctx, &tc)
+		return ctrl.Result{}, err
+	}
+
+	tc.Status.DesiredAgents = ds.Status.DesiredNumberScheduled
+	tc.Status.ReadyAgents = ds.Status.NumberReady
+	tc.Status.ObservedGeneration = tc.Generation
+	r.setCondition(&tc, ConditionReconciled, metav1.ConditionTrue, "Reconciled", "agent infrastructure reconciled")
+	r.setCondition(&tc, ConditionReady,
+		conditionStatusFromBool(tc.Status.ReadyAgents == tc.Status.DesiredAgents && tc.Status.DesiredAgents > 0),
+		"AgentFleetReady",
+		fmt.Sprintf("%d/%d agents Ready", tc.Status.ReadyAgents, tc.Status.DesiredAgents),
+	)
+	r.setCondition(&tc, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
+
+	if err := r.Status().Update(ctx, &tc); err != nil {
+		// Conflict: the TracerConfig was mutated between our Get and
+		// our Status().Update (often controller-runtime itself writing
+		// ownerReferences on child adoption). Re-queue rather than
+		// surfacing the race as a terminal error — the next reconcile
+		// reads the fresh resourceVersion and succeeds.
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the reconciler, declaring owned resources
+// so controller-runtime requeues the TracerConfig whenever an owned
+// resource's status changes.
+func (r *TracerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("tracerconfig").
+		For(&podtracev1alpha1.TracerConfig{}).
+		Owns(&appsv1.DaemonSet{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		WithEventFilter(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.LabelChangedPredicate{},
+		)).
+		WithOptions(defaultControllerOptions()).
+		Complete(r)
+}
+
+func (r *TracerConfigReconciler) systemNamespaceFor(tc *podtracev1alpha1.TracerConfig) string {
+	if tc.Spec.SystemNamespace != "" {
+		return tc.Spec.SystemNamespace
+	}
+	return r.SystemNamespace
+}
+
+// ensureAgentRBAC creates / updates the agent SA, ClusterRole, and
+// ClusterRoleBinding. All three are owned by the TracerConfig so that
+// deleting the TracerConfig tears them down.
+func (r *TracerConfigReconciler) ensureAgentRBAC(ctx context.Context, tc *podtracev1alpha1.TracerConfig, systemNS string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: ManagedObjectMeta(AgentServiceAccountName(), systemNS, ComponentAgent, nil),
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
+		sa.Labels = mergeLabels(sa.Labels, map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent})
+		return controllerutil.SetControllerReference(tc, sa, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("ServiceAccount: %w", err)
+	}
+
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: ManagedObjectMeta(AgentClusterRoleName(), "", ComponentAgent, nil),
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, cr, func() error {
+		cr.Labels = mergeLabels(cr.Labels, map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent})
+		cr.Rules = agentClusterRoleRules(systemNS)
+		return controllerutil.SetControllerReference(tc, cr, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("ClusterRole: %w", err)
+	}
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: ManagedObjectMeta(AgentClusterRoleBindingName(), "", ComponentAgent, nil),
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
+		crb.Labels = mergeLabels(crb.Labels, map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent})
+		crb.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     AgentClusterRoleName(),
+		}
+		crb.Subjects = []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      AgentServiceAccountName(),
+			Namespace: systemNS,
+		}}
+		return controllerutil.SetControllerReference(tc, crb, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("ClusterRoleBinding: %w", err)
+	}
+	return nil
+}
+
+// ensureAgentDaemonSet creates / updates the DaemonSet, returning its
+// current status so Reconcile can roll it up.
+func (r *TracerConfigReconciler) ensureAgentDaemonSet(ctx context.Context, tc *podtracev1alpha1.TracerConfig, systemNS string) (*appsv1.DaemonSet, error) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: ManagedObjectMeta(AgentDaemonSetName(), systemNS, ComponentAgent, map[string]string{
+			LabelTracerConfig: tc.Name,
+		}),
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ds, func() error {
+		ds.Labels = mergeLabels(ds.Labels, map[string]string{
+			LabelManagedBy:    ManagedByValue,
+			LabelComponent:    ComponentAgent,
+			LabelTracerConfig: tc.Name,
+		})
+		ds.Spec = buildAgentDaemonSetSpec(tc, systemNS)
+		return controllerutil.SetControllerReference(tc, ds, r.Scheme)
+	}); err != nil {
+		return nil, err
+	}
+	return ds, nil
+}
+
+// agentClusterRoleRules returns the minimum RBAC the agent needs:
+//
+//   - List/watch PodTrace cluster-wide (so it can merge CRs on its node)
+//   - Patch PodTrace/status (so it can write its per-node status entry)
+//   - Read Pods cluster-wide (to resolve selectors against pod labels;
+//     scoped narrower if operators later introduce per-namespace agents)
+//   - Read ConfigMap/Secret only inside systemNS (exporter bundles)
+//   - Create/patch Events (surface attach failures back to operators)
+//
+// The rules are intentionally over-scoped for PodTrace reads because the
+// SharedInformer list-watches cluster-wide; restricting to a namespace
+// breaks the multi-namespace selector story.
+func agentClusterRoleRules(systemNS string) []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"podtrace.io"},
+			Resources: []string{"podtraces"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"podtrace.io"},
+			Resources: []string{"podtraces/status"},
+			Verbs:     []string{"get", "update", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"create", "patch"},
+		},
+		// Bundles live in systemNS; agent reads them via a namespaced
+		// request. ClusterRole is still used for simplicity — a
+		// RoleBinding per agent pod would add deploy complexity for no
+		// practical security gain given the rest of the scope.
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps", "secrets"},
+			Verbs:         []string{"get", "list", "watch"},
+			ResourceNames: []string{}, // namespace scoping applied by agent's code; cluster-level rule is broad
+		},
+	}
+}
+
+// setCondition applies one Condition to the TracerConfig status, keyed
+// by Type. The library-standard meta.SetStatusCondition semantics are
+// replicated inline to avoid a dependency on k8s.io/apimachinery/pkg/api/meta
+// just for this.
+func (r *TracerConfigReconciler) setCondition(tc *podtracev1alpha1.TracerConfig, condType string, status metav1.ConditionStatus, reason, message string) {
+	tc.Status.Conditions = upsertCondition(tc.Status.Conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: tc.Generation,
+	})
+}
+

--- a/internal/operator/tracerconfig_controller_test.go
+++ b/internal/operator/tracerconfig_controller_test.go
@@ -1,0 +1,126 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestTracerConfigReconciler_EnvtestLifecycle(t *testing.T) {
+	scheme, c, _ := setupSharedEnvtest(t)
+	systemNS := ensureDedicatedSystemNamespace(t, c, "lifecycle")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	tcObj := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "lifecycle"},
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image:           "ghcr.io/podtrace/podtrace:test",
+			SystemNamespace: systemNS,
+		},
+	}
+	if err := c.Create(ctx, tcObj); err != nil {
+		t.Fatalf("create TracerConfig: %v", err)
+	}
+	t.Cleanup(func() {
+		// Best-effort cleanup for cluster-scoped resources envtest does
+		// not garbage-collect automatically.
+		_ = c.Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: AgentClusterRoleBindingName()}})
+		_ = c.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: AgentClusterRoleName()}})
+	})
+
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+
+	// --- Phase: create ----------------------------------------------------
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var ds appsv1.DaemonSet
+			return c.Get(ctx, types.NamespacedName{Name: AgentDaemonSetName(), Namespace: systemNS}, &ds)
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "lifecycle"}})
+			return err
+		},
+	)
+
+	var ds appsv1.DaemonSet
+	if err := c.Get(ctx, types.NamespacedName{Name: AgentDaemonSetName(), Namespace: systemNS}, &ds); err != nil {
+		t.Fatalf("DaemonSet missing: %v", err)
+	}
+	if !ownedByTracerConfig(&ds.ObjectMeta, tcObj.Name) {
+		t.Errorf("DaemonSet has no ownerRef to TracerConfig: %+v", ds.OwnerReferences)
+	}
+	if ds.Spec.Template.Spec.Containers[0].Image != tcObj.Spec.Image {
+		t.Errorf("image not propagated: %q", ds.Spec.Template.Spec.Containers[0].Image)
+	}
+
+	var cr rbacv1.ClusterRole
+	if err := c.Get(ctx, types.NamespacedName{Name: AgentClusterRoleName()}, &cr); err != nil {
+		t.Fatalf("ClusterRole missing: %v", err)
+	}
+	if !hasRule(&cr, "podtrace.io", "podtraces") {
+		t.Error("ClusterRole missing rule for podtrace.io/podtraces")
+	}
+
+	var crb rbacv1.ClusterRoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Name: AgentClusterRoleBindingName()}, &crb); err != nil {
+		t.Fatalf("ClusterRoleBinding missing: %v", err)
+	}
+	if len(crb.Subjects) != 1 || crb.Subjects[0].Name != AgentServiceAccountName() {
+		t.Errorf("ClusterRoleBinding subjects wrong: %+v", crb.Subjects)
+	}
+
+	// --- Phase: delete ---------------------------------------------------
+	if err := c.Delete(ctx, tcObj); err != nil {
+		t.Fatalf("delete TracerConfig: %v", err)
+	}
+	// Post-delete reconcile should be a clean no-op (not-found path).
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tcObj.Name}}); err != nil {
+		t.Fatalf("post-delete reconcile should be nil: %v", err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: tcObj.Name}, &podtracev1alpha1.TracerConfig{}); !apierrors.IsNotFound(err) {
+		t.Errorf("TracerConfig still present after delete: %v", err)
+	}
+}
+
+func ownedByTracerConfig(meta *metav1.ObjectMeta, tcName string) bool {
+	for _, o := range meta.OwnerReferences {
+		if o.Kind == "TracerConfig" && o.Name == tcName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRule(cr *rbacv1.ClusterRole, apiGroup, resource string) bool {
+	for _, r := range cr.Rules {
+		ag := false
+		for _, g := range r.APIGroups {
+			if g == apiGroup {
+				ag = true
+				break
+			}
+		}
+		if !ag {
+			continue
+		}
+		for _, res := range r.Resources {
+			if res == resource {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/operator/tracerconfig_daemonset.go
+++ b/internal/operator/tracerconfig_daemonset.go
@@ -1,0 +1,181 @@
+package operator
+
+import (
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// buildAgentDaemonSetSpec renders the DaemonSet.Spec for the agent
+// derived from a TracerConfig. Extracted from the reconciler so unit
+// tests can assert on the resulting spec without spinning envtest.
+//
+// Design invariants:
+//
+//   - The agent runs privileged (CAP_BPF + CAP_SYS_ADMIN + CAP_PERFMON)
+//     and as root. The podtrace-system namespace is PSA-privileged so
+//     the pod is admitted.
+//   - Host mounts are kept to the minimum the tracer needs:
+//     /sys/fs/bpf, /sys/kernel/btf, /proc, /sys/fs/cgroup, and the CRI
+//     socket path. All read-only except /sys/fs/bpf (BPF objects
+//     require RW) and /proc (read-only is enough).
+//   - NODE_NAME is injected via the downward API so the agent's
+//     informers can filter with fieldSelector=spec.nodeName=$NODE_NAME.
+//   - PriorityClassName defaults to system-node-critical so scheduling
+//     pressure does not evict the agent.
+func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string) appsv1.DaemonSetSpec {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			LabelManagedBy:    ManagedByValue,
+			LabelComponent:    ComponentAgent,
+			LabelTracerConfig: tc.Name,
+		},
+	}
+
+	hostPathType := corev1.HostPathDirectory
+	hostPathFileType := corev1.HostPathFile
+	priv := true
+	runAsRoot := int64(0)
+
+	imagePullPolicy := tc.Spec.ImagePullPolicy
+	if imagePullPolicy == "" {
+		imagePullPolicy = corev1.PullIfNotPresent
+	}
+
+	priorityClassName := tc.Spec.Agent.PriorityClassName
+	if priorityClassName == "" {
+		priorityClassName = "system-node-critical"
+	}
+
+	env := []corev1.EnvVar{
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			},
+		},
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		},
+	}
+
+	if lvl := tc.Spec.Agent.LogLevel; lvl != "" {
+		env = append(env, corev1.EnvVar{Name: "PODTRACE_LOG_LEVEL", Value: lvl})
+	}
+	if n := tc.Spec.Agent.EventBufferSize; n > 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  "PODTRACE_EVENT_BUFFER_SIZE",
+			Value: itoa(int(n)),
+		})
+	}
+
+	args := []string{
+		"agent",
+		"--system-namespace", systemNS,
+		"--tracer-config", tc.Name,
+	}
+	if tc.Spec.Agent.StatusReportInterval != nil {
+		args = append(args, "--status-report-interval", tc.Spec.Agent.StatusReportInterval.Duration.String())
+	}
+
+	return appsv1.DaemonSetSpec{
+		Selector: selector,
+		UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+			Type: appsv1.RollingUpdateDaemonSetStrategyType,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: selector.MatchLabels,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName:           AgentServiceAccountName(),
+				PriorityClassName:            priorityClassName,
+				HostPID:                      true, // needed for pid→cgroup traversal via /proc
+				NodeSelector:                 tc.Spec.NodeSelector,
+				Tolerations:                  tc.Spec.Tolerations,
+				Affinity:                     tc.Spec.Affinity,
+				ImagePullSecrets:             tc.Spec.ImagePullSecrets,
+				TerminationGracePeriodSeconds: ptrInt64(30),
+				Containers: []corev1.Container{{
+					Name:            "agent",
+					Image:           tc.Spec.Image,
+					ImagePullPolicy: imagePullPolicy,
+					Args:            args,
+					Env:             env,
+					Resources:       tc.Spec.Agent.Resources,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &priv,
+						RunAsUser:  &runAsRoot,
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{
+								"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN",
+							},
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+						{Name: "health", ContainerPort: 9091, Protocol: corev1.ProtocolTCP},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstrFromString("health")},
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       20,
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstrFromString("health")},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "bpf", MountPath: "/sys/fs/bpf", MountPropagation: mountPropagationHostToContainer()},
+						{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
+						{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
+						{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+					},
+				}},
+				Volumes: []corev1.Volume{
+					{Name: "bpf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &hostPathType}}},
+					{Name: "btf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/btf/vmlinux", Type: &hostPathFileType}}},
+					{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc", Type: &hostPathType}}},
+					{Name: "cgroup", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/cgroup", Type: &hostPathType}}},
+				},
+			},
+		},
+	}
+}
+
+// mountPropagationHostToContainer returns a pointer to
+// corev1.MountPropagationHostToContainer, required for the BPF
+// filesystem: without it, bpffs pins created by the agent would not be
+// visible to other processes on the host.
+func mountPropagationHostToContainer() *corev1.MountPropagationMode {
+	mp := corev1.MountPropagationHostToContainer
+	return &mp
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+func itoa(n int) string       { return strconv.Itoa(n) }
+
+// intstrFromString returns an IntOrString whose StrVal names a port by
+// name. Extracted into a helper purely for call-site readability.
+func intstrFromString(name string) intstr.IntOrString {
+	return intstr.FromString(name)
+}

--- a/internal/operator/tracerconfig_daemonset_test.go
+++ b/internal/operator/tracerconfig_daemonset_test.go
@@ -1,0 +1,177 @@
+package operator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func tc(mod func(*podtracev1alpha1.TracerConfig)) *podtracev1alpha1.TracerConfig {
+	t := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image: "ghcr.io/podtrace/podtrace:test",
+		},
+	}
+	if mod != nil {
+		mod(t)
+	}
+	return t
+}
+
+func TestBuildAgentDaemonSetSpec_SelectorStability(t *testing.T) {
+	// The DaemonSet selector is IMMUTABLE after creation — agent pods
+	// would orphan themselves if it changed. Lock in the key labels the
+	// selector depends on.
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	want := map[string]string{
+		LabelManagedBy:    ManagedByValue,
+		LabelComponent:    ComponentAgent,
+		LabelTracerConfig: "default",
+	}
+	for k, v := range want {
+		if spec.Selector.MatchLabels[k] != v {
+			t.Errorf("selector[%q]=%q want %q", k, spec.Selector.MatchLabels[k], v)
+		}
+	}
+	for k, v := range want {
+		if spec.Template.Labels[k] != v {
+			t.Errorf("template labels[%q]=%q want %q", k, spec.Template.Labels[k], v)
+		}
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_PrivilegedContainer(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	c := spec.Template.Spec.Containers[0]
+	if c.SecurityContext == nil {
+		t.Fatal("SecurityContext is nil")
+	}
+	if c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Error("agent container must be privileged")
+	}
+	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Error("agent must run as root (user 0)")
+	}
+	// Must request the four eBPF-relevant capabilities.
+	wantCaps := map[corev1.Capability]bool{
+		"BPF": false, "SYS_ADMIN": false, "PERFMON": false, "NET_ADMIN": false,
+	}
+	for _, added := range c.SecurityContext.Capabilities.Add {
+		if _, ok := wantCaps[added]; ok {
+			wantCaps[added] = true
+		}
+	}
+	for cap, ok := range wantCaps {
+		if !ok {
+			t.Errorf("missing required capability: %s", cap)
+		}
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_HostMounts(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	expected := map[string]string{
+		"bpf":    "/sys/fs/bpf",
+		"btf":    "/sys/kernel/btf/vmlinux",
+		"proc":   "/proc",
+		"cgroup": "/sys/fs/cgroup",
+	}
+	found := map[string]string{}
+	for _, v := range spec.Template.Spec.Volumes {
+		if v.HostPath != nil {
+			found[v.Name] = v.HostPath.Path
+		}
+	}
+	for name, path := range expected {
+		if found[name] != path {
+			t.Errorf("volume %q path=%q want %q", name, found[name], path)
+		}
+	}
+	// HostPID MUST be on for pid → cgroup traversal.
+	if !spec.Template.Spec.HostPID {
+		t.Error("HostPID must be true")
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_NodeNameEnvInjected(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	c := spec.Template.Spec.Containers[0]
+	foundNodeName := false
+	for _, e := range c.Env {
+		if e.Name == "NODE_NAME" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil && e.ValueFrom.FieldRef.FieldPath == "spec.nodeName" {
+			foundNodeName = true
+		}
+	}
+	if !foundNodeName {
+		t.Error("NODE_NAME env var (downward API) missing; informer filter will break")
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_ArgsCarryTracerConfigName(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Name = "alt"
+	}), "podtrace-system")
+	args := spec.Template.Spec.Containers[0].Args
+	// Expect the `agent` subcommand with system-namespace and tracer-config flags.
+	if len(args) == 0 || args[0] != "agent" {
+		t.Fatalf("args[0]=%q want agent (full args: %v)", args[0], args)
+	}
+	joined := ""
+	for _, a := range args {
+		joined += a + " "
+	}
+	if !contains(joined, "--tracer-config alt") {
+		t.Errorf("--tracer-config name not wired: %v", args)
+	}
+	if !contains(joined, "--system-namespace podtrace-system") {
+		t.Errorf("--system-namespace not wired: %v", args)
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_PriorityClassDefault(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	if spec.Template.Spec.PriorityClassName != "system-node-critical" {
+		t.Errorf("priorityClassName=%q want system-node-critical", spec.Template.Spec.PriorityClassName)
+	}
+	// Explicit override wins.
+	spec = buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.Agent.PriorityClassName = "podtrace-high"
+	}), "podtrace-system")
+	if spec.Template.Spec.PriorityClassName != "podtrace-high" {
+		t.Errorf("priorityClassName override not applied: %q", spec.Template.Spec.PriorityClassName)
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_ProbesWireHealthPort(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	c := spec.Template.Spec.Containers[0]
+	if c.LivenessProbe == nil || c.LivenessProbe.HTTPGet == nil {
+		t.Fatal("livenessProbe not wired")
+	}
+	if c.LivenessProbe.HTTPGet.Port.StrVal != "health" {
+		t.Errorf("livenessProbe port=%q want health", c.LivenessProbe.HTTPGet.Port.StrVal)
+	}
+	if c.ReadinessProbe == nil {
+		t.Error("readinessProbe not wired")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return indexOf(haystack, needle) >= 0
+}
+
+func indexOf(h, n string) int {
+	if len(n) > len(h) {
+		return -1
+	}
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -166,6 +166,84 @@ func TestChart_NamespacePSALabels(t *testing.T) {
 	}
 }
 
+// TestChart_OperatorToggleRendersFullStack asserts that enabling the
+// operator pulls in the Deployment, SA, ClusterRole, ClusterRoleBinding,
+// and metrics Service — and that default (off) mode does not.
+func TestChart_OperatorToggleRendersFullStack(t *testing.T) {
+	off := renderChart(t)
+	on := renderChart(t, "operator.enabled=true")
+
+	offKinds := parseKinds(t, off)
+	onKinds := parseKinds(t, on)
+
+	if offKinds["Deployment"] != 0 {
+		t.Errorf("operator Deployment should not render with operator.enabled=false, got %d", offKinds["Deployment"])
+	}
+	for _, kind := range []string{"Deployment", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Service"} {
+		if onKinds[kind] < 1 {
+			t.Errorf("operator.enabled=true: expected >=1 %s, got %d", kind, onKinds[kind])
+		}
+	}
+}
+
+// TestChart_WebhookRequiresOperatorToRender asserts that webhook
+// templates render only when BOTH operator AND webhook are enabled,
+// because the webhook server runs inside the operator Deployment.
+func TestChart_WebhookRequiresOperatorToRender(t *testing.T) {
+	webhookOnly := renderChart(t, "webhook.enabled=true")
+	both := renderChart(t, "operator.enabled=true", "webhook.enabled=true")
+
+	woKinds := parseKinds(t, webhookOnly)
+	bothKinds := parseKinds(t, both)
+
+	// Webhook-alone still renders the ValidatingWebhookConfiguration
+	// (the user may be managing the operator out-of-band) but the
+	// webhook Service only makes sense when the operator renders too.
+	if woKinds["Service"] > 0 {
+		t.Errorf("webhook-only should not render operator Services, got %d", woKinds["Service"])
+	}
+	if bothKinds["ValidatingWebhookConfiguration"] < 1 {
+		t.Error("operator+webhook: ValidatingWebhookConfiguration missing")
+	}
+	// Operator+webhook should render exactly two Services: metrics + webhook.
+	if bothKinds["Service"] != 2 {
+		t.Errorf("operator+webhook: expected 2 Services, got %d", bothKinds["Service"])
+	}
+}
+
+// TestChart_CertManagerCertificateConditional asserts the cert-manager
+// Certificate only renders when webhook is enabled AND certSource is
+// "cert-manager" (not self-signed or external).
+func TestChart_CertManagerCertificateConditional(t *testing.T) {
+	with := renderChart(t, "operator.enabled=true", "webhook.enabled=true")
+	withoutCM := renderChart(t, "operator.enabled=true", "webhook.enabled=true", "webhook.certSource=self-signed")
+
+	if !bytes.Contains(with, []byte("kind: Certificate")) {
+		t.Error("cert-manager default: Certificate should render")
+	}
+	if bytes.Contains(withoutCM, []byte("kind: Certificate")) {
+		t.Error("webhook.certSource=self-signed: Certificate should NOT render")
+	}
+}
+
+// TestChart_OperatorDeploymentSecurityContext locks in the unprivileged
+// operator runtime: non-root, read-only rootfs, no privilege escalation,
+// all caps dropped. A regression that loosens these would be a real
+// security finding, so it belongs in CI.
+func TestChart_OperatorDeploymentSecurityContext(t *testing.T) {
+	out := renderChart(t, "operator.enabled=true")
+	for _, marker := range []string{
+		"runAsNonRoot: true",
+		"readOnlyRootFilesystem: true",
+		"allowPrivilegeEscalation: false",
+		`drop: ["ALL"]`,
+	} {
+		if !bytes.Contains(out, []byte(marker)) {
+			t.Errorf("operator Deployment missing hardened securityContext marker: %q", marker)
+		}
+	}
+}
+
 // TestChart_SystemNamespaceOverride verifies the operator reads its
 // namespace from values.
 func TestChart_SystemNamespaceOverride(t *testing.T) {

--- a/test/e2e/kind-smoke.sh
+++ b/test/e2e/kind-smoke.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+#
+# kind-smoke.sh — Phase 2 end-to-end validation on a kind cluster.
+#
+# This script does not create a kind cluster (the user is expected to
+# have one already). It installs the podtrace chart with the operator
+# enabled, applies a sample PodTraceSession, and verifies that the
+# operator:
+#
+#   1. Creates the agent DaemonSet + RBAC under TracerConfig control.
+#   2. Resolves the session's selector, fans out into a per-node Job.
+#   3. Syncs an exporter bundle (ConfigMap) for the referenced
+#      ExporterConfig into the system namespace.
+#   4. Reports the session's phase on .status.phase.
+#
+# The script only asserts control-plane behaviour. The agent and session
+# Jobs will CrashLoopBackOff until the Phase-3 agent runtime lands —
+# that is expected, and does not affect the operator's reconciliation
+# loop.
+#
+# Usage:
+#
+#   KUBECONFIG=$HOME/.kube/config test/e2e/kind-smoke.sh [cleanup]
+#
+# The optional `cleanup` argument tears down the release and sample
+# manifests without running assertions.
+
+set -euo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly RELEASE="podtrace-e2e"
+readonly SYSTEM_NS="podtrace-system"
+readonly SAMPLE_NS="e2e-sample"
+
+log_err() {
+	printf '%s: %s\n' "${SCRIPT_NAME}" "$*" >&2
+}
+
+log_info() {
+	printf '%s: %s\n' "${SCRIPT_NAME}" "$*"
+}
+
+require_tool() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		log_err "required tool not on PATH: $1"
+		exit 1
+	fi
+}
+
+repo_root() {
+	cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd
+}
+
+cleanup() {
+	log_info "cleaning up"
+
+	strip_finalizers podtraces.podtrace.io "${SAMPLE_NS}"
+	strip_finalizers podtracesessions.podtrace.io "${SAMPLE_NS}"
+	strip_finalizers tracerconfigs.podtrace.io ""
+
+	# User-namespace CRs first so their finalizers don't block the
+	# operator teardown.
+	kubectl delete podtrace --all -n "${SAMPLE_NS}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	kubectl delete podtracesession --all -n "${SAMPLE_NS}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	kubectl delete tracerconfig --all --ignore-not-found --wait=false >/dev/null 2>&1 || true
+
+	helm uninstall "${RELEASE}" -n "${SYSTEM_NS}" >/dev/null 2>&1 || true
+	kubectl delete namespace "${SAMPLE_NS}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	kubectl delete clusterrole podtrace-agent --ignore-not-found >/dev/null 2>&1 || true
+	kubectl delete clusterrolebinding podtrace-agent --ignore-not-found >/dev/null 2>&1 || true
+	log_info "cleanup issued (deletions run async; kubectl get may still show items for a few seconds)"
+}
+
+strip_finalizers() {
+	local kind="$1"
+	local namespace="$2"
+	local names
+	if [[ -n "${namespace}" ]]; then
+		names=$(kubectl get "${kind}" -n "${namespace}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+	else
+		names=$(kubectl get "${kind}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+	fi
+	for name in ${names}; do
+		if [[ -n "${namespace}" ]]; then
+			kubectl patch "${kind}" "${name}" -n "${namespace}" \
+				--type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+		else
+			kubectl patch "${kind}" "${name}" \
+				--type=merge -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+		fi
+	done
+}
+
+wait_for() {
+	local description="$1"
+	local timeout_seconds="$2"
+	local check_cmd="$3"
+
+	log_info "waiting for: ${description}"
+	local elapsed=0
+	while [[ ${elapsed} -lt ${timeout_seconds} ]]; do
+		if eval "${check_cmd}" >/dev/null 2>&1; then
+			log_info "  ok: ${description}"
+			return 0
+		fi
+		sleep 2
+		elapsed=$((elapsed + 2))
+	done
+	log_err "timeout after ${timeout_seconds}s: ${description}"
+	return 1
+}
+
+tracerconfig_converged() {
+	local gen observed reconciled
+	gen=$(kubectl get tracerconfig default -o jsonpath='{.metadata.generation}' 2>/dev/null)
+	observed=$(kubectl get tracerconfig default -o jsonpath='{.status.observedGeneration}' 2>/dev/null)
+	reconciled=$(kubectl get tracerconfig default \
+		-o jsonpath='{range .status.conditions[?(@.type=="Reconciled")]}{.status}{end}' 2>/dev/null)
+	[[ -n "${gen}" && "${gen}" == "${observed}" && "${reconciled}" == "True" ]]
+}
+
+assert_resource_exists() {
+	local kind="$1"
+	local name="$2"
+	local namespace="${3:-}"
+
+	if [[ -n "${namespace}" ]]; then
+		if ! kubectl get "${kind}" "${name}" -n "${namespace}" >/dev/null 2>&1; then
+			log_err "expected ${kind} ${namespace}/${name}"
+			return 1
+		fi
+	else
+		if ! kubectl get "${kind}" "${name}" >/dev/null 2>&1; then
+			log_err "expected cluster-scoped ${kind} ${name}"
+			return 1
+		fi
+	fi
+	log_info "  found: ${kind} ${namespace:+${namespace}/}${name}"
+}
+
+main() {
+	require_tool kubectl
+	require_tool helm
+
+	local action="${1:-run}"
+	if [[ "${action}" == "cleanup" ]]; then
+		cleanup
+		return 0
+	fi
+
+	local root
+	root="$(repo_root)"
+
+	# --- step 1: install chart ------------------------------------------
+	log_info "ensuring system namespace ${SYSTEM_NS}"
+	kubectl get namespace "${SYSTEM_NS}" >/dev/null 2>&1 ||
+		kubectl create namespace "${SYSTEM_NS}"
+	kubectl label namespace "${SYSTEM_NS}" \
+		pod-security.kubernetes.io/enforce=privileged \
+		pod-security.kubernetes.io/audit=privileged \
+		pod-security.kubernetes.io/warn=privileged \
+		--overwrite >/dev/null
+
+	log_info "installing chart from ${root}/deploy/charts/podtrace"
+	helm upgrade --install "${RELEASE}" "${root}/deploy/charts/podtrace" \
+		--namespace "${SYSTEM_NS}" \
+		--set namespace.create=false \
+		--set operator.enabled=true \
+		--set image.repository=ghcr.io/podtrace/podtrace \
+		--set image.tag=dev \
+		--wait --timeout 120s
+
+	# --- step 2: operator Deployment becomes Ready ----------------------
+	wait_for "operator Deployment Ready" 120 \
+		"kubectl -n ${SYSTEM_NS} rollout status deploy/${RELEASE}-operator --timeout=60s"
+
+	# --- step 3: apply a TracerConfig; reconciler creates agent infra ---
+	log_info "applying TracerConfig"
+	kubectl apply -f "${root}/examples/tracerconfig.yaml"
+
+	wait_for "TracerConfig reconciled to current generation" 60 \
+		tracerconfig_converged
+
+	assert_resource_exists daemonset podtrace-agent "${SYSTEM_NS}"
+	assert_resource_exists serviceaccount podtrace-agent "${SYSTEM_NS}"
+	assert_resource_exists clusterrole podtrace-agent
+	assert_resource_exists clusterrolebinding podtrace-agent
+
+	# --- step 4: user-namespace resources -------------------------------
+	log_info "creating sample workload namespace"
+	kubectl create namespace "${SAMPLE_NS}" --dry-run=client -o yaml | kubectl apply -f -
+
+	log_info "creating sample ExporterConfig"
+	kubectl -n "${SAMPLE_NS}" apply -f - <<EOF
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: prod-otlp
+spec:
+  type: otlp
+  otlp:
+    endpoint: otel-collector:4318
+    protocol: http
+EOF
+
+	# --- step 5: a tiny target workload the session can select on ------
+	# pause:3.9 is tiny and always reaches Running; we just need pods
+	# that a selector can match so the operator's fan-out path fires.
+	log_info "creating sample target workload (pause pods)"
+	kubectl -n "${SAMPLE_NS}" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-target
+  template:
+    metadata:
+      labels:
+        app: smoke-target
+    spec:
+      containers:
+        - name: app
+          image: registry.k8s.io/pause:3.9
+EOF
+	kubectl -n "${SAMPLE_NS}" rollout status deploy/smoke-target --timeout=60s
+
+	# --- step 6: session targeting the sample workload via label -------
+	log_info "creating sample PodTraceSession"
+	kubectl -n "${SAMPLE_NS}" apply -f - <<EOF
+apiVersion: podtrace.io/v1alpha1
+kind: PodTraceSession
+metadata:
+  name: smoke
+spec:
+  selector:
+    matchLabels:
+      app: smoke-target
+  duration: 30s
+  filters: [dns, net]
+  exporterRef:
+    name: prod-otlp
+EOF
+
+	# --- step 7: per-node Job landed under podtrace-system --------------
+	wait_for "session Job created in ${SYSTEM_NS}" 60 \
+		"kubectl -n ${SYSTEM_NS} get jobs -l podtrace.io/session=smoke -o name | grep -q job"
+
+	# --- step 8: continuous PodTrace drives the bundle-sync reconciler --
+	# Bundles are owned by PodTrace (continuous mode), not PodTraceSession;
+	# applying a PodTrace here exercises the bundle-sync path and proves
+	# PodTraceReconciler is wired.
+	log_info "creating continuous PodTrace (exercises bundle sync)"
+	kubectl -n "${SAMPLE_NS}" apply -f - <<EOF
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: smoke-continuous
+spec:
+  selector:
+    matchLabels:
+      app: smoke-target
+  filters: [dns, net]
+  exporterRef:
+    name: prod-otlp
+EOF
+
+	wait_for "exporter bundle ConfigMap landed in ${SYSTEM_NS}" 60 \
+		"kubectl -n ${SYSTEM_NS} get cm -l podtrace.io/component=exporter-bundle -o name | grep -q configmap"
+
+	# --- step 9: print a summary for humans -----------------------------
+	log_info "phase-2 smoke passed — cluster state snapshot follows"
+	echo
+	kubectl get tracerconfig
+	echo
+	kubectl -n "${SAMPLE_NS}" get podtrace,podtracesession,exporterconfig
+	echo
+	kubectl -n "${SYSTEM_NS}" get deploy,daemonset,job,cm -l app.kubernetes.io/part-of=podtrace
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Lands the operator control plane: `podtrace operator` now runs a controller-runtime manager with three reconcilers, leader-elected and unprivileged, plus the operator Deployment/RBAC/cert-manager Certificate in the Helm chart, plus an end-to-end kind smoke script.

## Why

The operator is the piece that turns user intent (`PodTrace`, `PodTraceSession`, `ExporterConfig`) into running infrastructure (DaemonSet, Jobs, bundles) and writes status back. This PR makes the API usable.

## What's in this PR

**Operator runtime**
**Three reconcilers**
**Cross-namespace cleanup**
**Helm chart**
**End-to-end smoke**

Run locally:

```sh
go test -race ./...                        # unit + race
make envtest                               # real apiserver: schemas + reconcilers
helm lint deploy/charts/podtrace           # chart validity
make e2e-kind                              # on a kind cluster
```
## Backwards compatibility

No change to the existing `podtrace` CLI or tracer behaviour.

## Out of scope

- The agent runtime. DaemonSet pods and session Job pods still `CrashLoopBackOff` because the `agent` subcommand is a stub; the operator correctly reconciles them either way.