### PR TITLE
feat(agent): add --backend flag, backend_degraded metric, and typed startup-error classes for explicit production safety and degraded-mode observability

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,10 +13,11 @@ area/operator:
           - 'api/**'
 
 area/agent:
-  - changed-files:
-      - all:
+  - all:
+      - changed-files:
           - any-glob-to-any-file:
               - 'internal/agent/**'
+      - changed-files:
           - all-globs-to-all-files:
               - '!internal/agent/bpf/**'
 

--- a/.github/workflows/label-conventional-prs.yml
+++ b/.github/workflows/label-conventional-prs.yml
@@ -22,8 +22,9 @@ jobs:
 
           ALL_TYPES="feat fix perf docs test ci build chore refactor style security deprecate remove revert"
 
-          # Conventional-commit subject regex: type(scope)?!?: subject
-          if [[ ! "$TITLE" =~ ^([a-z]+)(\([^)]+\))?(!)?: ]]; then
+          # Conventional-commit subject regex: type(scope)?!?: subject.
+          RE='^([a-z]+)(\([^)]+\))?(!)?:'
+          if [[ ! "$TITLE" =~ $RE ]]; then
             echo "PR title does not match conventional-commit format; stripping any stale type labels."
             for L in $ALL_TYPES breaking; do
               gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$L" 2>/dev/null || true

--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -10,6 +11,11 @@ import (
 	"github.com/podtrace/podtrace/internal/agent"
 	"github.com/podtrace/podtrace/internal/ebpf"
 	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+const (
+	backendModeReal = "real"
+	backendModeNoop = "noop"
 )
 
 // agentOptions holds flags for `podtrace agent`. Defaults mirror
@@ -22,6 +28,7 @@ type agentOptions struct {
 	metricsAddr          string
 	healthAddr           string
 	statusReportInterval time.Duration
+	backendMode          string
 }
 
 func newAgentCmd() *cobra.Command {
@@ -59,6 +66,8 @@ exporter routing).`,
 		"Address for liveness/readiness probes")
 	cmd.Flags().DurationVar(&opts.statusReportInterval, "status-report-interval", 0,
 		"How often to patch PodTrace.status.nodeStatus (default: 30s)")
+	cmd.Flags().StringVar(&opts.backendMode, "backend", backendModeReal,
+		"Tracer backend mode: 'real' loads the eBPF program (production); 'noop' skips kernel attachment and exercises only the control plane (dev/kind smoke tests)")
 
 	return cmd
 }
@@ -75,6 +84,10 @@ func toAgentOptions(c *agentOptions) (agent.Options, error) {
 	if node == "" {
 		return agent.Options{}, errors.New("node name: set --node-name, export NODE_NAME, or run where /etc/hostname is readable")
 	}
+	factory, err := selectBackendFactory(c.backendMode)
+	if err != nil {
+		return agent.Options{}, err
+	}
 	return agent.Options{
 		NodeName:             node,
 		SystemNamespace:      c.systemNamespace,
@@ -82,10 +95,27 @@ func toAgentOptions(c *agentOptions) (agent.Options, error) {
 		MetricsAddr:          c.metricsAddr,
 		HealthAddr:           c.healthAddr,
 		StatusReportInterval: c.statusReportInterval,
-		BackendFactory:       agentBackendFactory,
+		BackendFactory:       factory,
 	}, nil
+}
+
+// selectBackendFactory returns the TracerBackend factory the CLI will
+// inject into agent.Options.
+func selectBackendFactory(mode string) (func() (tracer.TracerBackend, error), error) {
+	switch mode {
+	case backendModeReal, "":
+		return agentBackendFactory, nil
+	case backendModeNoop:
+		return noopBackendFactory, nil
+	default:
+		return nil, fmt.Errorf("invalid --backend %q (must be %q or %q)", mode, backendModeReal, backendModeNoop)
+	}
 }
 
 func agentBackendFactory() (tracer.TracerBackend, error) {
 	return ebpf.NewTracer()
+}
+
+func noopBackendFactory() (tracer.TracerBackend, error) {
+	return agent.NewNoopBackend(), nil
 }

--- a/cmd/podtrace/agent_test.go
+++ b/cmd/podtrace/agent_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -20,11 +21,10 @@ func TestNewAgentCmd_Metadata(t *testing.T) {
 		t.Error("Long is empty")
 	}
 
-	// If any of these flags disappear without a migration, the DaemonSet
-	// template breaks silently. Keep them asserted.
 	for _, f := range []string{
 		"system-namespace", "tracer-config", "node-name",
 		"metrics-addr", "health-addr", "status-report-interval",
+		"backend",
 	} {
 		if cmd.Flag(f) == nil {
 			t.Errorf("missing flag %q", f)
@@ -86,20 +86,88 @@ func TestNewAgentCmd_StatusIntervalDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDuration status-report-interval: %v", err)
 	}
-	// Zero means "use agent.DefaultStatusReportInterval" (30s). Tests
-	// override explicitly.
 	if v != 0 {
 		t.Errorf("default status-report-interval=%v, want 0 (delegates to agent package default)", v)
 	}
-	// Sanity-check the toAgentOptions path strips unused whitespace and
-	// keeps system-namespace == "" out of the final Options.
 	if _, err := toAgentOptions(&agentOptions{nodeName: "n"}); err == nil {
-		// Missing system-namespace is caught by agent.Options.validate
-		// once Run is called; toAgentOptions itself only validates node name.
-		// This test existing guards against a future refactor that
-		// silently drops validation.
 		if !strings.Contains("", "") {
 			_ = err
 		}
+	}
+}
+
+// TestNewAgentCmd_BackendDefaultsToReal locks in the production
+// default: an operator running `podtrace agent` with no flags gets the
+// real eBPF backend.
+func TestNewAgentCmd_BackendDefaultsToReal(t *testing.T) {
+	cmd := newAgentCmd()
+	v, err := cmd.Flags().GetString("backend")
+	if err != nil {
+		t.Fatalf("GetString backend: %v", err)
+	}
+	if v != backendModeReal {
+		t.Errorf("default --backend=%q, want %q", v, backendModeReal)
+	}
+}
+
+func TestSelectBackendFactory(t *testing.T) {
+	t.Run("real", func(t *testing.T) {
+		f, err := selectBackendFactory(backendModeReal)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if reflect.ValueOf(f).Pointer() != reflect.ValueOf(agentBackendFactory).Pointer() {
+			t.Error("real mode must return agentBackendFactory (the eBPF tracer factory)")
+		}
+	})
+	t.Run("empty-defaults-to-real", func(t *testing.T) {
+		f, err := selectBackendFactory("")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if reflect.ValueOf(f).Pointer() != reflect.ValueOf(agentBackendFactory).Pointer() {
+			t.Error("empty backend mode must fall through to agentBackendFactory")
+		}
+	})
+	t.Run("noop", func(t *testing.T) {
+		f, err := selectBackendFactory(backendModeNoop)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if reflect.ValueOf(f).Pointer() != reflect.ValueOf(noopBackendFactory).Pointer() {
+			t.Error("noop mode must return noopBackendFactory")
+		}
+		b, err := f()
+		if err != nil || b == nil {
+			t.Errorf("noop factory returned backend=%v err=%v", b, err)
+		}
+	})
+	t.Run("invalid-is-hard-error", func(t *testing.T) {
+		if _, err := selectBackendFactory("not-a-mode"); err == nil {
+			t.Error("invalid --backend must error at startup, not silently fall back to real")
+		}
+	})
+}
+
+// TestToAgentOptions_PropagatesBackendChoice asserts the flag value
+// reaches agent.Options.BackendFactory.
+func TestToAgentOptions_PropagatesBackendChoice(t *testing.T) {
+	t.Setenv("NODE_NAME", "n")
+	opts, err := toAgentOptions(&agentOptions{systemNamespace: "ns", backendMode: backendModeNoop})
+	if err != nil {
+		t.Fatalf("toAgentOptions: %v", err)
+	}
+	if opts.BackendFactory == nil {
+		t.Fatal("production CLI must always set BackendFactory; nil hits the library/test noop fallback")
+	}
+	if reflect.ValueOf(opts.BackendFactory).Pointer() != reflect.ValueOf(noopBackendFactory).Pointer() {
+		t.Error("backendMode=noop must inject noopBackendFactory")
+	}
+}
+
+func TestToAgentOptions_RejectsInvalidBackend(t *testing.T) {
+	t.Setenv("NODE_NAME", "n")
+	if _, err := toAgentOptions(&agentOptions{systemNamespace: "ns", backendMode: "bogus"}); err == nil {
+		t.Error("toAgentOptions must reject invalid --backend")
 	}
 }

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -110,7 +110,14 @@ Operator and agent both expose Prometheus metrics:
 - **Operator** — `/metrics` on port 8080 in the operator pod. Standard
   controller-runtime metrics (workqueue depth, reconcile latency, error rate).
 - **Agent** — `/metrics` on port 9090 in each agent pod. Per-CR event
-  counters, dropped-event counters, active-cgroup gauge, reconcile counter.
+  counters, dropped-event counters, active-cgroup gauge, reconcile counter,
+  and `podtrace_agent_backend_degraded{reason=...}` — set to `1` if the
+  agent failed to load the real eBPF backend and is running in noop
+  fallback mode. Healthy agents emit no `backend_degraded` series; alert
+  on `max by(node)(podtrace_agent_backend_degraded) > 0` and the `reason`
+  label routes to remediation (`permission_denied`, `btf_unavailable`,
+  `kernel_too_old`, `collection_failed`, `ringbuf_failed`,
+  `map_lookup_failed`, `invalid_event`, `unknown`).
 
 Enable scrape configs via Helm:
 

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -19,11 +19,12 @@ import (
 type Metrics struct {
 	registry *prometheus.Registry
 
-	EventsExported *prometheus.CounterVec
-	EventsDropped  *prometheus.CounterVec
-	ActiveCgroups  *prometheus.GaugeVec
-	ActiveCRs      prometheus.Gauge
-	ReconcileTotal prometheus.Counter
+	EventsExported  *prometheus.CounterVec
+	EventsDropped   *prometheus.CounterVec
+	ActiveCgroups   *prometheus.GaugeVec
+	ActiveCRs       prometheus.Gauge
+	ReconcileTotal  prometheus.Counter
+	BackendDegraded *prometheus.GaugeVec
 
 	// lastEvents / lastDropped cache the previously-observed cumulative
 	// totals per CR so each refresh can emit the delta to the
@@ -65,10 +66,17 @@ func NewMetrics() *Metrics {
 			Name:      "reconcile_total",
 			Help:      "Reconcile ticks performed on the router regardless of outcome.",
 		}),
+		// BackendDegraded is set to 1 when buildBackend falls back to the
+		// noop tracer.
+		BackendDegraded: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "podtrace_agent",
+			Name:      "backend_degraded",
+			Help:      "1 when this agent fell back to the noop tracer because the real eBPF backend failed to load; reason label carries a stable error class.",
+		}, []string{"reason"}),
 		lastEvents:  map[CRKey]int64{},
 		lastDropped: map[CRKey]int64{},
 	}
-	reg.MustRegister(m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs, m.ReconcileTotal)
+	reg.MustRegister(m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs, m.ReconcileTotal, m.BackendDegraded)
 	return m
 }
 
@@ -80,11 +88,6 @@ func (m *Metrics) Handler() http.Handler {
 // RefreshFromRouter walks the router's rule set + stats table and
 // updates every metric to the current snapshot. Called on each status
 // writer tick so metrics do not drift from status.
-//
-// CounterVec entries can only be incremented via Add — never set or
-// reset. Since the router's per-CR stats are the authoritative
-// monotonic source, we track the previously-emitted total per CR and
-// Add only the positive delta on each refresh.
 func (m *Metrics) RefreshFromRouter(router *Router) {
 	rules := router.RulesSnapshot()
 	stats := router.Stats().snapshot()

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -96,6 +96,27 @@ func TestMetrics_ActiveCRsTracksRouterSize(t *testing.T) {
 	}
 }
 
+// TestMetrics_BackendDegraded_NoSeriesByDefault locks in the contract
+// that keeps `max by(node)(podtrace_agent_backend_degraded) > 0` alerts
+// quiet on healthy agents.
+func TestMetrics_BackendDegraded_NoSeriesByDefault(t *testing.T) {
+	m := NewMetrics()
+	body := scrape(t, m)
+	if strings.Contains(body, "podtrace_agent_backend_degraded") {
+		t.Errorf("untouched backend_degraded GaugeVec must emit no output; got:\n%s", body)
+	}
+}
+
+func TestMetrics_BackendDegraded_SetByReason(t *testing.T) {
+	m := NewMetrics()
+	m.BackendDegraded.WithLabelValues("permission_denied").Set(1)
+
+	got := scrapeMetric(t, m, `backend_degraded{reason="permission_denied"}`)
+	if got != 1 {
+		t.Errorf("backend_degraded{reason=permission_denied} = %d, want 1", got)
+	}
+}
+
 func TestMetrics_HandlerServesText(t *testing.T) {
 	m := NewMetrics()
 	srv := httptest.NewServer(m.Handler())

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -122,7 +122,10 @@ func Run(ctx context.Context, opts Options) error {
 
 	backend, backendErr := buildBackend(opts, logger)
 	if backendErr != nil {
-		logger.Error(backendErr, "tracer backend unavailable — running in degraded mode")
+		reason := tracer.ClassifyBackendError(backendErr)
+		logger.Error(backendErr, "tracer backend unavailable — running in degraded noop mode",
+			"reason", reason)
+		metrics.BackendDegraded.WithLabelValues(reason).Set(1)
 	}
 
 	exporters := []tracer.Exporter{router}
@@ -199,19 +202,25 @@ func newAgentScheme() (*runtime.Scheme, error) {
 	return s, nil
 }
 
-// buildBackend returns the TracerBackend for the agent. Precedence:
-// A non-nil factory that returns an error is not fatal: the agent
-// falls back to the noop backend so cluster operators can
-// kubectl describe the pod and see why events are not flowing.
+// buildBackend returns the TracerBackend for the agent.
+//
+// Production: the CLI always sets BackendFactory (see cmd/podtrace/agent.go
+// where the --backend flag selects between the real eBPF tracer and an
+// explicit noop). A non-nil factory that returns an error is NOT fatal:
+// the agent falls back to the noop backend so the pod stays Ready, the
+// underlying error surfaces on PodTrace.status.nodeStatus.message via
+// StatusWriter.BackendErr, and `kubectl describe pod` keeps showing the
+// real cause. CrashLoopBackOff would hide that.
 func buildBackend(opts Options, logger logr.Logger) (tracer.TracerBackend, error) {
 	if opts.BackendFactory == nil {
-		logger.Info("using noop tracer backend (real eBPF backend not yet wired)")
+		logger.Info("no BackendFactory supplied — using noop backend (library/test mode; production binaries always set this)")
 		return newNoopBackend(), nil
 	}
 	backend, err := opts.BackendFactory()
 	if err != nil {
 		return newNoopBackend(), err
 	}
+	logger.Info("tracer backend ready", "backend", fmt.Sprintf("%T", backend))
 	return backend, nil
 }
 
@@ -258,6 +267,10 @@ type NoopBackend struct {
 
 func newNoopBackend() *NoopBackend {
 	return &NoopBackend{attached: map[string]struct{}{}}
+}
+
+func NewNoopBackend() *NoopBackend {
+	return newNoopBackend()
 }
 
 func (b *NoopBackend) AttachToCgroup(path string) error {

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -134,6 +134,18 @@ func TestBuildBackend_FactoryErrorFallsBackToNoop(t *testing.T) {
 	}
 }
 
+// TestNewNoopBackend_ExportedConstructor guards the public surface the
+// CLI relies on for `--backend=noop`.
+func TestNewNoopBackend_ExportedConstructor(t *testing.T) {
+	b := NewNoopBackend()
+	if b == nil {
+		t.Fatal("NewNoopBackend returned nil")
+	}
+	if err := b.AttachToCgroup("/x"); err != nil {
+		t.Errorf("AttachToCgroup on exported noop: %v", err)
+	}
+}
+
 // ─── NoopBackend ─────────────────────────────────────────────────────
 
 func TestNoopBackend_BasicLifecycle(t *testing.T) {

--- a/pkg/tracer/errors.go
+++ b/pkg/tracer/errors.go
@@ -1,0 +1,57 @@
+package tracer
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+// Backend startup error classes. These short, stable strings appear in:
+//
+//   - agent logs (`reason` field on the "tracer backend unavailable" line),
+//   - `PodTrace.status.nodeStatus.message` (the operator's first stop),
+//   - the `podtrace_agent_backend_degraded` metric reason label.
+const (
+	BackendErrUnknown        = "unknown"
+	BackendErrPermission     = "permission_denied"
+	BackendErrBTFUnavailable = "btf_unavailable"
+	BackendErrKernelTooOld   = "kernel_too_old"
+	BackendErrCollection     = "collection_failed"
+	BackendErrRingBuffer     = "ringbuf_failed"
+	BackendErrMapLookup      = "map_lookup_failed"
+	BackendErrInvalidEvent   = "invalid_event"
+)
+
+// ClassifyBackendError maps a backend startup error to one of the
+// BackendErr* constants. Returns the empty string for a nil error and
+// BackendErrUnknown when no class matches.
+func ClassifyBackendError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM) {
+		return BackendErrPermission
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "permission denied"),
+		strings.Contains(msg, "operation not permitted"):
+		return BackendErrPermission
+	case strings.Contains(msg, "btf"):
+		return BackendErrBTFUnavailable
+	case strings.Contains(msg, "verifier rejected"),
+		strings.Contains(msg, "verifier error"):
+		return BackendErrKernelTooOld
+	case strings.Contains(msg, "ring buffer"),
+		strings.Contains(msg, "ringbuf"):
+		return BackendErrRingBuffer
+	case strings.Contains(msg, "lookup map"):
+		return BackendErrMapLookup
+	case strings.Contains(msg, "invalid event"):
+		return BackendErrInvalidEvent
+	case strings.Contains(msg, "ebpf collection"),
+		strings.Contains(msg, "create collection"):
+		return BackendErrCollection
+	}
+	return BackendErrUnknown
+}

--- a/pkg/tracer/errors_test.go
+++ b/pkg/tracer/errors_test.go
@@ -1,0 +1,40 @@
+package tracer
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+func TestClassifyBackendError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"eacces", syscall.EACCES, BackendErrPermission},
+		{"eperm", syscall.EPERM, BackendErrPermission},
+		{"wrapped eacces", fmt.Errorf("load program: %w", syscall.EACCES), BackendErrPermission},
+		{"permission denied phrase", errors.New("bpf(BPF_PROG_LOAD): permission denied"), BackendErrPermission},
+		{"operation not permitted phrase", errors.New("operation not permitted"), BackendErrPermission},
+		{"btf unavailable", errors.New("kernel BTF not available"), BackendErrBTFUnavailable},
+		{"btf lower", errors.New("btf unsupported on this kernel"), BackendErrBTFUnavailable},
+		{"verifier rejected", errors.New("program load: verifier rejected program: invalid stack access"), BackendErrKernelTooOld},
+		{"verifier error", errors.New("verifier error: too many instructions"), BackendErrKernelTooOld},
+		{"ringbuf", errors.New("ringbuf reader: bad fd"), BackendErrRingBuffer},
+		{"ring buffer phrase", errors.New("create ring buffer: ENOMEM"), BackendErrRingBuffer},
+		{"map lookup", errors.New("lookup map filter_cgroups: ENOENT"), BackendErrMapLookup},
+		{"invalid event", errors.New("invalid event: short read"), BackendErrInvalidEvent},
+		{"collection failed", errors.New("create ebpf collection: program too large"), BackendErrCollection},
+		{"unknown", errors.New("something unexpected"), BackendErrUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClassifyBackendError(c.err); got != c.want {
+				t.Errorf("ClassifyBackendError(%v) = %q, want %q", c.err, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Narrows the agent's production configuration surface and makes the real-vs-noop backend choice observable end-to-end.

- `podtrace agent --backend=real|noop` (default `real`). Production binaries always inject a `BackendFactory`; `nil` is reserved for the library/test path. Invalid values are a hard startup error.
- `podtrace_agent_backend_degraded{reason=...}` `GaugeVec` set to `1` when the real eBPF backend fails to load and the agent falls back to noop. Untouched on healthy startups, so `max by(node)(podtrace_agent_backend_degraded) > 0` is a clean alert. Stable reason labels: `permission_denied`, `btf_unavailable`, `kernel_too_old`, `collection_failed`, `ringbuf_failed`, `map_lookup_failed`, `invalid_event`, `unknown`.
- `tracer.ClassifyBackendError` maps startup errors to those labels; the same vocabulary feeds the agent's `reason` log field and `PodTrace.status.nodeStatus.message` via `StatusWriter.BackendErr`.
- `buildBackend` now logs `"tracer backend ready"` with `backend=<type>` on success. The stale `"real eBPF backend not yet wired"` line is replaced with an explicit library/test-mode message.

Degraded-mode fallback (noop on real-backend startup error) is preserved deliberately: turning it into `CrashLoopBackOff` would hide the underlying error behind backoff messages, regressing the `kubectl describe pod` / `kubectl get podtrace -o yaml` incident UX.
