### PR TITLE
ci: add release-notes enrichment, PR labeller, and Release-As trigger

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,57 @@
+# Path globs area label mapping consumed by actions/labeler.
+
+area/bpf:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bpf/**'
+          - 'internal/agent/bpf/**'
+
+area/operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/operator/**'
+          - 'api/**'
+
+area/agent:
+  - changed-files:
+      - all:
+          - any-glob-to-any-file:
+              - 'internal/agent/**'
+          - all-globs-to-all-files:
+              - '!internal/agent/bpf/**'
+
+area/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**'
+          - 'internal/cli/**'
+
+area/helm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'deploy/charts/**'
+
+area/olm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'deploy/olm/**'
+          - 'hack/olm/**'
+
+area/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'README.md'
+          - 'CONTRIBUTING.md'
+
+area/tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/**'
+
+area/ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'Makefile'
+          - 'scripts/**'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Category vocabulary consumed by the GitHub `generate-notes` API.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes
+      labels: [breaking]
+    - title: Features
+      labels: [feat, feature]
+    - title: Bug Fixes
+      labels: [fix, bug]
+    - title: Performance
+      labels: [perf, performance]
+    - title: Security
+      labels: [security]
+    - title: Deprecated
+      labels: [deprecate, deprecated]
+    - title: Removed
+      labels: [remove, removed]
+    - title: Documentation
+      labels: [docs, documentation]
+    - title: Tests
+      labels: [test, tests]
+    - title: CI / Build
+      labels: [ci, build]
+    - title: Maintenance
+      labels: [chore, refactor, style, revert]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/label-conventional-prs.yml
+++ b/.github/workflows/label-conventional-prs.yml
@@ -1,0 +1,59 @@
+name: Label Conventional PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply conventional-commit label from PR title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ALL_TYPES="feat fix perf docs test ci build chore refactor style security deprecate remove revert"
+
+          # Conventional-commit subject regex: type(scope)?!?: subject
+          if [[ ! "$TITLE" =~ ^([a-z]+)(\([^)]+\))?(!)?: ]]; then
+            echo "PR title does not match conventional-commit format; stripping any stale type labels."
+            for L in $ALL_TYPES breaking; do
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$L" 2>/dev/null || true
+            done
+            exit 0
+          fi
+
+          TYPE="${BASH_REMATCH[1]}"
+          BANG="${BASH_REMATCH[3]}"
+
+          # Strip any other conventional-type labels first so a rename
+          # leaves the PR with only the current type label.
+          for L in $ALL_TYPES; do
+            if [[ "$L" != "$TYPE" ]]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$L" 2>/dev/null || true
+            fi
+          done
+
+          case "$TYPE" in
+            feat|fix|perf|docs|test|ci|build|chore|refactor|style|security|deprecate|remove|revert)
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$TYPE"
+              ;;
+            *)
+              echo "Unknown type $TYPE; no label applied."
+              ;;
+          esac
+
+          # Breaking-change marker: `!` before the colon in the subject.
+          if [[ -n "$BANG" ]]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label breaking
+          else
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label breaking 2>/dev/null || true
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Area Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,42 @@
+name: Release-As
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version (e.g. 0.12.0 or 1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  push-release-as:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Version must be semver (e.g. 0.12.0, 1.0.0, 1.0.0-rc.1)"
+            exit 1
+          fi
+
+      - name: Push Release-As commit
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --allow-empty -m "chore: announce ${VERSION}
+
+          Release-As: ${VERSION}"
+          git push

--- a/.github/workflows/release-notes-enrich.yml
+++ b/.github/workflows/release-notes-enrich.yml
@@ -1,0 +1,116 @@
+name: Enrich Release Notes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Target tag (e.g. v0.12.0)"
+        required: true
+        type: string
+      previous_tag:
+        description: "Override previous tag (leave blank to auto-compute)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'release' &&
+        endsWith(github.event.release.tag_name, '.0'))
+    steps:
+      - name: Resolve tag inputs
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_PREV: ${{ inputs.previous_tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$EVENT_TAG}"
+          PREV="${INPUT_PREV:-}"
+
+          if [ -z "$PREV" ]; then
+            VER="${TAG#v}"
+            MAJOR="${VER%%.*}"
+            REST="${VER#*.}"
+            MINOR="${REST%%.*}"
+            if [ "$MINOR" -gt 0 ]; then
+              CANDIDATE="v${MAJOR}.$((MINOR - 1)).0"
+              # Fall back to the highest patch of the previous minor if
+              # the .0 wasn't tagged (e.g. project went straight to .1).
+              if gh release view "$CANDIDATE" --repo "$REPO" >/dev/null 2>&1; then
+                PREV="$CANDIDATE"
+              else
+                PREV=$(gh release list --repo "$REPO" --limit 200 \
+                  --json tagName --jq '.[].tagName' \
+                  | grep -E "^v${MAJOR}\\.$((MINOR - 1))\\.[0-9]+$" \
+                  | sort -V | tail -n 1)
+              fi
+            elif [ "$MAJOR" -gt 0 ]; then
+              # vN.0.0 → highest v(N-1).X.X
+              PREV=$(gh release list --repo "$REPO" --limit 200 \
+                --json tagName --jq '.[].tagName' \
+                | grep -E "^v$((MAJOR - 1))\\.[0-9]+\\.[0-9]+$" \
+                | sort -V | tail -n 1)
+            else
+              echo "::error::Cannot compute previous tag for $TAG"
+              exit 1
+            fi
+          fi
+
+          if [ -z "$PREV" ]; then
+            echo "::error::Previous tag is empty after resolution; aborting."
+            exit 1
+          fi
+
+          echo "tag=$TAG"        >> "$GITHUB_OUTPUT"
+          echo "previous=$PREV"  >> "$GITHUB_OUTPUT"
+          echo "Spanning $PREV -> $TAG"
+
+      - name: Capture original release body (for rollback audit)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "--- Original release body for ${TAG} (kept in this log for manual rollback) ---"
+          gh release view "$TAG" --repo "$REPO" --json body --jq '.body' || true
+          echo "--- End original body ---"
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          PREV: ${{ steps.resolve.outputs.previous }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="${TAG}" \
+            -f previous_tag_name="${PREV}" \
+            --jq '.body' > "${RUNNER_TEMP}/release-notes.md"
+          echo "--- Generated body (preview) ---"
+          head -c 4000 "${RUNNER_TEMP}/release-notes.md"
+          echo
+          echo "--- End preview ---"
+
+      - name: Overwrite release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" \
+            --repo "$REPO" \
+            --notes-file "${RUNNER_TEMP}/release-notes.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,34 @@ lands on `main`:
 Zero manual clicks per release. All artifacts are cosign-signed keyless
 and recorded in the [Sigstore Rekor transparency log](https://search.sigstore.dev/).
 
+### Cutting a minor or major release
+
+The flow above describes patch releases, where release-please reacts to
+each `feat:`/`fix:` merge on `main`. For minor (`0.Y.0`) and major
+(`X.0.0`) cuts, use the manual trigger so the version bump is intentional:
+
+1. **Actions → "Release-As" → Run workflow**, enter the target version (e.g. `0.12.0`)
+2. release-please opens a `chore(release): release X.Y.Z` PR; review and merge it
+3. After the tag is created, `release-notes-enrich.yml` fires automatically
+   and overwrites the GitHub Release body with the full cross-minor PR list
+   grouped per [`.github/release.yml`](.github/release.yml)
+
+The enriched Release body is broader than `CHANGELOG.md` — it includes
+docs, test, CI, build, and maintenance PRs that are intentionally hidden
+from the user-facing changelog. Two artifacts, two audiences.
+
+PRs also receive an `area/*` label automatically based on the paths they
+touch (driven by [`.github/labeler.yml`](.github/labeler.yml)) — e.g. a
+PR editing `internal/operator/**` gets `area/operator`. Filter merged
+work with `gh pr list --label area/bpf` etc. Area labels are independent
+of the conventional-commit type label and do not affect release-note
+grouping.
+
+If the auto-computed previous tag is wrong (e.g. you want to span more
+than one minor), re-run `release-notes-enrich.yml` manually with both
+inputs filled in. Patch releases skip enrichment entirely and keep
+release-please's per-patch body.
+
 ### Rehearsing the release pipeline
 
 To exercise the workflow without burning a real version, push a tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,15 +123,15 @@ no trailing period, ≤ 72 chars.
 
 | Type | Visible in changelog? | Effect on version (pre-1.0) |
 |---|---|---|
-| `feat:` | ✅ Added section | patch bump |
-| `fix:` | ✅ Fixed section | patch bump |
+| `feat:` | ✅ Features section | patch bump |
+| `fix:` | ✅ Bug Fixes section | patch bump |
 | `perf:` | ✅ Performance section | patch bump |
+| `security:` | ✅ Security section | patch bump |
 | `deprecate:` | ✅ Deprecated section | patch bump |
 | `remove:` | ✅ Removed section | patch bump |
-| `security:` | ✅ Security section | patch bump |
-| `revert:` | ✅ Changed section | patch bump |
-| `refactor:`, `chore:`, `docs:`, `style:`, `test:`, `build:`, `ci:` | ❌ Hidden | no bump |
-| Footer `BREAKING CHANGE:` | ✅ called out | **minor bump** (your only path to `v0.X+1.0`) |
+| `revert:` | ✅ Maintenance section | patch bump |
+| `refactor:`, `chore:`, `docs:`, `style:`, `test:`, `build:`, `ci:` | ❌ Hidden in CHANGELOG, ✅ shown on Release page | no bump |
+| Title suffix `feat!:` / footer `BREAKING CHANGE:` | ✅ ⚠ BREAKING CHANGES section | **minor bump** (your only path to `v0.X+1.0`) |
 | Footer `Release-As: 0.X.Y` | overrides version explicitly | Forces release-please to propose the named version |
 
 A few notes on type choice:
@@ -153,6 +153,11 @@ A few notes on type choice:
   extensions** to the standard Conventional Commits vocabulary. They
   exist because Keep-a-Changelog defines Security / Deprecated /
   Removed sections that the upstream spec has no native types for.
+- **CHANGELOG.md sections align with the enriched Release page** —
+  both use Features / Bug Fixes / Performance / Security / Deprecated
+  / Removed / Maintenance. The Release page additionally surfaces the
+  types hidden from CHANGELOG (Documentation, Tests, CI/Build), which
+  is why the two artifacts look similar but not identical.
 
 Examples:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,20 +29,20 @@
         }
       ],
       "changelog-sections": [
-        { "type": "feat",      "section": "Added" },
-        { "type": "fix",       "section": "Fixed" },
+        { "type": "feat",      "section": "Features" },
+        { "type": "fix",       "section": "Bug Fixes" },
         { "type": "perf",      "section": "Performance" },
+        { "type": "security",  "section": "Security" },
         { "type": "deprecate", "section": "Deprecated" },
         { "type": "remove",    "section": "Removed" },
-        { "type": "security",  "section": "Security" },
-        { "type": "revert",    "section": "Changed" },
-        { "type": "refactor",  "section": "Changed", "hidden": true },
-        { "type": "chore",     "section": "Changed", "hidden": true },
-        { "type": "docs",      "section": "Changed", "hidden": true },
-        { "type": "style",     "section": "Changed", "hidden": true },
-        { "type": "test",      "section": "Changed", "hidden": true },
-        { "type": "build",     "section": "Changed", "hidden": true },
-        { "type": "ci",        "section": "Changed", "hidden": true }
+        { "type": "revert",    "section": "Maintenance" },
+        { "type": "refactor",  "section": "Maintenance", "hidden": true },
+        { "type": "chore",     "section": "Maintenance", "hidden": true },
+        { "type": "docs",      "section": "Maintenance", "hidden": true },
+        { "type": "style",     "section": "Maintenance", "hidden": true },
+        { "type": "test",      "section": "Maintenance", "hidden": true },
+        { "type": "build",     "section": "Maintenance", "hidden": true },
+        { "type": "ci",        "section": "Maintenance", "hidden": true }
       ]
     }
   }

--- a/scripts/release-notes-setup.sh
+++ b/scripts/release-notes-setup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${REPO:-gma1k/podtrace}"
+
+LABELS=(
+	feat fix perf docs test ci build chore refactor style
+	security deprecate remove revert breaking ignore-for-release
+)
+
+AREA_LABELS=(
+	area/bpf area/operator area/agent area/cli area/helm
+	area/olm area/docs area/tests area/ci
+)
+
+VALID_TYPES_RE='^(feat|fix|perf|docs|test|ci|build|chore|refactor|style|security|deprecate|remove|revert)$'
+
+require_gh() {
+	if ! command -v gh >/dev/null 2>&1; then
+		echo "Error: gh CLI not found. Install from https://cli.github.com/" >&2
+		exit 1
+	fi
+	if ! gh auth status >/dev/null 2>&1; then
+		echo "Error: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+		exit 1
+	fi
+}
+
+create_labels() {
+	echo "==> Step A: create labels on ${REPO}"
+	local label
+	for label in "${LABELS[@]}"; do
+		if gh label create "${label}" \
+			--repo "${REPO}" \
+			--description "Conventional-commit type: ${label}" >/dev/null 2>&1; then
+			echo "  created: ${label}"
+		else
+			echo "  exists:  ${label}"
+		fi
+	done
+	for label in "${AREA_LABELS[@]}"; do
+		local area="${label#area/}"
+		if gh label create "${label}" \
+			--repo "${REPO}" \
+			--color "0052cc" \
+			--description "Codebase area: ${area}" >/dev/null 2>&1; then
+			echo "  created: ${label}"
+		else
+			echo "  exists:  ${label}"
+		fi
+	done
+}
+
+backfill_labels() {
+	echo
+	echo "==> Step B: backfill labels on merged PRs"
+	local jq_filter='.[] | select(.title | test("^[a-z]+(\\([^)]+\\))?!?:")) |
+		[(.number|tostring), (.title | capture("^(?<t>[a-z]+)") | .t)] | @tsv'
+
+	local rows
+	rows=$(gh pr list --repo "${REPO}" --state merged --base main --limit 200 \
+		--json number,title --jq "${jq_filter}")
+
+	if [[ -z "${rows}" ]]; then
+		echo "  no merged PRs matched conventional-commit format"
+		return 0
+	fi
+
+	local number type
+	while IFS=$'\t' read -r number type; do
+		if [[ "${type}" =~ ${VALID_TYPES_RE} ]]; then
+			echo "  PR #${number}: ${type}"
+			gh pr edit "${number}" --repo "${REPO}" --add-label "${type}" >/dev/null
+		else
+			echo "  PR #${number}: skipping unknown type '${type}'"
+		fi
+	done <<<"${rows}"
+}
+
+main() {
+	require_gh
+	create_labels
+	backfill_labels
+	echo
+	echo "Done. Verify with: gh pr list --repo ${REPO} --label feat --limit 50"
+}
+
+main "$@"


### PR DESCRIPTION
Adds release-notes automation and PR-labelling on top of the existing release-please flow:

- `.github/release.yml` — category vocabulary for GitHub's `generate-notes` API (Features, Bug Fixes, Documentation, Tests, CI/Build, Maintenance, …)
- `.github/workflows/label-conventional-prs.yml` — applies a label matching the conventional-commit type from the PR title; strips stale type labels on rename
- `.github/labeler.yml` + `.github/workflows/labeler.yml` — applies `area/*` labels based on changed paths (bpf / operator / agent / cli / helm / olm / docs / tests / ci) via `actions/labeler@v6.1.0`
- `.github/workflows/release-bump.yml` — `workflow_dispatch` trigger that pushes an empty `Release-As: X.Y.Z` commit so release-please proposes the named version
- `.github/workflows/release-notes-enrich.yml` — fires on `release: published` for `*.0` tags, resolves the previous minor tag, calls `generate-notes` across that span, and overwrites the GitHub Release body. Patches keep release-please's per-patch body. Original body is logged to the run for rollback.
- `scripts/release-notes-setup.sh` — one-time, idempotent: creates the type-label and area-label vocabulary and backfills type labels on already-merged PRs

## Notes

- Existing patch-release behavior is unchanged
- All workflows are inert until invoked (workflow_dispatch / release event); the only behavior that starts on merge is the two labellers on new PRs
- Both labellers read only PR metadata (title, changed-file paths) and never check out PR code, keeping `pull_request_target` safe
- `release-notes-enrich.yml` only edits the Release body — never touches tags, CHANGELOG.md, or git