### PR TITLE
ci(release): wire krew-release-bot for automated krew-index PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,7 @@ jobs:
             release/checksums.txt.bundle.json
           fail_on_unmatched_files: true
           prerelease: ${{ startsWith(github.ref_name, 'test') || contains(github.ref_name, '-') }}
+
+      - name: Update plugin manifest in krew-index
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && !startsWith(github.ref_name, 'test')
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3  # v0.0.51

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: podtrace
+spec:
+  version: "{{ .TagName }}"
+  homepage: https://github.com/gma1k/podtrace
+  shortDescription: eBPF diagnostics for Kubernetes pods
+  description: |
+    Podtrace runs eBPF probes against Kubernetes pods to surface low-level
+    diagnostics: TCP/UDP latency, DNS resolution, file I/O, syscall traces,
+    lock contention, OOM events, and more. Run from your workstation for
+    ad-hoc diagnose runs of single or multiple pods, with bounded duration
+    and optional JSON/OTLP/Jaeger/Splunk/Datadog export.
+
+    The same binary also powers the in-cluster operator and per-session
+    Job runtime when installed via Helm; the CLI is one mode of three
+    (CLI, continuous PodTrace CR, bounded PodTraceSession CR).
+  caveats: |
+    Podtrace requires Linux nodes with kernel 5.8+ (BPF ring buffer) and,
+    for some probes (gRPC, FastCGI, full path resolution), BTF available
+    at /sys/kernel/btf/vmlinux.
+
+    The agent and per-session Jobs run as privileged in-cluster
+    containers with CAP_BPF + CAP_PERFMON + hostPID. The kubectl plugin
+    itself does not need elevated permissions on your workstation.
+
+    Supported platforms: linux/amd64, linux/arm64, darwin/amd64,
+    darwin/arm64. Compatibility matrix:
+    https://github.com/gma1k/podtrace/blob/main/doc/compatibility.md
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/gma1k/podtrace/releases/download/{{ .TagName }}/podtrace_linux_amd64.tar.gz" .TagName }}
+      bin: podtrace
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/gma1k/podtrace/releases/download/{{ .TagName }}/podtrace_linux_arm64.tar.gz" .TagName }}
+      bin: podtrace
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/gma1k/podtrace/releases/download/{{ .TagName }}/podtrace_darwin_amd64.tar.gz" .TagName }}
+      bin: podtrace
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/gma1k/podtrace/releases/download/{{ .TagName }}/podtrace_darwin_arm64.tar.gz" .TagName }}
+      bin: podtrace

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_l
 without sudo, extract to a user-writable directory on `$PATH` instead, e.g.
 `mkdir -p ~/.local/bin && tar xz -C ~/.local/bin podtrace`.)
 
+Or via [krew](https://krew.sigs.k8s.io/):
+
+```bash
+kubectl krew install podtrace
+kubectl podtrace -n production my-pod
+```
+
 Then:
 
 ```bash

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -88,6 +88,17 @@ curl -fsSL https://github.com/gma1k/podtrace/releases/latest/download/podtrace_l
 
 `podtrace --version` should report the tag you installed.
 
+#### Install via krew
+
+If you have [krew](https://krew.sigs.k8s.io/) installed, the simplest
+path is `kubectl krew install`:
+
+```bash
+kubectl krew install podtrace
+kubectl podtrace --version
+kubectl krew upgrade podtrace
+```
+
 #### Verify the tarball signature (cosign keyless + sha256sum)
 
 The release pipeline signs `checksums.txt` via cosign keyless and


### PR DESCRIPTION
- Add `.krew.yaml` template at repo root with `{{ .TagName }}` + `addURIAndSha` placeholders for all supported platforms.
- Wire `krew-release-bot` into the `cli` job after tarballs are uploaded to the GitHub Release.
