### PR TITLE
chore(ci): release-please bumps patch on feat: while pre-1.0

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -64,6 +64,18 @@ While we are at `v0.x`:
 - Helm chart values: same rule. Minors may rename or restructure values;
   patches will not.
 
+### How releases get versioned (pre-1.0)
+
+While Podtrace at `v0.x`, release-please bumps **patch** for both
+`feat:` and `fix:` (and `refactor:`/`perf:`). The minor digit only
+moves when a commit explicitly carries a `BREAKING CHANGE:` footer (or
+when a maintainer overrides the next version via release-please's
+`Release-As: 0.X.0` footer). This makes the minor bump a deliberate
+opt-in rather than a side effect of every new feature.
+
+After `v1.0.0`, the standard semver rules apply: `feat:` bumps minor,
+`BREAKING CHANGE:` bumps major.
+
 ### Path to `v1beta1`
 
 A CRD graduates from `v1alpha1` to `v1beta1` when **all** of the following

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": false,
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "package-name": "podtrace",


### PR DESCRIPTION
Flips release-please's pre-1.0 bump policy so that `feat:` commits bump the **patch** digit (`v0.X.Y → v0.X.(Y+1)`) instead of the minor digit (`v0.X.Y → v0.(X+1).0`). Makes the minor bump a deliberate opt-in via `BREAKING CHANGE:` footer rather than an automatic consequence of every new feature.
