### PR TITLE
feat(cli): add Make-based release pipeline for signed multi-platform tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v*", "test*"]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +35,7 @@ env:
 
 jobs:
   image:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -92,6 +93,7 @@ jobs:
           done
 
   chart:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: image
     outputs:
@@ -137,6 +139,7 @@ jobs:
             "${{ env.CHART_REPO }}/podtrace@${{ steps.package.outputs.digest }}"
 
   quickstart:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: chart
     steps:
@@ -176,3 +179,50 @@ jobs:
             dist/quickstart.yaml
             dist/quickstart.yaml.sha256
           fail_on_unmatched_files: true
+
+  cli:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install BPF toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang llvm libbpf-dev libelf-dev make pkg-config
+
+      - name: Build CLI tarballs (linux+darwin x amd64+arm64)
+        run: make release VERSION=${{ github.ref_name }}
+
+      - uses: sigstore/cosign-installer@v4.1.1
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Sign checksums.txt (cosign keyless)
+        working-directory: release
+        run: |
+          cosign sign-blob --yes \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            checksums.txt
+
+      - name: Attach tarballs + checksums + signature to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            release/podtrace_*.tar.gz
+            release/checksums.txt
+            release/checksums.txt.sig
+            release/checksums.txt.pem
+          fail_on_unmatched_files: true
+          prerelease: ${{ startsWith(github.ref_name, 'test') || contains(github.ref_name, '-') }}

--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,55 @@ build: $(BPF_OBJ)
 	@mkdir -p bin
 	$(GO) build -tags embed_bpf -o $(BINARY) ./cmd/podtrace
 
+# Release: produce cross-arch tarballs for linux+darwin × amd64+arm64.
+# Each binary embeds the per-arch BPF object via the embed_bpf tag.
+RELEASE_DIR ?= release
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+MODULE = github.com/podtrace/podtrace
+RELEASE_TARGETS = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
+
+.PHONY: release release-bpf-objects
+
+release-bpf-objects:
+	$(MAKE) internal/ebpf/embedded/podtrace.amd64.bpf.o BPF_GOARCH=amd64
+	$(MAKE) internal/ebpf/embedded/podtrace.arm64.bpf.o BPF_GOARCH=arm64
+
+release: release-bpf-objects
+	@rm -rf $(RELEASE_DIR)
+	@mkdir -p $(RELEASE_DIR)
+	@for tgt in $(RELEASE_TARGETS); do \
+	  os=$${tgt%%-*}; arch=$${tgt##*-}; \
+	  echo ">>> Building podtrace for $$os/$$arch (VERSION=$(VERSION))"; \
+	  staging="$(RELEASE_DIR)/staging-$$os-$$arch"; \
+	  mkdir -p "$$staging"; \
+	  GOOS=$$os GOARCH=$$arch CGO_ENABLED=0 \
+	    $(GO) build -trimpath -tags=embed_bpf \
+	      -ldflags "-s -w \
+	        -X $(MODULE)/internal/config.Version=$(VERSION) \
+	        -X $(MODULE)/internal/config.Commit=$(COMMIT)" \
+	      -o "$$staging/podtrace" ./cmd/podtrace; \
+	  cp LICENSE README.md CHANGELOG.md "$$staging/"; \
+	  ( cd "$(RELEASE_DIR)" && \
+	    tar --sort=name --owner=root:0 --group=root:0 \
+	        -czf "podtrace_$$os""_""$$arch.tar.gz" \
+	        -C "staging-$$os-$$arch" \
+	        podtrace LICENSE README.md CHANGELOG.md ); \
+	  rm -rf "$$staging"; \
+	done
+	cd $(RELEASE_DIR) && sha256sum podtrace_*.tar.gz > checksums.txt
+	@echo ""
+	@echo "=== Tarballs ==="
+	@ls -lh $(RELEASE_DIR)/podtrace_*.tar.gz
+	@echo ""
+	@echo "=== checksums.txt ==="
+	@cat $(RELEASE_DIR)/checksums.txt
+
 clean:
 	rm -f internal/ebpf/embedded/podtrace.*.bpf.o
 	rm -f $(BINARY)
 	rm -rf bin
+	rm -rf $(RELEASE_DIR)
 	rm -f coverage.out coverage.html
 	rm -rf "$(BPF_GEN_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,27 @@ fits your workflow:
 ### 1. Standalone CLI binary
 
 Best for ad-hoc, interactive debugging from a workstation or a
-privileged debug pod.
+privileged debug pod. Install via signed tarball:
+
+```bash
+curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_linux_amd64.tar.gz \
+  | tar xz -C /usr/local/bin podtrace
+```
+
+Then:
 
 ```bash
 # Realtime trace
-./bin/podtrace -n production my-pod
+podtrace -n production my-pod
 
 # Bounded diagnose with a JSON report
-./bin/podtrace -n production my-pod --diagnose 30s --export json > report.json
+podtrace -n production my-pod --diagnose 30s --export json > report.json
 ```
 
-Full reference: [doc/usage.md](doc/usage.md).
+For other platforms (linux/arm64, darwin/amd64, darwin/arm64) and
+cosign-verifiable installs, see
+[doc/installation.md#install-the-cli](doc/installation.md#install-the-cli).
+Full CLI reference: [doc/usage.md](doc/usage.md).
 
 ### 2. Continuous tracing via the `PodTrace` CR
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -47,6 +47,63 @@ cosign download attestation ghcr.io/gma1k/podtrace:0.11.0 \
   --predicate-type https://spdx.dev/Document | jq .
 ```
 
+### Install the CLI
+
+For workstation use (interactive `podtrace` invocations from a laptop
+or CI runner), separate from the cluster operator install above. Each
+release ships signed tarballs for linux + macOS × amd64 + arm64:
+
+```bash
+# Linux amd64
+curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_linux_amd64.tar.gz \
+  | tar xz -C /usr/local/bin podtrace
+
+# Linux arm64
+curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_linux_arm64.tar.gz \
+  | tar xz -C /usr/local/bin podtrace
+
+# macOS Apple Silicon
+curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_darwin_arm64.tar.gz \
+  | tar xz -C /usr/local/bin podtrace
+
+# macOS Intel
+curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_darwin_amd64.tar.gz \
+  | tar xz -C /usr/local/bin podtrace
+```
+
+`podtrace --version` should report the tag you installed.
+
+#### Verify the tarball signature (cosign keyless + sha256sum)
+
+The release pipeline signs `checksums.txt` via cosign keyless and
+records the signing event in the [public Rekor transparency log](https://search.sigstore.dev/).
+Trust chain: signature → checksums file → tarball.
+
+```bash
+cd $(mktemp -d)
+
+# Pull checksums + signature + signing certificate
+for f in checksums.txt checksums.txt.sig checksums.txt.pem; do
+  curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/$f
+done
+
+# Verify the signature was produced by a workflow in gma1k/podtrace
+cosign verify-blob \
+  --signature checksums.txt.sig \
+  --certificate checksums.txt.pem \
+  --certificate-identity-regexp 'https://github.com/gma1k/podtrace/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+
+# Verify the tarball matches the (now-trusted) checksum
+curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/podtrace_linux_amd64.tar.gz
+sha256sum -c checksums.txt --ignore-missing
+```
+
+If the cosign verify step succeeds, the certificate's `--certificate-identity-regexp`
+field proves the tarball was built by a workflow run inside the
+`gma1k/podtrace` repository — not by a third party.
+
 ### Building from source
 
 If you need a custom build (development, air-gapped clusters, or


### PR DESCRIPTION
Adds a Make-based release pipeline that produces signed cross-platform tarballs of the standalone `podtrace` CLI on every `v*` tag. Users can `curl | tar` the binary on Linux + macOS × amd64 + arm64, no clone, no build toolchain.