### PR TITLE
feat(agent): surface per-CR failures as Degraded condition with cause on NodeStatus.Message

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -31,12 +31,6 @@ import (
 // to changes on three resource types — PodTrace (cluster), Pod
 // (node-local), and ConfigMap (system-NS bundles) — and rebuilds the
 // Router's full rule set from scratch on every tick.
-//
-// "Rebuild from scratch" rather than incremental deltas is deliberate:
-// the rule set is small (usually <10 CRs per cluster, not per node),
-// the informer cache is already in memory, and a full rebuild is
-// simpler to reason about than a diff loop that has to track
-// add/modify/delete per informer.
 type AgentReconciler struct {
 	client.Client
 	NodeName        string
@@ -46,16 +40,10 @@ type AgentReconciler struct {
 
 	TargetsCh chan tracer.TargetSet
 
-	// ExporterBuilder is the dependency injection point for
-	// BuildExporter. Tests override with a fake exporter factory.
 	ExporterBuilder func(payload *BundlePayload, crKey CRKey) (tracer.Exporter, error)
 
 	CgroupResolver func(pods []*corev1.Pod) (map[uint64]struct{}, error)
 
-	// ExporterCache memoizes the tracer.Exporter per CR keyed by
-	// bundle ResourceVersion. A bundle ResourceVersion change (e.g.
-	// secret rotation) forces a rebuild; a no-op reconcile does not
-	// reopen connections.
 	exporterCacheMu sync.Mutex
 	exporterCache   map[CRKey]cachedExporter
 }
@@ -101,12 +89,10 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		r.Metrics.ReconcileTotal.Inc()
 	}
 
-	// --- step 1: list CRs ------------------------------------------------
 	var ptList podtracev1alpha1.PodTraceList
 	if err := r.List(ctx, &ptList); err != nil {
 		return ctrl.Result{}, fmt.Errorf("list PodTrace: %w", err)
 	}
-	// --- step 2: list local pods ---------------------------------------
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods); err != nil {
 		return ctrl.Result{}, fmt.Errorf("list Pods: %w", err)
@@ -119,7 +105,6 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
-	// --- step 3: for each CR, match pods → compute cgroups → load bundle
 	rules := make([]CRRule, 0, len(ptList.Items))
 	activeKeys := make(map[CRKey]struct{}, len(ptList.Items))
 
@@ -133,12 +118,14 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		matched, err := MatchPodTraceAgainstPods(pt, localPods)
 		if err != nil {
 			logger.Error(err, "match pods", "cr", key)
+			rules = append(rules, CRRule{
+				Key: key,
+				Err: fmt.Errorf("match pods: %w", err),
+			})
+			activeKeys[key] = struct{}{}
 			continue
 		}
 		if len(matched) == 0 {
-			// No pods on this node match — release the cached exporter
-			// so credential memory does not linger, and skip publishing
-			// a rule for this CR.
 			r.releaseExporter(key)
 			continue
 		}
@@ -146,6 +133,13 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		cgroupIDs, err := r.CgroupResolver(matched)
 		if err != nil {
 			logger.Error(err, "resolve cgroup IDs", "cr", key)
+			rules = append(rules, CRRule{
+				Key:         key,
+				Filters:     filtersToSet(pt.Spec.Filters),
+				MatchedPods: lenToInt32(len(matched)),
+				Err:         fmt.Errorf("resolve cgroup IDs: %w", err),
+			})
+			activeKeys[key] = struct{}{}
 			continue
 		}
 
@@ -156,12 +150,29 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				continue
 			}
 			logger.Error(err, "load bundle", "cr", key)
+			rules = append(rules, CRRule{
+				Key:         key,
+				CgroupIDs:   cgroupIDs,
+				Filters:     filtersToSet(pt.Spec.Filters),
+				MatchedPods: lenToInt32(len(matched)),
+				Err:         fmt.Errorf("load bundle: %w", err),
+			})
+			activeKeys[key] = struct{}{}
 			continue
 		}
 
 		exporter, err := r.obtainExporter(key, bundle)
 		if err != nil {
 			logger.Error(err, "build exporter", "cr", key)
+			rules = append(rules, CRRule{
+				Key:            key,
+				CgroupIDs:      cgroupIDs,
+				Filters:        filtersToSet(pt.Spec.Filters),
+				BundleRevision: bundle.ResourceVer,
+				MatchedPods:    lenToInt32(len(matched)),
+				Err:            fmt.Errorf("build exporter: %w", err),
+			})
+			activeKeys[key] = struct{}{}
 			continue
 		}
 
@@ -176,17 +187,14 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		activeKeys[key] = struct{}{}
 	}
 
-	// Release cached exporters for CRs that dropped off the active set.
 	r.reapStaleExporters(activeKeys)
 
 	r.Router.Publish(rules)
 
-	// --- step 4: feed the union cgroup set to the tracer ---------------
 	targets := buildTargetSet(rules, localPods)
 	select {
 	case r.TargetsCh <- targets:
 	default:
-		// Channel full → keep-latest semantics. Drop one and retry.
 		select {
 		case <-r.TargetsCh:
 		default:
@@ -197,7 +205,6 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
-	// --- step 5: refresh metrics view ----------------------------------
 	if r.Metrics != nil {
 		r.Metrics.RefreshFromRouter(r.Router)
 	}
@@ -205,8 +212,6 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return ctrl.Result{}, nil
 }
 
-// enqueueAllPodTraces turns a Pod event into one reconcile request per
-// PodTrace: any pod change can affect any CR's matched set.
 func (r *AgentReconciler) enqueueAllPodTraces(ctx context.Context, _ client.Object) []reconcile.Request {
 	var list podtracev1alpha1.PodTraceList
 	if err := r.List(ctx, &list); err != nil {
@@ -247,7 +252,6 @@ func (r *AgentReconciler) obtainExporter(key CRKey, bundle *BundlePayload) (trac
 		if entry.bundleRV == bundle.ResourceVer {
 			return entry.exporter, nil
 		}
-		// Bundle RV changed: close the old exporter before replacing.
 		if entry.exporter != nil {
 			_ = entry.exporter.Close(context.Background())
 		}
@@ -295,9 +299,6 @@ func (r *AgentReconciler) reapStaleExporters(active map[CRKey]struct{}) {
 // number — the value the kernel stamps on every event. Pods with
 // unresolvable cgroups are silently skipped (they will return on the
 // next reconcile when the kubelet has published a cgroup path).
-//
-// The agent must run with host PID + cgroup mounts for Stat to reach
-// the actual inode; the DaemonSet manifest guarantees this.
 func resolveCgroupIDs(pods []*corev1.Pod) (map[uint64]struct{}, error) {
 	out := map[uint64]struct{}{}
 	for _, p := range pods {
@@ -322,11 +323,6 @@ func resolveCgroupIDs(pods []*corev1.Pod) (map[uint64]struct{}, error) {
 // heuristic here is slightly-lossy and relies on the reconcile loop
 // picking up a pod on a later tick once its cgroup path materializes.
 func cgroupPathForContainer(p *corev1.Pod, _ string) string {
-	// Systemd cgroup driver emits paths under
-	//   /sys/fs/cgroup/kubepods.slice/kubepods-<qos>.slice/kubepods-<qos>-pod<UID>.slice
-	// kubelet's "cgroupfs" driver emits
-	//   /sys/fs/cgroup/kubepods/<qos>/pod<UID>
-	// We walk both layouts and return the first that stat()s.
 	uid := strings.ReplaceAll(string(p.UID), "-", "_")
 	qos := strings.ToLower(string(p.Status.QOSClass))
 	if qos == "" {
@@ -374,8 +370,6 @@ func buildTargetSet(rules []CRRule, pods []*corev1.Pod) tracer.TargetSet {
 				continue
 			}
 			seen[id] = struct{}{}
-			// Find the pod whose cgroup matches this ID, copy its
-			// metadata onto the Target so exporters can enrich events.
 			for _, p := range pods {
 				path := cgroupPathForContainer(p, "")
 				if path == "" {

--- a/internal/agent/reconciler_envtest_test.go
+++ b/internal/agent/reconciler_envtest_test.go
@@ -5,6 +5,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -45,14 +47,6 @@ func (e *recordingExporter) count() int {
 // TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams is the
 // multi-CR merge acceptance test. It asserts that applying two
 // PodTrace CRs with overlapping selectors on the same node produces:
-//
-//  1. One tracer: a single Router/Engine pipeline servicing both CRs.
-//  2. Correctly-scoped events: each recorder receives only the events
-//     whose (cgroup, filter) tuple matches its CR. Router unit tests
-//     cover this in isolation; this test re-verifies against
-//     apiserver-backed CRRules to catch integration regressions.
-//  3. Healthy per-node status: the StatusWriter patches nodeStatus
-//     entries on both CRs with non-zero counters after dispatch.
 func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 	scheme, c := setupSharedEnvtest(t)
 	_ = scheme
@@ -62,14 +56,9 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// --- fixtures ---------------------------------------------------------
-	// Two pods on the same node, both labeled app=api. Both CRs select
-	// app=api so they overlap: each CR matches both pods.
 	createRunningPod(t, c, ns, "api-a", node, map[string]string{"app": "api"})
 	createRunningPod(t, c, ns, "api-b", node, map[string]string{"app": "api"})
 
-	// Synthetic cgroup IDs — tests do not have /sys/fs/cgroup access in
-	// envtest, so we map each pod name to a deterministic ID.
 	cgroupIDByPod := map[string]uint64{
 		"api-a": 1001,
 		"api-b": 1002,
@@ -98,9 +87,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		t.Fatalf("create ptB: %v", err)
 	}
 
-	// Bundle ConfigMaps in system NS so LoadBundle returns cleanly.
-	// Content is arbitrary: the reconciler's ExporterBuilder is
-	// overridden by the test to return recorders regardless of payload.
 	for _, pt := range []*podtracev1alpha1.PodTrace{ptA, ptB} {
 		bundle := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +104,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		}
 	}
 
-	// --- reconciler with injected cgroup resolver + recorder exporters ----
 	recorders := map[CRKey]*recordingExporter{}
 	buildExporter := func(_ *BundlePayload, key CRKey) (tracer.Exporter, error) {
 		rec := &recordingExporter{name: key.String()}
@@ -147,11 +132,8 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		ExporterBuilder: buildExporter,
 		CgroupResolver:  resolveCg,
 	}
-	// Initialise the exporter cache without calling SetupWithManager
-	// (which would require a real manager).
 	r.exporterCache = map[CRKey]cachedExporter{}
 
-	// --- run reconcile --------------------------------------------------
 	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: ptA.Name, Namespace: ns}}); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
@@ -180,7 +162,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		t.Error("CR-B filter missing EventConnect")
 	}
 
-	// Both CRs match the same two cgroup IDs (overlap).
 	for _, id := range []uint64{1001, 1002} {
 		if _, ok := ruleA.CgroupIDs[id]; !ok {
 			t.Errorf("CR-A missing cgroup %d", id)
@@ -190,8 +171,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		}
 	}
 
-	// --- assertion 2: dispatch scopes events correctly ------------------
-	// Events for cgroup 1001 (both CRs claim it).
 	batch := []*events.Event{
 		{CgroupID: 1001, Type: events.EventDNS},      // A only (B does not filter DNS)
 		{CgroupID: 1001, Type: events.EventConnect},  // B only (A does not filter Connect)
@@ -215,7 +194,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 		t.Errorf("CR-B events=%d want 2", recB.count())
 	}
 
-	// --- assertion 3: status writer patches nodeStatus on both CRs ------
 	writer := &StatusWriter{
 		Client:   c,
 		NodeName: node,
@@ -250,11 +228,6 @@ func TestAgentEnvtest_TwoOverlappingCRs_ProduceScopedStreams(t *testing.T) {
 	}
 }
 
-// TestAgentEnvtest_EngineNoopBackendDispatch covers the Engine+Router
-// integration: events pushed through a NoopBackend reach the per-CR
-// exporters via the Router. Complements the acceptance test by
-// exercising the real engine loop rather than calling Router.Export
-// directly.
 func TestAgentEnvtest_EngineNoopBackendDispatch(t *testing.T) {
 	scheme, c := setupSharedEnvtest(t)
 	_ = scheme
@@ -324,14 +297,12 @@ func TestAgentEnvtest_EngineNoopBackendDispatch(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	// Inject events via the backend, which the Engine pumps into the Router.
 	for i := 0; i < 5; i++ {
 		if !backend.Inject(&events.Event{CgroupID: cgID, Type: events.EventDNS}) {
 			t.Fatalf("inject: backend not started")
 		}
 	}
 
-	// Wait for the recorder to see all five events.
 	deadline := time.Now().Add(5 * time.Second)
 	for rec.count() < 5 {
 		if time.Now().After(deadline) {
@@ -345,5 +316,118 @@ func TestAgentEnvtest_EngineNoopBackendDispatch(t *testing.T) {
 	case <-engineDone:
 	case <-time.After(3 * time.Second):
 		t.Error("engine did not shut down cleanly")
+	}
+}
+
+func TestAgentEnvtest_TombstoneSurfacesOnNodeStatus(t *testing.T) {
+	scheme, c := setupSharedEnvtest(t)
+	_ = scheme
+	systemNS := ensureSystemNamespace(t, c)
+	ns := freshNamespace(t, c)
+	const node = "tombstone-node"
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	createRunningPod(t, c, ns, "svc", node, map[string]string{"app": "svc"})
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: "uid-tomb"},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "svc"}},
+			Filters:     []podtracev1alpha1.EventFilter{podtracev1alpha1.FilterDNS},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ignored"},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatalf("create pt: %v", err)
+	}
+	bundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operator.ExporterBundleName(pt.UID),
+			Namespace: systemNS,
+			Labels: map[string]string{
+				operator.LabelManagedBy: operator.ManagedByValue,
+				operator.LabelComponent: operator.ComponentBundle,
+			},
+		},
+		Data: map[string]string{"type": "jaeger", "endpoint": "http://jaeger:14250"},
+	}
+	if err := c.Create(ctx, bundle); err != nil {
+		t.Fatalf("create bundle: %v", err)
+	}
+
+	router := NewRouter(nil)
+	var buildShouldFail bool = true
+	r := &AgentReconciler{
+		Client:          c,
+		NodeName:        node,
+		SystemNamespace: systemNS,
+		Router:          router,
+		TargetsCh:       make(chan tracer.TargetSet, 4),
+		ExporterBuilder: func(p *BundlePayload, _ CRKey) (tracer.Exporter, error) {
+			if buildShouldFail {
+				return nil, fmt.Errorf("exporter type %q not yet implemented in agent mode", p.Type)
+			}
+			return &recordingExporter{name: "fixed"}, nil
+		},
+		CgroupResolver: func(pods []*corev1.Pod) (map[uint64]struct{}, error) {
+			out := map[uint64]struct{}{}
+			for range pods {
+				out[100] = struct{}{}
+			}
+			return out, nil
+		},
+		exporterCache: map[CRKey]cachedExporter{},
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: pt.Name}}); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	writer := &StatusWriter{Client: c, NodeName: node, Router: router, Ready: func() bool { return true }}
+	if err := writer.emitOnce(ctx); err != nil {
+		t.Fatalf("emitOnce 1: %v", err)
+	}
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: pt.Name}, &got); err != nil {
+		t.Fatalf("get pt 1: %v", err)
+	}
+	if len(got.Status.NodeStatus) != 1 {
+		t.Fatalf("rows after failure = %d, want 1", len(got.Status.NodeStatus))
+	}
+	row := got.Status.NodeStatus[0]
+	if row.Ready {
+		t.Error("Ready = true after build failure; want false")
+	}
+	if row.Message == "" {
+		t.Fatal("Message is empty after build failure; tombstone should surface the cause")
+	}
+	if !strings.Contains(row.Message, "build exporter") {
+		t.Errorf("Message = %q; expected 'build exporter:' prefix", row.Message)
+	}
+	if !strings.Contains(row.Message, "not yet implemented") {
+		t.Errorf("Message = %q; expected wrapped builder error", row.Message)
+	}
+
+	buildShouldFail = false
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: pt.Name}}); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	if err := writer.emitOnce(ctx); err != nil {
+		t.Fatalf("emitOnce 2: %v", err)
+	}
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: pt.Name}, &got); err != nil {
+		t.Fatalf("get pt 2: %v", err)
+	}
+	if len(got.Status.NodeStatus) != 1 {
+		t.Fatalf("rows after recovery = %d, want 1", len(got.Status.NodeStatus))
+	}
+	row = got.Status.NodeStatus[0]
+	if !row.Ready {
+		t.Errorf("Ready = false after recovery; want true. Message=%q", row.Message)
+	}
+	if row.Message != "" {
+		t.Errorf("Message = %q after recovery; want empty (stale messages confuse users)", row.Message)
 	}
 }

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -476,7 +477,13 @@ func TestReconcile_BundleNotFoundIsNonFatal(t *testing.T) {
 
 // TestReconcile_ExporterBuilderErrorIsNonFatal: builder failure logs
 // and continues; no rule is published for that CR.
-func TestReconcile_ExporterBuilderErrorIsNonFatal(t *testing.T) {
+// TestReconcile_ExporterBuilderErrorPublishesTombstone covers the
+// agent's failure-visibility contract for the most common case: a
+// bundle the agent does not know how to build (e.g. unsupported
+// exporter type). The reconcile must not crash, must publish a
+// tombstone rule (so the status writer can surface the cause on
+// NodeStatus.Message), and must not cache the failed exporter.
+func TestReconcile_ExporterBuilderErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-err")
 	pt := &podtracev1alpha1.PodTrace{
@@ -498,7 +505,7 @@ func TestReconcile_ExporterBuilderErrorIsNonFatal(t *testing.T) {
 		Client: c, NodeName: node, SystemNamespace: sysNS,
 		Router: NewRouter(nil), TargetsCh: make(chan tracer.TargetSet, 4),
 		ExporterBuilder: func(_ *BundlePayload, _ CRKey) (tracer.Exporter, error) {
-			return nil, errors.New("synthetic build error")
+			return nil, errors.New("not yet implemented")
 		},
 		CgroupResolver: func(_ []*corev1.Pod) (map[uint64]struct{}, error) {
 			return map[uint64]struct{}{1: {}}, nil
@@ -510,20 +517,48 @@ func TestReconcile_ExporterBuilderErrorIsNonFatal(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Reconcile must not propagate exporter-build errors: %v", err)
 	}
-	if got := len(r.Router.RulesSnapshot()); got != 0 {
-		t.Errorf("router should have no rules; got %d", got)
+
+	rules := r.Router.RulesSnapshot()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 tombstone rule, got %d", len(rules))
+	}
+	rule := rules[0]
+	if rule.Err == nil {
+		t.Fatal("tombstone rule must carry Err")
+	}
+	if rule.Exporter != nil {
+		t.Error("tombstone rule must have nil Exporter")
+	}
+	if !strings.Contains(rule.Err.Error(), "build exporter") {
+		t.Errorf("err = %q; expected 'build exporter:' prefix", rule.Err.Error())
+	}
+	if !strings.Contains(rule.Err.Error(), "not yet implemented") {
+		t.Errorf("err = %q; expected wrapped builder error", rule.Err.Error())
+	}
+	if len(rule.CgroupIDs) != 1 {
+		t.Errorf("CgroupIDs = %d, want 1 (kept for diagnostic visibility)", len(rule.CgroupIDs))
+	}
+	if rule.BundleRevision != "1" {
+		t.Errorf("BundleRevision = %q, want 1", rule.BundleRevision)
+	}
+
+	if _, cached := r.exporterCache[CRKey{Namespace: ns, Name: "pt"}]; cached {
+		t.Error("failed build must not leave a cached entry")
 	}
 }
 
-// TestReconcile_CgroupResolverErrorSkipsCR: resolver failure logs and
-// continues; no rule is published.
-func TestReconcile_CgroupResolverErrorSkipsCR(t *testing.T) {
+// TestReconcile_CgroupResolverErrorPublishesTombstone: resolver failure
+// produces a tombstone rule that carries the wrapped error and a nil
+// exporter. CgroupIDs is empty because resolution failed before we
+// could obtain them.
+func TestReconcile_CgroupResolverErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-cgerr")
 	pt := &podtracev1alpha1.PodTrace{
 		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: uid},
 		Spec: podtracev1alpha1.PodTraceSpec{
 			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Filters:     []podtracev1alpha1.EventFilter{podtracev1alpha1.FilterDNS},
 			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "x"},
 		},
 	}
@@ -550,8 +585,131 @@ func TestReconcile_CgroupResolverErrorSkipsCR(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if got := len(r.Router.RulesSnapshot()); got != 0 {
-		t.Errorf("router rules = %d, want 0", got)
+	rules := r.Router.RulesSnapshot()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 tombstone rule, got %d", len(rules))
+	}
+	if rules[0].Err == nil || !strings.Contains(rules[0].Err.Error(), "resolve cgroup IDs") {
+		t.Errorf("err = %v; expected 'resolve cgroup IDs:' prefix", rules[0].Err)
+	}
+	if rules[0].Exporter != nil {
+		t.Error("tombstone rule must have nil Exporter")
+	}
+	if _, ok := rules[0].Filters[events.EventDNS]; !ok {
+		t.Error("Filters not preserved on tombstone")
+	}
+}
+
+// TestReconcile_BundleLoadErrorPublishesTombstone covers the non-
+// NotFound bundle load failure path: a real apiserver / network error
+// must tombstone the rule, but NotFound (operator hasn't synced yet)
+// must stay a silent skip — see TestReconcile_BundleNotFoundIsNonFatal.
+func TestReconcile_BundleLoadErrorPublishesTombstone(t *testing.T) {
+	const node, sysNS, ns = "n", "ns-sys", "default"
+	uid := types.UID("uid-bundle-err")
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: uid},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "x"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns, Labels: map[string]string{"a": "b"}},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	badCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operator.ExporterBundleName(uid),
+			Namespace: sysNS,
+			Labels: map[string]string{
+				operator.LabelManagedBy: operator.ManagedByValue,
+				operator.LabelComponent: operator.ComponentBundle,
+			},
+		},
+		Data: map[string]string{"type": "otlp", "sample_percent": "not-a-number"},
+	}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(pt, pod, badCM).Build()
+	r := &AgentReconciler{
+		Client: c, NodeName: node, SystemNamespace: sysNS,
+		Router: NewRouter(nil), TargetsCh: make(chan tracer.TargetSet, 4),
+		ExporterBuilder: func(_ *BundlePayload, _ CRKey) (tracer.Exporter, error) {
+			t.Fatal("ExporterBuilder must not be called when bundle parsing fails")
+			return nil, nil
+		},
+		CgroupResolver: func(_ []*corev1.Pod) (map[uint64]struct{}, error) {
+			return map[uint64]struct{}{1: {}}, nil
+		},
+		exporterCache: map[CRKey]cachedExporter{},
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: "pt"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rules := r.Router.RulesSnapshot()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 tombstone rule, got %d", len(rules))
+	}
+	if rules[0].Err == nil || !strings.Contains(rules[0].Err.Error(), "load bundle") {
+		t.Errorf("err = %v; expected 'load bundle:' prefix", rules[0].Err)
+	}
+	if rules[0].Exporter != nil {
+		t.Error("tombstone rule must have nil Exporter")
+	}
+}
+
+// TestReconcile_MatchPodsErrorPublishesTombstone covers the defensive
+// tombstone for selector evaluation. The webhook normally catches bad
+// label selectors at admission; this test verifies the agent's belt-
+// and-braces behaviour when an invalid selector somehow reaches it.
+func TestReconcile_MatchPodsErrorPublishesTombstone(t *testing.T) {
+	const node, sysNS, ns = "n", "ns-sys", "default"
+	uid := types.UID("uid-match-err")
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: uid},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "k", Operator: "bogus-op", Values: []string{"v"}},
+				},
+			},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "x"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(pt, pod, makeBundleCM(sysNS, uid, "1")).Build()
+	r := &AgentReconciler{
+		Client: c, NodeName: node, SystemNamespace: sysNS,
+		Router: NewRouter(nil), TargetsCh: make(chan tracer.TargetSet, 4),
+		ExporterBuilder: func(_ *BundlePayload, _ CRKey) (tracer.Exporter, error) {
+			t.Fatal("ExporterBuilder must not be called when match fails")
+			return nil, nil
+		},
+		CgroupResolver: func(_ []*corev1.Pod) (map[uint64]struct{}, error) {
+			t.Fatal("CgroupResolver must not be called when match fails")
+			return nil, nil
+		},
+		exporterCache: map[CRKey]cachedExporter{},
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: "pt"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rules := r.Router.RulesSnapshot()
+	if len(rules) != 1 {
+		t.Fatalf("want 1 tombstone rule, got %d", len(rules))
+	}
+	if rules[0].Err == nil || !strings.Contains(rules[0].Err.Error(), "match pods") {
+		t.Errorf("err = %v; expected 'match pods:' prefix", rules[0].Err)
 	}
 }
 

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -38,13 +38,6 @@ func NewRouter(stats *perCRStats) *Router {
 	}
 }
 
-// Publish atomically replaces the rule set. Callers must supply a
-// *complete* snapshot; Publish does not merge. Rules are deep-copied
-// defensively so the caller is free to mutate its own copy afterward.
-//
-// Per-CR stats are preserved for CRs that still appear in the new
-// snapshot and dropped for CRs that are removed — so a CR that blinks
-// out and back does not accumulate stale counters.
 func (r *Router) Publish(rules []CRRule) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -56,7 +49,6 @@ func (r *Router) Publish(rules []CRRule) {
 		seen[rule.Key] = struct{}{}
 	}
 
-	// Drop stats for any CR that disappeared from this publish.
 	for existing := range r.stats.snapshot() {
 		if _, ok := seen[existing]; !ok {
 			r.stats.drop(existing)
@@ -66,9 +58,6 @@ func (r *Router) Publish(rules []CRRule) {
 	r.rules = cp
 }
 
-// Snapshot returns the union of cgroup IDs across all active rules —
-// the set the tracer should currently be attached to. Order is not
-// guaranteed; uniqueness is.
 func (r *Router) Snapshot() []uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -86,10 +75,6 @@ func (r *Router) Snapshot() []uint64 {
 	return out
 }
 
-// FilterUnion returns the union of enabled event filters across all
-// active rules. The tracer uses this to decide which kprobe categories
-// to attach kernel-side — attaching a kprobe nobody consumes wastes
-// per-event CPU.
 func (r *Router) FilterUnion() []events.EventType {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -107,8 +92,6 @@ func (r *Router) FilterUnion() []events.EventType {
 	return out
 }
 
-// RulesSnapshot returns a read-only copy of the current rules. Used by
-// the status writer and by tests.
 func (r *Router) RulesSnapshot() []CRRule {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -117,25 +100,10 @@ func (r *Router) RulesSnapshot() []CRRule {
 	return out
 }
 
-// Stats exposes the shared per-CR counter table.
 func (r *Router) Stats() *perCRStats { return r.stats }
 
-// Name implements tracer.Exporter.
 func (r *Router) Name() string { return "cr-router" }
 
-// Export implements tracer.Exporter. It dispatches each event in the
-// batch to the subset of CR exporters whose cgroup set contains the
-// event's CgroupID AND whose filters include the event's type.
-//
-// A single event may fan out to multiple exporters (overlapping CRs)
-// or to none (an event from a cgroup no CR currently claims — rare,
-// usually means the tracer saw a detach-in-progress). In either case
-// we count the event against every CR that received it.
-//
-// Dispatch errors from one exporter must not abort delivery to others;
-// the router records the error via incrDropped and continues. This
-// matches pkg/tracer.Engine's contract that exporter failures are
-// non-fatal.
 func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	r.mu.RLock()
 	rules := r.rules
@@ -145,8 +113,6 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 		return nil
 	}
 
-	// Per-rule filtered batches: amortises allocations when many rules
-	// overlap the same cgroup set.
 	filtered := make([][]*events.Event, len(rules))
 	for i := range rules {
 		filtered[i] = filtered[i][:0]
@@ -157,6 +123,9 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 			continue
 		}
 		for i := range rules {
+			if rules[i].Err != nil || rules[i].Exporter == nil {
+				continue
+			}
 			if !matchRule(&rules[i], ev) {
 				continue
 			}
@@ -168,6 +137,9 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 		if len(filtered[i]) == 0 {
 			continue
 		}
+		if rules[i].Exporter == nil {
+			continue
+		}
 		if err := rules[i].Exporter.Export(ctx, filtered[i]); err != nil {
 			r.stats.incrDropped(rules[i].Key, int64(len(filtered[i])))
 			continue
@@ -177,8 +149,6 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	return nil
 }
 
-// Close implements tracer.Exporter. Called once during tracer shutdown.
-// Closes every downstream exporter; collects errors but never fails fast.
 func (r *Router) Close(ctx context.Context) error {
 	r.mu.Lock()
 	rules := r.rules
@@ -194,24 +164,10 @@ func (r *Router) Close(ctx context.Context) error {
 	return nil
 }
 
-// matchRule returns true when event `ev` should be delivered to the
-// exporter for `rule`. Both conditions must hold:
-//
-//  1. The event's cgroup ID is in the rule's cgroup set (the rule's
-//     PodTrace claims that pod right now).
-//  2. The event's type is enabled in the rule's filter set (the rule's
-//     PodTrace opted into that event category).
-//
-// Rule (1) relies on the kernel's cgroup-ID delivery semantics: our
-// kprobes stamp the task's cgroup inode on each event, so the agent
-// can route without knowing the per-pod path.
 func matchRule(rule *CRRule, ev *events.Event) bool {
 	if _, ok := rule.CgroupIDs[ev.CgroupID]; !ok {
 		return false
 	}
-	// Empty filter set means "no categories accepted" rather than "all
-	// accepted" — the operator always seeds a non-empty default, but we
-	// defend against an empty CR spec here to avoid a silent flood.
 	if len(rule.Filters) == 0 {
 		return false
 	}
@@ -219,16 +175,13 @@ func matchRule(rule *CRRule, ev *events.Event) bool {
 	return ok
 }
 
-// cloneCRRule returns a defensive copy of a CRRule. The maps are
-// reallocated; the Exporter reference is shared (Exporters are
-// intentionally long-lived — constructing one on every Publish would
-// reopen connections).
 func cloneCRRule(in CRRule) CRRule {
 	out := CRRule{
 		Key:            in.Key,
 		Exporter:       in.Exporter,
 		BundleRevision: in.BundleRevision,
 		MatchedPods:    in.MatchedPods,
+		Err:            in.Err,
 	}
 	if in.CgroupIDs != nil {
 		out.CgroupIDs = make(map[uint64]struct{}, len(in.CgroupIDs))

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -130,15 +130,12 @@ func TestRouter_ExporterErrorIsCountedAsDrop(t *testing.T) {
 	if stats[CRKey{"ns", "ok"}].Events != 1 {
 		t.Errorf("healthy exporter should still receive event, got %+v", stats[CRKey{"ns", "ok"}])
 	}
-	// One bad exporter must not prevent the other from getting events.
 	if good.count() != 1 {
 		t.Errorf("good exporter count=%d, want 1", good.count())
 	}
 }
 
 func TestRouter_EmptyFiltersDeliversNothing(t *testing.T) {
-	// Empty filter set must be "deny all" rather than "match all" — a
-	// misconfigured CR should not produce a flood.
 	exp := &recExp{name: "x"}
 	r := NewRouter(nil)
 	r.Publish([]CRRule{
@@ -188,6 +185,77 @@ func TestRouter_PublishDropsStaleStats(t *testing.T) {
 	}
 }
 
+// TestRouter_Export_SkipsTombstoneRules covers the router's tombstone
+// contract: a CRRule with Err != nil (or Exporter == nil) must be
+// dropped during dispatch — never NPE, never deliver events to a nil
+// exporter, never count the tombstone as a successful or dropped
+// delivery. Healthy rules sharing the same cgroup must still receive
+// their events.
+func TestRouter_Export_SkipsTombstoneRules(t *testing.T) {
+	good := &recExp{name: "good"}
+	r := NewRouter(nil)
+	r.Publish([]CRRule{
+		{
+			Key:       CRKey{"ns", "tomb"},
+			CgroupIDs: map[uint64]struct{}{1: {}},
+			Filters:   map[events.EventType]struct{}{events.EventDNS: {}},
+			Exporter:  nil,
+			Err:       errors.New("build exporter: not yet implemented"),
+		},
+		mkRule("ns", "ok", []uint64{1}, []events.EventType{events.EventDNS}, good),
+	})
+
+	batch := []*events.Event{{CgroupID: 1, Type: events.EventDNS}}
+	if err := r.Export(context.Background(), batch); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if good.count() != 1 {
+		t.Errorf("healthy exporter count = %d, want 1", good.count())
+	}
+	stats := r.Stats().snapshot()
+	if stats[CRKey{"ns", "tomb"}].Events != 0 || stats[CRKey{"ns", "tomb"}].Dropped != 0 {
+		t.Errorf("tombstone must not bump any counter, got %+v", stats[CRKey{"ns", "tomb"}])
+	}
+	if stats[CRKey{"ns", "ok"}].Events != 1 {
+		t.Errorf("healthy CR events = %d, want 1", stats[CRKey{"ns", "ok"}].Events)
+	}
+}
+
+// TestRouter_Export_TombstoneWithNilExporterButNoErr defends against
+// a hypothetical caller that builds a CRRule with Exporter==nil but
+// forgot to set Err. The dispatch path must still skip it rather than
+// NPE — Exporter==nil is the canonical "do not dispatch" signal.
+func TestRouter_Export_TombstoneWithNilExporterButNoErr(t *testing.T) {
+	r := NewRouter(nil)
+	r.Publish([]CRRule{
+		{
+			Key:       CRKey{"ns", "nilexp"},
+			CgroupIDs: map[uint64]struct{}{1: {}},
+			Filters:   map[events.EventType]struct{}{events.EventDNS: {}},
+			Exporter:  nil,
+		},
+	})
+	if err := r.Export(context.Background(), []*events.Event{{CgroupID: 1, Type: events.EventDNS}}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+}
+
+// TestRouter_Close_TombstonesAreSafeToClose asserts that Close handles
+// tombstone rules (Exporter == nil) without panicking. Documents that
+// the router's shutdown path coexists with the reconciler's tombstone
+// pattern.
+func TestRouter_Close_TombstonesAreSafeToClose(t *testing.T) {
+	r := NewRouter(nil)
+	r.Publish([]CRRule{
+		{Key: CRKey{"ns", "tomb"}, Err: errors.New("x")},
+		mkRule("ns", "ok", []uint64{1}, []events.EventType{events.EventDNS}, &recExp{name: "ok"}),
+	})
+	if err := r.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestRouter_ConcurrentExportAndPublish(t *testing.T) {
 	r := NewRouter(nil)
 	exp := &recExp{name: "e"}
@@ -211,8 +279,6 @@ func TestRouter_ConcurrentExportAndPublish(t *testing.T) {
 		}
 	}()
 	wg.Wait()
-	// No deadlock, no race (run with -race). Exact counts are
-	// non-deterministic; correctness is that we returned at all.
 }
 
 // helpers

--- a/internal/agent/status_writer.go
+++ b/internal/agent/status_writer.go
@@ -12,20 +12,8 @@ import (
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
 
-// DefaultStatusReportInterval matches the TracerConfig default. Tests
-// override to a much shorter interval.
 const DefaultStatusReportInterval = 30 * time.Second
 
-// StatusWriter patches PodTrace.status.nodeStatus on a timer. One entry
-// per node is maintained, keyed on the node name via the
-// `patchMergeKey: "node"` strategic-merge marker declared on the Go
-// field. Many agents writing concurrently therefore do not overwrite
-// each other's entries.
-//
-// The writer never reads per-CR state directly — it takes a snapshot
-// from the router (for cgroup counts) and the per-CR stats table (for
-// events/drops) under the router's own lock. This keeps status writes
-// off the event hot path.
 type StatusWriter struct {
 	Client   client.Client
 	NodeName string
@@ -35,8 +23,6 @@ type StatusWriter struct {
 	Ready func() bool
 }
 
-// Run blocks until ctx is done, emitting status patches every
-// Interval. Safe to call at most once per StatusWriter instance.
 func (w *StatusWriter) Run(ctx context.Context) error {
 	interval := w.Interval
 	if interval <= 0 {
@@ -59,34 +45,37 @@ func (w *StatusWriter) Run(ctx context.Context) error {
 	}
 }
 
-// emitOnce walks every active CR rule and patches that CR's
-// status.nodeStatus with the writer's row. Errors are returned
-// per-tick (not per-CR) so the Run loop can log one line rather than
-// spamming one per CR.
 func (w *StatusWriter) emitOnce(ctx context.Context) error {
 	rules := w.Router.RulesSnapshot()
 	stats := w.Router.Stats().snapshot()
-	ready := true
+	agentReady := true
 	if w.Ready != nil {
-		ready = w.Ready()
+		agentReady = w.Ready()
 	}
 
 	var firstErr error
 	for _, rule := range rules {
-		counters := stats[rule.Key]
-		entry := podtracev1alpha1.PodTraceNodeStatus{
-			Node:          w.NodeName,
-			Ready:         ready,
-			ActiveCgroups: lenToInt32(len(rule.CgroupIDs)),
-			EventsTotal:   counters.Events,
-			DroppedEvents: counters.Dropped,
-			LastHeartbeat: metav1.NewTime(time.Now()),
-		}
+		entry := buildNodeStatusEntry(w.NodeName, &rule, stats[rule.Key], agentReady, time.Now())
 		if err := w.patchCRStatus(ctx, rule.Key, entry); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
+}
+
+func buildNodeStatusEntry(node string, rule *CRRule, counters crCounters, agentReady bool, now time.Time) podtracev1alpha1.PodTraceNodeStatus {
+	entry := podtracev1alpha1.PodTraceNodeStatus{
+		Node:          node,
+		Ready:         agentReady && rule.Err == nil,
+		ActiveCgroups: lenToInt32(len(rule.CgroupIDs)),
+		EventsTotal:   counters.Events,
+		DroppedEvents: counters.Dropped,
+		LastHeartbeat: metav1.NewTime(now),
+	}
+	if rule.Err != nil {
+		entry.Message = rule.Err.Error()
+	}
+	return entry
 }
 
 func (w *StatusWriter) patchCRStatus(ctx context.Context, key CRKey, entry podtracev1alpha1.PodTraceNodeStatus) error {
@@ -107,10 +96,6 @@ func (w *StatusWriter) patchCRStatus(ctx context.Context, key CRKey, entry podtr
 	)
 }
 
-// ComputeNodeReport assembles the aggregate counters a liveness
-// handler might expose. Split out so the probes package and the
-// /metrics server can share the same view without duplicating the
-// snapshotting code.
 func ComputeNodeReport(nodeName string, router *Router, ready bool) NodeReport {
 	rules := router.RulesSnapshot()
 	stats := router.Stats().snapshot()
@@ -139,6 +124,4 @@ func ComputeNodeReport(nodeName string, router *Router, ready bool) NodeReport {
 	}
 }
 
-// compile-time assertion we do not accidentally lose thread-safety by
-// adding a mutable field.
 var _ sync.Locker = (*sync.Mutex)(nil)

--- a/internal/agent/status_writer_test.go
+++ b/internal/agent/status_writer_test.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/podtrace/podtrace/internal/events"
 )
@@ -42,5 +44,106 @@ func TestComputeNodeReport_EmptyRouterIsZeroed(t *testing.T) {
 	}
 	if rep.Node != "node-x" {
 		t.Errorf("Node=%q want node-x", rep.Node)
+	}
+}
+
+// TestBuildNodeStatusEntry covers the Phase 0 contract: how a CRRule
+// — healthy, tombstoned, or running on an unready agent — gets
+// rendered onto the PodTrace.status.nodeStatus row that the status
+// writer patches. The apiserver round-trip is exercised by the
+// envtest in reconciler_envtest_test.go.
+func TestBuildNodeStatusEntry(t *testing.T) {
+	const node = "node-x"
+	now := time.Now()
+
+	cases := []struct {
+		name          string
+		rule          *CRRule
+		counters      crCounters
+		agentReady    bool
+		wantReady     bool
+		wantMessage   string
+		wantCgroups   int32
+		wantEvents    int64
+		wantDropped   int64
+	}{
+		{
+			name: "HealthyRule",
+			rule: &CRRule{
+				Key:       CRKey{"ns", "ok"},
+				CgroupIDs: map[uint64]struct{}{1: {}, 2: {}},
+				Exporter:  &recExp{},
+			},
+			counters:    crCounters{Events: 7, Dropped: 3},
+			agentReady:  true,
+			wantReady:   true,
+			wantCgroups: 2,
+			wantEvents:  7,
+			wantDropped: 3,
+		},
+		{
+			name: "TombstoneOnHealthyAgent",
+			rule: &CRRule{
+				Key:       CRKey{"ns", "tomb"},
+				CgroupIDs: map[uint64]struct{}{42: {}},
+				Err:       errors.New("build exporter: not yet implemented in agent mode"),
+			},
+			counters:    crCounters{},
+			agentReady:  true,
+			wantReady:   false,
+			wantMessage: "build exporter: not yet implemented in agent mode",
+			wantCgroups: 1,
+		},
+		{
+			name: "HealthyRuleOnUnreadyAgent",
+			rule: &CRRule{
+				Key:       CRKey{"ns", "ok"},
+				CgroupIDs: map[uint64]struct{}{1: {}},
+				Exporter:  &recExp{},
+			},
+			counters:   crCounters{Events: 1},
+			agentReady: false,
+			wantReady:  false,
+			wantEvents: 1,
+			wantCgroups: 1,
+		},
+		{
+			name: "TombstoneOnUnreadyAgent",
+			rule: &CRRule{
+				Key: CRKey{"ns", "tomb"},
+				Err: errors.New("load bundle: parse error"),
+			},
+			counters:    crCounters{},
+			agentReady:  false,
+			wantReady:   false,
+			wantMessage: "load bundle: parse error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildNodeStatusEntry(node, tc.rule, tc.counters, tc.agentReady, now)
+			if got.Node != node {
+				t.Errorf("Node = %q, want %q", got.Node, node)
+			}
+			if got.Ready != tc.wantReady {
+				t.Errorf("Ready = %v, want %v", got.Ready, tc.wantReady)
+			}
+			if got.Message != tc.wantMessage {
+				t.Errorf("Message = %q, want %q", got.Message, tc.wantMessage)
+			}
+			if got.ActiveCgroups != tc.wantCgroups {
+				t.Errorf("ActiveCgroups = %d, want %d", got.ActiveCgroups, tc.wantCgroups)
+			}
+			if got.EventsTotal != tc.wantEvents {
+				t.Errorf("EventsTotal = %d, want %d", got.EventsTotal, tc.wantEvents)
+			}
+			if got.DroppedEvents != tc.wantDropped {
+				t.Errorf("DroppedEvents = %d, want %d", got.DroppedEvents, tc.wantDropped)
+			}
+			if got.LastHeartbeat.Time.IsZero() {
+				t.Error("LastHeartbeat must be set")
+			}
+		})
 	}
 }

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -15,16 +15,8 @@ import (
 	"github.com/podtrace/podtrace/pkg/tracer"
 )
 
-// NodeName is supplied by the agent DaemonSet via the downward API
-// ($NODE_NAME). It scopes every informer filter and every status patch.
-// Kept as a package-level string rather than threaded everywhere
-// because it is set once at process start and never changes.
 type NodeName string
 
-// CRKey uniquely identifies a PodTrace CR cluster-wide.
-// (namespace, name) is guaranteed unique by the apiserver; we do not
-// use UID because it is not stable across recreate-with-same-name and
-// our router rules are keyed on user-facing identity.
 type CRKey struct {
 	Namespace string
 	Name      string
@@ -32,25 +24,19 @@ type CRKey struct {
 
 func (k CRKey) String() string { return k.Namespace + "/" + k.Name }
 
-// CRRule is the per-CR snapshot the router needs to route events.
-// Assembled by the reconcile loop from matched pods + exporter bundles
-// and handed to the router as a complete replacement each time
-// anything under the CR changes. Immutable once published.
 type CRRule struct {
 	Key       CRKey
-	CgroupIDs map[uint64]struct{}   // kernel cgroup inode numbers the tracer will see on events
+	CgroupIDs map[uint64]struct{} // kernel cgroup inode numbers the tracer will see on events
 	Filters   map[events.EventType]struct{}
 	Exporter  tracer.Exporter
 
-	// BundleRevision is the ResourceVersion of the exporter bundle
-	// ConfigMap+Secret used to construct Exporter. Recorded so the
-	// reconcile loop can detect credential rotation without recreating
-	// an identical exporter.
 	BundleRevision string
 
 	// MatchedPods is the count of local pods currently satisfying the
 	// CR's selector. Status writer reports this on status.nodeStatus.
 	MatchedPods int32
+
+	Err error
 }
 
 // NodeReport aggregates the counters the status writer reports on one

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -30,9 +30,6 @@ import (
 //   - Aggregates status.conditions from the per-node status entries
 //     written directly by agents. It does NOT touch status.nodeStatus —
 //     that array is agent-owned and patched via merge.
-//
-// The agent is not in the hot path: status rollup runs on the standard
-// reconcile cadence, not per-event.
 type PodTraceReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
@@ -56,8 +53,6 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("get PodTrace: %w", err)
 	}
 
-	// Deletion path: tear down cross-namespace children first, then
-	// release the finalizer so the apiserver actually removes the CR.
 	if !pt.DeletionTimestamp.IsZero() {
 		if err := cleanupPodTraceChildren(ctx, r.Client, &pt, r.SystemNamespace); err != nil {
 			return ctrl.Result{}, err
@@ -73,8 +68,6 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err := r.Update(ctx, &pt); err != nil {
 			return ctrl.Result{}, fmt.Errorf("set finalizer: %w", err)
 		}
-		// Re-queue; the Update mutated the object and we want a fresh
-		// Get before running the rest of the reconcile.
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -85,7 +78,6 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	r.setCondition(&pt, ConditionPaused, metav1.ConditionFalse, "NotPaused", "")
 
-	// Resolve the exporter. Its readiness gates bundle sync.
 	var ec podtracev1alpha1.ExporterConfig
 	ecKey := types.NamespacedName{Namespace: pt.Namespace, Name: pt.Spec.ExporterRef.Name}
 	if err := r.Get(ctx, ecKey, &ec); err != nil {
@@ -105,11 +97,14 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		_ = r.Status().Update(ctx, &pt)
 		return ctrl.Result{}, err
 	}
-	r.setCondition(&pt, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
 
-	// matchedPods and ready-rollup are conservative when there are no
-	// per-node reports yet (first reconcile). Agents patch status.nodeStatus
-	// every ~30s (StatusReportInterval), after which this rollup is accurate.
+	if node, msg, ok := firstDegradedNode(pt.Status.NodeStatus); ok {
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "AgentNodeStatus",
+			fmt.Sprintf("node %s: %s", node, msg))
+	} else {
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
+	}
+
 	pt.Status.MatchedPods = countReadyPods(pt.Status.NodeStatus)
 	allReady := len(pt.Status.NodeStatus) > 0 && allNodesReady(pt.Status.NodeStatus)
 	r.setCondition(&pt, ConditionReady, conditionStatusFromBool(allReady), "AgentsReady",
@@ -159,14 +154,6 @@ func (r *PodTraceReconciler) exporterConfigToPodTraces(ctx context.Context, obj 
 	return reqs
 }
 
-// syncExporterBundle creates / updates the per-PodTrace ConfigMap+Secret
-// in the system namespace. The ConfigMap carries endpoint metadata that
-// agents use to construct the exporter; the Secret carries the resolved
-// credential material (copied from user-namespace Secrets at sync time).
-//
-// One bundle per PodTrace simplifies the agent-side view: an agent looks
-// up "the bundle for PodTrace X" and that is the ground truth for
-// everything needed to export its events.
 func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig) error {
 	systemNS := r.SystemNamespace
 	name := ExporterBundleName(pt.UID)
@@ -183,9 +170,6 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 			LabelExporterConfig: ec.Name,
 		}),
 	}
-	// No ownerReference: Kubernetes forbids a namespaced owner (PodTrace)
-	// from owning a child in a different namespace. Finalizer + label-
-	// based cleanup handles deletion — see finalizer.go.
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
 		cm.Labels = mergeLabels(cm.Labels, map[string]string{
 			LabelManagedBy:      ManagedByValue,
@@ -203,9 +187,6 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 		return fmt.Errorf("bundle ConfigMap: %w", err)
 	}
 
-	// Only create a companion Secret when the exporter actually references
-	// one. Exporters without credentials (e.g. plain Jaeger/Zipkin) get a
-	// ConfigMap-only bundle.
 	if credSecretRef != nil {
 		credData, err := r.loadCredentialSecret(ctx, ec.Namespace, *credSecretRef)
 		if err != nil {
@@ -255,7 +236,6 @@ func (r *PodTraceReconciler) loadCredentialSecret(ctx context.Context, namespace
 	return map[string][]byte{"credential": val}, nil
 }
 
-// setCondition, scoped to PodTrace status.
 func (r *PodTraceReconciler) setCondition(pt *podtracev1alpha1.PodTrace, condType string, status metav1.ConditionStatus, reason, message string) {
 	pt.Status.Conditions = upsertCondition(pt.Status.Conditions, metav1.Condition{
 		Type:               condType,
@@ -274,6 +254,27 @@ func allNodesReady(ns []podtracev1alpha1.PodTraceNodeStatus) bool {
 		}
 	}
 	return true
+}
+
+// firstDegradedNode returns the (node, message) of the lexicographically
+// first NodeStatus row that an agent has tombstoned (Ready=false with a
+// non-empty Message). The lexicographic pick keeps the rolled-up
+// condition stable across reconciles when multiple nodes report errors;
+// users see one representative cause and can run
+//   kubectl get podtrace -o jsonpath
+// to enumerate the rest.
+func firstDegradedNode(ns []podtracev1alpha1.PodTraceNodeStatus) (node, message string, ok bool) {
+	for _, n := range ns {
+		if n.Ready || n.Message == "" {
+			continue
+		}
+		if !ok || n.Node < node {
+			node = n.Node
+			message = n.Message
+			ok = true
+		}
+	}
+	return node, message, ok
 }
 
 // countReadyPods sums activeCgroups across all per-node reports as a

--- a/internal/operator/podtrace_controller_test.go
+++ b/internal/operator/podtrace_controller_test.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,13 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
 
-// TestPodTraceReconciler_EnvtestBundleSync_OTLPLiteral asserts the happy
-// path for a credential-less OTLP exporter: a ConfigMap lands in the
-// system namespace with correct data, no companion Secret.
 func TestPodTraceReconciler_EnvtestBundleSync_OTLPLiteral(t *testing.T) {
 	scheme, c, ns := setupSharedEnvtest(t)
 	systemNS := ensureSystemNamespace(t, c)
@@ -77,10 +76,6 @@ func TestPodTraceReconciler_EnvtestBundleSync_OTLPLiteral(t *testing.T) {
 	}
 }
 
-// TestPodTraceReconciler_EnvtestBundleSync_SecretCredentials covers the
-// DataDog path: operator must read the user-namespace Secret, copy its
-// key into the system-namespace bundle Secret, and leave the original
-// Secret untouched.
 func TestPodTraceReconciler_EnvtestBundleSync_SecretCredentials(t *testing.T) {
 	scheme, c, ns := setupSharedEnvtest(t)
 	systemNS := ensureSystemNamespace(t, c)
@@ -150,10 +145,6 @@ func TestPodTraceReconciler_EnvtestBundleSync_SecretCredentials(t *testing.T) {
 	}
 }
 
-// TestPodTraceReconciler_EnvtestExporterRefMissing exercises the
-// fail-closed path: when the referenced ExporterConfig does not exist,
-// the reconciler must set Degraded=True with a clear reason instead of
-// erroring out.
 func TestPodTraceReconciler_EnvtestExporterRefMissing(t *testing.T) {
 	scheme, c, ns := setupSharedEnvtest(t)
 	systemNS := ensureSystemNamespace(t, c)
@@ -173,7 +164,6 @@ func TestPodTraceReconciler_EnvtestExporterRefMissing(t *testing.T) {
 
 	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
 
-	// Loop-reconcile past the finalizer-add Requeue until Degraded shows up.
 	reconcileUntil(t, 10*time.Second,
 		func() error {
 			var got podtracev1alpha1.PodTrace
@@ -198,6 +188,114 @@ func TestPodTraceReconciler_EnvtestExporterRefMissing(t *testing.T) {
 	if !conditionIs(got.Status.Conditions, ConditionReady, metav1.ConditionFalse) {
 		t.Errorf("expected Ready=False, got %+v", got.Status.Conditions)
 	}
+}
+
+func TestPodTraceReconciler_DegradedRollupFromNodeStatus(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	if err := c.Create(ctx, ec); err != nil {
+		t.Fatal(err)
+	}
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-agent-failure", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var got podtracev1alpha1.PodTrace
+			if err := c.Get(ctx, types.NamespacedName{Name: pt.Name, Namespace: ns}, &got); err != nil {
+				return err
+			}
+			if !conditionIs(got.Status.Conditions, ConditionDegraded, metav1.ConditionFalse) {
+				return fmt.Errorf("Degraded not yet False (baseline): %+v", got.Status.Conditions)
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
+
+	agentPatch := &podtracev1alpha1.PodTrace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: podtracev1alpha1.GroupVersion.String(),
+			Kind:       "PodTrace",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: pt.Name, Namespace: ns},
+		Status: podtracev1alpha1.PodTraceStatus{
+			NodeStatus: []podtracev1alpha1.PodTraceNodeStatus{
+				{
+					Node:          "broken-1",
+					Ready:         false,
+					Message:       "build exporter: exporter type \"jaeger\" not yet implemented in agent mode",
+					LastHeartbeat: metav1.Now(),
+				},
+			},
+		},
+	}
+	if err := c.Status().Patch(ctx, agentPatch,
+		client.Apply,
+		client.FieldOwner("podtrace-agent-broken-1"),
+		client.ForceOwnership,
+	); err != nil {
+		t.Fatalf("agent status patch: %v", err)
+	}
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var got podtracev1alpha1.PodTrace
+			if err := c.Get(ctx, types.NamespacedName{Name: pt.Name, Namespace: ns}, &got); err != nil {
+				return err
+			}
+			var cond *metav1.Condition
+			for i := range got.Status.Conditions {
+				if got.Status.Conditions[i].Type == ConditionDegraded {
+					cond = &got.Status.Conditions[i]
+					break
+				}
+			}
+			if cond == nil {
+				return fmt.Errorf("Degraded condition missing")
+			}
+			if cond.Status != metav1.ConditionTrue {
+				return fmt.Errorf("Degraded status = %q, want True", cond.Status)
+			}
+			if cond.Reason != "AgentNodeStatus" {
+				return fmt.Errorf("Degraded reason = %q, want AgentNodeStatus", cond.Reason)
+			}
+			if !strings.Contains(cond.Message, "broken-1") {
+				return fmt.Errorf("Degraded message = %q, want it to name node 'broken-1'", cond.Message)
+			}
+			if !strings.Contains(cond.Message, "not yet implemented") {
+				return fmt.Errorf("Degraded message = %q, want it to surface the agent's cause", cond.Message)
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
 }
 
 func conditionIs(conds []metav1.Condition, condType string, want metav1.ConditionStatus) bool {

--- a/internal/operator/podtrace_controller_unit_test.go
+++ b/internal/operator/podtrace_controller_unit_test.go
@@ -1,0 +1,88 @@
+package operator
+
+import (
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TestFirstDegradedNode pins the rollup contract that turns one or more
+// agent-reported per-node failures into a single ConditionDegraded
+// message on the parent PodTrace. The rule: pick the lexicographically
+// first failing node so the rolled-up message stays stable across
+// reconciles when multiple nodes report errors at the same time.
+func TestFirstDegradedNode(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          []podtracev1alpha1.PodTraceNodeStatus
+		wantNode    string
+		wantMessage string
+		wantOK      bool
+	}{
+		{
+			name:   "EmptyInputReturnsNotOK",
+			in:     nil,
+			wantOK: false,
+		},
+		{
+			name: "OnlyHealthyRowsReturnsNotOK",
+			in: []podtracev1alpha1.PodTraceNodeStatus{
+				{Node: "a", Ready: true, Message: ""},
+				{Node: "b", Ready: true, Message: "stale message that should be ignored"},
+			},
+			wantOK: false,
+		},
+		{
+			name: "ReadyFalseWithoutMessageReturnsNotOK",
+			in: []podtracev1alpha1.PodTraceNodeStatus{
+				{Node: "a", Ready: false, Message: ""},
+			},
+			wantOK: false,
+		},
+		{
+			name: "SingleDegradedRow",
+			in: []podtracev1alpha1.PodTraceNodeStatus{
+				{Node: "n1", Ready: false, Message: "build exporter: not yet implemented"},
+			},
+			wantNode:    "n1",
+			wantMessage: "build exporter: not yet implemented",
+			wantOK:      true,
+		},
+		{
+			name: "PicksLexicographicallyFirstNode",
+			in: []podtracev1alpha1.PodTraceNodeStatus{
+				{Node: "zeta", Ready: false, Message: "z failed"},
+				{Node: "alpha", Ready: false, Message: "a failed"},
+				{Node: "mu", Ready: false, Message: "m failed"},
+			},
+			wantNode:    "alpha",
+			wantMessage: "a failed",
+			wantOK:      true,
+		},
+		{
+			name: "MixHealthyAndDegraded",
+			in: []podtracev1alpha1.PodTraceNodeStatus{
+				{Node: "healthy-z", Ready: true},
+				{Node: "broken-m", Ready: false, Message: "load bundle: timeout"},
+				{Node: "healthy-a", Ready: true},
+			},
+			wantNode:    "broken-m",
+			wantMessage: "load bundle: timeout",
+			wantOK:      true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotNode, gotMsg, gotOK := firstDegradedNode(tc.in)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotNode != tc.wantNode {
+				t.Errorf("node = %q, want %q", gotNode, tc.wantNode)
+			}
+			if gotMsg != tc.wantMessage {
+				t.Errorf("message = %q, want %q", gotMsg, tc.wantMessage)
+			}
+		})
+	}
+}

--- a/test/chainsaw/tests/unsupported-exporter/assert-degraded.yaml
+++ b/test/chainsaw/tests/unsupported-exporter/assert-degraded.yaml
@@ -7,5 +7,6 @@ status:
   (conditions[?type == 'Degraded'].reason | [0]): AgentNodeStatus
   (conditions[?type == 'Degraded'].message | [0]):
     (contains(@, 'not yet implemented')): true
-  (nodeStatus[?ready == `false`] | length(@) >= `1`): true
-  (nodeStatus[?contains(message, 'not yet implemented')] | length(@) >= `1`): true
+  nodeStatus:
+  - ready: false
+    (contains(message, 'not yet implemented')): true

--- a/test/chainsaw/tests/unsupported-exporter/assert-degraded.yaml
+++ b/test/chainsaw/tests/unsupported-exporter/assert-degraded.yaml
@@ -1,0 +1,11 @@
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: unsupported-pt
+status:
+  (conditions[?type == 'Degraded'].status | [0]): "True"
+  (conditions[?type == 'Degraded'].reason | [0]): AgentNodeStatus
+  (conditions[?type == 'Degraded'].message | [0]):
+    (contains(@, 'not yet implemented')): true
+  (nodeStatus[?ready == `false`] | length(@) >= `1`): true
+  (nodeStatus[?contains(message, 'not yet implemented')] | length(@) >= `1`): true

--- a/test/chainsaw/tests/unsupported-exporter/chainsaw-test.yaml
+++ b/test/chainsaw/tests/unsupported-exporter/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: unsupported-exporter
+spec:
+  description: |
+    A PodTrace bound to a Jaeger ExporterConfig must NOT silently fail
+    on the agent side. The agent returns "not yet implemented in agent
+    mode" from BuildExporter, the StatusWriter publishes that as a
+    Ready=false NodeStatus row with the cause on Message, and the
+    operator rolls the row up into ConditionDegraded=True with
+    reason=AgentNodeStatus. This is the user-visible failure path on
+    kubectl describe podtrace.
+  timeouts:
+    apply: 30s
+    assert: 180s
+  steps:
+    - name: setup
+      try:
+        - apply:
+            file: ./resources.yaml
+
+    - name: degraded-surfaces
+      try:
+        - assert:
+            file: ./assert-degraded.yaml

--- a/test/chainsaw/tests/unsupported-exporter/resources.yaml
+++ b/test/chainsaw/tests/unsupported-exporter/resources.yaml
@@ -1,0 +1,38 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: unsupported-jaeger
+spec:
+  type: jaeger
+  jaeger:
+    endpoint: http://jaeger.observability:14250
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unsupported-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: unsupported-target
+  template:
+    metadata:
+      labels:
+        app: unsupported-target
+    spec:
+      containers:
+        - name: app
+          image: registry.k8s.io/pause:3.9
+---
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: unsupported-pt
+spec:
+  selector:
+    matchLabels:
+      app: unsupported-target
+  filters: [dns]
+  exporterRef:
+    name: unsupported-jaeger


### PR DESCRIPTION
- Agent reconciler now publishes tombstone `CRRule`s (rule.Err != nil) for per-CR failures — selector match, cgroup resolve, bundle load, and exporter build — instead of silently `continue`ing.
- `StatusWriter` writes the wrapped cause to `NodeStatus[*].Message` and forces `Ready=false` for tombstoned rules; the agent-global Ready callback only governs healthy rules.
- Operator's `PodTraceReconciler` rolls any tombstoned `NodeStatus` row up into `ConditionDegraded=True` with `Reason=AgentNodeStatus`, lexicographically naming the first failing node so the message stays stable across reconciles.
- User-visible benefit: `ExporterConfig`s with `type: jaeger|zipkin|splunk|datadog` (not yet implemented in the agent) now show `build exporter: ... not yet implemented in agent mode` on `kubectl describe podtrace`, instead of failing silently.