### PR TITLE
feat: cross-namespace PodTrace targeting via spec.namespaceSelector and chart namespace-bootstrap hardening

### DIFF
--- a/api/v1alpha1/podtrace_types.go
+++ b/api/v1alpha1/podtrace_types.go
@@ -104,6 +104,10 @@ type PodTraceStatus struct {
 	// MatchedPods is the total number of pods currently matched across all nodes.
 	MatchedPods int32 `json:"matchedPods,omitempty"`
 
+	// TargetNamespaces is the sorted list of namespace names the operator
+	// resolved spec.namespaceSelector to at the last successful reconcile.
+	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
+
 	// ObservedGeneration is the most recent generation observed for this PodTrace.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/api/v1alpha1/podtrace_webhook.go
+++ b/api/v1alpha1/podtrace_webhook.go
@@ -64,6 +64,9 @@ func (v *PodTraceCustomValidator) validate(ctx context.Context, pt *PodTrace) (a
 	if err := validateSelectorExclusivity(pt.Spec.Selector, pt.Spec.PodRefs); err != nil {
 		return nil, err
 	}
+	if err := validateNamespaceSelector(pt.Spec.NamespaceSelector); err != nil {
+		return nil, err
+	}
 	if err := resolveExporterRef(ctx, v.Client, pt.Namespace, pt.Spec.ExporterRef.Name); err != nil {
 		return nil, err
 	}

--- a/api/v1alpha1/podtracesession_types.go
+++ b/api/v1alpha1/podtracesession_types.go
@@ -140,6 +140,10 @@ type PodTraceSessionStatus struct {
 	// +optional
 	Summary *SessionSummary `json:"summary,omitempty"`
 
+	// TargetNamespaces is the sorted list of namespace names the operator
+	// resolved spec.namespaceSelector.
+	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
+
 	// Conditions is the latest available observations of session state.
 	// +optional
 	// +patchMergeKey=type

--- a/api/v1alpha1/podtracesession_webhook.go
+++ b/api/v1alpha1/podtracesession_webhook.go
@@ -61,6 +61,9 @@ func (v *PodTraceSessionCustomValidator) validate(ctx context.Context, s *PodTra
 	if err := validateSelectorExclusivity(s.Spec.Selector, s.Spec.PodRefs); err != nil {
 		return nil, err
 	}
+	if err := validateNamespaceSelector(s.Spec.NamespaceSelector); err != nil {
+		return nil, err
+	}
 	if s.Spec.Duration.Duration <= 0 {
 		return nil, fmt.Errorf("spec.duration must be greater than zero")
 	}

--- a/api/v1alpha1/webhook_helpers.go
+++ b/api/v1alpha1/webhook_helpers.go
@@ -10,14 +10,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// validateSelectorExclusivity enforces that exactly one of Selector or
-// PodRefs is populated on a trace intent. Shared by PodTrace and
-// PodTraceSession: both resources target pods identically.
-//
-// Neither-or-both configurations are silently ambiguous — either no pods
-// would be targeted or the two sources could disagree — so we reject at
-// admission time rather than leaving the ambiguity to agent runtime
-// heuristics.
+func validateNamespaceSelector(sel *metav1.LabelSelector) error {
+	if sel == nil {
+		return nil
+	}
+	if _, err := metav1.LabelSelectorAsSelector(sel); err != nil {
+		return fmt.Errorf("spec.namespaceSelector: %w", err)
+	}
+	return nil
+}
+
 func validateSelectorExclusivity(selector *metav1.LabelSelector, podRefs []PodRef) error {
 	hasSelector := selector != nil && (len(selector.MatchLabels) > 0 || len(selector.MatchExpressions) > 0)
 	hasPodRefs := len(podRefs) > 0

--- a/api/v1alpha1/webhook_test.go
+++ b/api/v1alpha1/webhook_test.go
@@ -30,8 +30,8 @@ func newClientWithExporter(t *testing.T, namespace, name string) client.Client {
 		builder = builder.WithObjects(&podtracev1alpha1.ExporterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: podtracev1alpha1.ExporterConfigSpec{
-				Type:   podtracev1alpha1.ExporterTypeOTLP,
-				OTLP:   &podtracev1alpha1.OTLPExporter{Endpoint: "x:4318"},
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "x:4318"},
 			},
 		})
 	}
@@ -403,7 +403,6 @@ func TestPodTraceValidator_Update(t *testing.T) {
 			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
 		},
 	}
-	// New spec flips the exporter to a non-existent one.
 	newPT := oldPT.DeepCopy()
 	newPT.Spec.ExporterRef.Name = "ghost"
 
@@ -433,5 +432,97 @@ func TestExporterConfigValidator_EmptyType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not match") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPodTraceValidator_RejectsMalformedNamespaceSelector(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	badSel := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "team",
+			Operator: "BogusOp",
+		}},
+	}
+
+	cases := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "PodTrace",
+			run: func() error {
+				v := &podtracev1alpha1.PodTraceCustomValidator{Client: c}
+				_, err := v.ValidateCreate(context.Background(), &podtracev1alpha1.PodTrace{
+					ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "default"},
+					Spec: podtracev1alpha1.PodTraceSpec{
+						Selector:          validSelector(),
+						ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+						NamespaceSelector: badSel,
+					},
+				})
+				return err
+			},
+		},
+		{
+			name: "PodTraceSession",
+			run: func() error {
+				v := &podtracev1alpha1.PodTraceSessionCustomValidator{Client: c}
+				_, err := v.ValidateCreate(context.Background(), &podtracev1alpha1.PodTraceSession{
+					ObjectMeta: metav1.ObjectMeta{Name: "pts", Namespace: "default"},
+					Spec: podtracev1alpha1.PodTraceSessionSpec{
+						Selector:          validSelector(),
+						Duration:          metav1.Duration{Duration: time.Minute},
+						ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+						NamespaceSelector: badSel,
+					},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil || !strings.Contains(err.Error(), "spec.namespaceSelector") {
+				t.Fatalf("expected namespaceSelector rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPodTraceValidator_AcceptsValidNamespaceSelectors(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &podtracev1alpha1.PodTraceCustomValidator{Client: c}
+
+	cases := []struct {
+		name string
+		sel  *metav1.LabelSelector
+	}{
+		{name: "nil", sel: nil},
+		{name: "empty-matches-all", sel: &metav1.LabelSelector{}},
+		{name: "match-labels", sel: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "a"}}},
+		{name: "match-expressions-in", sel: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "team",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a", "b"},
+			}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &podtracev1alpha1.PodTrace{
+				ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "default"},
+				Spec: podtracev1alpha1.PodTraceSpec{
+					Selector:          validSelector(),
+					ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+					NamespaceSelector: tc.sel,
+				},
+			}
+			if _, err := v.ValidateCreate(context.Background(), obj); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/deploy/charts/podtrace/templates/NOTES.txt
+++ b/deploy/charts/podtrace/templates/NOTES.txt
@@ -1,9 +1,16 @@
 Podtrace installed — release {{ .Release.Name | quote }}.
 
+Note: `helm install --create-namespace` (or a pre-created release
+namespace) is required. Helm writes its release record into the target
+namespace before any chart hook runs, so the chart cannot bootstrap
+that namespace itself. The bootstrap Job in kube-system patches PSA
+labels onto the existing namespace after Helm creates it.
+
 Installed resources
 -------------------
-  CRDs (podtrace.io/v1alpha1) — installed from the chart's crds/ directory
-                                (Helm always installs these before templates):
+  CRDs (podtrace.io/v1alpha1) — installed by the chart's pre-install hook
+                                (templates/crds/, weight -10, runs before
+                                regular templates):
     PodTrace          continuous realtime tracing
     PodTraceSession   bounded diagnose-mode tracing
     ExporterConfig    reusable trace exporter

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
@@ -376,6 +376,13 @@ spec:
                   for this PodTrace.
                 format: int64
                 type: integer
+              targetNamespaces:
+                description: |-
+                  TargetNamespaces is the sorted list of namespace names the operator
+                  resolved spec.namespaceSelector to at the last successful reconcile.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -484,6 +484,13 @@ spec:
                 required:
                 - totalEvents
                 type: object
+              targetNamespaces:
+                description: |-
+                  TargetNamespaces is the sorted list of namespace names the operator
+                  resolved spec.namespaceSelector.
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/deploy/charts/podtrace/templates/namespace.yaml
+++ b/deploy/charts/podtrace/templates/namespace.yaml
@@ -1,22 +1,160 @@
+{{/*
+namespace-bootstrap — idempotent creation + PSA-labeling of the system
+namespace via a pre-install/pre-upgrade hook Job.
+
+Why a Job instead of a templated Namespace resource:
+
+  Templating a Namespace as a regular release manifest conflicts with
+  both common install paths:
+
+    1. `helm install --create-namespace` creates the namespace BEFORE
+       rendering templates, but without Helm ownership labels. The
+       chart's Namespace template then tries to "import" it and Helm
+       refuses with "invalid ownership metadata".
+
+    2. Pre-creating the namespace by hand has the same failure mode.
+
+  A pre-install hook Job that runs `kubectl apply` on the Namespace
+  sidesteps both problems. `kubectl apply` is the idempotent operation —
+  it creates the namespace if missing and patches labels if existing,
+  with no Helm ownership check involved. The Job itself lives in
+  kube-system (always present on every cluster), so it has somewhere to
+  land regardless of whether the user used --create-namespace.
+
+  Weight -100 puts this before crd-labeler (-20) and the CRD templates
+  (-10), so by the time those hooks run, the target namespace exists.
+
+  The hook-delete-policy clears the Job after success, so it does not
+  accumulate across upgrades. The Namespace itself persists — there is
+  no delete-policy on the manifest applied inside the Job.
+*/}}
 {{- if .Values.namespace.create }}
+---
 apiVersion: v1
-kind: Namespace
+kind: ServiceAccount
 metadata:
-  name: {{ include "podtrace.systemNamespace" . }}
+  name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+  namespace: kube-system
   labels:
-    {{- include "podtrace.labels" . | nindent 4 }}
-    # podtrace-system must be a PSA "privileged" namespace because the
-    # agent DaemonSet and session Jobs run as root with CAP_BPF /
-    # CAP_SYS_ADMIN / CAP_PERFMON. User PodTrace / PodTraceSession CRs
-    # live in user namespaces; only the implementation pods land here.
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/warn: privileged
-    {{- with .Values.namespace.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- with .Values.namespace.annotations }}
+    app.kubernetes.io/name: podtrace
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: namespace-bootstrap
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-100"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+  labels:
+    app.kubernetes.io/name: podtrace
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: namespace-bootstrap
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-100"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+  labels:
+    app.kubernetes.io/name: podtrace
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: namespace-bootstrap
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-100"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+    namespace: kube-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: podtrace
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: namespace-bootstrap
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-100"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 60
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: podtrace
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: namespace-bootstrap
+    spec:
+      serviceAccountName: {{ include "podtrace.fullname" . }}-namespace-bootstrap
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4" }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              NS="{{ include "podtrace.systemNamespace" . }}"
+              cat <<EOF | kubectl apply -f -
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: $NS
+                labels:
+                  app.kubernetes.io/name: podtrace
+                  app.kubernetes.io/instance: {{ .Release.Name }}
+                  app.kubernetes.io/managed-by: {{ .Release.Service }}
+                  app.kubernetes.io/part-of: podtrace
+                  # podtrace-system runs the agent DaemonSet and session
+                  # Jobs, which require CAP_BPF / CAP_SYS_ADMIN / CAP_PERFMON.
+                  # User-namespace CRs (PodTrace / PodTraceSession) stay
+                  # under restricted PSA; only implementation pods land here.
+                  pod-security.kubernetes.io/enforce: privileged
+                  pod-security.kubernetes.io/audit: privileged
+                  pod-security.kubernetes.io/warn: privileged
+              EOF
+              echo "namespace-bootstrap: $NS ready"
 {{- end }}

--- a/deploy/charts/podtrace/templates/operator-rbac.yaml
+++ b/deploy/charts/podtrace/templates/operator-rbac.yaml
@@ -43,6 +43,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  # Namespace lookup for spec.namespaceSelector resolution. The operator
+  # lists namespaces, filters by the user-supplied LabelSelector, and
+  # writes the result into the agent bundle's target_namespaces field.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
   # System-namespace infrastructure: SAs, bundles (ConfigMap+Secret)
   - apiGroups: [""]
     resources: ["serviceaccounts", "configmaps", "secrets"]

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -11,10 +11,12 @@
 #   rbac      optional overrides for cluster/namespaced RBAC
 #   metrics   Prometheus ServiceMonitor / PodMonitor
 #
-# By default this chart installs the CRDs and the podtrace-system
-# namespace. The operator Deployment, agent DaemonSet, webhook, and
-# ServiceMonitors are off by default — enable them individually below
-# once the rest of your setup is ready (Secrets, cert-manager, etc.).
+# By default this chart installs everything required for a working
+# Podtrace setup: CRDs, the podtrace-system namespace, the operator
+# Deployment, and a default TracerConfig that brings up the agent
+# DaemonSet. The webhook and ServiceMonitors stay off by default — flip
+# `webhook.enabled` / `metrics.*.enabled` once cert-manager and your
+# Prometheus stack are wired up.
 
 crds:
   install: true
@@ -38,7 +40,7 @@ namespace:
   annotations: {}
 
 operator:
-  enabled: false
+  enabled: true
   replicas: 1
   leaderElect: true
   resources:
@@ -55,7 +57,6 @@ operator:
   extraEnv: []
 
 agent:
-  enabled: false
   resources:
     requests:
       cpu: 100m

--- a/internal/agent/matcher.go
+++ b/internal/agent/matcher.go
@@ -11,9 +11,21 @@ import (
 )
 
 // MatchPodTraceAgainstPods returns the subset of `pods` that match the
-// PodTrace's selector (or appear in its PodRefs) AND are currently
-// schedulable for tracing (Running + have a container status).
-func MatchPodTraceAgainstPods(pt *podtracev1alpha1.PodTrace, pods []*corev1.Pod) ([]*corev1.Pod, error) {
+// PodTrace's selector (or appear in its PodRefs), are currently
+// schedulable for tracing (Running + container status), and live in a
+// namespace permitted by the operator-resolved allowlist.
+//
+// The allowlist is a tri-state argument:
+//
+//	nil           — the bundle did not carry target_namespaces. Either
+//	                the CR has no spec.namespaceSelector or the operator
+//	                hasn't yet upgraded. The matcher falls back to
+//	                own-namespace-only matching.
+//	[]string{}    — spec.namespaceSelector was set but matched zero
+//	                namespaces. No pods can match for this CR.
+//	[ns, ...]     — the bundle carries the resolved allowlist; only
+//	                pods in these namespaces are eligible.
+func MatchPodTraceAgainstPods(pt *podtracev1alpha1.PodTrace, pods []*corev1.Pod, allowlist []string) ([]*corev1.Pod, error) {
 	if pt == nil {
 		return nil, fmt.Errorf("nil PodTrace")
 	}
@@ -32,7 +44,7 @@ func MatchPodTraceAgainstPods(pt *podtracev1alpha1.PodTrace, pods []*corev1.Pod)
 		if p == nil || !isEligiblePod(p) {
 			continue
 		}
-		if !inNamespaceScope(pt, p) {
+		if !inNamespaceScope(pt, p, allowlist) {
 			continue
 		}
 		switch {
@@ -79,17 +91,19 @@ func buildPodRefIndex(pt *podtracev1alpha1.PodTrace) map[string]struct{} {
 	return idx
 }
 
-// inNamespaceScope enforces the same "own-namespace-only unless
-// NamespaceSelector is set" rule the operator's session reconciler
-// uses. A non-nil NamespaceSelector opens cross-namespace matching;
-// the NamespaceSelector's own expressions are not yet honoured —
-// evaluating them would require a Namespace informer that is not
-// wired here.
-func inNamespaceScope(pt *podtracev1alpha1.PodTrace, p *corev1.Pod) bool {
-	if pt.Spec.NamespaceSelector != nil {
-		return true
+func inNamespaceScope(pt *podtracev1alpha1.PodTrace, p *corev1.Pod, allowlist []string) bool {
+	if pt.Spec.NamespaceSelector == nil {
+		return p.Namespace == pt.Namespace
 	}
-	return p.Namespace == pt.Namespace
+	if allowlist == nil {
+		return p.Namespace == pt.Namespace
+	}
+	for _, ns := range allowlist {
+		if p.Namespace == ns {
+			return true
+		}
+	}
+	return false
 }
 
 // isEligiblePod is the agent-side counterpart to the operator's pod

--- a/internal/agent/matcher_test.go
+++ b/internal/agent/matcher_test.go
@@ -30,7 +30,7 @@ func TestMatchPodTraceAgainstPods_SelectorMatch(t *testing.T) {
 		mkPod("default", "api-b", map[string]string{"app": "api"}),
 		mkPod("default", "worker", map[string]string{"app": "worker"}),
 	}
-	matched, err := MatchPodTraceAgainstPods(pt, pods)
+	matched, err := MatchPodTraceAgainstPods(pt, pods, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestMatchPodTraceAgainstPods_PodRefs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pt"},
 		Spec: podtracev1alpha1.PodTraceSpec{
 			PodRefs: []podtracev1alpha1.PodRef{
-				{Name: "api-a"},                    // defaults to default ns
+				{Name: "api-a"},                         // defaults to default ns
 				{Namespace: "kube-system", Name: "dns"}, // explicit ns
 			},
 			NamespaceSelector: &metav1.LabelSelector{}, // allow cross-ns
@@ -58,12 +58,37 @@ func TestMatchPodTraceAgainstPods_PodRefs(t *testing.T) {
 		mkPod("default", "unrelated", nil),
 		mkPod("kube-system", "dns", nil),
 	}
-	matched, err := MatchPodTraceAgainstPods(pt, pods)
+	allowlist := []string{"default", "kube-system"}
+	matched, err := MatchPodTraceAgainstPods(pt, pods, allowlist)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(matched) != 2 {
 		t.Fatalf("matched=%d want 2: %+v", len(matched), matched)
+	}
+}
+
+func TestMatchPodTraceAgainstPods_PodRefs_NilAllowlistFallsBackToOwnNamespace(t *testing.T) {
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pt"},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			PodRefs: []podtracev1alpha1.PodRef{
+				{Name: "api-a"},
+				{Namespace: "kube-system", Name: "dns"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{},
+		},
+	}
+	pods := []*corev1.Pod{
+		mkPod("default", "api-a", nil),
+		mkPod("kube-system", "dns", nil),
+	}
+	matched, err := MatchPodTraceAgainstPods(pt, pods, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matched) != 1 || matched[0].Name != "api-a" {
+		t.Fatalf("conservative fallback should match only the own-ns pod; got %+v", matched)
 	}
 }
 
@@ -76,7 +101,7 @@ func TestMatchPodTraceAgainstPods_PausedReturnsNothing(t *testing.T) {
 		},
 	}
 	pods := []*corev1.Pod{mkPod("default", "api-a", map[string]string{"app": "api"})}
-	matched, err := MatchPodTraceAgainstPods(pt, pods)
+	matched, err := MatchPodTraceAgainstPods(pt, pods, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +123,7 @@ func TestMatchPodTraceAgainstPods_NamespaceScope(t *testing.T) {
 		mkPod("default", "a", map[string]string{"app": "x"}),
 		mkPod("other-ns", "b", map[string]string{"app": "x"}),
 	}
-	matched, err := MatchPodTraceAgainstPods(pt, pods)
+	matched, err := MatchPodTraceAgainstPods(pt, pods, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +149,7 @@ func TestMatchPodTraceAgainstPods_OnlyRunningPodsEligible(t *testing.T) {
 	}
 	running := mkPod("default", "running", map[string]string{"app": "x"})
 
-	matched, err := MatchPodTraceAgainstPods(pt, []*corev1.Pod{pending, failed, running})
+	matched, err := MatchPodTraceAgainstPods(pt, []*corev1.Pod{pending, failed, running}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +169,7 @@ func TestMatchPodTraceAgainstPods_EmptySelectorIsUnset(t *testing.T) {
 		},
 	}
 	pods := []*corev1.Pod{mkPod("default", "a", map[string]string{"app": "x"})}
-	matched, err := MatchPodTraceAgainstPods(pt, pods)
+	matched, err := MatchPodTraceAgainstPods(pt, pods, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +179,7 @@ func TestMatchPodTraceAgainstPods_EmptySelectorIsUnset(t *testing.T) {
 }
 
 func TestMatchPodTraceAgainstPods_NilPtRejected(t *testing.T) {
-	if _, err := MatchPodTraceAgainstPods(nil, nil); err == nil {
+	if _, err := MatchPodTraceAgainstPods(nil, nil, nil); err == nil {
 		t.Error("expected error on nil PodTrace")
 	}
 }
@@ -166,8 +191,75 @@ func TestMatchPodTraceAgainstPods_HandlesNilPodSlice(t *testing.T) {
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
 		},
 	}
-	matched, err := MatchPodTraceAgainstPods(pt, nil)
+	matched, err := MatchPodTraceAgainstPods(pt, nil, nil)
 	if err != nil || len(matched) != 0 {
 		t.Errorf("nil pod slice: err=%v matched=%+v", err, matched)
+	}
+}
+
+func TestInNamespaceScope_AllowlistSemantics(t *testing.T) {
+	ptOwnNS := func(sel *metav1.LabelSelector) *podtracev1alpha1.PodTrace {
+		return &podtracev1alpha1.PodTrace{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pt"},
+			Spec:       podtracev1alpha1.PodTraceSpec{NamespaceSelector: sel},
+		}
+	}
+	cases := []struct {
+		name      string
+		pt        *podtracev1alpha1.PodTrace
+		pod       *corev1.Pod
+		allowlist []string
+		want      bool
+	}{
+		{
+			name:      "NilSelector_OwnNamespacePodAccepted",
+			pt:        ptOwnNS(nil),
+			pod:       mkPod("default", "p", nil),
+			allowlist: nil,
+			want:      true,
+		},
+		{
+			name:      "NilSelector_OtherNamespacePodRejected",
+			pt:        ptOwnNS(nil),
+			pod:       mkPod("kube-system", "p", nil),
+			allowlist: nil,
+			want:      false,
+		},
+		{
+			name:      "SelectorSet_NilAllowlist_FallsBackToOwnNamespace",
+			pt:        ptOwnNS(&metav1.LabelSelector{}),
+			pod:       mkPod("kube-system", "p", nil),
+			allowlist: nil,
+			want:      false,
+		},
+		{
+			name:      "SelectorSet_EmptyAllowlist_NothingMatches",
+			pt:        ptOwnNS(&metav1.LabelSelector{}),
+			pod:       mkPod("default", "p", nil),
+			allowlist: []string{},
+			want:      false,
+		},
+		{
+			name:      "SelectorSet_AllowlistContainsPodNamespace",
+			pt:        ptOwnNS(&metav1.LabelSelector{}),
+			pod:       mkPod("team-a", "p", nil),
+			allowlist: []string{"team-a", "team-b"},
+			want:      true,
+		},
+		{
+			name:      "SelectorSet_AllowlistMissingPodNamespace",
+			pt:        ptOwnNS(&metav1.LabelSelector{}),
+			pod:       mkPod("team-c", "p", nil),
+			allowlist: []string{"team-a", "team-b"},
+			want:      false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inNamespaceScope(tc.pt, tc.pod, tc.allowlist)
+			if got != tc.want {
+				t.Errorf("inNamespaceScope = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -115,7 +115,25 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 		key := CRKey{Namespace: pt.Namespace, Name: pt.Name}
 
-		matched, err := MatchPodTraceAgainstPods(pt, localPods)
+		// Load the bundle BEFORE matching, so bundle.TargetNamespaces
+		// is available to the matcher.
+		bundle, err := LoadBundle(ctx, r.Client, r.SystemNamespace, pt.UID)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("bundle not yet synced", "cr", key)
+				continue
+			}
+			logger.Error(err, "load bundle", "cr", key)
+			rules = append(rules, CRRule{
+				Key:     key,
+				Filters: filtersToSet(pt.Spec.Filters),
+				Err:     fmt.Errorf("load bundle: %w", err),
+			})
+			activeKeys[key] = struct{}{}
+			continue
+		}
+
+		matched, err := MatchPodTraceAgainstPods(pt, localPods, bundle.TargetNamespaces)
 		if err != nil {
 			logger.Error(err, "match pods", "cr", key)
 			rules = append(rules, CRRule{
@@ -138,24 +156,6 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				Filters:     filtersToSet(pt.Spec.Filters),
 				MatchedPods: lenToInt32(len(matched)),
 				Err:         fmt.Errorf("resolve cgroup IDs: %w", err),
-			})
-			activeKeys[key] = struct{}{}
-			continue
-		}
-
-		bundle, err := LoadBundle(ctx, r.Client, r.SystemNamespace, pt.UID)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.V(1).Info("bundle not yet synced", "cr", key)
-				continue
-			}
-			logger.Error(err, "load bundle", "cr", key)
-			rules = append(rules, CRRule{
-				Key:         key,
-				CgroupIDs:   cgroupIDs,
-				Filters:     filtersToSet(pt.Spec.Filters),
-				MatchedPods: lenToInt32(len(matched)),
-				Err:         fmt.Errorf("load bundle: %w", err),
 			})
 			activeKeys[key] = struct{}{}
 			continue

--- a/internal/operator/exporter_bundle.go
+++ b/internal/operator/exporter_bundle.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 	"github.com/podtrace/podtrace/pkg/exporter/bundle"
@@ -22,18 +24,19 @@ import (
 //	headers.<name>       = literal value (OTLP only)
 //	header_secret_keys   = space-separated list of ConfigMap keys that
 //	                       reference the companion Secret (OTLP only)
-//
-// The second return value, if non-nil, names the user-namespace Secret
-// key the operator should load for the bundle's companion credential
-// Secret. Exporters without credentials (Jaeger, Zipkin, credential-less
-// OTLP) return nil here.
-func renderBundlePayload(ec *podtracev1alpha1.ExporterConfig) (map[string]string, *podtracev1alpha1.SecretKeySelector, error) {
+func renderBundlePayload(ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) (map[string]string, *podtracev1alpha1.SecretKeySelector, error) {
 	data := map[string]string{
 		"version": bundle.CurrentVersion,
 		"type":    string(ec.Spec.Type),
 	}
 	if ec.Spec.SamplePercent != nil {
 		data["sample_percent"] = itoa(int(*ec.Spec.SamplePercent))
+	}
+	if targetNamespaces != nil {
+		sorted := make([]string, len(targetNamespaces))
+		copy(sorted, targetNamespaces)
+		sort.Strings(sorted)
+		data["target_namespaces"] = strings.Join(sorted, ",")
 	}
 
 	switch ec.Spec.Type {
@@ -49,14 +52,7 @@ func renderBundlePayload(ec *podtracev1alpha1.ExporterConfig) (map[string]string
 		}
 		data["insecure"] = boolString(ec.Spec.OTLP.Insecure)
 		for _, h := range ec.Spec.OTLP.Headers {
-			// Literal-valued headers go straight into the ConfigMap.
-			// Secret-valued headers are deferred to the credential path;
-			// this first iteration supports exactly one Secret-valued
-			// header (the most common pattern — an Authorization bearer).
 			if h.ValueFrom != nil {
-				// Use the first Secret-backed header as THE credential,
-				// exposed in the companion Secret under key "credential".
-				// Multi-Secret support is tracked as a future enhancement.
 				sk := h.ValueFrom.DeepCopy()
 				data["header_secret_name"] = h.Name
 				return data, sk, nil

--- a/internal/operator/exporter_bundle_test.go
+++ b/internal/operator/exporter_bundle_test.go
@@ -29,7 +29,7 @@ func TestRenderBundlePayload_OTLP_LiteralHeaders(t *testing.T) {
 				{Name: "X-Env", Value: "prod"},
 			},
 		},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestRenderBundlePayload_OTLP_SecretBackedHeader(t *testing.T) {
 				}},
 			},
 		},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestRenderBundlePayload_Jaeger_NoCredentials(t *testing.T) {
 	data, secret, err := renderBundlePayload(ec("j", podtracev1alpha1.ExporterConfigSpec{
 		Type:   podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://jaeger:14268"},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestRenderBundlePayload_Zipkin(t *testing.T) {
 	data, secret, err := renderBundlePayload(ec("z", podtracev1alpha1.ExporterConfigSpec{
 		Type:   podtracev1alpha1.ExporterTypeZipkin,
 		Zipkin: &podtracev1alpha1.ZipkinExporter{Endpoint: "http://zipkin:9411/api/v2/spans"},
-	}))
+	}), nil)
 	if err != nil || secret != nil || data["type"] != "zipkin" {
 		t.Fatalf("zipkin payload: err=%v secret=%v data=%v", err, secret, data)
 	}
@@ -109,7 +109,7 @@ func TestRenderBundlePayload_Splunk_RequiresTokenSecret(t *testing.T) {
 			Endpoint:       "https://splunk:8088",
 			TokenSecretRef: podtracev1alpha1.SecretKeySelector{Name: "hec", Key: "token"},
 		},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestRenderBundlePayload_DataDog_DefaultSite(t *testing.T) {
 		DataDog: &podtracev1alpha1.DataDogExporter{
 			APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api"},
 		},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestRenderBundlePayload_ErrorOnMissingVariant(t *testing.T) {
 	_, _, err := renderBundlePayload(ec("broken", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeOTLP,
 		// no OTLP block populated
-	}))
+	}), nil)
 	if err == nil {
 		t.Fatal("expected error when spec.otlp is nil for type=otlp")
 	}
@@ -152,7 +152,7 @@ func TestRenderBundlePayload_ErrorOnMissingVariant(t *testing.T) {
 func TestRenderBundlePayload_UnknownType(t *testing.T) {
 	_, _, err := renderBundlePayload(ec("xxx", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterType("made-up"),
-	}))
+	}), nil)
 	if err == nil {
 		t.Fatal("expected error for unknown type")
 	}
@@ -164,7 +164,7 @@ func TestRenderBundlePayload_SamplePercent(t *testing.T) {
 		Type:          podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger:        &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
 		SamplePercent: &pct,
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestRenderBundlePayload_AlwaysStampsVersion(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			data, _, err := renderBundlePayload(ec("v-"+tc.name, tc.spec))
+			data, _, err := renderBundlePayload(ec("v-"+tc.name, tc.spec), nil)
 			if err != nil {
 				t.Fatalf("render: %v", err)
 			}

--- a/internal/operator/namespace_resolver.go
+++ b/internal/operator/namespace_resolver.go
@@ -1,0 +1,49 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ResolveNamespaceSelector returns the sorted list of namespace names a
+// given LabelSelector matches against the cluster's current Namespace objects.
+func ResolveNamespaceSelector(
+	ctx context.Context,
+	c client.Reader,
+	sel *metav1.LabelSelector,
+) ([]string, error) {
+	if sel == nil {
+		return nil, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return nil, fmt.Errorf("invalid NamespaceSelector: %w", err)
+	}
+
+	var nsList corev1.NamespaceList
+	if err := c.List(ctx, &nsList); err != nil {
+		return nil, fmt.Errorf("list namespaces: %w", err)
+	}
+
+	matches := make([]string, 0, len(nsList.Items))
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		if ns.DeletionTimestamp != nil {
+			continue
+		}
+		if selector.Matches(labels.Set(ns.Labels)) {
+			matches = append(matches, ns.Name)
+		}
+	}
+	sort.Strings(matches)
+	if matches == nil {
+		matches = []string{}
+	}
+	return matches, nil
+}

--- a/internal/operator/namespace_resolver_test.go
+++ b/internal/operator/namespace_resolver_test.go
@@ -1,0 +1,155 @@
+package operator
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func nsObj(name string, labels map[string]string, terminating bool) *corev1.Namespace {
+	n := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+	if terminating {
+		t := metav1.NewTime(time.Now())
+		n.DeletionTimestamp = &t
+		n.Finalizers = []string{"kubernetes"}
+	}
+	return n
+}
+
+func TestResolveNamespaceSelector(t *testing.T) {
+	cases := []struct {
+		name       string
+		seedNS     []*corev1.Namespace
+		selector   *metav1.LabelSelector
+		wantNil    bool
+		wantResult []string
+		wantErr    bool
+	}{
+		{
+			name:    "NilSelectorReturnsNil",
+			selector: nil,
+			wantNil:  true,
+		},
+		{
+			name: "EmptySelectorMatchesAllNonTerminating",
+			seedNS: []*corev1.Namespace{
+				nsObj("a", nil, false),
+				nsObj("b", map[string]string{"x": "y"}, false),
+				nsObj("c", nil, true),
+			},
+			selector:   &metav1.LabelSelector{},
+			wantResult: []string{"a", "b"},
+		},
+		{
+			name: "MatchLabelsOnlyMatchesMatching",
+			seedNS: []*corev1.Namespace{
+				nsObj("prod-east", map[string]string{"tier": "prod"}, false),
+				nsObj("prod-west", map[string]string{"tier": "prod"}, false),
+				nsObj("staging", map[string]string{"tier": "staging"}, false),
+				nsObj("misc", nil, false),
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "prod"},
+			},
+			wantResult: []string{"prod-east", "prod-west"},
+		},
+		{
+			name: "MatchExpressionsHonored",
+			seedNS: []*corev1.Namespace{
+				nsObj("team-a", map[string]string{"env": "production"}, false),
+				nsObj("team-b", map[string]string{"env": "qa"}, false),
+				nsObj("team-c", map[string]string{"env": "production"}, false),
+			},
+			selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"production"}},
+				},
+			},
+			wantResult: []string{"team-a", "team-c"},
+		},
+		{
+			name: "NoMatchesReturnsEmptyNotNil",
+			seedNS: []*corev1.Namespace{
+				nsObj("a", map[string]string{"tier": "staging"}, false),
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "prod"},
+			},
+			wantResult: []string{},
+		},
+		{
+			name: "TerminatingNamespacesExcluded",
+			seedNS: []*corev1.Namespace{
+				nsObj("alive", map[string]string{"tier": "prod"}, false),
+				nsObj("dying", map[string]string{"tier": "prod"}, true),
+			},
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"tier": "prod"},
+			},
+			wantResult: []string{"alive"},
+		},
+		{
+			name: "MalformedSelectorReturnsError",
+			selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "k", Operator: "BogusOp", Values: []string{"v"}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "OutputAlwaysSorted",
+			seedNS: []*corev1.Namespace{
+				nsObj("zeta", map[string]string{"x": "y"}, false),
+				nsObj("alpha", map[string]string{"x": "y"}, false),
+				nsObj("mu", map[string]string{"x": "y"}, false),
+			},
+			selector:   &metav1.LabelSelector{MatchLabels: map[string]string{"x": "y"}},
+			wantResult: []string{"alpha", "mu", "zeta"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme, err := NewScheme()
+			if err != nil {
+				t.Fatalf("scheme: %v", err)
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for _, ns := range tc.seedNS {
+				builder = builder.WithObjects(ns)
+			}
+			c := builder.Build()
+
+			got, err := ResolveNamespaceSelector(context.Background(), c, tc.selector)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("expected nil result, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil slice (possibly empty), got nil")
+			}
+			if !reflect.DeepEqual(got, tc.wantResult) {
+				t.Errorf("got %v, want %v", got, tc.wantResult)
+			}
+		})
+	}
+}

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -41,6 +41,7 @@ type PodTraceReconciler struct {
 // +kubebuilder:rbac:groups=podtrace.io,resources=podtraces/finalizers,verbs=update
 // +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 
 func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("podtrace", req.String())
@@ -91,12 +92,27 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
 	}
 
-	if err := r.syncExporterBundle(ctx, &pt, &ec); err != nil {
+	// Resolve spec.namespaceSelector against the cluster's Namespace
+	// labels. Tri-state result:
+	//   nil   → selector not set on the CR (agent falls back to own-ns)
+	//   []{}  → selector set but matched zero namespaces
+	//   list  → resolved allowlist
+	targetNamespaces, err := ResolveNamespaceSelector(ctx, r.Client, pt.Spec.NamespaceSelector)
+	if err != nil {
+		logger.Error(err, "resolve namespace selector")
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "NamespaceSelectorInvalid", err.Error())
+		_ = r.Status().Update(ctx, &pt)
+		return ctrl.Result{}, err
+	}
+
+	if err := r.syncExporterBundle(ctx, &pt, &ec, targetNamespaces); err != nil {
 		logger.Error(err, "sync exporter bundle")
 		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
 		_ = r.Status().Update(ctx, &pt)
 		return ctrl.Result{}, err
 	}
+
+	pt.Status.TargetNamespaces = targetNamespaces
 
 	if node, msg, ok := firstDegradedNode(pt.Status.NodeStatus); ok {
 		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "AgentNodeStatus",
@@ -129,8 +145,32 @@ func (r *PodTraceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&podtracev1alpha1.ExporterConfig{},
 			handler.EnqueueRequestsFromMapFunc(r.exporterConfigToPodTraces),
 		).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.namespaceToPodTraces),
+		).
 		WithOptions(defaultControllerOptions()).
 		Complete(r)
+}
+
+// namespaceToPodTraces returns the set of PodTraces that should
+// re-reconcile when any Namespace event fires.
+func (r *PodTraceReconciler) namespaceToPodTraces(ctx context.Context, _ client.Object) []reconcile.Request {
+	var list podtracev1alpha1.PodTraceList
+	if err := r.List(ctx, &list); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		pt := &list.Items[i]
+		if pt.Spec.NamespaceSelector == nil {
+			continue
+		}
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: pt.Namespace, Name: pt.Name},
+		})
+	}
+	return out
 }
 
 func (r *PodTraceReconciler) exporterConfigToPodTraces(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -154,11 +194,11 @@ func (r *PodTraceReconciler) exporterConfigToPodTraces(ctx context.Context, obj 
 	return reqs
 }
 
-func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig) error {
+func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) error {
 	systemNS := r.SystemNamespace
 	name := ExporterBundleName(pt.UID)
 
-	payload, credSecretRef, err := renderBundlePayload(ec)
+	payload, credSecretRef, err := renderBundlePayload(ec, targetNamespaces)
 	if err != nil {
 		return err
 	}

--- a/internal/operator/podtrace_namespace_selector_test.go
+++ b/internal/operator/podtrace_namespace_selector_test.go
@@ -1,0 +1,248 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestPodTraceReconciler_NamespaceSelectorAllowlist(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const tracedKey = "podtrace.io/test-ns-selector-allowlist"
+	matchNS := ensureLabeledNamespace(t, c, tracedKey, "yes")
+	otherNS := ensureLabeledNamespace(t, c, tracedKey, "no")
+
+	ensureExporterConfig(t, c, ns, "otlp")
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-selector", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{tracedKey: "yes"},
+			},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	bundleName := ExporterBundleName(pt.UID)
+	doReconcile := func() error {
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+		return err
+	}
+
+	wantAllowlist := func(want []string) func() error {
+		sort.Strings(want)
+		return func() error {
+			var cm corev1.ConfigMap
+			if err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &cm); err != nil {
+				return err
+			}
+			raw, ok := cm.Data["target_namespaces"]
+			if !ok {
+				return fmt.Errorf("bundle missing target_namespaces key")
+			}
+			got := strings.Split(raw, ",")
+			sort.Strings(got)
+			if !equalStringSlices(got, want) {
+				return fmt.Errorf("bundle target_namespaces = %v, want %v", got, want)
+			}
+			var got2 podtracev1alpha1.PodTrace
+			if err := c.Get(ctx, types.NamespacedName{Name: pt.Name, Namespace: ns}, &got2); err != nil {
+				return err
+			}
+			gotStatus := append([]string(nil), got2.Status.TargetNamespaces...)
+			sort.Strings(gotStatus)
+			if !equalStringSlices(gotStatus, want) {
+				return fmt.Errorf("status.targetNamespaces = %v, want %v", gotStatus, want)
+			}
+			return nil
+		}
+	}
+
+	reconcileUntil(t, 10*time.Second, wantAllowlist([]string{matchNS}), doReconcile)
+
+	// Re-label the previously-excluded namespace to bring it into scope.
+	// The watch wiring is exercised by a manager run; here we drive
+	// reconcile manually to verify the resolver picks up the new label.
+	var nsObj corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: otherNS}, &nsObj); err != nil {
+		t.Fatal(err)
+	}
+	nsObj.Labels[tracedKey] = "yes"
+	if err := c.Update(ctx, &nsObj); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileUntil(t, 10*time.Second, wantAllowlist([]string{matchNS, otherNS}), doReconcile)
+}
+
+// TestPodTraceReconciler_NamespaceSelector_EmptyMatch covers the
+// tri-state "selector set but matched zero namespaces" branch. The agent
+// must see target_namespaces="" (key present, value empty) so it knows
+// to match nothing, distinct from the unset case.
+func TestPodTraceReconciler_NamespaceSelector_EmptyMatch(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ensureExporterConfig(t, c, ns, "otlp")
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-empty", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"podtrace.io/never-set-by-anyone": "definitely-not",
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, pt); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	bundleName := ExporterBundleName(pt.UID)
+
+	reconcileUntil(t, 10*time.Second,
+		func() error {
+			var cm corev1.ConfigMap
+			if err := c.Get(ctx, types.NamespacedName{Name: bundleName, Namespace: systemNS}, &cm); err != nil {
+				return err
+			}
+			raw, ok := cm.Data["target_namespaces"]
+			if !ok {
+				return fmt.Errorf("bundle missing target_namespaces key (empty-match must still write the key)")
+			}
+			if raw != "" {
+				return fmt.Errorf("bundle target_namespaces = %q, want \"\"", raw)
+			}
+			return nil
+		},
+		func() error {
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns}})
+			return err
+		},
+	)
+}
+
+// TestPodTraceReconciler_NamespaceToPodTraces_EnqueuesOnlySelectorUsers
+// checks the watch handler — PodTraces without a NamespaceSelector are
+// namespace-pinned and need no re-evaluation on Namespace events.
+func TestPodTraceReconciler_NamespaceToPodTraces_EnqueuesOnlySelectorUsers(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ensureExporterConfig(t, c, ns, "otlp")
+	withSel := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-sel", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+			NamespaceSelector: &metav1.LabelSelector{},
+		},
+	}
+	withoutSel := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "without-sel", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "y"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "otlp"},
+		},
+	}
+	if err := c.Create(ctx, withSel); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Create(ctx, withoutSel); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	reqs := r.namespaceToPodTraces(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "any-ns"}})
+
+	var sawWithSel bool
+	for _, rq := range reqs {
+		if rq.Name == withoutSel.Name && rq.Namespace == ns {
+			t.Errorf("namespaceToPodTraces requeued %q, which has no NamespaceSelector", rq.Name)
+		}
+		if rq.Name == withSel.Name && rq.Namespace == ns {
+			sawWithSel = true
+		}
+	}
+	if !sawWithSel {
+		t.Errorf("namespaceToPodTraces did not enqueue %q/%q (got %+v)", ns, withSel.Name, reqs)
+	}
+}
+
+func ensureLabeledNamespace(t *testing.T, c client.Client, key, value string) string {
+	t.Helper()
+	name := "ns-" + sanitiseDNS(t.Name()+"-"+value)
+	if len(name) > 60 {
+		name = name[:60]
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	nsObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{key: value}},
+	}
+	if err := c.Create(ctx, nsObj); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create labeled namespace %q: %v", name, err)
+	}
+	// If the namespace already existed from a prior run of the shared
+	// envtest, the Create above no-ops — force the label onto it so the
+	// selector sees what this test expects.
+	var got corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, &got); err != nil {
+		t.Fatalf("get labeled namespace %q: %v", name, err)
+	}
+	if got.Labels == nil {
+		got.Labels = map[string]string{}
+	}
+	if got.Labels[key] != value {
+		got.Labels[key] = value
+		if err := c.Update(ctx, &got); err != nil {
+			t.Fatalf("update labeled namespace %q: %v", name, err)
+		}
+	}
+	return name
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -15,7 +16,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
@@ -84,12 +87,21 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.reconcileTerminalSession(ctx, &session)
 	}
 
-	targetNodes, err := r.resolveTargetNodes(ctx, &session)
+	targetNodes, targetNamespaces, err := r.resolveTargetNodes(ctx, &session)
 	if err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ResolveTargets", err.Error())
+		// Distinguish a malformed NamespaceSelector (admission webhook
+		// should normally catch it, but envtest harnesses skip webhooks)
+		// from a general resolve failure for a clearer Degraded reason.
+		reason := "ResolveTargets"
+		if strings.Contains(err.Error(), "invalid NamespaceSelector") {
+			reason = "NamespaceSelectorInvalid"
+		}
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, reason, err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
+	// Surface the resolved allowlist on .status for debuggability.
+	session.Status.TargetNamespaces = targetNamespaces
 	if len(targetNodes) == 0 {
 		logger.Info("no matched pods; session stays Pending until pods appear")
 		session.Status.Phase = podtracev1alpha1.SessionPhasePending
@@ -190,40 +202,99 @@ func (r *PodTraceSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("podtracesession").
 		For(&podtracev1alpha1.PodTraceSession{}).
+		Watches(
+			&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.namespaceToPodTraceSessions),
+		).
 		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }
 
+// namespaceToPodTraceSessions returns the set of PodTraceSessions
+// that should re-reconcile when any Namespace event fires.
+func (r *PodTraceSessionReconciler) namespaceToPodTraceSessions(ctx context.Context, _ client.Object) []reconcile.Request {
+	var list podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &list); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		s := &list.Items[i]
+		if s.Spec.NamespaceSelector == nil {
+			continue
+		}
+		if s.Status.Phase == podtracev1alpha1.SessionPhaseCompleted ||
+			s.Status.Phase == podtracev1alpha1.SessionPhaseFailed {
+			continue
+		}
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: s.Namespace, Name: s.Name},
+		})
+	}
+	return out
+}
+
 // resolveTargetNodes expands spec.selector / spec.podRefs into the set of
-// node names hosting at least one matched pod. Deterministic ordering
-// (sorted) so reconcile is idempotent under flaky informer caches.
-func (r *PodTraceSessionReconciler) resolveTargetNodes(ctx context.Context, s *podtracev1alpha1.PodTraceSession) ([]string, error) {
+// node names hosting at least one matched pod.
+func (r *PodTraceSessionReconciler) resolveTargetNodes(ctx context.Context, s *podtracev1alpha1.PodTraceSession) ([]string, []string, error) {
 	nodes := map[string]struct{}{}
+
+	targetNamespaces, err := ResolveNamespaceSelector(ctx, r.Client, s.Spec.NamespaceSelector)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if s.Spec.Selector != nil {
 		sel, err := metav1.LabelSelectorAsSelector(s.Spec.Selector)
 		if err != nil {
-			return nil, fmt.Errorf("invalid selector: %w", err)
+			return nil, nil, fmt.Errorf("invalid selector: %w", err)
 		}
-		var list corev1.PodList
-		listOpts := &client.ListOptions{
-			LabelSelector: sel,
-			Namespace:     s.Namespace,
-		}
-		if s.Spec.NamespaceSelector != nil {
-			// NamespaceSelector opens cross-namespace search. The
-			// selector's own label expressions are not yet honoured —
-			// that would require a Namespace informer we do not wire
-			// here. Presence of the field alone is enough to widen
-			// scope to every namespace.
-			listOpts.Namespace = ""
-		}
-		if err := r.List(ctx, &list, listOpts); err != nil {
-			return nil, fmt.Errorf("list pods for selector: %w", err)
-		}
-		for _, p := range list.Items {
-			if p.Spec.NodeName != "" && isPodEligible(&p) {
-				nodes[p.Spec.NodeName] = struct{}{}
+
+		// Allowlist drives the namespace scope. Three cases:
+		//
+		//   targetNamespaces == nil  → selector unset on the CR; restrict
+		//                              to the session's own namespace.
+		//   targetNamespaces empty   → selector set but no namespaces
+		//                              match; skip the List entirely (no
+		//                              pods can be selected).
+		//   targetNamespaces non-empty → list cluster-wide and filter the
+		//                              results in-memory against the set.
+		//
+		// In-memory filtering after a cluster-wide List is cheaper than N
+		// per-namespace Lists when the cached informer is cluster-scoped
+		// (which it is for our manager).
+		switch {
+		case targetNamespaces == nil:
+			listOpts := &client.ListOptions{LabelSelector: sel, Namespace: s.Namespace}
+			var list corev1.PodList
+			if err := r.List(ctx, &list, listOpts); err != nil {
+				return nil, nil, fmt.Errorf("list pods for selector: %w", err)
+			}
+			for _, p := range list.Items {
+				if p.Spec.NodeName != "" && isPodEligible(&p) {
+					nodes[p.Spec.NodeName] = struct{}{}
+				}
+			}
+		case len(targetNamespaces) == 0:
+			// Selector matched zero namespaces — no pods are reachable.
+			// Fall through; the function returns an empty node set.
+		default:
+			allowSet := make(map[string]struct{}, len(targetNamespaces))
+			for _, ns := range targetNamespaces {
+				allowSet[ns] = struct{}{}
+			}
+			listOpts := &client.ListOptions{LabelSelector: sel} // Namespace empty == cluster-wide
+			var list corev1.PodList
+			if err := r.List(ctx, &list, listOpts); err != nil {
+				return nil, nil, fmt.Errorf("list pods for selector: %w", err)
+			}
+			for _, p := range list.Items {
+				if _, ok := allowSet[p.Namespace]; !ok {
+					continue
+				}
+				if p.Spec.NodeName != "" && isPodEligible(&p) {
+					nodes[p.Spec.NodeName] = struct{}{}
+				}
 			}
 		}
 	}
@@ -238,7 +309,7 @@ func (r *PodTraceSessionReconciler) resolveTargetNodes(ctx context.Context, s *p
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return nil, fmt.Errorf("get pod %s/%s: %w", ns, ref.Name, err)
+			return nil, nil, fmt.Errorf("get pod %s/%s: %w", ns, ref.Name, err)
 		}
 		if pod.Spec.NodeName != "" && isPodEligible(&pod) {
 			nodes[pod.Spec.NodeName] = struct{}{}
@@ -250,7 +321,7 @@ func (r *PodTraceSessionReconciler) resolveTargetNodes(ctx context.Context, s *p
 		out = append(out, n)
 	}
 	sort.Strings(out)
-	return out, nil
+	return out, targetNamespaces, nil
 }
 
 // isPodEligible filters out pods the tracer cannot attach to: those in

--- a/internal/operator/reconcilers_unit_test.go
+++ b/internal/operator/reconcilers_unit_test.go
@@ -742,11 +742,10 @@ func TestResolveTargetNodes_BySelectorAndPodRefs(t *testing.T) {
 	}
 
 	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme}
-	got, err := r.resolveTargetNodes(context.Background(), s)
+	got, _, err := r.resolveTargetNodes(context.Background(), s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Pending pod n3 must be skipped; n1, n2, n4 included; sorted.
 	want := []string{"n1", "n2", "n4"}
 	if len(got) != len(want) {
 		t.Fatalf("got %v, want %v", got, want)

--- a/internal/operator/session_bundle.go
+++ b/internal/operator/session_bundle.go
@@ -47,7 +47,7 @@ func SessionBundleName(sessionUID types.UID) string {
 func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string) error {
 	name := SessionBundleName(s.UID)
 
-	payload, credSecretRef, err := renderBundlePayload(ec)
+	payload, credSecretRef, err := renderBundlePayload(ec, nil)
 	if err != nil {
 		return fmt.Errorf("render session bundle payload: %w", err)
 	}

--- a/pkg/exporter/bundle/bundle.go
+++ b/pkg/exporter/bundle/bundle.go
@@ -20,12 +20,10 @@ import (
 )
 
 // CredentialKey is the fixed key under which the operator stores the
-// resolved credential material in the companion Secret. Agents and CLI
-// both read exactly this key; the operator abstracts any upstream
-// SecretKeySelector into it.
+// resolved credential material in the companion Secret.
 const CredentialKey = "credential"
 
-const CurrentVersion = "v1"
+const CurrentVersion = "v2"
 
 // Type names the exporter implementation a Payload targets.
 type Type string
@@ -67,6 +65,19 @@ type Payload struct {
 	// companion Secret's CredentialKey. Empty when no Secret-backed
 	// header is configured.
 	HeaderName string `yaml:"headerName,omitempty"`
+
+	// TargetNamespaces is the resolved allowlist of namespace names a
+	// PodTrace's spec.namespaceSelector matched at bundle-render time.
+	// The semantics are tri-state and the wire format preserves all
+	// three (see ConfigMapHasTargetNamespacesKey for the on-wire
+	// representation):
+	//
+	//	nil         — spec.namespaceSelector is nil on the CR; agents
+	//	              fall back to own-namespace matching (legacy).
+	//	[]string{}  — spec.namespaceSelector is set but matched no
+	//	              namespaces; agents match nothing for this CR.
+	//	["a", "b"]  — spec.namespaceSelector matched these namespaces.
+	TargetNamespaces []string `yaml:"targetNamespaces,omitempty"`
 
 	// Credential is the resolved secret material (Splunk token,
 	// DataDog API key, or OTLP Secret-backed header value). Transport
@@ -117,6 +128,19 @@ func FromConfigMapData(data map[string]string) (*Payload, error) {
 			p.Headers[rest] = v
 		}
 	}
+	// TargetNamespaces uses key-presence semantics on "target_namespaces"
+	// to distinguish the three states the agent needs to act on:
+	//
+	//	key absent         → nil result        (selector not set)
+	//	key present, ""    → []string{} result (selector set, no match)
+	//	key present, "a,b" → ["a","b"] result  (selector matched)
+	if raw, ok := data["target_namespaces"]; ok {
+		if raw == "" {
+			p.TargetNamespaces = []string{}
+		} else {
+			p.TargetNamespaces = strings.Split(raw, ",")
+		}
+	}
 	return p, nil
 }
 
@@ -153,9 +177,6 @@ func ToConfigMapData(p *Payload) map[string]string {
 		percent := int(p.Sample*100 + 0.5)
 		out["sample_percent"] = strconv.Itoa(percent)
 	}
-	// Deterministic key order is not an on-disk invariant (ConfigMap
-	// keys are unordered), but tests compare rendered data maps and
-	// sorted construction makes failure diffs readable.
 	keys := make([]string, 0, len(p.Headers))
 	for k := range p.Headers {
 		keys = append(keys, k)
@@ -163,6 +184,12 @@ func ToConfigMapData(p *Payload) map[string]string {
 	sort.Strings(keys)
 	for _, k := range keys {
 		out["headers."+k] = p.Headers[k]
+	}
+	if p.TargetNamespaces != nil {
+		sorted := make([]string, len(p.TargetNamespaces))
+		copy(sorted, p.TargetNamespaces)
+		sort.Strings(sorted)
+		out["target_namespaces"] = strings.Join(sorted, ",")
 	}
 	return out
 }

--- a/pkg/exporter/bundle/bundle_test.go
+++ b/pkg/exporter/bundle/bundle_test.go
@@ -274,3 +274,86 @@ func TestVersion_WritersAlwaysStampCurrent(t *testing.T) {
 		t.Errorf("ToYAML/FromYAML version = %q, want %q", parsed.Version, CurrentVersion)
 	}
 }
+
+// TestTargetNamespaces_ConfigMapTriState pins the wire contract for
+// allowlist field: agents have to distinguish "selector
+// not set"
+func TestTargetNamespaces_ConfigMapTriState(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     *Payload
+		wantKey   bool
+		wantValue string
+		wantField []string
+		fieldIsNil bool
+	}{
+		{
+			name:      "NilFieldOmitsKey",
+			input:     &Payload{Type: TypeOTLP, Endpoint: "x:4318", TargetNamespaces: nil},
+			wantKey:   false,
+			fieldIsNil: true,
+		},
+		{
+			name:      "EmptySliceWritesEmptyValue",
+			input:     &Payload{Type: TypeOTLP, Endpoint: "x:4318", TargetNamespaces: []string{}},
+			wantKey:   true,
+			wantValue: "",
+			wantField: []string{},
+		},
+		{
+			name:      "PopulatedSliceWritesCommaJoined",
+			input:     &Payload{Type: TypeOTLP, Endpoint: "x:4318", TargetNamespaces: []string{"team-b", "team-a", "prod"}},
+			wantKey:   true,
+			wantValue: "prod,team-a,team-b",
+			wantField: []string{"prod", "team-a", "team-b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := ToConfigMapData(tc.input)
+			val, ok := data["target_namespaces"]
+			if ok != tc.wantKey {
+				t.Fatalf("target_namespaces key presence = %v, want %v", ok, tc.wantKey)
+			}
+			if ok && val != tc.wantValue {
+				t.Errorf("target_namespaces value = %q, want %q", val, tc.wantValue)
+			}
+			parsed, err := FromConfigMapData(data)
+			if err != nil {
+				t.Fatalf("parse back: %v", err)
+			}
+			if tc.fieldIsNil {
+				if parsed.TargetNamespaces != nil {
+					t.Errorf("expected nil after round-trip, got %v", parsed.TargetNamespaces)
+				}
+				return
+			}
+			if parsed.TargetNamespaces == nil {
+				t.Fatal("expected non-nil slice after round-trip, got nil")
+			}
+			if !reflect.DeepEqual(parsed.TargetNamespaces, tc.wantField) {
+				t.Errorf("round-trip slice = %v, want %v", parsed.TargetNamespaces, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestTargetNamespaces_AgentRejectV1BundleAfterV2Migration(t *testing.T) {
+	_, err := FromConfigMapData(map[string]string{
+		"version":           "v3-future",
+		"type":              "otlp",
+		"endpoint":          "x:4318",
+		"target_namespaces": "team-a",
+	})
+	if err == nil {
+		t.Fatal("FromConfigMapData should reject unknown future version")
+	}
+	if !contains(err.Error(), "v3-future") {
+		t.Errorf("error %q should name the unknown version", err.Error())
+	}
+	if !contains(err.Error(), CurrentVersion) {
+		t.Errorf("error %q should name the current version", err.Error())
+	}
+}
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }

--- a/test/chainsaw/tests/namespace-selector/assert-grown-allowlist.yaml
+++ b/test/chainsaw/tests/namespace-selector/assert-grown-allowlist.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: podtrace-system
+  labels:
+    podtrace.io/managed-by: podtrace-operator
+    podtrace.io/component: exporter-bundle
+    podtrace.io/exporter-config: ns-selector-otlp
+data:
+  target_namespaces: ns-selector-in,ns-selector-out
+---
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: ns-selector-pt
+status:
+  targetNamespaces:
+    - ns-selector-in
+    - ns-selector-out

--- a/test/chainsaw/tests/namespace-selector/assert-initial-allowlist.yaml
+++ b/test/chainsaw/tests/namespace-selector/assert-initial-allowlist.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: podtrace-system
+  labels:
+    podtrace.io/managed-by: podtrace-operator
+    podtrace.io/component: exporter-bundle
+    podtrace.io/exporter-config: ns-selector-otlp
+data:
+  type: otlp
+  endpoint: otel-collector:4318
+  target_namespaces: ns-selector-in
+---
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: ns-selector-pt
+status:
+  targetNamespaces:
+    - ns-selector-in
+  (conditions[?type == 'Reconciled'].status | [0]): "True"

--- a/test/chainsaw/tests/namespace-selector/chainsaw-test.yaml
+++ b/test/chainsaw/tests/namespace-selector/chainsaw-test.yaml
@@ -1,0 +1,60 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: namespace-selector
+spec:
+  description: |
+    Verifies cross-namespace targeting via spec.namespaceSelector:
+      1. Create two test namespaces with distinct labels.
+      2. Create a PodTrace whose NamespaceSelector matches exactly one.
+      3. Assert the bundle ConfigMap surfaces the resolved namespace
+         allowlist in data.target_namespaces and the PodTrace status
+         echoes it in status.targetNamespaces.
+      4. Re-label the previously-excluded namespace; assert the operator
+         requeues on the Namespace event and the allowlist grows.
+
+    The Namespace event watch is the load-bearing piece — without it the
+    bundle would only update on the next PodTrace reconcile, which is
+    operator-period-bound and not user-visible.
+  timeouts:
+    apply: 30s
+    assert: 120s
+    delete: 60s
+  steps:
+    - name: prepare-namespaces
+      try:
+        - apply:
+            file: ./namespaces.yaml
+
+    - name: apply-cr
+      try:
+        - apply:
+            file: ./resources.yaml
+        - assert:
+            file: ./assert-initial-allowlist.yaml
+
+    - name: relabel-namespace
+      try:
+        - patch:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: ns-selector-out
+                labels:
+                  podtrace.io/chainsaw-ns-selector: "in"
+        - assert:
+            file: ./assert-grown-allowlist.yaml
+
+    - name: cleanup
+      cleanup:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Namespace
+              name: ns-selector-in
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Namespace
+              name: ns-selector-out

--- a/test/chainsaw/tests/namespace-selector/namespaces.yaml
+++ b/test/chainsaw/tests/namespace-selector/namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-selector-in
+  labels:
+    podtrace.io/chainsaw-ns-selector: "in"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-selector-out
+  labels:
+    podtrace.io/chainsaw-ns-selector: "out"

--- a/test/chainsaw/tests/namespace-selector/resources.yaml
+++ b/test/chainsaw/tests/namespace-selector/resources.yaml
@@ -1,0 +1,24 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ns-selector-otlp
+spec:
+  type: otlp
+  otlp:
+    endpoint: otel-collector:4318
+    protocol: http
+    insecure: true
+---
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: ns-selector-pt
+spec:
+  selector:
+    matchLabels:
+      app: ns-selector-target
+  namespaceSelector:
+    matchLabels:
+      podtrace.io/chainsaw-ns-selector: "in"
+  exporterRef:
+    name: ns-selector-otlp

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -89,10 +89,12 @@ func TestChart_DefaultValues(t *testing.T) {
 	if resources["CustomResourceDefinition"] != 4 {
 		t.Errorf("default `helm template` should render 4 CRDs; got %d", resources["CustomResourceDefinition"])
 	}
-	if resources["Namespace"] != 1 {
-		t.Errorf("Namespace count: got %d want 1", resources["Namespace"])
+	if resources["Namespace"] != 0 {
+		t.Errorf("Namespace count: got %d want 0 (namespace is created by the bootstrap Job, not as a tracked resource)", resources["Namespace"])
 	}
-	// Should NOT render the webhook by default (operator not enabled).
+	if !bytes.Contains(out, []byte("namespace-bootstrap")) {
+		t.Error("default render must include the namespace-bootstrap Job that creates the system namespace")
+	}
 	if resources["ValidatingWebhookConfiguration"] != 0 {
 		t.Errorf("webhook should be disabled by default, got %d", resources["ValidatingWebhookConfiguration"])
 	}
@@ -172,22 +174,21 @@ func TestChart_NamespacePSALabels(t *testing.T) {
 	}
 }
 
-// TestChart_OperatorToggleRendersFullStack asserts that enabling the
-// operator pulls in the Deployment, SA, ClusterRole, ClusterRoleBinding,
-// and metrics Service — and that default (off) mode does not.
+// TestChart_OperatorToggleRendersFullStack asserts the operator stack
+// renders by default and disappears when explicitly disabled.
 func TestChart_OperatorToggleRendersFullStack(t *testing.T) {
-	off := renderChart(t)
-	on := renderChart(t, "operator.enabled=true")
+	on := renderChart(t)
+	off := renderChart(t, "operator.enabled=false")
 
-	offKinds := parseKinds(t, off)
 	onKinds := parseKinds(t, on)
+	offKinds := parseKinds(t, off)
 
 	if offKinds["Deployment"] != 0 {
 		t.Errorf("operator Deployment should not render with operator.enabled=false, got %d", offKinds["Deployment"])
 	}
 	for _, kind := range []string{"Deployment", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Service"} {
 		if onKinds[kind] < 1 {
-			t.Errorf("operator.enabled=true: expected >=1 %s, got %d", kind, onKinds[kind])
+			t.Errorf("default render: expected >=1 %s, got %d", kind, onKinds[kind])
 		}
 	}
 }
@@ -196,7 +197,7 @@ func TestChart_OperatorToggleRendersFullStack(t *testing.T) {
 // templates render only when BOTH operator AND webhook are enabled,
 // because the webhook server runs inside the operator Deployment.
 func TestChart_WebhookRequiresOperatorToRender(t *testing.T) {
-	webhookOnly := renderChart(t, "webhook.enabled=true")
+	webhookOnly := renderChart(t, "operator.enabled=false", "webhook.enabled=true")
 	both := renderChart(t, "operator.enabled=true", "webhook.enabled=true")
 
 	woKinds := parseKinds(t, webhookOnly)
@@ -254,8 +255,11 @@ func TestChart_OperatorDeploymentSecurityContext(t *testing.T) {
 // namespace from values.
 func TestChart_SystemNamespaceOverride(t *testing.T) {
 	out := renderChart(t, "namespace.name=custom-podtrace")
-	if !bytes.Contains(out, []byte("name: custom-podtrace")) {
+	if !bytes.Contains(out, []byte("namespace: custom-podtrace")) {
 		t.Error("namespace.name override not reflected in rendered output")
+	}
+	if !bytes.Contains(out, []byte(`NS="custom-podtrace"`)) {
+		t.Error("namespace.name override not threaded into the bootstrap Job's kubectl apply payload")
 	}
 }
 


### PR DESCRIPTION
- Cross-namespace `PodTrace` / `PodTraceSession` targeting: `spec.namespaceSelector` resolves to an explicit allowlist of namespaces, threaded into the exporter bundle's new `target_namespaces` key and echoed on `status.targetNamespaces`. Tri-state semantics (`nil` / `[]` / `[list]`) are preserved on the wire so agents can distinguish "selector not set" (legacy own-ns fallback) from "selector matched zero namespaces" (match nothing).
- Bundle schema bumped to `v2`; agents reject `v1` payloads with a clear error.
- Agent matcher reordered to load the bundle before evaluating selectors, with a conservative own-namespace fallback when the allowlist is unknown.
- Operator gains a `Namespace` watch on both reconcilers so a label change on a Namespace re-evaluates every `PodTrace` / `PodTraceSession` that uses a `namespaceSelector`.
- Admission webhook now rejects malformed `spec.namespaceSelector` before the reconciler trips on `LabelSelectorAsSelector`.
- Operator RBAC extended with `namespaces: get;list;watch` (kubebuilder marker + chart `ClusterRole`).
- Chart install path hardened: the templated `Namespace` resource was replaced with a pre-install hook `Job` in `kube-system` that runs `kubectl apply` to create/adopt the system namespace and stamp PSA labels. This sidesteps the "invalid ownership metadata" error Helm raises when the namespace exists from `--create-namespace` or a prior install. `operator.enabled` now defaults to `true` so a fresh `helm install` produces a working setup out of the box; the dead `agent.enabled` toggle was removed (the agent is created by the operator from the `TracerConfig` CR).
