### PR TITLE
ci: migrate CLI checksum signing to cosign v3 keyless bundle format to fix release workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,8 +212,7 @@ jobs:
         working-directory: release
         run: |
           cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.bundle.json \
             checksums.txt
 
       - name: Attach tarballs + checksums + signature to GitHub Release
@@ -222,7 +221,6 @@ jobs:
           files: |
             release/podtrace_*.tar.gz
             release/checksums.txt
-            release/checksums.txt.sig
-            release/checksums.txt.pem
+            release/checksums.txt.bundle.json
           fail_on_unmatched_files: true
           prerelease: ${{ startsWith(github.ref_name, 'test') || contains(github.ref_name, '-') }}

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -77,20 +77,19 @@ curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_d
 
 The release pipeline signs `checksums.txt` via cosign keyless and
 records the signing event in the [public Rekor transparency log](https://search.sigstore.dev/).
-Trust chain: signature → checksums file → tarball.
+Trust chain: sigstore bundle → checksums file → tarball.
 
 ```bash
 cd $(mktemp -d)
 
-# Pull checksums + signature + signing certificate
-for f in checksums.txt checksums.txt.sig checksums.txt.pem; do
+# Pull checksums + sigstore bundle
+for f in checksums.txt checksums.txt.bundle.json; do
   curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/$f
 done
 
 # Verify the signature was produced by a workflow in gma1k/podtrace
 cosign verify-blob \
-  --signature checksums.txt.sig \
-  --certificate checksums.txt.pem \
+  --bundle checksums.txt.bundle.json \
   --certificate-identity-regexp 'https://github.com/gma1k/podtrace/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt


### PR DESCRIPTION
Updating the release CLI signing flow to use Cosign v3 keyless bundle output (`--bundle`) for `checksums.txt`, replacing deprecated detached signature/certificate flags that caused tag-release workflow failures.
