### PR TITLE
feat(operator): ExporterConfig status reconciler, changelog and CI hygiene

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -54,8 +54,6 @@ jobs:
       - name: Install dependencies
         run: GOTOOLCHAIN=auto go mod download
 
-      # v1.64 is built with Go <1.25 and exits with "targeted Go version ... is higher than ..."
-      # when go.mod uses go 1.25.x. Use a 2.x release built with Go 1.25+.
       - name: Run golangci-lint
         timeout-minutes: 5
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
@@ -72,18 +70,6 @@ jobs:
       - name: Build
         timeout-minutes: 5
         run: GOTOOLCHAIN=auto go build ./...
-
-      - name: Cross-compile sanity check
-        timeout-minutes: 5
-        run: |
-          set -e
-          for goos_goarch in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-            os=$(echo $goos_goarch | cut -d/ -f1)
-            arch=$(echo $goos_goarch | cut -d/ -f2)
-            echo "==> $os/$arch"
-            GOTOOLCHAIN=auto GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
-              go build ./...
-          done
 
       - name: Run unit tests
         timeout-minutes: 10
@@ -135,6 +121,40 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  cross-compile:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: GOTOOLCHAIN=auto go build ./...
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -85,69 +85,21 @@ jobs:
               go build ./...
           done
 
-      - name: Detect changed packages
-        id: changed-packages
-        if: github.event_name == 'pull_request'
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.sha }}"
-          echo "Detecting changed packages between $BASE_SHA and $HEAD_SHA"
-          
-          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA 2>/dev/null | grep '\.go$' | grep -E '^(cmd|internal)/' || true)
-          
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No changed Go files in cmd/ or internal/, testing all packages"
-            echo "packages=./cmd/... ./internal/..." >> $GITHUB_OUTPUT
-          else
-            CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | \
-              xargs -r dirname | \
-              sort -u | \
-              sed 's|^|./|' | \
-              sed 's|/$||' | \
-              awk '{print $0"/..."}' | \
-              tr '\n' ' ' | \
-              sed 's/ $//' || echo "./cmd/... ./internal/...")
-            echo "packages=$CHANGED_PACKAGES" >> $GITHUB_OUTPUT
-            echo "Changed packages: $CHANGED_PACKAGES"
-          fi
-
       - name: Run unit tests
         timeout-minutes: 10
         run: |
           rm -f coverage.out coverage-*.out
-          
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "${{ steps.changed-packages.outputs.packages }}" ]; then
-            PACKAGES="${{ steps.changed-packages.outputs.packages }}"
-            echo "Testing changed packages: $PACKAGES"
-          else
-            PACKAGES="./cmd/... ./internal/..."
-            echo "Testing all packages: $PACKAGES"
-          fi
-          
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "Running tests with race detection on main branch"
-            set +e
-            GOTOOLCHAIN=auto go test -short -race -parallel=4 -timeout=10m -coverprofile=coverage.out -covermode=atomic $PACKAGES
-            TEST_EXIT_CODE=$?
-            set -e
-            if [ $TEST_EXIT_CODE -ne 0 ]; then
-              echo "::error::Unit tests failed with exit code $TEST_EXIT_CODE"
-              exit $TEST_EXIT_CODE
-            fi
-          else
-            echo "Running tests with race detection on PR"
-            set +e
-            GOTOOLCHAIN=auto go test -short -race -parallel=4 -timeout=5m -coverprofile=coverage.out -covermode=atomic $PACKAGES
-            TEST_EXIT_CODE=$?
-            set -e
-            if [ $TEST_EXIT_CODE -ne 0 ]; then
-              echo "::error::Unit tests failed with exit code $TEST_EXIT_CODE"
-              exit $TEST_EXIT_CODE
-            fi
-          fi
-          
-          echo "Running test/... tests"
-          GOTOOLCHAIN=auto go test -short -tags=integration -timeout=5m ./test/... || true
+          GOTOOLCHAIN=auto go test \
+            -short -race -parallel=4 -timeout=10m \
+            -coverprofile=coverage.out -covermode=atomic \
+            ./cmd/... ./internal/...
+
+      - name: Run integration suite
+        timeout-minutes: 5
+        run: |
+          GOTOOLCHAIN=auto go test \
+            -short -tags=integration -timeout=5m \
+            ./test/...
 
       - name: Generate coverage report
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - language: go
-            build-mode: none
+            build-mode: autobuild
           - language: cpp
             build-mode: manual
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,8 @@
 name: Security - CodeQL
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: ["**"]
   schedule:
@@ -24,7 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "cpp"]
+        include:
+          - language: go
+            build-mode: none
+          - language: cpp
+            build-mode: manual
 
     steps:
       - name: Checkout
@@ -41,9 +47,10 @@ jobs:
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           languages: ${{ matrix.language }}
-          build-mode: manual
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Install BPF toolchain
+        if: matrix.language == 'cpp'
         uses: ./.github/actions/setup-bpf-toolchain
 
       - name: Run gosec security scanner
@@ -51,8 +58,6 @@ jobs:
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@latest
           gosec -fmt sarif -out gosec-results.sarif -exclude-dir=test ./... || true
-          # Normalize SARIF: gosec may emit relationships as plain strings instead
-          # of objects, which fails GitHub's SARIF schema validation.
           python3 - <<'EOF'
           import json, sys
           try:
@@ -77,12 +82,6 @@ jobs:
         with:
           sarif_file: gosec-results.sarif
           category: gosec
-
-      - name: Build Go
-        if: matrix.language == 'go'
-        run: |
-          GOTOOLCHAIN=auto go mod download
-          GOTOOLCHAIN=auto go build ./...
 
       - name: Build eBPF C
         if: matrix.language == 'cpp'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,34 @@ no trailing period, ≤ 72 chars.
 |---|---|---|
 | `feat:` | ✅ Added section | patch bump |
 | `fix:` | ✅ Fixed section | patch bump |
-| `refactor:`, `perf:`, `revert:` | ✅ Changed section | patch bump |
-| `chore:`, `docs:`, `style:`, `test:`, `build:`, `ci:` | ❌ Hidden | no bump |
+| `perf:` | ✅ Performance section | patch bump |
+| `deprecate:` | ✅ Deprecated section | patch bump |
+| `remove:` | ✅ Removed section | patch bump |
 | `security:` | ✅ Security section | patch bump |
+| `revert:` | ✅ Changed section | patch bump |
+| `refactor:`, `chore:`, `docs:`, `style:`, `test:`, `build:`, `ci:` | ❌ Hidden | no bump |
 | Footer `BREAKING CHANGE:` | ✅ called out | **minor bump** (your only path to `v0.X+1.0`) |
 | Footer `Release-As: 0.X.Y` | overrides version explicitly | Forces release-please to propose the named version |
+
+A few notes on type choice:
+
+- **One PR = one type.** Pick the type that matches the PR's dominant
+  intent and stick with it. release-please reads only the squash-merge
+  subject line — sub-bullets in the PR body do *not* get categorised.
+  Mixed-intent PRs should be split.
+- **`refactor:` is hidden** because, by definition, a refactor has no
+  user-visible behaviour change. If the change *does* affect a public
+  surface (CLI flag, CRD field, env var, Helm value), it is not a
+  refactor — use `feat:` or `feat!:` / `BREAKING CHANGE:`.
+- **`deprecate:` vs `remove:`** — deprecating something keeps it
+  working for one or more releases with a warning; removing it
+  breaks the contract. A removal should usually carry a
+  `BREAKING CHANGE:` footer too, so the minor-version bump signals
+  the contract change.
+- **`security:` and `deprecate:` / `remove:` are project-specific
+  extensions** to the standard Conventional Commits vocabulary. They
+  exist because Keep-a-Changelog defines Security / Deprecated /
+  Removed sections that the upstream spec has no native types for.
 
 Examples:
 
@@ -147,10 +170,25 @@ BPF object instead of erroring on load.
 ```
 
 ```
-refactor(build): per-arch BPF objects under internal/ebpf/embedded
+deprecate(api): spec.legacySelector is replaced by spec.selector
 
-BREAKING CHANGE: env var PODTRACE_BPF_OBJECT now defaults to a
-per-arch path. Users overriding this var must update.
+spec.legacySelector keeps working in 0.x but emits a warning event
+on every reconcile. It will be removed in v1.0.0; switch to
+spec.selector now.
+```
+
+```
+remove(api): drop spec.legacySelector
+
+BREAKING CHANGE: spec.legacySelector was deprecated in 0.10 and is
+now removed. Use spec.selector. Existing CRs that still set
+legacySelector will fail admission until updated.
+```
+
+```
+perf(agent): hash cgroup IDs with xxh3 instead of sha256
+
+Reduces per-event hashing overhead by ~70% on hot paths.
 ```
 
 The bump rules above apply pre-1.0. After `v1.0.0`, the standard semver
@@ -164,7 +202,7 @@ The release pipeline is fully automated once a release-worthy commit
 lands on `main`:
 
 ```
-1. You merge a PR with a non-hidden commit type (feat:/fix:/refactor:/perf:/security:)
+1. You merge a PR with a non-hidden commit type (feat:/fix:/perf:/deprecate:/remove:/security:/revert:)
    ↓
 2. release-please opens a "chore(main): release X.Y.Z" PR
    - Updates CHANGELOG.md

--- a/api/v1alpha1/exporterconfig_webhook.go
+++ b/api/v1alpha1/exporterconfig_webhook.go
@@ -35,7 +35,7 @@ func (v *ExporterConfigCustomValidator) ValidateCreate(_ context.Context, obj ru
 	if !ok {
 		return nil, fmt.Errorf("expected *ExporterConfig, got %T", obj)
 	}
-	return nil, validateExporterConfigVariant(ec.Spec)
+	return nil, ValidateExporterConfigVariant(ec.Spec)
 }
 
 func (v *ExporterConfigCustomValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
@@ -43,7 +43,7 @@ func (v *ExporterConfigCustomValidator) ValidateUpdate(_ context.Context, _, new
 	if !ok {
 		return nil, fmt.Errorf("expected *ExporterConfig, got %T", newObj)
 	}
-	return nil, validateExporterConfigVariant(ec.Spec)
+	return nil, ValidateExporterConfigVariant(ec.Spec)
 }
 
 func (v *ExporterConfigCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {

--- a/api/v1alpha1/webhook_helpers.go
+++ b/api/v1alpha1/webhook_helpers.go
@@ -91,9 +91,9 @@ func resolveExporterRef(ctx context.Context, c client.Client, namespace, name st
 	return fmt.Errorf("spec.exporterRef.name %q: %w", name, err)
 }
 
-// validateExporterConfigVariant enforces that the typed field matching
+// ValidateExporterConfigVariant enforces that the typed field matching
 // spec.type is populated, and only that one.
-func validateExporterConfigVariant(spec ExporterConfigSpec) error {
+func ValidateExporterConfigVariant(spec ExporterConfigSpec) error {
 	present := map[ExporterType]bool{
 		ExporterTypeOTLP:    spec.OTLP != nil,
 		ExporterTypeJaeger:  spec.Jaeger != nil,

--- a/doc/crd-exporterconfig.md
+++ b/doc/crd-exporterconfig.md
@@ -163,16 +163,50 @@ the CR into each namespace (the bundle is per-CR anyway).
 
 ## Status reference
 
+The operator runs a dedicated reconciler that keeps an ExporterConfig's
+status fresh:
+
 ```yaml
 status:
+  ready: true
+  referencedBy: 3
+  observedGeneration: 4
   conditions:
-    - type: Reconciled
+    - type: Ready
       status: "True"
-      reason: Reconciled
+      reason: SecretsResolved
+      message: all referenced Secrets resolved
+    - type: Referenced
+      status: "True"
+      reason: Referenced
+      message: 3 referent(s)
 ```
 
-ExporterConfig itself is mostly passive — the heavy reconcile happens
-when a PodTrace or PodTraceSession references it.
+### Field semantics
+
+| Field | Meaning |
+|---|---|
+| `ready` | `true` when the spec variant validates AND every referenced Secret (and required key, if any) exists. |
+| `referencedBy` | Count of `PodTrace` + non-terminal `PodTraceSession` objects in the same namespace whose `spec.exporterRef.name` matches this EC. Terminal sessions (`Completed`, `Failed`) are excluded so the count reflects active load. |
+| `observedGeneration` | Mirrors `metadata.generation` on the last successful reconcile. |
+
+### Conditions
+
+| Type | Status | Reason | Meaning |
+|---|---|---|---|
+| `Ready` | `True` | `SecretsResolved` | All required Secrets and keys resolved. |
+| `Ready` | `False` | `SecretMissing` | A referenced Secret does not exist. The message names the Secret. |
+| `Ready` | `False` | `SecretKeyMissing` | The referenced Secret exists but lacks the required key. The message names both. |
+| `Ready` | `False` | `InvalidSpec` | `spec.type` does not match the populated typed field. Normally blocked by the admission webhook; this reason appears on clusters where the webhook is disabled. |
+| `Ready` | `Unknown` | `TransientError` | Transient API error during reconcile. Self-heals on the next watch event. |
+| `Referenced` | `True` | `Referenced` | At least one `PodTrace` or active `PodTraceSession` uses this EC. |
+| `Referenced` | `False` | `Unreferenced` | No active referents. Useful for alerting on orphaned ECs: `kubectl wait --for=condition=Referenced=false`. |
+
+### What the status reconciler does *not* do
+
+- It does **not** probe the exporter endpoint. Network reachability is reported by the agent at first export, surfacing as a `Degraded` condition on the referring `PodTrace` / `PodTraceSession`. Probing here would flap on transient backend issues and cause false alerts across every CR that references the EC.
+- It does **not** validate credential *contents* against the remote service (e.g. it never tries the Splunk token against Splunk). The agent learns about credential rejections on first export.
+- It does **not** mutate the spec. Missing Secrets must be fixed by the user; the controller surfaces the condition and waits.
 
 ## Related
 

--- a/internal/operator/exporterconfig_controller.go
+++ b/internal/operator/exporterconfig_controller.go
@@ -1,0 +1,347 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// ExporterConfigReconciler populates an ExporterConfig's status:
+//
+//   - Ready=true when spec variant validates AND every referenced Secret
+//     (and required key, if any) exists.
+//   - ReferencedBy = #PodTraces + #non-terminal PodTraceSessions in the
+//     same namespace whose .spec.exporterRef.name matches.
+//   - Referenced condition mirrors ReferencedBy > 0.
+type ExporterConfigReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// Reason strings for the Ready / Referenced conditions. Stable
+// contract — operators match against these in alerts / kubectl wait.
+const (
+	ecReasonSecretsResolved  = "SecretsResolved"
+	ecReasonSecretMissing    = "SecretMissing"
+	ecReasonSecretKeyMissing = "SecretKeyMissing"
+	ecReasonInvalidSpec      = "InvalidSpec"
+	ecReasonTransientError   = "TransientError"
+	ecReasonReferenced       = "Referenced"
+	ecReasonUnreferenced     = "Unreferenced"
+
+	ecMaxConditionMessageLen = 256
+)
+
+// Field-indexer keys. Registered against PodTrace and PodTraceSession
+// in registerExporterConfigIndexers — reverse lookup so the
+// reconciler can ask "which PT/PTS objects point at this EC name?"
+// without listing the entire namespace.
+const (
+	IndexFieldPodTraceExporterRef        = "spec.exporterRef.name"
+	IndexFieldPodTraceSessionExporterRef = "spec.exporterRef.name"
+)
+
+// +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+
+func (r *ExporterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var ec podtracev1alpha1.ExporterConfig
+	if err := r.Get(ctx, req.NamespacedName, &ec); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
+	}
+
+	orig := ec.DeepCopy()
+
+	ready, readyStatus, readyReason, readyMessage := r.evaluateReadiness(ctx, &ec)
+
+	refs, err := r.countReferences(ctx, &ec)
+	if err != nil {
+		// Listing failures are transient — keep the previous count
+		// rather than zeroing it and triggering false alerts.
+		logger.V(1).Info("count references failed; keeping previous count", "error", err)
+		refs = ec.Status.ReferencedBy
+	}
+
+	ec.Status.ObservedGeneration = ec.Generation
+	ec.Status.Ready = ready
+	ec.Status.ReferencedBy = refs
+
+	setCondition(&ec.Status.Conditions, ec.Generation, metav1.Condition{
+		Type:    ConditionReady,
+		Status:  readyStatus,
+		Reason:  readyReason,
+		Message: clampMessage(readyMessage),
+	})
+
+	if refs > 0 {
+		setCondition(&ec.Status.Conditions, ec.Generation, metav1.Condition{
+			Type:    ConditionReferenced,
+			Status:  metav1.ConditionTrue,
+			Reason:  ecReasonReferenced,
+			Message: fmt.Sprintf("%d referent(s)", refs),
+		})
+	} else {
+		setCondition(&ec.Status.Conditions, ec.Generation, metav1.Condition{
+			Type:    ConditionReferenced,
+			Status:  metav1.ConditionFalse,
+			Reason:  ecReasonUnreferenced,
+			Message: "no PodTrace or active PodTraceSession references this ExporterConfig",
+		})
+	}
+
+	if statusEqual(orig.Status, ec.Status) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.Status().Patch(ctx, &ec, client.MergeFrom(orig)); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("patch status: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// evaluateReadiness returns (ready, conditionStatus, reason, message).
+// The first failure short-circuits — operators see one actionable
+// cause, not a list.
+func (r *ExporterConfigReconciler) evaluateReadiness(ctx context.Context, ec *podtracev1alpha1.ExporterConfig) (bool, metav1.ConditionStatus, string, string) {
+	logger := log.FromContext(ctx)
+
+	if err := podtracev1alpha1.ValidateExporterConfigVariant(ec.Spec); err != nil {
+		return false, metav1.ConditionFalse, ecReasonInvalidSpec, err.Error()
+	}
+
+	for _, ref := range collectSecretRefs(ec.Spec) {
+		var sec corev1.Secret
+		key := types.NamespacedName{Namespace: ec.Namespace, Name: ref.Name}
+		if err := r.Get(ctx, key, &sec); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(1).Info("secret missing", "secret", key.String())
+				return false, metav1.ConditionFalse, ecReasonSecretMissing,
+					fmt.Sprintf("Secret %s/%s not found", ec.Namespace, ref.Name)
+			}
+			logger.V(1).Info("secret lookup transient error", "secret", key.String(), "error", err)
+			return false, metav1.ConditionUnknown, ecReasonTransientError, err.Error()
+		}
+		if ref.Key != "" {
+			if _, ok := sec.Data[ref.Key]; !ok {
+				logger.V(1).Info("secret key missing", "secret", key.String(), "key", ref.Key)
+				return false, metav1.ConditionFalse, ecReasonSecretKeyMissing,
+					fmt.Sprintf("Secret %s/%s has no key %q", ec.Namespace, ref.Name, ref.Key)
+			}
+		}
+	}
+
+	return true, metav1.ConditionTrue, ecReasonSecretsResolved, "all referenced Secrets resolved"
+}
+
+// countReferences sums PodTraces and non-terminal PodTraceSessions in
+// the EC's namespace whose .spec.exporterRef.name == ec.Name. Uses
+// the field indexers registered in registerExporterConfigIndexers so
+// the call cost is O(refs), not O(namespace).
+func (r *ExporterConfigReconciler) countReferences(ctx context.Context, ec *podtracev1alpha1.ExporterConfig) (int32, error) {
+	var ptList podtracev1alpha1.PodTraceList
+	if err := r.List(ctx, &ptList,
+		client.InNamespace(ec.Namespace),
+		client.MatchingFields{IndexFieldPodTraceExporterRef: ec.Name},
+	); err != nil {
+		return 0, fmt.Errorf("list PodTrace: %w", err)
+	}
+
+	var ptsList podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &ptsList,
+		client.InNamespace(ec.Namespace),
+		client.MatchingFields{IndexFieldPodTraceSessionExporterRef: ec.Name},
+	); err != nil {
+		return 0, fmt.Errorf("list PodTraceSession: %w", err)
+	}
+
+	count := int32(len(ptList.Items))
+	for i := range ptsList.Items {
+		if !isSessionTerminal(ptsList.Items[i].Status.Phase) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func isSessionTerminal(p podtracev1alpha1.SessionPhase) bool {
+	return p == podtracev1alpha1.SessionPhaseCompleted || p == podtracev1alpha1.SessionPhaseFailed
+}
+
+// SetupWithManager wires the controller's watches. Field indexers
+// must already be installed (see registerExporterConfigIndexers).
+func (r *ExporterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("exporterconfig").
+		For(&podtracev1alpha1.ExporterConfig{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.secretToExporterConfigs),
+		).
+		Watches(
+			&podtracev1alpha1.PodTrace{},
+			handler.EnqueueRequestsFromMapFunc(r.podTraceToExporterConfig),
+		).
+		Watches(
+			&podtracev1alpha1.PodTraceSession{},
+			handler.EnqueueRequestsFromMapFunc(r.sessionToExporterConfig),
+		).
+		WithOptions(defaultControllerOptions()).
+		Complete(r)
+}
+
+// secretToExporterConfigs lists ECs in the Secret's namespace and
+// emits a reconcile request for each whose spec references this
+// Secret name. Same-namespace by construction — the EC types only
+// allow LocalObjectReference / SecretKeySelector.
+func (r *ExporterConfigReconciler) secretToExporterConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
+	sec, ok := obj.(*corev1.Secret)
+	if !ok {
+		return nil
+	}
+	var list podtracev1alpha1.ExporterConfigList
+	if err := r.List(ctx, &list, client.InNamespace(sec.Namespace)); err != nil {
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range list.Items {
+		ec := &list.Items[i]
+		for _, ref := range collectSecretRefs(ec.Spec) {
+			if ref.Name == sec.Name {
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: client.ObjectKey{Namespace: ec.Namespace, Name: ec.Name},
+				})
+				break
+			}
+		}
+	}
+	return reqs
+}
+
+func (r *ExporterConfigReconciler) podTraceToExporterConfig(_ context.Context, obj client.Object) []reconcile.Request {
+	pt, ok := obj.(*podtracev1alpha1.PodTrace)
+	if !ok {
+		return nil
+	}
+	if pt.Spec.ExporterRef.Name == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: pt.Namespace, Name: pt.Spec.ExporterRef.Name},
+	}}
+}
+
+func (r *ExporterConfigReconciler) sessionToExporterConfig(_ context.Context, obj client.Object) []reconcile.Request {
+	pts, ok := obj.(*podtracev1alpha1.PodTraceSession)
+	if !ok {
+		return nil
+	}
+	if pts.Spec.ExporterRef.Name == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: pts.Namespace, Name: pts.Spec.ExporterRef.Name},
+	}}
+}
+
+// registerExporterConfigIndexers installs the field indexers the
+// ExporterConfig reconciler needs to look up referencing PodTrace and
+// PodTraceSession objects in O(refs) time. Must run before the
+// manager starts.
+func registerExporterConfigIndexers(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &podtracev1alpha1.PodTrace{},
+		IndexFieldPodTraceExporterRef,
+		func(o client.Object) []string {
+			pt, ok := o.(*podtracev1alpha1.PodTrace)
+			if !ok || pt.Spec.ExporterRef.Name == "" {
+				return nil
+			}
+			return []string{pt.Spec.ExporterRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("index PodTrace.spec.exporterRef.name: %w", err)
+	}
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &podtracev1alpha1.PodTraceSession{},
+		IndexFieldPodTraceSessionExporterRef,
+		func(o client.Object) []string {
+			pts, ok := o.(*podtracev1alpha1.PodTraceSession)
+			if !ok || pts.Spec.ExporterRef.Name == "" {
+				return nil
+			}
+			return []string{pts.Spec.ExporterRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("index PodTraceSession.spec.exporterRef.name: %w", err)
+	}
+	return nil
+}
+
+// setCondition wraps meta.SetStatusCondition with the project's
+// shared invariant: every condition we write carries the current
+// ObservedGeneration. apimachinery already manages
+// LastTransitionTime (only updated when Status changes) and dedupes
+// identical entries.
+func setCondition(conds *[]metav1.Condition, generation int64, c metav1.Condition) {
+	c.ObservedGeneration = generation
+	meta.SetStatusCondition(conds, c)
+}
+
+func clampMessage(s string) string {
+	if len(s) <= ecMaxConditionMessageLen {
+		return s
+	}
+	return s[:ecMaxConditionMessageLen-3] + "..."
+}
+
+// statusEqual returns true when two ExporterConfigStatus values are
+// indistinguishable from the API server's perspective. Used to skip
+// no-op Patch calls in the reconcile loop.
+func statusEqual(a, b podtracev1alpha1.ExporterConfigStatus) bool {
+	if a.Ready != b.Ready ||
+		a.ReferencedBy != b.ReferencedBy ||
+		a.ObservedGeneration != b.ObservedGeneration {
+		return false
+	}
+	return conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func conditionsEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	bm := make(map[string]metav1.Condition, len(b))
+	for _, c := range b {
+		bm[c.Type] = c
+	}
+	for _, c := range a {
+		other, ok := bm[c.Type]
+		if !ok {
+			return false
+		}
+		if c.Status != other.Status || c.Reason != other.Reason || c.Message != other.Message {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/operator/exporterconfig_controller.go
+++ b/internal/operator/exporterconfig_controller.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/internal/safeconv"
 )
 
 // ExporterConfigReconciler populates an ExporterConfig's status:
@@ -75,8 +76,6 @@ func (r *ExporterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	refs, err := r.countReferences(ctx, &ec)
 	if err != nil {
-		// Listing failures are transient — keep the previous count
-		// rather than zeroing it and triggering false alerts.
 		logger.V(1).Info("count references failed; keeping previous count", "error", err)
 		refs = ec.Status.ReferencedBy
 	}
@@ -176,7 +175,7 @@ func (r *ExporterConfigReconciler) countReferences(ctx context.Context, ec *podt
 		return 0, fmt.Errorf("list PodTraceSession: %w", err)
 	}
 
-	count := int32(len(ptList.Items))
+	count := safeconv.IntToInt32(len(ptList.Items))
 	for i := range ptsList.Items {
 		if !isSessionTerminal(ptsList.Items[i].Status.Phase) {
 			count++

--- a/internal/operator/exporterconfig_controller_test.go
+++ b/internal/operator/exporterconfig_controller_test.go
@@ -1,0 +1,419 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// newECTestScheme builds a scheme with core + podtrace v1alpha1
+// registered.
+func newECTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgo scheme: %v", err)
+	}
+	if err := podtracev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("podtrace scheme: %v", err)
+	}
+	return s
+}
+
+// newECFakeClient wires the same field indexers the real manager
+// registers.
+func newECFakeClient(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithIndex(&podtracev1alpha1.PodTrace{}, IndexFieldPodTraceExporterRef,
+			func(o client.Object) []string {
+				pt := o.(*podtracev1alpha1.PodTrace)
+				if pt.Spec.ExporterRef.Name == "" {
+					return nil
+				}
+				return []string{pt.Spec.ExporterRef.Name}
+			},
+		).
+		WithIndex(&podtracev1alpha1.PodTraceSession{}, IndexFieldPodTraceSessionExporterRef,
+			func(o client.Object) []string {
+				pts := o.(*podtracev1alpha1.PodTraceSession)
+				if pts.Spec.ExporterRef.Name == "" {
+					return nil
+				}
+				return []string{pts.Spec.ExporterRef.Name}
+			},
+		).
+		Build()
+}
+
+func reconcileEC(t *testing.T, c client.Client, scheme *runtime.Scheme, ns, name string) *podtracev1alpha1.ExporterConfig {
+	t.Helper()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var got podtracev1alpha1.ExporterConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &got); err != nil {
+		t.Fatalf("get reconciled ec: %v", err)
+	}
+	return &got
+}
+
+func ecCondition(ec *podtracev1alpha1.ExporterConfig, typ string) *metav1.Condition {
+	for i := range ec.Status.Conditions {
+		if ec.Status.Conditions[i].Type == typ {
+			return &ec.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func TestExporterConfigReconciler_ReadyConditions(t *testing.T) {
+	scheme := newECTestScheme(t)
+
+	tests := []struct {
+		name        string
+		ec          *podtracev1alpha1.ExporterConfig
+		secrets     []*corev1.Secret
+		wantReady   bool
+		wantReason  string
+		wantMsgPart string
+		wantStatus  metav1.ConditionStatus
+	}{
+		{
+			name: "otlp with no secret refs → Ready=true",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type: podtracev1alpha1.ExporterTypeOTLP,
+					OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "o:4317"},
+				},
+			},
+			wantReady:  true,
+			wantReason: ecReasonSecretsResolved,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "otlp with HeadersFromSecret missing → Ready=false SecretMissing",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type: podtracev1alpha1.ExporterTypeOTLP,
+					OTLP: &podtracev1alpha1.OTLPExporter{
+						Endpoint:          "o:4317",
+						HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "missing"},
+					},
+				},
+			},
+			wantReady:   false,
+			wantReason:  ecReasonSecretMissing,
+			wantMsgPart: "Secret ns/missing not found",
+			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			name: "otlp with header ValueFrom key missing → Ready=false SecretKeyMissing",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type: podtracev1alpha1.ExporterTypeOTLP,
+					OTLP: &podtracev1alpha1.OTLPExporter{
+						Endpoint: "o:4317",
+						Headers: []podtracev1alpha1.OTLPHeader{
+							{Name: "X-Auth", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "missing-key"}},
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns"}, Data: map[string][]byte{"other-key": []byte("v")}},
+			},
+			wantReady:   false,
+			wantReason:  ecReasonSecretKeyMissing,
+			wantMsgPart: `no key "missing-key"`,
+			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			name: "splunk with token secret present → Ready=true",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "splunk", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type: podtracev1alpha1.ExporterTypeSplunk,
+					Splunk: &podtracev1alpha1.SplunkExporter{
+						Endpoint:       "https://splunk:8088",
+						TokenSecretRef: podtracev1alpha1.SecretKeySelector{Name: "hec", Key: "token"},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "hec", Namespace: "ns"}, Data: map[string][]byte{"token": []byte("xxx")}},
+			},
+			wantReady:  true,
+			wantReason: ecReasonSecretsResolved,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "splunk with token secret missing → Ready=false",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "splunk", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type: podtracev1alpha1.ExporterTypeSplunk,
+					Splunk: &podtracev1alpha1.SplunkExporter{
+						Endpoint:       "https://splunk:8088",
+						TokenSecretRef: podtracev1alpha1.SecretKeySelector{Name: "hec", Key: "token"},
+					},
+				},
+			},
+			wantReady:  false,
+			wantReason: ecReasonSecretMissing,
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "datadog with api key secret present → Ready=true",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type:    podtracev1alpha1.ExporterTypeDataDog,
+					DataDog: &podtracev1alpha1.DataDogExporter{APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api-key"}},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: "ns"}, Data: map[string][]byte{"api-key": []byte("k")}},
+			},
+			wantReady:  true,
+			wantReason: ecReasonSecretsResolved,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "spec variant mismatch → Ready=false InvalidSpec",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type:   podtracev1alpha1.ExporterTypeOTLP,
+					Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://j"},
+				},
+			},
+			wantReady:  false,
+			wantReason: ecReasonInvalidSpec,
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "jaeger with no secrets → Ready=true",
+			ec: &podtracev1alpha1.ExporterConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "j", Namespace: "ns"},
+				Spec: podtracev1alpha1.ExporterConfigSpec{
+					Type:   podtracev1alpha1.ExporterTypeJaeger,
+					Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://j:14268"},
+				},
+			},
+			wantReady:  true,
+			wantReason: ecReasonSecretsResolved,
+			wantStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{tc.ec}
+			for _, s := range tc.secrets {
+				objs = append(objs, s)
+			}
+			c := newECFakeClient(t, scheme, objs...)
+			got := reconcileEC(t, c, scheme, tc.ec.Namespace, tc.ec.Name)
+
+			if got.Status.Ready != tc.wantReady {
+				t.Errorf("Ready: got %v, want %v", got.Status.Ready, tc.wantReady)
+			}
+			cond := ecCondition(got, ConditionReady)
+			if cond == nil {
+				t.Fatalf("Ready condition missing")
+			}
+			if cond.Reason != tc.wantReason {
+				t.Errorf("Reason: got %q, want %q", cond.Reason, tc.wantReason)
+			}
+			if cond.Status != tc.wantStatus {
+				t.Errorf("ConditionStatus: got %q, want %q", cond.Status, tc.wantStatus)
+			}
+			if tc.wantMsgPart != "" && !strings.Contains(cond.Message, tc.wantMsgPart) {
+				t.Errorf("Message: got %q, want substring %q", cond.Message, tc.wantMsgPart)
+			}
+			if got.Status.ObservedGeneration != got.Generation {
+				t.Errorf("ObservedGeneration: got %d, want %d", got.Status.ObservedGeneration, got.Generation)
+			}
+		})
+	}
+}
+
+func TestExporterConfigReconciler_ReferenceCounts(t *testing.T) {
+	scheme := newECTestScheme(t)
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec1", Namespace: "ns"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "o:4317"},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		extra      []client.Object
+		wantRefs   int32
+		wantStatus metav1.ConditionStatus
+	}{
+		{
+			name:       "zero references",
+			wantRefs:   0,
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "one PodTrace reference",
+			extra: []client.Object{
+				&podtracev1alpha1.PodTrace{
+					ObjectMeta: metav1.ObjectMeta{Name: "pt1", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+				},
+			},
+			wantRefs:   1,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "PodTrace plus running session",
+			extra: []client.Object{
+				&podtracev1alpha1.PodTrace{
+					ObjectMeta: metav1.ObjectMeta{Name: "pt1", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+				},
+				&podtracev1alpha1.PodTraceSession{
+					ObjectMeta: metav1.ObjectMeta{Name: "pts1", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSessionSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+					Status:     podtracev1alpha1.PodTraceSessionStatus{Phase: podtracev1alpha1.SessionPhaseRunning},
+				},
+			},
+			wantRefs:   2,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "completed session is excluded",
+			extra: []client.Object{
+				&podtracev1alpha1.PodTrace{
+					ObjectMeta: metav1.ObjectMeta{Name: "pt1", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+				},
+				&podtracev1alpha1.PodTraceSession{
+					ObjectMeta: metav1.ObjectMeta{Name: "done", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSessionSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+					Status:     podtracev1alpha1.PodTraceSessionStatus{Phase: podtracev1alpha1.SessionPhaseCompleted},
+				},
+			},
+			wantRefs:   1,
+			wantStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "failed session is excluded",
+			extra: []client.Object{
+				&podtracev1alpha1.PodTraceSession{
+					ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSessionSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec1"}},
+					Status:     podtracev1alpha1.PodTraceSessionStatus{Phase: podtracev1alpha1.SessionPhaseFailed},
+				},
+			},
+			wantRefs:   0,
+			wantStatus: metav1.ConditionFalse,
+		},
+		{
+			name: "PodTrace pointing at a different EC is not counted",
+			extra: []client.Object{
+				&podtracev1alpha1.PodTrace{
+					ObjectMeta: metav1.ObjectMeta{Name: "pt-other", Namespace: "ns"},
+					Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "other"}},
+				},
+			},
+			wantRefs:   0,
+			wantStatus: metav1.ConditionFalse,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{ec.DeepCopy()}
+			objs = append(objs, tc.extra...)
+			c := newECFakeClient(t, scheme, objs...)
+			got := reconcileEC(t, c, scheme, ec.Namespace, ec.Name)
+
+			if got.Status.ReferencedBy != tc.wantRefs {
+				t.Errorf("ReferencedBy: got %d, want %d", got.Status.ReferencedBy, tc.wantRefs)
+			}
+			cond := ecCondition(got, ConditionReferenced)
+			if cond == nil {
+				t.Fatalf("Referenced condition missing")
+			}
+			if cond.Status != tc.wantStatus {
+				t.Errorf("Referenced status: got %q, want %q", cond.Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestExporterConfigReconciler_NoOpSuppression(t *testing.T) {
+	scheme := newECTestScheme(t)
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec1", Namespace: "ns", Generation: 1},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "o:4317"},
+		},
+	}
+	c := newECFakeClient(t, scheme, ec.DeepCopy())
+
+	got1 := reconcileEC(t, c, scheme, ec.Namespace, ec.Name)
+	firstResourceVersion := got1.ResourceVersion
+
+	got2 := reconcileEC(t, c, scheme, ec.Namespace, ec.Name)
+	if got2.ResourceVersion != firstResourceVersion {
+		t.Errorf("ResourceVersion bumped on no-op reconcile: %q → %q", firstResourceVersion, got2.ResourceVersion)
+	}
+}
+
+func TestExporterConfigReconciler_NotFoundIsNoOp(t *testing.T) {
+	scheme := newECTestScheme(t)
+	c := newECFakeClient(t, scheme)
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "missing"},
+	})
+	if err != nil {
+		t.Fatalf("expected nil error for missing EC, got %v", err)
+	}
+}
+
+func TestClampMessage(t *testing.T) {
+	short := "short message"
+	if clampMessage(short) != short {
+		t.Errorf("short message altered")
+	}
+	long := strings.Repeat("x", ecMaxConditionMessageLen+50)
+	got := clampMessage(long)
+	if len(got) != ecMaxConditionMessageLen {
+		t.Errorf("clamped len = %d, want %d", len(got), ecMaxConditionMessageLen)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("clamped message should end with '...': %q", got[len(got)-5:])
+	}
+}

--- a/internal/operator/exporterconfig_secrets.go
+++ b/internal/operator/exporterconfig_secrets.go
@@ -1,0 +1,59 @@
+package operator
+
+import (
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// secretRef is one (Secret-name, required-key) pair an ExporterConfig
+// depends on.
+type secretRef struct {
+	Name     string
+	Key      string
+	Required bool
+}
+
+// collectSecretRefs returns every Secret reference an ExporterConfig
+// declares, regardless of its Type.
+func collectSecretRefs(spec podtracev1alpha1.ExporterConfigSpec) []secretRef {
+	var out []secretRef
+
+	if spec.OTLP != nil {
+		if spec.OTLP.HeadersFromSecret != nil && spec.OTLP.HeadersFromSecret.Name != "" {
+			out = append(out, secretRef{
+				Name:     spec.OTLP.HeadersFromSecret.Name,
+				Required: true,
+			})
+		}
+		for _, h := range spec.OTLP.Headers {
+			if h.ValueFrom == nil {
+				continue
+			}
+			if h.ValueFrom.Name == "" || h.ValueFrom.Key == "" {
+				continue
+			}
+			out = append(out, secretRef{
+				Name:     h.ValueFrom.Name,
+				Key:      h.ValueFrom.Key,
+				Required: true,
+			})
+		}
+	}
+
+	if spec.Splunk != nil && spec.Splunk.TokenSecretRef.Name != "" {
+		out = append(out, secretRef{
+			Name:     spec.Splunk.TokenSecretRef.Name,
+			Key:      spec.Splunk.TokenSecretRef.Key,
+			Required: true,
+		})
+	}
+
+	if spec.DataDog != nil && spec.DataDog.APIKeySecretRef.Name != "" {
+		out = append(out, secretRef{
+			Name:     spec.DataDog.APIKeySecretRef.Name,
+			Key:      spec.DataDog.APIKeySecretRef.Key,
+			Required: true,
+		})
+	}
+
+	return out
+}

--- a/internal/operator/exporterconfig_secrets_test.go
+++ b/internal/operator/exporterconfig_secrets_test.go
@@ -1,0 +1,153 @@
+package operator
+
+import (
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestCollectSecretRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		spec podtracev1alpha1.ExporterConfigSpec
+		want []secretRef
+	}{
+		{
+			name: "jaeger has no secret refs",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type:   podtracev1alpha1.ExporterTypeJaeger,
+				Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://j:14268"},
+			},
+			want: nil,
+		},
+		{
+			name: "zipkin has no secret refs",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type:   podtracev1alpha1.ExporterTypeZipkin,
+				Zipkin: &podtracev1alpha1.ZipkinExporter{Endpoint: "http://z:9411"},
+			},
+			want: nil,
+		},
+		{
+			name: "otlp with no header refs",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4317"},
+			},
+			want: nil,
+		},
+		{
+			name: "otlp with HeadersFromSecret",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{
+					Endpoint:          "otel:4317",
+					HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "otel-headers"},
+				},
+			},
+			want: []secretRef{{Name: "otel-headers", Required: true}},
+		},
+		{
+			name: "otlp with per-header ValueFrom",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{
+					Endpoint: "otel:4317",
+					Headers: []podtracev1alpha1.OTLPHeader{
+						{Name: "X-Static", Value: "abc"},
+						{Name: "X-Secret", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"}},
+					},
+				},
+			},
+			want: []secretRef{{Name: "auth", Key: "token", Required: true}},
+		},
+		{
+			name: "splunk requires token secret ref",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeSplunk,
+				Splunk: &podtracev1alpha1.SplunkExporter{
+					Endpoint:       "https://splunk:8088",
+					TokenSecretRef: podtracev1alpha1.SecretKeySelector{Name: "splunk-hec", Key: "token"},
+				},
+			},
+			want: []secretRef{{Name: "splunk-hec", Key: "token", Required: true}},
+		},
+		{
+			name: "datadog requires api key secret ref",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeDataDog,
+				DataDog: &podtracev1alpha1.DataDogExporter{
+					APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api-key"},
+				},
+			},
+			want: []secretRef{{Name: "dd", Key: "api-key", Required: true}},
+		},
+		{
+			name: "otlp with empty HeadersFromSecret name is skipped",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{
+					Endpoint:          "otel:4317",
+					HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: ""},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "otlp with malformed ValueFrom (missing key) is skipped",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{
+					Endpoint: "otel:4317",
+					Headers: []podtracev1alpha1.OTLPHeader{
+						{Name: "X-Bad", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "x", Key: ""}},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "otlp with both HeadersFromSecret and per-header refs",
+			spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{
+					Endpoint:          "otel:4317",
+					HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "bulk"},
+					Headers: []podtracev1alpha1.OTLPHeader{
+						{Name: "X-A", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "a", Key: "k"}},
+					},
+				},
+			},
+			want: []secretRef{
+				{Name: "bulk", Required: true},
+				{Name: "a", Key: "k", Required: true},
+			},
+		},
+		{
+			name: "nil typed fields do not panic",
+			spec: podtracev1alpha1.ExporterConfigSpec{Type: podtracev1alpha1.ExporterTypeOTLP},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectSecretRefs(tc.spec)
+			if !secretRefsEqual(got, tc.want) {
+				t.Fatalf("collectSecretRefs:\n  got:  %+v\n  want: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func secretRefsEqual(a, b []secretRef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/operator/naming.go
+++ b/internal/operator/naming.go
@@ -37,11 +37,12 @@ const (
 
 // Condition types reported on CR .status.conditions.
 const (
-	ConditionReady      = "Ready"
-	ConditionReconciled = "Reconciled"
-	ConditionDegraded   = "Degraded"
-	ConditionPaused     = "Paused"
+	ConditionReady          = "Ready"
+	ConditionReconciled     = "Reconciled"
+	ConditionDegraded       = "Degraded"
+	ConditionPaused         = "Paused"
 	ConditionReportUploaded = "ReportUploaded"
+	ConditionReferenced     = "Referenced"
 )
 
 // AgentDaemonSetName is the fixed DaemonSet name created by

--- a/internal/operator/reconcilers.go
+++ b/internal/operator/reconcilers.go
@@ -1,16 +1,22 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// registerReconcilers wires all three reconcilers onto the manager.
-// Order does not matter — the manager starts them in parallel — but we
-// construct them in dependency order (TracerConfig first, then Session,
-// then PodTrace) so a stack trace points at the failing one.
+// registerReconcilers wires every reconciler onto the manager. Order
+// does not matter — the manager starts them in parallel — but we
+// construct them in dependency order (TracerConfig first, then
+// Session, then PodTrace, then ExporterConfig) so a stack trace
+// points at the failing one.
 func registerReconcilers(mgr ctrl.Manager, opts Options) error {
+	if err := registerExporterConfigIndexers(context.Background(), mgr); err != nil {
+		return fmt.Errorf("ExporterConfig indexers: %w", err)
+	}
+
 	tcr := &TracerConfigReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
@@ -36,6 +42,14 @@ func registerReconcilers(mgr ctrl.Manager, opts Options) error {
 	}
 	if err := ptr.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("PodTraceReconciler: %w", err)
+	}
+
+	ecr := &ExporterConfigReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	if err := ecr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("ExporterConfigReconciler: %w", err)
 	}
 
 	return nil

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "include-v-in-tag": true,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": true,
+  "pull-request-title-pattern": "chore(release): release ${version}",
   "packages": {
     ".": {
       "package-name": "podtrace",
@@ -28,18 +29,20 @@
         }
       ],
       "changelog-sections": [
-        { "type": "feat",     "section": "Added" },
-        { "type": "fix",      "section": "Fixed" },
-        { "type": "perf",     "section": "Changed" },
-        { "type": "revert",   "section": "Changed" },
-        { "type": "refactor", "section": "Changed" },
-        { "type": "chore",    "section": "Changed", "hidden": true },
-        { "type": "docs",     "section": "Changed", "hidden": true },
-        { "type": "style",    "section": "Changed", "hidden": true },
-        { "type": "test",     "section": "Changed", "hidden": true },
-        { "type": "build",    "section": "Changed", "hidden": true },
-        { "type": "ci",       "section": "Changed", "hidden": true },
-        { "type": "security", "section": "Security" }
+        { "type": "feat",      "section": "Added" },
+        { "type": "fix",       "section": "Fixed" },
+        { "type": "perf",      "section": "Performance" },
+        { "type": "deprecate", "section": "Deprecated" },
+        { "type": "remove",    "section": "Removed" },
+        { "type": "security",  "section": "Security" },
+        { "type": "revert",    "section": "Changed" },
+        { "type": "refactor",  "section": "Changed", "hidden": true },
+        { "type": "chore",     "section": "Changed", "hidden": true },
+        { "type": "docs",      "section": "Changed", "hidden": true },
+        { "type": "style",     "section": "Changed", "hidden": true },
+        { "type": "test",      "section": "Changed", "hidden": true },
+        { "type": "build",     "section": "Changed", "hidden": true },
+        { "type": "ci",        "section": "Changed", "hidden": true }
       ]
     }
   }

--- a/test/chainsaw/tests/exporterconfig-status/assert-ready.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/assert-ready.yaml
@@ -1,0 +1,8 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec-status-splunk
+status:
+  ready: true
+  (conditions[?type == 'Ready'].status | [0]): "True"
+  (conditions[?type == 'Ready'].reason | [0]): SecretsResolved

--- a/test/chainsaw/tests/exporterconfig-status/assert-referenced.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/assert-referenced.yaml
@@ -1,0 +1,9 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec-status-splunk
+status:
+  ready: true
+  referencedBy: 1
+  (conditions[?type == 'Referenced'].status | [0]): "True"
+  (conditions[?type == 'Referenced'].reason | [0]): Referenced

--- a/test/chainsaw/tests/exporterconfig-status/assert-secret-missing.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/assert-secret-missing.yaml
@@ -1,0 +1,9 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec-status-splunk
+status:
+  (conditions[?type == 'Ready'].status | [0]): "False"
+  (conditions[?type == 'Ready'].reason | [0]): SecretMissing
+  (conditions[?type == 'Ready'].message | [0]):
+    (contains(@, 'ec-status-secret')): true

--- a/test/chainsaw/tests/exporterconfig-status/assert-unreferenced.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/assert-unreferenced.yaml
@@ -1,0 +1,8 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec-status-splunk
+status:
+  ready: true
+  (conditions[?type == 'Referenced'].status | [0]): "False"
+  (conditions[?type == 'Referenced'].reason | [0]): Unreferenced

--- a/test/chainsaw/tests/exporterconfig-status/chainsaw-test.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/chainsaw-test.yaml
@@ -1,0 +1,50 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: exporterconfig-status
+spec:
+  description: |
+    Property tested: the ExporterConfig status reconciler populates
+    .status.ready, .status.referencedBy, and the Ready/Referenced
+    conditions in response to changes in (a) referenced Secrets and
+    (b) PodTraces / PodTraceSessions pointing at the EC.
+
+    Walks four transitions:
+      1. EC referencing a missing Secret → Ready=false, reason=SecretMissing
+      2. Create the Secret               → Ready=true,  reason=SecretsResolved
+      3. Create PodTrace referencing EC  → referencedBy=1, Referenced=True
+      4. Delete PodTrace                 → referencedBy=0, Referenced=False
+  timeouts:
+    apply: 30s
+    assert: 60s
+  steps:
+    - name: ec-without-secret
+      try:
+        - apply:
+            file: ./ec-and-target.yaml
+        - assert:
+            file: ./assert-secret-missing.yaml
+
+    - name: create-secret
+      try:
+        - apply:
+            file: ./secret.yaml
+        - assert:
+            file: ./assert-ready.yaml
+
+    - name: add-reference
+      try:
+        - apply:
+            file: ./podtrace.yaml
+        - assert:
+            file: ./assert-referenced.yaml
+
+    - name: remove-reference
+      try:
+        - delete:
+            ref:
+              apiVersion: podtrace.io/v1alpha1
+              kind: PodTrace
+              name: ec-status-pt
+        - assert:
+            file: ./assert-unreferenced.yaml

--- a/test/chainsaw/tests/exporterconfig-status/ec-and-target.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/ec-and-target.yaml
@@ -1,0 +1,29 @@
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec-status-splunk
+spec:
+  type: splunk
+  splunk:
+    endpoint: https://splunk.observability:8088
+    tokenSecretRef:
+      name: ec-status-secret
+      key: token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ec-status-target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ec-status-target
+  template:
+    metadata:
+      labels:
+        app: ec-status-target
+    spec:
+      containers:
+        - name: app
+          image: registry.k8s.io/pause:3.9

--- a/test/chainsaw/tests/exporterconfig-status/podtrace.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/podtrace.yaml
@@ -1,0 +1,11 @@
+apiVersion: podtrace.io/v1alpha1
+kind: PodTrace
+metadata:
+  name: ec-status-pt
+spec:
+  selector:
+    matchLabels:
+      app: ec-status-target
+  filters: [dns]
+  exporterRef:
+    name: ec-status-splunk

--- a/test/chainsaw/tests/exporterconfig-status/secret.yaml
+++ b/test/chainsaw/tests/exporterconfig-status/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ec-status-secret
+type: Opaque
+stringData:
+  token: dummy-hec-token-for-test-only


### PR DESCRIPTION
**`ExporterConfig` status reconciler.** New controller populates `.status.ready`, `.status.referencedBy`, `.status.observedGeneration`, and `Ready` / `Referenced` conditions on every `ExporterConfig`. Watches `Secret`, `PodTrace`, and `PodTraceSession` so transitions surface within one reconcile cycle. Reference counting uses field indexers (`spec.exporterRef.name` on both `PodTrace` and `PodTraceSession`) for O(refs) cost; terminal-phase sessions (`Completed`, `Failed`) are excluded so the count reflects active load. Status writes are suppressed when nothing changes, so the reconciler never burns API calls or flaps `LastTransitionTime`.

**`release-please` config + `CONTRIBUTING.md` tweaks** so the CHANGELOG carries every change-type, not only `Added`. `refactor:` is hidden (refactors are by definition not user-visible); `perf:` gets its own **Performance** section; new project-specific types `deprecate:` → **Deprecated** and `remove:` → **Removed** complete the Keep-a-Changelog story; `pull-request-title-pattern` makes the release PR recognisable.

**`go-ci.yml` runs the full unit-test suite on every PR.** Removes the "test only changed packages" optimisation, which reported per-package coverage as if it were project-wide and let cross-package regressions reach `main`. Drops `|| true` on the integration step so failures actually fail the job. Coverage threshold + Codecov upload steps are unchanged but now operate on real numbers.