### PR TITLE
refactor: per-arch BPF objects under internal/ebpf/embedded and sync docs

### DIFF
--- a/.github/workflows/ebpf-build.yml
+++ b/.github/workflows/ebpf-build.yml
@@ -60,16 +60,19 @@ jobs:
 
       - name: Compile eBPF program
         run: |
-          make bpf/podtrace.bpf.o BPF_GOARCH=${{ matrix.goarch }}
+          make internal/ebpf/embedded/podtrace.${{ matrix.goarch }}.bpf.o BPF_GOARCH=${{ matrix.goarch }}
           echo "eBPF object compiled via Makefile (arch=${{ matrix.bpf_arch }})"
 
       - name: Build Go binary
         run: GOTOOLCHAIN=auto GOARCH=${{ matrix.goarch }} go build -o bin/podtrace ./cmd/podtrace
 
+      - name: Run embed smoke test
+        run: GOTOOLCHAIN=auto GOARCH=${{ matrix.goarch }} go test -tags embed_bpf ./internal/ebpf/embedded/...
+
       - name: List outputs
         run: |
           echo "=== eBPF object (arch=${{ matrix.bpf_arch }}) ==="
-          ls -lh bpf/podtrace.bpf.o
+          ls -lh internal/ebpf/embedded/podtrace.*.bpf.o
           echo "=== Go binary (goarch=${{ matrix.goarch }}) ==="
           ls -lh bin/podtrace
           file bin/podtrace

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build eBPF C
         if: matrix.language == 'cpp'
         run: |
-          make bpf/podtrace.bpf.o BPF_GOARCH=amd64
+          make internal/ebpf/embedded/podtrace.amd64.bpf.o BPF_GOARCH=amd64
 
       - name: Analyze
         uses: github/codeql-action/analyze@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,26 +40,18 @@ ARG TARGETOS=linux
 ARG VERSION=dev
 ARG COMMIT=unknown
 
-# The Makefile derives BPF_GOARCH from `go env GOARCH`; override to match the
-# image's target platform so cross-builds produce a BPF object with the
-# correct __TARGET_ARCH_* define (pt_regs layout differs across architectures).
 ENV BPF_GOARCH=${TARGETARCH} \
     CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH}
 
-# Build the BPF object first. When bpftool or /sys/kernel/btf/vmlinux is
-# unavailable (always true inside image builders), the Makefile falls back
-# to the committed bpf/vmlinux.h stub. That is CO-RE-correct for the probes
-# that rely on stub-defined types; gRPC/FastCGI iov_iter probes pick up
-# runtime BTF from the node kernel at pod start.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    if [ -s bpf/podtrace.bpf.o ]; then \
-        touch bpf/podtrace.bpf.o; \
+    if [ -s internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o ]; then \
+        touch internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o; \
         echo "Reusing prebuilt BPF object from build context"; \
     else \
-        make bpf/podtrace.bpf.o; \
+        make internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o; \
     fi
 
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LLC ?= llc
 # Prefer /usr/local/go/bin/go if available (newer Go versions), otherwise use system go
 GO ?= $(shell if [ -f /usr/local/go/bin/go ]; then echo /usr/local/go/bin/go; else echo go; fi)
 BPF_SRC = bpf/podtrace.bpf.c bpf/network.c bpf/filesystem.c bpf/cpu.c bpf/memory.c
-BPF_OBJ = bpf/podtrace.bpf.o
+BPF_OBJ = internal/ebpf/embedded/podtrace.$(BPF_GOARCH).bpf.o
 BPF_GEN_DIR = bpf/.generated
 VMLINUX_GEN = $(BPF_GEN_DIR)/vmlinux.h
 BINARY = bin/podtrace
@@ -112,7 +112,7 @@ build: $(BPF_OBJ)
 	$(GO) build -tags embed_bpf -o $(BINARY) ./cmd/podtrace
 
 clean:
-	rm -f $(BPF_OBJ)
+	rm -f internal/ebpf/embedded/podtrace.*.bpf.o
 	rm -f $(BINARY)
 	rm -rf bin
 	rm -f coverage.out coverage.html

--- a/cmd/podtrace/diagnose_env.go
+++ b/cmd/podtrace/diagnose_env.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 
-	podtrace "github.com/podtrace/podtrace"
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/cri"
+	"github.com/podtrace/podtrace/internal/ebpf/embedded"
 	"github.com/podtrace/podtrace/internal/ebpf/loader"
 )
 
@@ -65,7 +65,7 @@ func collectEnvReport() envReport {
 		CRIEndpointEnv: os.Getenv("PODTRACE_CRI_ENDPOINT"),
 		CRICandidates:  cri.DefaultCandidateEndpoints(),
 		BPFObjectPath:  config.BPFObjectPath,
-		BPFEmbedded:    len(podtrace.EmbeddedPodtraceBPFObj) > 0,
+		BPFEmbedded:    len(embedded.EmbeddedPodtraceBPFObj) > 0,
 	}
 
 	var u unix.Utsname

--- a/doc/aks.md
+++ b/doc/aks.md
@@ -13,7 +13,20 @@ since AKS 1.25+. All standard node pools support BPF kprobes.
 | Container runtime | containerd | containerd |
 | Cgroup driver | systemd | systemd |
 
-## Build
+## Install
+
+For most AKS deployments, install the published Helm chart:
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+See [installation.md](installation.md) for the full install guide,
+cosign verification, and quickstart manifest.
+
+## Build (from source, for contributors)
 
 ```bash
 sudo ./scripts/install-deps.sh   # Debian/Ubuntu path

--- a/doc/development.md
+++ b/doc/development.md
@@ -357,7 +357,7 @@ go test ./test/... -v
 1. **Check compilation**:
    ```bash
    clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3 \
-         -Ibpf -I. -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+         -Ibpf -I. -c bpf/podtrace.bpf.c -o internal/ebpf/embedded/podtrace.amd64.bpf.o
    ```
 
 2. **Check kernel logs**:

--- a/doc/ebpf-internals.md
+++ b/doc/ebpf-internals.md
@@ -300,7 +300,7 @@ The eBPF program is compiled with:
 
 ```bash
 clang -O2 -g -target bpf -D__TARGET_ARCH_x86 -mcpu=v3 \
-      -Ibpf -I. -c bpf/podtrace.bpf.c -o bpf/podtrace.bpf.o
+      -Ibpf -I. -c bpf/podtrace.bpf.c -o internal/ebpf/embedded/podtrace.amd64.bpf.o
 ```
 
 Note: The eBPF code is now modular. `podtrace.bpf.c` includes all modules:

--- a/doc/eks.md
+++ b/doc/eks.md
@@ -13,7 +13,20 @@
 
 **Fargate does not support BPF kprobes.** Use EC2 node groups.
 
-## Build
+## Install
+
+For most EKS deployments, install the published Helm chart:
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+See [installation.md](installation.md) for the full install guide,
+cosign verification, and quickstart manifest.
+
+## Build (from source, for contributors)
 
 ```bash
 sudo ./scripts/install-deps.sh   # auto-detects AL2/AL2023 → dnf

--- a/doc/gke.md
+++ b/doc/gke.md
@@ -11,7 +11,20 @@
 
 **GKE Autopilot does not support BPF kprobes.** Use Standard node pools.
 
-## Build
+## Install
+
+For most GKE Standard deployments, install the published Helm chart:
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+See [installation.md](installation.md) for the full install guide,
+cosign verification, and quickstart manifest.
+
+## Build (from source, for contributors)
 
 Build on any Linux machine with kernel 5.8+ or cross-compile:
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,5 +1,58 @@
 # Installation
 
+## Install
+
+The fastest path uses the published OCI Helm chart in GHCR — no clone,
+no build toolchain.
+
+### Helm chart (recommended)
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+The chart installs CRDs, namespace, operator, agent DaemonSet, and a
+default `TracerConfig`. See [operator.md](operator.md) for what each
+piece does.
+
+### Quickstart manifest (one-shot)
+
+A pre-rendered manifest including a sample workload + a 30s
+`PodTraceSession` is attached to every GitHub Release:
+
+```bash
+kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
+```
+
+After ~45s, `kubectl get podtracesession demo-trace -n podtrace-demo`
+should show `phase: Completed`.
+
+### Verifying signatures (cosign keyless)
+
+Every released image and chart is signed via cosign keyless OIDC,
+recorded in the public Rekor transparency log. Verify before running:
+
+```bash
+cosign verify ghcr.io/gma1k/podtrace:0.11.0 \
+  --certificate-identity-regexp 'https://github.com/gma1k/podtrace/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The image also ships an SBOM and SLSA provenance attestation:
+
+```bash
+cosign download attestation ghcr.io/gma1k/podtrace:0.11.0 \
+  --predicate-type https://spdx.dev/Document | jq .
+```
+
+### Building from source
+
+If you need a custom build (development, air-gapped clusters, or
+unsupported architectures), the rest of this document covers the
+toolchain setup and build steps.
+
 ## Prerequisites
 
 ### System Requirements
@@ -68,8 +121,11 @@ make build
 ```
 
 This will:
-- Compile the eBPF program (`bpf/podtrace.bpf.c`) to `bpf/podtrace.bpf.o`
-- Build the Go binary to `bin/podtrace`
+- Compile the eBPF program (`bpf/podtrace.bpf.c`) to a per-arch object at
+  `internal/ebpf/embedded/podtrace.<arch>.bpf.o` (e.g.
+  `internal/ebpf/embedded/podtrace.amd64.bpf.o`)
+- Build the Go binary to `bin/podtrace`, embedding the per-arch BPF object
+  via the `embed_bpf` build tag
 
 ### 4. Set Capabilities (Optional)
 
@@ -292,6 +348,16 @@ For the CRD-driven workflows (continuous `PodTrace`, bounded
 chart ships under `deploy/charts/podtrace/`.
 
 ### Quick install
+
+For a public release, prefer the OCI chart (no clone needed):
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+For a custom build of this checkout:
 
 ```bash
 helm install podtrace deploy/charts/podtrace \

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -129,6 +129,16 @@ spec:
 The operator runs in `podtrace-system` and does not affect users running
 the CLI binary directly. Running both in parallel is fine.
 
+For a public release:
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+For a custom build of this checkout:
+
 ```bash
 helm install podtrace deploy/charts/podtrace \
   --namespace podtrace-system \

--- a/doc/operator.md
+++ b/doc/operator.md
@@ -61,6 +61,16 @@ Three reconcilers, each owning one CRD:
 
 ## Install via Helm
 
+For a public release:
+
+```bash
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace --version 0.1.0 \
+  --namespace podtrace-system --create-namespace \
+  --set operator.enabled=true
+```
+
+For a custom build of this checkout:
+
 ```bash
 helm install podtrace deploy/charts/podtrace \
   --namespace podtrace-system \

--- a/embedded_bpf.go
+++ b/embedded_bpf.go
@@ -1,5 +1,0 @@
-//go:build !embed_bpf
-
-package podtrace
-
-var EmbeddedPodtraceBPFObj []byte

--- a/embedded_bpf_embed.go
+++ b/embedded_bpf_embed.go
@@ -1,8 +1,0 @@
-//go:build embed_bpf
-
-package podtrace
-
-import _ "embed"
-
-//go:embed bpf/podtrace.bpf.o
-var EmbeddedPodtraceBPFObj []byte

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -252,7 +253,7 @@ const (
 var (
 	CgroupBasePath     = getEnvOrDefault("PODTRACE_CGROUP_BASE", "/sys/fs/cgroup")
 	ProcBasePath       = getEnvOrDefault("PODTRACE_PROC_BASE", "/proc")
-	BPFObjectPath      = getEnvOrDefault("PODTRACE_BPF_OBJECT", "bpf/podtrace.bpf.o")
+	BPFObjectPath      = getEnvOrDefault("PODTRACE_BPF_OBJECT", DefaultBPFObjectPath())
 	BTFFilePath        = getEnvOrDefault("PODTRACE_BTF_FILE", "")
 	DockerBasePath     = getEnvOrDefault("PODTRACE_DOCKER_BASE", DockerContainersPath)
 	ContainerdBasePath = getEnvOrDefault("PODTRACE_CONTAINERD_BASE", "/var/lib/containerd")
@@ -261,6 +262,10 @@ var (
 
 func SetCgroupBasePath(path string) {
 	CgroupBasePath = path
+}
+
+func DefaultBPFObjectPath() string {
+	return fmt.Sprintf("internal/ebpf/embedded/podtrace.%s.bpf.o", runtime.GOARCH)
 }
 
 func SetProcBasePath(path string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,21 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestDefaultBPFObjectPath(t *testing.T) {
+	want := fmt.Sprintf("internal/ebpf/embedded/podtrace.%s.bpf.o", runtime.GOARCH)
+	if got := DefaultBPFObjectPath(); got != want {
+		t.Errorf("DefaultBPFObjectPath() = %q, want %q", got, want)
+	}
+}
 
 func TestGetEnvOrDefault(t *testing.T) {
 	key := "TEST_ENV_VAR"

--- a/internal/ebpf/embedded/amd64.go
+++ b/internal/ebpf/embedded/amd64.go
@@ -1,0 +1,8 @@
+//go:build embed_bpf && amd64
+
+package embedded
+
+import _ "embed"
+
+//go:embed podtrace.amd64.bpf.o
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/embedded/arm64.go
+++ b/internal/ebpf/embedded/arm64.go
@@ -1,0 +1,8 @@
+//go:build embed_bpf && arm64
+
+package embedded
+
+import _ "embed"
+
+//go:embed podtrace.arm64.bpf.o
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/embedded/embedded_test.go
+++ b/internal/ebpf/embedded/embedded_test.go
@@ -1,0 +1,11 @@
+//go:build embed_bpf
+
+package embedded
+
+import "testing"
+
+func TestEmbeddedPodtraceBPFObj_NonEmpty(t *testing.T) {
+	if len(EmbeddedPodtraceBPFObj) == 0 {
+		t.Fatal("EmbeddedPodtraceBPFObj is empty — likely missing per-arch embed for current GOARCH")
+	}
+}

--- a/internal/ebpf/embedded/ppc64le.go
+++ b/internal/ebpf/embedded/ppc64le.go
@@ -1,0 +1,8 @@
+//go:build embed_bpf && ppc64le
+
+package embedded
+
+import _ "embed"
+
+//go:embed podtrace.ppc64le.bpf.o
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/embedded/riscv64.go
+++ b/internal/ebpf/embedded/riscv64.go
@@ -1,0 +1,8 @@
+//go:build embed_bpf && riscv64
+
+package embedded
+
+import _ "embed"
+
+//go:embed podtrace.riscv64.bpf.o
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/embedded/s390x.go
+++ b/internal/ebpf/embedded/s390x.go
@@ -1,0 +1,8 @@
+//go:build embed_bpf && s390x
+
+package embedded
+
+import _ "embed"
+
+//go:embed podtrace.s390x.bpf.o
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/embedded/stub.go
+++ b/internal/ebpf/embedded/stub.go
@@ -1,0 +1,5 @@
+//go:build !embed_bpf
+
+package embedded
+
+var EmbeddedPodtraceBPFObj []byte

--- a/internal/ebpf/loader/loader.go
+++ b/internal/ebpf/loader/loader.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cilium/ebpf"
 
-	podtrace "github.com/podtrace/podtrace"
 	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/ebpf/embedded"
 )
 
 func LoadPodtrace() (*ebpf.CollectionSpec, error) {
@@ -14,8 +14,8 @@ func LoadPodtrace() (*ebpf.CollectionSpec, error) {
 	if err != nil {
 		spec, err = ebpf.LoadCollectionSpec("../" + config.BPFObjectPath)
 		if err != nil {
-			if config.BPFObjectPath == "bpf/podtrace.bpf.o" && len(podtrace.EmbeddedPodtraceBPFObj) > 0 {
-				if embeddedSpec, embeddedErr := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(podtrace.EmbeddedPodtraceBPFObj)); embeddedErr == nil {
+			if config.BPFObjectPath == config.DefaultBPFObjectPath() && len(embedded.EmbeddedPodtraceBPFObj) > 0 {
+				if embeddedSpec, embeddedErr := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(embedded.EmbeddedPodtraceBPFObj)); embeddedErr == nil {
 					return embeddedSpec, nil
 				}
 			}

--- a/internal/ebpf/loader/loader_test.go
+++ b/internal/ebpf/loader/loader_test.go
@@ -36,7 +36,7 @@ func TestLoadPodtrace_DefaultPathFallsBackToEmbedded(t *testing.T) {
 		t.Fatalf("Chdir: %v", err)
 	}
 
-	config.BPFObjectPath = "bpf/podtrace.bpf.o"
+	config.BPFObjectPath = config.DefaultBPFObjectPath()
 	spec, err := LoadPodtrace()
 	if err != nil {
 		t.Skipf("BPF object not available in test environment: %v", err)


### PR DESCRIPTION
## Summary

1. **Path B per-arch BPF infrastructure**, with embed Go files relocated from repo root to `internal/ebpf/embedded/`. Aligns with the cilium/ebpf ecosystem pattern.
2. **Documentation sync** to reflect the public release shape we shipped in Phase 1, OCI Helm chart, signed images, quickstart manifest. Docs were referencing the old "build from source" install path and the old `bpf/podtrace.bpf.o` location.
