### PR TITLE
chore: align external URLs and image registry references to gma1k

### DIFF
--- a/.github/workflows/chainsaw.yml
+++ b/.github/workflows/chainsaw.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build podtrace image
         run: |
           make docker-build IMAGE_TAG=ci
-          kind load docker-image ghcr.io/podtrace/podtrace:ci \
+          kind load docker-image ghcr.io/gma1k/podtrace:ci \
             --name podtrace-chainsaw
 
       - name: Install operator via Helm
@@ -87,7 +87,7 @@ jobs:
             --namespace podtrace-system \
             --set namespace.create=false \
             --set operator.enabled=true \
-            --set image.repository=ghcr.io/podtrace/podtrace \
+            --set image.repository=ghcr.io/gma1k/podtrace \
             --set image.tag=ci \
             --set image.pullPolicy=Never \
             --wait --timeout 180s

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 
 LABEL org.opencontainers.image.title="podtrace" \
       org.opencontainers.image.description="eBPF-based troubleshooting tool for Kubernetes pods (CLI, agent, operator)" \
-      org.opencontainers.image.source="https://github.com/podtrace/podtrace" \
+      org.opencontainers.image.source="https://github.com/gma1k/podtrace" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=builder /out/podtrace /usr/local/bin/podtrace

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ CONTROLLER_GEN ?= $(shell go env GOPATH 2>/dev/null)/bin/controller-gen
 CRD_OUT_DIR ?= deploy/charts/podtrace/crds
 BOILERPLATE ?= hack/boilerplate.go.txt
 
-IMAGE_REPO ?= ghcr.io/podtrace/podtrace
+IMAGE_REPO ?= ghcr.io/gma1k/podtrace
 IMAGE_TAG  ?= dev
 IMAGE      ?= $(IMAGE_REPO):$(IMAGE_TAG)
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -46,7 +46,7 @@ Three artifacts version on three different cadences:
 | Artifact | Versioning | Where | Cadence |
 |---|---|---|---|
 | Operator + agent + CLI binary | Semver, single tag | Git tag `vX.Y.Z` | Coupled — one tag, one binary |
-| Container image | Mirrors binary tag | `ghcr.io/podtrace/podtrace:vX.Y.Z` (when published) | Same as binary |
+| Container image | Mirrors binary tag | `ghcr.io/gma1k/podtrace:vX.Y.Z` (when published) | Same as binary |
 | Helm chart | Semver, independent | `Chart.yaml.version` | Bumps per chart change; `appVersion` always tracks the binary |
 | CRDs (`podtrace.io/vN`) | Kubernetes API conventions | Bumped only on breaking schema change | Independent of binary version |
 

--- a/api/v1alpha1/envtest_suite_test.go
+++ b/api/v1alpha1/envtest_suite_test.go
@@ -408,7 +408,7 @@ func TestEnvtest_TracerConfigIsClusterScoped(t *testing.T) {
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 		},
 	}
 	// TracerConfig is cluster-scoped; supplying a namespace at Create

--- a/deploy/charts/podtrace/Chart.yaml
+++ b/deploy/charts/podtrace/Chart.yaml
@@ -24,15 +24,15 @@ keywords:
   - operator
   - diagnostics
 
-home: https://github.com/podtrace/podtrace
+home: https://github.com/gma1k/podtrace
 sources:
-  - https://github.com/podtrace/podtrace
+  - https://github.com/gma1k/podtrace
 
 maintainers:
   - name: podtrace maintainers
-    url: https://github.com/podtrace/podtrace
+    url: https://github.com/gma1k/podtrace
 
-icon: https://raw.githubusercontent.com/podtrace/podtrace/main/assets/logo.png
+icon: https://raw.githubusercontent.com/gma1k/podtrace/main/assets/logo.png
 
 annotations:
   artifacthub.io/changes: |

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -21,7 +21,7 @@ crds:
   keep: true      # DEPRECATED: no-op. CRDs always carry helm.sh/resource-policy: keep.
 
 image:
-  repository: ghcr.io/podtrace/podtrace
+  repository: ghcr.io/gma1k/podtrace
   tag: ""
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/doc/crd-tracerconfig.md
+++ b/doc/crd-tracerconfig.md
@@ -46,7 +46,7 @@ kind: TracerConfig
 metadata:
   name: default
 spec:
-  image: ghcr.io/podtrace/podtrace:0.11.0
+  image: ghcr.io/gma1k/podtrace:0.11.0
   imagePullPolicy: IfNotPresent
   systemNamespace: podtrace-system
   maxConcurrentSessionsPerNode: 2

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -39,7 +39,7 @@ export PATH=$PATH:/usr/local/go/bin
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/podtrace/podtrace.git
+git clone https://github.com/gma1k/podtrace.git
 cd podtrace
 ```
 
@@ -362,13 +362,13 @@ doesn't try to pull from a registry:
 
 ```bash
 make docker-build IMAGE_TAG=dev
-kind load docker-image ghcr.io/podtrace/podtrace:dev
+kind load docker-image ghcr.io/gma1k/podtrace:dev
 
 helm install podtrace deploy/charts/podtrace \
   --namespace podtrace-system \
   --create-namespace \
   --set operator.enabled=true \
-  --set image.repository=ghcr.io/podtrace/podtrace \
+  --set image.repository=ghcr.io/gma1k/podtrace \
   --set image.tag=dev \
   --set image.pullPolicy=Never
 ```

--- a/examples/tracerconfig.yaml
+++ b/examples/tracerconfig.yaml
@@ -5,7 +5,7 @@ kind: TracerConfig
 metadata:
   name: default
 spec:
-  image: ghcr.io/podtrace/podtrace:0.11.0
+  image: ghcr.io/gma1k/podtrace:0.11.0
   imagePullPolicy: IfNotPresent
   systemNamespace: podtrace-system
   # Cap privileged Job pods per node to protect scheduling capacity.

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -94,7 +94,7 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	backoff := int32(0)
 	tc := &podtracev1alpha1.TracerConfig{
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 			Session: podtracev1alpha1.SessionRuntimeSpec{
 				TTLSecondsAfterFinished:     &ttl,
 				BackoffLimit:                &backoff,
@@ -122,7 +122,7 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 		t.Errorf("restartPolicy=%v want Never", spec.Template.Spec.RestartPolicy)
 	}
 	// Image propagated
-	if spec.Template.Spec.Containers[0].Image != "ghcr.io/podtrace/podtrace:test" {
+	if spec.Template.Spec.Containers[0].Image != "ghcr.io/gma1k/podtrace:test" {
 		t.Errorf("image: %q", spec.Template.Spec.Containers[0].Image)
 	}
 	if spec.Template.Spec.ServiceAccountName != SessionServiceAccountName() {
@@ -154,7 +154,7 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 func TestBuildSessionJobSpec_SidecarOptedIn(t *testing.T) {
 	tc := &podtracev1alpha1.TracerConfig{
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 			Session: podtracev1alpha1.SessionRuntimeSpec{
 				SidecarUploader: true,
 			},
@@ -188,7 +188,7 @@ func TestBuildSessionJobSpec_SidecarSuppressedWithoutReportRef(t *testing.T) {
 	// without a report sink — the sidecar must be suppressed.
 	tc := &podtracev1alpha1.TracerConfig{
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 			Session: podtracev1alpha1.SessionRuntimeSpec{
 				SidecarUploader: true,
 			},

--- a/internal/operator/suite_test.go
+++ b/internal/operator/suite_test.go
@@ -170,7 +170,7 @@ func ensureDefaultTracerConfig(t *testing.T, c client.Client) {
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 		},
 	}
 	err := c.Create(ctx, tc)

--- a/internal/operator/tracerconfig_controller_test.go
+++ b/internal/operator/tracerconfig_controller_test.go
@@ -27,7 +27,7 @@ func TestTracerConfigReconciler_EnvtestLifecycle(t *testing.T) {
 	tcObj := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "lifecycle"},
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image:           "ghcr.io/podtrace/podtrace:test",
+			Image:           "ghcr.io/gma1k/podtrace:test",
 			SystemNamespace: systemNS,
 		},
 	}

--- a/internal/operator/tracerconfig_daemonset_test.go
+++ b/internal/operator/tracerconfig_daemonset_test.go
@@ -13,7 +13,7 @@ func tc(mod func(*podtracev1alpha1.TracerConfig)) *podtracev1alpha1.TracerConfig
 	t := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Spec: podtracev1alpha1.TracerConfigSpec{
-			Image: "ghcr.io/podtrace/podtrace:test",
+			Image: "ghcr.io/gma1k/podtrace:test",
 		},
 	}
 	if mod != nil {

--- a/pkg/client/clientset/versioned/clientset_smoke_test.go
+++ b/pkg/client/clientset/versioned/clientset_smoke_test.go
@@ -71,7 +71,7 @@ func TestClientset_CreateListGet_RoundTrip(t *testing.T) {
 	// TracerConfig is cluster-scoped.
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
-		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/podtrace/podtrace:test"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	if _, err := cs.PodtraceV1alpha1().TracerConfigs().Create(ctx, tc, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create TracerConfig: %v", err)

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -229,7 +229,7 @@ main() {
 		echo ""
 		echo "Manual install — required packages:"
 		echo "  clang, llvm, libbpf-dev (or libbpf-devel), linux-headers, bpftool, Go 1.24+"
-		echo "  See https://github.com/podtrace/podtrace for details."
+		echo "  See https://github.com/gma1k/podtrace for details."
 		exit 1
 		;;
 	esac

--- a/test/chainsaw/README.md
+++ b/test/chainsaw/README.md
@@ -9,7 +9,7 @@ independently runnable.
 
 - A running Kubernetes cluster reachable via the current `KUBECONFIG`
   (kind is the expected target).
-- Image `ghcr.io/podtrace/podtrace:dev` loaded into the cluster
+- Image `ghcr.io/gma1k/podtrace:dev` loaded into the cluster
   (`make docker-build IMAGE_TAG=dev && kind load docker-image …`).
 - The operator already installed via Helm with the chart-rendered
   defaults (the smoke script `test/e2e/kind-smoke.sh` does this).

--- a/test/e2e/kind-smoke.sh
+++ b/test/e2e/kind-smoke.sh
@@ -166,7 +166,7 @@ main() {
 		--namespace "${SYSTEM_NS}" \
 		--set namespace.create=false \
 		--set operator.enabled=true \
-		--set image.repository=ghcr.io/podtrace/podtrace \
+		--set image.repository=ghcr.io/gma1k/podtrace \
 		--set image.tag=dev \
 		--set image.pullPolicy=Never \
 		--wait --timeout 120s


### PR DESCRIPTION
## Summary

Aligns all external-facing URLs and image-registry references in the repo with the actual GitHub repo location (`github.com/gma1k/podtrace`) and intended GHCR path (`ghcr.io/gma1k/podtrace`). Pure string replacements; no behavioral changes.

Unblocks the release pipeline PR coming next: the chart's `image.repository`, the Makefile `IMAGE_REPO` default, and the CI helm install commands all need to point at `gma1k` so a tag-triggered release publishes to the right place.