### PR TITLE
feat: add release pipeline for multi-arch image, signed Helm chart, and quickstart manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: Release
+
+# Triggered by version tags (vX.Y.Z, vX.Y.Z-rc.N). Builds and signs the
+# multi-arch container image, packages and pushes the Helm chart to GHCR
+# OCI, and attaches a one-shot quickstart manifest to the GitHub Release.
+#
+# Note on chaining with release-please: tags pushed by release-please via
+# the default GITHUB_TOKEN do not trigger downstream workflows (GitHub
+# blocks token-driven event recursion). To produce a fully-automatic
+# release, either:
+#   (a) Manually re-run this workflow via "Run workflow" → tag ref, or
+#   (b) Configure release-please-action with a PAT that has workflow scope
+#       so its tag pushes trigger this workflow on their own.
+# Option (a) requires zero setup; option (b) is the long-term cleanup.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write       # GitHub Release create/update + asset upload
+  packages: write       # push to ghcr.io
+  id-token: write       # cosign keyless OIDC
+  attestations: write   # SLSA provenance attestation
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/gma1k/podtrace
+  CHART_PATH: deploy/charts/podtrace
+  CHART_REPO: ghcr.io/gma1k/charts
+  COSIGN_VERSION: v3.0.6
+  HELM_VERSION: v4.1.4
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - uses: sigstore/cosign-installer@v4
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          for t in $TAGS; do
+            cosign sign --yes "${t}@${DIGEST}"
+          done
+
+  chart:
+    runs-on: ubuntu-latest
+    needs: image
+    outputs:
+      version: ${{ steps.package.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ${{ env.REGISTRY }} \
+                -u ${{ github.actor }} --password-stdin
+
+      - id: package
+        name: Lint, package, push
+        run: |
+          set -euo pipefail
+          helm lint ${{ env.CHART_PATH }}
+          mkdir -p dist
+          helm package ${{ env.CHART_PATH }} -d dist/
+          tgz=$(ls dist/podtrace-*.tgz | head -n1)
+          version=$(helm show chart ${{ env.CHART_PATH }} | awk '/^version:/{print $2}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          helm push "$tgz" oci://${{ env.CHART_REPO }} 2>&1 | tee push.log
+          digest=$(grep '^Digest:' push.log | awk '{print $2}')
+          if [ -z "$digest" ]; then
+            echo "::error::could not extract chart digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - uses: sigstore/cosign-installer@v4
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Sign chart (keyless)
+        run: |
+          cosign sign --yes \
+            "${{ env.CHART_REPO }}/podtrace@${{ steps.package.outputs.digest }}"
+
+  quickstart:
+    runs-on: ubuntu-latest
+    needs: chart
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Render quickstart manifest
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # Operator + CRDs from the chart, namespace-creating defaults.
+          helm template podtrace ${{ env.CHART_PATH }} \
+            --namespace podtrace-system \
+            --include-crds \
+            --set namespace.create=true \
+            --set operator.enabled=true \
+            > dist/operator.yaml
+          # Append the demo workload + sample CRs.
+          {
+            echo "---"
+            cat deploy/quickstart-sample.yaml
+          } > dist/sample.yaml
+          cat dist/operator.yaml dist/sample.yaml > dist/quickstart.yaml
+          echo "Rendered $(wc -l < dist/quickstart.yaml) lines"
+
+      - name: Compute checksum
+        run: |
+          cd dist && sha256sum quickstart.yaml > quickstart.yaml.sha256
+
+      - name: Attach to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            dist/quickstart.yaml
+            dist/quickstart.yaml.sha256
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -115,16 +115,36 @@ Full reference: [doc/crd-podtracesession.md](doc/crd-podtracesession.md).
 
 ### Install the operator
 
+The fastest path is the published Helm chart in GHCR — no clone, no
+build toolchain:
+
 ```bash
-helm install podtrace deploy/charts/podtrace \
-  --namespace podtrace-system \
-  --create-namespace \
-  --set operator.enabled=true \
-  --set image.tag=<version>
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace \
+  --namespace podtrace-system --create-namespace
 ```
 
-See [doc/installation.md](doc/installation.md) for prerequisites and
-[doc/operator.md](doc/operator.md) for architecture.
+Or apply the bundled quickstart manifest (operator + CRDs + a sample
+diagnose session against an nginx workload) in one shot:
+
+```bash
+kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
+```
+
+Verify the image was built by this repository (cosign keyless):
+
+```bash
+cosign verify ghcr.io/gma1k/podtrace:latest \
+  --certificate-identity-regexp 'https://github.com/gma1k/podtrace/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+For prerequisites, supported kernels, and per-distro notes see
+[doc/installation.md](doc/installation.md) and
+[doc/compatibility.md](doc/compatibility.md). For chart values and
+operator architecture see [doc/operator.md](doc/operator.md).
+
+Building from source (for contributors or air-gapped clusters) is
+covered below under [Building](#building).
 
 ### Coming from the CLI
 

--- a/deploy/quickstart-sample.yaml
+++ b/deploy/quickstart-sample.yaml
@@ -1,0 +1,86 @@
+# Quickstart demo workload + diagnose session.
+#
+# Concatenated to the chart-rendered operator manifest by release.yml to
+# produce dist/quickstart.yaml on each tagged release. End users can
+# then apply the combined file in a single command:
+#
+#   kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
+#
+# After the operator becomes Ready, the PodTraceSession runs for 30s
+# against the nginx Deployment and writes a human-readable report to
+# the nginx-trace-report ConfigMap in the podtrace-demo namespace.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podtrace-demo
+  labels:
+    app.kubernetes.io/managed-by: podtrace-quickstart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: podtrace-demo
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+# OTLP exporter pointing at a localhost collector — replace the endpoint
+# with your own OTLP receiver to ship traces externally. The session
+# still produces a ConfigMap report regardless of whether traces reach
+# this endpoint.
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: demo-otlp
+  namespace: podtrace-demo
+spec:
+  type: otlp
+  otlp:
+    endpoint: localhost:4318
+    protocol: http
+    insecure: true
+---
+# 30-second diagnose session against the nginx pod. Inspect the result:
+#
+#   kubectl get podtracesession demo-trace -n podtrace-demo
+#   kubectl get cm nginx-trace-report -n podtrace-demo \
+#     -o jsonpath='{.data.report\.txt}'
+apiVersion: podtrace.io/v1alpha1
+kind: PodTraceSession
+metadata:
+  name: demo-trace
+  namespace: podtrace-demo
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  duration: 30s
+  filters: [dns, net, fs]
+  exporterRef:
+    name: demo-otlp
+  reportRef:
+    configMap:
+      name: nginx-trace-report
+  ttlSecondsAfterFinished: 600


### PR DESCRIPTION
Adds the tag-triggered pipeline that publishes podtrace as installable artifacts. On each `v*` tag push, builds a signed multi-arch container image, pushes a signed Helm chart to GHCR OCI, and attaches a one-shot quickstart manifest to the GitHub Release.
