### PR TITLE
feat(tracer): snapshot-replace cgroup lifecycle with atomic filter set prunes stale attachments on pod churn and closes a kernel-cgroup-ID-recycling correctness bug

### DIFF
--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/podtrace/podtrace/internal/agent"
 	"github.com/podtrace/podtrace/internal/ebpf"
+	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/pkg/tracer"
 )
 
@@ -43,8 +45,6 @@ tracer. Multiple PodTrace CRs targeting the same node are merged into a
 single tracer instance (one set of cgroups, union of filters, per-CR
 exporter routing).`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Signal handler is process-singleton; wired here so
-			// internal/agent stays a reusable library.
 			ctx := ctrl.SetupSignalHandler()
 			resolved, err := toAgentOptions(opts)
 			if err != nil {
@@ -73,9 +73,7 @@ exporter routing).`,
 }
 
 // toAgentOptions translates the Cobra flag struct into agent.Options
-// and resolves $NODE_NAME / hostname fallbacks. Returns an error only
-// when the node name cannot be determined, because the agent cannot
-// function without knowing which node it is on.
+// and resolves $NODE_NAME / hostname fallbacks.
 func toAgentOptions(c *agentOptions) (agent.Options, error) {
 	node := c.nodeName
 	if node == "" {
@@ -113,7 +111,45 @@ func selectBackendFactory(mode string) (func() (tracer.TracerBackend, error), er
 }
 
 func agentBackendFactory() (tracer.TracerBackend, error) {
-	return ebpf.NewTracer()
+	tr, err := ebpf.NewTracer()
+	if err != nil {
+		return nil, err
+	}
+	return &ebpfBackendAdapter{tr: tr}, nil
+}
+
+// ebpfBackendAdapter narrows the internal eBPF tracer interface
+// (path-list cgroup contract) to the pkg/tracer.TracerBackend contract
+// (CgroupTarget snapshot).
+type ebpfBackendAdapter struct {
+	tr ebpf.TracerInterface
+}
+
+func (a *ebpfBackendAdapter) SetCgroups(targets []tracer.CgroupTarget) error {
+	paths := make([]string, 0, len(targets))
+	for _, t := range targets {
+		if t.CgroupPath == "" {
+			continue
+		}
+		paths = append(paths, t.CgroupPath)
+	}
+	return a.tr.SetCgroups(paths)
+}
+
+func (a *ebpfBackendAdapter) AttachToCgroup(path string) error {
+	return a.tr.AttachToCgroup(path)
+}
+
+func (a *ebpfBackendAdapter) SetContainerID(id string) error {
+	return a.tr.SetContainerID(id)
+}
+
+func (a *ebpfBackendAdapter) Start(ctx context.Context, ch chan<- *events.Event) error {
+	return a.tr.Start(ctx, ch)
+}
+
+func (a *ebpfBackendAdapter) Stop() error {
+	return a.tr.Stop()
 }
 
 func noopBackendFactory() (tracer.TracerBackend, error) {

--- a/cmd/podtrace/mocks.go
+++ b/cmd/podtrace/mocks.go
@@ -27,14 +27,22 @@ func (m *mockPodResolver) ResolvePod(ctx context.Context, podName, namespace, co
 
 type mockTracer struct {
 	attachToCgroupFunc func(cgroupPath string) error
-	setContainerIDFunc  func(containerID string) error
-	startFunc           func(ctx context.Context, eventChan chan<- *events.Event) error
-	stopFunc            func() error
+	setCgroupsFunc     func(cgroupPaths []string) error
+	setContainerIDFunc func(containerID string) error
+	startFunc          func(ctx context.Context, eventChan chan<- *events.Event) error
+	stopFunc           func() error
 }
 
 func (m *mockTracer) AttachToCgroup(cgroupPath string) error {
 	if m.attachToCgroupFunc != nil {
 		return m.attachToCgroupFunc(cgroupPath)
+	}
+	return nil
+}
+
+func (m *mockTracer) SetCgroups(cgroupPaths []string) error {
+	if m.setCgroupsFunc != nil {
+		return m.setCgroupsFunc(cgroupPaths)
 	}
 	return nil
 }

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -9,34 +9,26 @@ import (
 )
 
 // Metrics registers every Prometheus counter/gauge the agent exposes
-// via /metrics. Counters are organised by (cr_namespace, cr_name)
-// labels so users can graph per-CR throughput and drops.
-//
-// Registration is done against a dedicated Registry (not the default)
-// so the agent's /metrics output is stable: a test that imports any
-// package registering against the default registry does not pollute
-// the agent's scrape surface.
+// via /metrics.
 type Metrics struct {
 	registry *prometheus.Registry
 
-	EventsExported  *prometheus.CounterVec
-	EventsDropped   *prometheus.CounterVec
-	ActiveCgroups   *prometheus.GaugeVec
-	ActiveCRs       prometheus.Gauge
-	ReconcileTotal  prometheus.Counter
-	BackendDegraded *prometheus.GaugeVec
+	EventsExported   *prometheus.CounterVec
+	EventsDropped    *prometheus.CounterVec
+	ActiveCgroups    *prometheus.GaugeVec
+	ActiveCRs        prometheus.Gauge
+	ReconcileTotal   prometheus.Counter
+	BackendDegraded  *prometheus.GaugeVec
+	CgroupsAttached  prometheus.Counter
+	CgroupsDetached  prometheus.Counter
 
-	// lastEvents / lastDropped cache the previously-observed cumulative
-	// totals per CR so each refresh can emit the delta to the
-	// monotonic Prometheus counters.
 	mu          sync.Mutex
 	lastEvents  map[CRKey]int64
 	lastDropped map[CRKey]int64
 }
 
 // NewMetrics constructs the full metric surface and registers it
-// against a fresh Registry. The returned Handler can be mounted on any
-// HTTP server.
+// against a fresh Registry.
 func NewMetrics() *Metrics {
 	reg := prometheus.NewRegistry()
 	m := &Metrics{
@@ -66,17 +58,25 @@ func NewMetrics() *Metrics {
 			Name:      "reconcile_total",
 			Help:      "Reconcile ticks performed on the router regardless of outcome.",
 		}),
-		// BackendDegraded is set to 1 when buildBackend falls back to the
-		// noop tracer.
 		BackendDegraded: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "podtrace_agent",
 			Name:      "backend_degraded",
 			Help:      "1 when this agent fell back to the noop tracer because the real eBPF backend failed to load; reason label carries a stable error class.",
 		}, []string{"reason"}),
+		CgroupsAttached: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "cgroups_attached_total",
+			Help:      "Cumulative cgroups added to the tracer filter set.",
+		}),
+		CgroupsDetached: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "cgroups_detached_total",
+			Help:      "Cumulative cgroups removed from the tracer filter set (pod churn).",
+		}),
 		lastEvents:  map[CRKey]int64{},
 		lastDropped: map[CRKey]int64{},
 	}
-	reg.MustRegister(m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs, m.ReconcileTotal, m.BackendDegraded)
+	reg.MustRegister(m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs, m.ReconcileTotal, m.BackendDegraded, m.CgroupsAttached, m.CgroupsDetached)
 	return m
 }
 
@@ -85,9 +85,33 @@ func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
 }
 
+// EngineObserver returns an adapter that bridges the engine's
+// tracer.EngineObserver callbacks into this Metrics' Prometheus
+// counters.
+func (m *Metrics) EngineObserver() *metricsEngineObserver {
+	return &metricsEngineObserver{m: m}
+}
+
+type metricsEngineObserver struct {
+	m *Metrics
+}
+
+func (o *metricsEngineObserver) OnCgroupsAttached(n int) {
+	if n <= 0 {
+		return
+	}
+	o.m.CgroupsAttached.Add(float64(n))
+}
+
+func (o *metricsEngineObserver) OnCgroupsDetached(n int) {
+	if n <= 0 {
+		return
+	}
+	o.m.CgroupsDetached.Add(float64(n))
+}
+
 // RefreshFromRouter walks the router's rule set + stats table and
-// updates every metric to the current snapshot. Called on each status
-// writer tick so metrics do not drift from status.
+// updates every metric to the current snapshot.
 func (m *Metrics) RefreshFromRouter(router *Router) {
 	rules := router.RulesSnapshot()
 	stats := router.Stats().snapshot()
@@ -117,9 +141,6 @@ func (m *Metrics) RefreshFromRouter(router *Router) {
 		m.lastDropped[rule.Key] = c.Dropped
 	}
 
-	// Drop cgroup gauge and cached deltas for CRs that disappeared —
-	// otherwise /metrics keeps emitting zero gauges for stale CR names
-	// forever and cardinality grows without bound.
 	for key := range m.lastEvents {
 		if _, ok := seen[key]; ok {
 			continue

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -129,7 +129,9 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	exporters := []tracer.Exporter{router}
-	engine, err := tracer.NewEngine(backend, exporters, tracer.Config{})
+	engine, err := tracer.NewEngine(backend, exporters, tracer.Config{
+		Observer: metrics.EngineObserver(),
+	})
 	if err != nil {
 		return fmt.Errorf("build tracer engine: %w", err)
 	}
@@ -280,6 +282,19 @@ func (b *NoopBackend) AttachToCgroup(path string) error {
 	return nil
 }
 
+func (b *NoopBackend) SetCgroups(targets []tracer.CgroupTarget) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.attached = make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if t.CgroupPath == "" {
+			continue
+		}
+		b.attached[t.CgroupPath] = struct{}{}
+	}
+	return nil
+}
+
 func (b *NoopBackend) SetContainerID(_ string) error { return nil }
 
 func (b *NoopBackend) Start(_ context.Context, ch chan<- *events.Event) error {
@@ -309,11 +324,6 @@ func (b *NoopBackend) Inject(ev *events.Event) bool {
 	return true
 }
 
-// Reconciler is implemented in agent_reconciler.go. Declared here in a
-// small stub comment so this file lists every integration point.
-
-// ResolveNodeName reads $NODE_NAME or falls back to the hostname. Safe
-// to call from the CLI before Run.
 func ResolveNodeName() string {
 	if n := strings.TrimSpace(os.Getenv("NODE_NAME")); n != "" {
 		return n
@@ -323,4 +333,3 @@ func ResolveNodeName() string {
 	}
 	return ""
 }
-

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -35,7 +35,6 @@ func TestDefaultOptions_NonEmptyAddrs(t *testing.T) {
 	if o.HealthAddr == "" {
 		t.Error("HealthAddr should be defaulted")
 	}
-	// NodeName + SystemNamespace deliberately left empty (CLI must set them).
 	if o.NodeName != "" || o.SystemNamespace != "" {
 		t.Errorf("DefaultOptions must NOT default NodeName/SystemNamespace, got %+v", o)
 	}
@@ -78,11 +77,9 @@ func TestNewAgentScheme_RegistersBothAPIs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// corev1 (clientgoscheme) must be present.
 	if _, _, err := s.ObjectKinds(&corev1.Pod{}); err != nil {
 		t.Errorf("corev1.Pod not registered: %v", err)
 	}
-	// podtracev1alpha1 must be present.
 	if _, _, err := s.ObjectKinds(&podtracev1alpha1.PodTrace{}); err != nil {
 		t.Errorf("podtracev1alpha1.PodTrace not registered: %v", err)
 	}
@@ -93,8 +90,9 @@ func TestNewAgentScheme_RegistersBothAPIs(t *testing.T) {
 type fakeBackend struct{ name string }
 
 func (b *fakeBackend) AttachToCgroup(_ string) error                          { return nil }
+func (b *fakeBackend) SetCgroups(_ []tracer.CgroupTarget) error               { return nil }
 func (b *fakeBackend) SetContainerID(_ string) error                          { return nil }
-func (b *fakeBackend) Start(_ context.Context, _ chan<- *events.Event) error { return nil }
+func (b *fakeBackend) Start(_ context.Context, _ chan<- *events.Event) error  { return nil }
 func (b *fakeBackend) Stop() error                                            { return nil }
 
 func TestBuildBackend_NilFactoryReturnsNoop(t *testing.T) {
@@ -208,7 +206,6 @@ func TestServeMetrics_BadAddrErrors(t *testing.T) {
 }
 
 func TestServeMetrics_ServesAndShutsDown(t *testing.T) {
-	// Bind to a free port the kernel hands out.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +219,6 @@ func TestServeMetrics_ServesAndShutsDown(t *testing.T) {
 		done <- serveMetrics(ctx, addr, NewMetrics(), logr.Discard())
 	}()
 
-	// Poll briefly for /metrics to come up.
 	deadline := time.Now().Add(2 * time.Second)
 	var ok bool
 	for time.Now().Before(deadline) {
@@ -611,10 +607,8 @@ func TestResolveNodeName_HostnameFallback(t *testing.T) {
 }
 
 // guard that StatusWriter.patchCRStatus uses the SSA path with
-// a deterministic field manager — we cannot easily inspect the
-// underlying request from the fake client, but we can prove
-// the call does not panic on a sentinel CR.
-var _ = sync.Mutex{} // satisfy the import in compile-only contexts
+// a deterministic field manager.
+var _ = sync.Mutex{}
 
 func TestRouter_NameAndStats(t *testing.T) {
 	r := NewRouter(nil)

--- a/internal/ebpf/tracer/interface.go
+++ b/internal/ebpf/tracer/interface.go
@@ -7,6 +7,8 @@ import (
 )
 
 type TracerInterface interface {
+	SetCgroups(cgroupPaths []string) error
+
 	AttachToCgroup(cgroupPath string) error
 	SetContainerID(containerID string) error
 	Start(ctx context.Context, eventChan chan<- *events.Event) error

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -14,6 +14,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -80,16 +81,30 @@ type Tracer struct {
 	cgroupPaths              []string
 	useUserspaceCgroupFilter bool
 	targetCgroupID           uint64
-	targetCgroupIDs          map[uint64]struct{}
+	targetCgroupIDs atomic.Pointer[map[uint64]struct{}]
+	cgroupWriteMu   sync.Mutex
 	cpAnalyzer               *criticalpath.Analyzer
 	piiRedactor              *redactor.Redactor
 	profilingCtrl            ProfilingController
 }
 
 // SetProfilingController wires an optional profiling controller into the
-// management API server.  Must be called before Start().
+// management API server.
 func (t *Tracer) SetProfilingController(ctrl ProfilingController) {
 	t.profilingCtrl = ctrl
+}
+
+// loadCgroupIDs returns the current cgroup-ID filter set.
+func (t *Tracer) loadCgroupIDs() map[uint64]struct{} {
+	if p := t.targetCgroupIDs.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// storeCgroupIDs atomically publishes a new cgroup-ID filter set.
+func (t *Tracer) storeCgroupIDs(m map[uint64]struct{}) {
+	t.targetCgroupIDs.Store(&m)
 }
 
 // roundUpPow2 rounds n up to the nearest power of two, minimum 4096.
@@ -142,10 +157,6 @@ func NewTracer() (*Tracer, error) {
 		return nil, err
 	}
 
-	// Patch ring buffer size (must be power-of-2 multiple of page size).
-	// ClampUint32 keeps the int → uint32 narrowing safe even if a
-	// pathological PODTRACE_RING_BUFFER_SIZE_KB overflows when multiplied
-	// by 1024.
 	rbBytes := config.RingBufferSizeKB
 	if rbBytes > 0 && rbBytes <= math.MaxInt/1024 {
 		rbBytes *= 1024
@@ -156,7 +167,6 @@ func NewTracer() (*Tracer, error) {
 	if m, ok := spec.Maps["events"]; ok {
 		m.MaxEntries = rbSize
 	}
-	// Patch hash map sizes.
 	hashSize := config.ClampUint32(config.BPFHashMapSize)
 	for name, m := range spec.Maps {
 		if m.Type == ebpf.Hash {
@@ -180,10 +190,6 @@ func NewTracer() (*Tracer, error) {
 		return nil, NewCollectionError(err)
 	}
 
-	// Initialize configurable alert thresholds in the BPF map. The
-	// AlertX values are pre-clamped to [0, 100] in config.go;
-	// ClampUint32 here is a no-op for valid configs and makes the
-	// narrowing locally verifiable to static analyzers.
 	if threshMap, ok := coll.Maps["alert_thresholds"]; ok && threshMap != nil {
 		thresholds := []uint32{
 			config.ClampUint32(config.AlertWarnPct),
@@ -226,8 +232,8 @@ func NewTracer() (*Tracer, error) {
 		processNameCache:         processCache,
 		pathCache:                cache.NewPathCache(),
 		useUserspaceCgroupFilter: true,
-		targetCgroupIDs:          make(map[uint64]struct{}),
 	}
+	t.storeCgroupIDs(map[uint64]struct{}{})
 
 	if config.CriticalPathEnabled {
 		window := time.Duration(config.CriticalPathWindowMS) * time.Millisecond
@@ -248,21 +254,34 @@ func NewTracer() (*Tracer, error) {
 	return t, nil
 }
 
+// SetCgroups replaces the tracer's entire cgroup filter set with the
+// given paths.
+func (t *Tracer) SetCgroups(cgroupPaths []string) error {
+	if len(cgroupPaths) == 0 {
+		t.cgroupWriteMu.Lock()
+		t.cgroupPaths = nil
+		t.cgroupPath = ""
+		t.targetCgroupID = 0
+		t.storeCgroupIDs(map[uint64]struct{}{})
+		t.filter.SetCgroupPaths(nil)
+		if err := t.syncTargetCgroupMap(); err != nil {
+			logger.Warn("Failed to clear target_cgroup_ids map", zap.Error(err))
+		}
+		t.cgroupWriteMu.Unlock()
+		logger.Debug("Detached all cgroups")
+		return nil
+	}
+	return t.attachCgroups(cgroupPaths, true /* replace */)
+}
+
 // AttachToCgroup adds cgroupPath to the tracer's filter set and is
-// idempotent. Repeated calls with the same path are a no-op; calls
-// with new paths merge into the existing set.
-//
-// Used by the engine's continuous-trace path, which discovers
-// per-pod cgroups one at a time as workloads come and go. Contrast
-// with AttachToCgroups, which replaces the entire set in one shot
-// (the session Job's bulk-attach contract).
+// idempotent.
 func (t *Tracer) AttachToCgroup(cgroupPath string) error {
 	return t.attachCgroups([]string{cgroupPath}, false /* replace */)
 }
 
 // AttachToCgroups replaces the tracer's entire cgroup filter set with
-// the given list. Used by the session Job's one-shot diagnose flow,
-// which knows the full target set up front.
+// the given list.
 func (t *Tracer) AttachToCgroups(cgroupPaths []string) error {
 	return t.attachCgroups(cgroupPaths, true /* replace */)
 }
@@ -293,14 +312,17 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		return fmt.Errorf("no valid cgroup paths provided")
 	}
 
-	// Build the desired path set. In replace mode it equals normalized.
-	// In merge mode it is the union of existing t.cgroupPaths and
-	// normalized — dedup via a map.
+	// Serialize multi-writer access (engine reconciles + the event-loop's
+	// auto-disable path) and build a fresh ID map for an atomic publish.
+	t.cgroupWriteMu.Lock()
+	defer t.cgroupWriteMu.Unlock()
+
 	var allPaths []string
+	var newIDs map[uint64]struct{}
 	if replace {
 		allPaths = normalized
 		t.targetCgroupID = 0
-		t.targetCgroupIDs = make(map[uint64]struct{}, len(normalized))
+		newIDs = make(map[uint64]struct{}, len(normalized))
 	} else {
 		seen := make(map[string]struct{}, len(t.cgroupPaths)+len(normalized))
 		for _, p := range t.cgroupPaths {
@@ -317,8 +339,9 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 			seen[p] = struct{}{}
 			allPaths = append(allPaths, p)
 		}
-		if t.targetCgroupIDs == nil {
-			t.targetCgroupIDs = make(map[uint64]struct{}, len(allPaths))
+		newIDs = make(map[uint64]struct{}, len(allPaths))
+		for k := range t.loadCgroupIDs() {
+			newIDs[k] = struct{}{}
 		}
 	}
 
@@ -341,7 +364,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		newPaths := normalized
 		for _, cgroupPath := range newPaths {
 			if cgid, err := getCgroupIDFromPath(cgroupPath); err == nil && cgid != 0 {
-				t.targetCgroupIDs[cgid] = struct{}{}
+				newIDs[cgid] = struct{}{}
 				if t.targetCgroupID == 0 {
 					t.targetCgroupID = cgid
 				}
@@ -355,26 +378,28 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 					}
 					child := filepath.Join(cgroupPath, e.Name())
 					if cgid, err := getCgroupIDFromPath(child); err == nil && cgid != 0 {
-						t.targetCgroupIDs[cgid] = struct{}{}
+						newIDs[cgid] = struct{}{}
 					}
 				}
 			}
 		}
+		t.storeCgroupIDs(newIDs)
 		if err := t.syncTargetCgroupMap(); err != nil {
 			logger.Warn("Failed to sync target_cgroup_ids map", zap.Error(err))
-		} else if len(t.targetCgroupIDs) > 0 {
-			logger.Debug("Set target cgroup IDs for in-kernel filtering", zap.Int("count", len(t.targetCgroupIDs)))
+		} else if len(newIDs) > 0 {
+			logger.Debug("Set target cgroup IDs for in-kernel filtering", zap.Int("count", len(newIDs)))
 		}
-		if len(t.targetCgroupIDs) > 0 && os.Getenv("PODTRACE_DISABLE_USERSPACE_CGROUP_FILTER") == "1" {
+		if len(newIDs) > 0 && os.Getenv("PODTRACE_DISABLE_USERSPACE_CGROUP_FILTER") == "1" {
 			t.useUserspaceCgroupFilter = false
 		}
 	} else {
+		t.storeCgroupIDs(newIDs)
 		logger.Debug("Cgroup v2 not detected, using userspace filtering only", zap.String("cgroup_base", config.CgroupBasePath))
 	}
 	logger.Debug("Attached to cgroups",
 		zap.Int("cgroup_count", len(t.cgroupPaths)),
 		zap.Uint32("container_pid", t.containerPID),
-		zap.Int("target_cgroup_id_count", len(t.targetCgroupIDs)),
+		zap.Int("target_cgroup_id_count", len(newIDs)),
 		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter),
 		zap.Bool("replace", replace))
 	return nil
@@ -389,11 +414,13 @@ func (t *Tracer) syncTargetCgroupMap() error {
 		return nil
 	}
 
+	ids := t.loadCgroupIDs()
+
 	// Clear existing keys.
 	var key uint64
 	var val uint8
 	iter := targetMap.Iterate()
-	keys := make([]uint64, 0, len(t.targetCgroupIDs))
+	keys := make([]uint64, 0, len(ids))
 	for iter.Next(&key, &val) {
 		keys = append(keys, key)
 	}
@@ -402,7 +429,7 @@ func (t *Tracer) syncTargetCgroupMap() error {
 	}
 
 	one := uint8(1)
-	for cgid := range t.targetCgroupIDs {
+	for cgid := range ids {
 		cgidCopy := cgid
 		if err := targetMap.Update(&cgidCopy, &one, ebpf.UpdateAny); err != nil {
 			return err
@@ -559,7 +586,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		zap.String("cgroup_path", t.cgroupPath),
 		zap.Uint32("container_pid", t.containerPID),
 		zap.Uint64("target_cgroup_id", t.targetCgroupID),
-		zap.Int("target_cgroup_id_count", len(t.targetCgroupIDs)),
+		zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
 		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter))
 
 	go func() {
@@ -580,12 +607,14 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 							zap.String("cgroup_path", t.cgroupPath),
 							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter))
 						filteringDisabled = true
+						t.cgroupWriteMu.Lock()
 						t.useUserspaceCgroupFilter = false
 						t.targetCgroupID = 0
-						t.targetCgroupIDs = map[uint64]struct{}{}
+						t.storeCgroupIDs(map[uint64]struct{}{})
 						if err := t.syncTargetCgroupMap(); err == nil {
 							logger.Info("Cleared kernel-side cgroup filter")
 						}
+						t.cgroupWriteMu.Unlock()
 					} else if !filterAutoDisableHintLogged {
 						filterAutoDisableHintLogged = true
 						logger.Warn("Events parsed but all filtered; automatic cgroup filter disable not applied. Set PODTRACE_ALLOW_CGROUP_FILTER_DISABLE=1 to allow clearing cgroup filters as a last resort",
@@ -725,18 +754,19 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 				}
 
 				allowed := true
+				cgroupIDs := t.loadCgroupIDs()
 				if filteringDisabled {
 					// Fallback mode: allow all events
 					allowed = true
-				} else if len(t.targetCgroupIDs) > 0 && event.CgroupID != 0 {
-					_, allowed = t.targetCgroupIDs[event.CgroupID]
+				} else if len(cgroupIDs) > 0 && event.CgroupID != 0 {
+					_, allowed = cgroupIDs[event.CgroupID]
 					if !allowed {
 						eventsFiltered++
 						// Log first few mismatches for debugging, then throttle
 						if eventsFiltered <= 5 || time.Now().Unix()%10 == 0 {
 							logger.Debug("Event filtered by cgroup ID mismatch",
 								zap.Uint64("event_cgroup_id", event.CgroupID),
-								zap.Int("target_cgroup_id_count", len(t.targetCgroupIDs)),
+								zap.Int("target_cgroup_id_count", len(cgroupIDs)),
 								zap.Uint32("pid", event.PID),
 								zap.String("process", event.ProcessName))
 						}

--- a/internal/ebpf/tracer_wrapper_test.go
+++ b/internal/ebpf/tracer_wrapper_test.go
@@ -48,6 +48,10 @@ func (m *mockTracerForInterface) AttachToCgroup(cgroupPath string) error {
 	return nil
 }
 
+func (m *mockTracerForInterface) SetCgroups(cgroupPaths []string) error {
+	return nil
+}
+
 func (m *mockTracerForInterface) SetContainerID(containerID string) error {
 	return nil
 }

--- a/pkg/tracer/engine.go
+++ b/pkg/tracer/engine.go
@@ -11,29 +11,24 @@ import (
 
 // Config tunes Engine behaviour. Defaults are applied by NewEngine when a
 // zero value is passed. Every field is operationally significant:
-//
-//   - EventBufferSize controls how much backpressure the backend can absorb
-//     before the engine drops events (and increments DroppedEvents).
-//   - ExportBatchSize is the soft upper bound on events forwarded to an
-//     exporter in a single call; larger values trade latency for throughput.
 type Config struct {
-	// EventBufferSize sizes the internal channel between the TracerBackend
-	// and the dispatch loop. Default 10_000 matches the legacy CLI default.
 	EventBufferSize int
 
-	// ExportBatchSize is the target batch size for exporter dispatches.
-	// Default 256.
 	ExportBatchSize int
+
+	Observer EngineObserver
 }
 
 // EngineStats is a point-in-time counter snapshot. Thread-safe snapshot is
 // exposed via Engine.Stats.
 type EngineStats struct {
-	EventsReceived  int64
-	EventsExported  int64
-	EventsDropped   int64
-	ActiveTargets   int
-	ExporterFailure int64
+	EventsReceived   int64
+	EventsExported   int64
+	EventsDropped    int64
+	ActiveTargets    int
+	ExporterFailure  int64
+	CgroupsAttached  int64
+	CgroupsDetached  int64
 }
 
 // Engine orchestrates a TracerBackend + Exporters over a stream of
@@ -41,13 +36,8 @@ type EngineStats struct {
 // CLI invocations, agent DaemonSet processes, and session Jobs each
 // construct an Engine with mode-appropriate backend/exporters/stream.
 type Engine interface {
-	// Run blocks until ctx is cancelled or the target stream closes.
-	// Returns nil on clean shutdown, otherwise the first terminal error
-	// encountered (backend attach failure, backend start failure).
 	Run(ctx context.Context, targets <-chan TargetSet) error
 
-	// Stats returns a snapshot of counters. Safe to call concurrently with
-	// Run; values may be slightly stale.
 	Stats() EngineStats
 }
 
@@ -62,6 +52,8 @@ type engine struct {
 	eventsExported  int64
 	eventsDropped   int64
 	exporterFailure int64
+	cgroupsAttached int64
+	cgroupsDetached int64
 }
 
 // NewEngine composes a backend and a set of exporters into a runnable
@@ -92,9 +84,6 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 		return errors.New("tracer: targets channel is required")
 	}
 
-	// loop running until the parent ctx is cancelled or the event channel
-	// is closed — neither of which is guaranteed by the TracerBackend
-	// contract.
 	dispatchCtx, cancelDispatch := context.WithCancel(ctx)
 
 	eventCh := make(chan *events.Event, e.cfg.EventBufferSize)
@@ -127,9 +116,6 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 				return nil
 			}
 			if err := e.applyTargets(set); err != nil {
-				// Attach failures are logged-only: missing one cgroup
-				// should not tear down the whole engine when other
-				// targets are still valid.
 				e.mu.Lock()
 				e.exporterFailure++
 				e.mu.Unlock()
@@ -138,44 +124,77 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 	}
 }
 
+// applyTargets reconciles the engine's view of attached cgroups with the
+// requested TargetSet via a single backend snapshot replace.
 func (e *engine) applyTargets(set TargetSet) error {
 	desired := make(map[string]Target, len(set))
+	snapshot := make([]CgroupTarget, 0, len(set))
 	for _, t := range set {
 		if t.CgroupPath == "" {
 			continue
 		}
+		if _, dup := desired[t.CgroupPath]; dup {
+			continue
+		}
 		desired[t.CgroupPath] = t
+		snapshot = append(snapshot, CgroupTarget{
+			CgroupPath:  t.CgroupPath,
+			ContainerID: t.ContainerID,
+		})
 	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Attach any new cgroups. We rely on backend idempotency: re-attaching
-	// an existing cgroup is a no-op.
-	var firstErr error
-	for path, t := range desired {
-		if _, ok := e.activeCgroups[path]; ok {
-			continue
+	added, removed := 0, 0
+	for path := range desired {
+		if _, ok := e.activeCgroups[path]; !ok {
+			added++
 		}
-		if t.ContainerID != "" {
-			if err := e.backend.SetContainerID(t.ContainerID); err != nil && firstErr == nil {
-				firstErr = err
-			}
+	}
+	for path := range e.activeCgroups {
+		if _, ok := desired[path]; !ok {
+			removed++
 		}
-		if err := e.backend.AttachToCgroup(path); err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		e.activeCgroups[path] = struct{}{}
 	}
 
-	// Detach is the backend's responsibility at Stop(); intra-run detach
-	// is not yet part of the TracerBackend contract because the existing
-	// internal/ebpf/tracer implementation holds links for lifetime. When
-	// a consumer needs dynamic detach, this is the hook point.
-	return firstErr
+	if added == 0 && removed == 0 {
+		return nil
+	}
+
+	if err := e.backend.SetCgroups(snapshot); err != nil {
+		return err
+	}
+
+	for path, t := range desired {
+		if t.ContainerID == "" {
+			continue
+		}
+		if _, alreadyActive := e.activeCgroups[path]; alreadyActive {
+			continue
+		}
+		if err := e.backend.SetContainerID(t.ContainerID); err != nil {
+			e.exporterFailure++
+		}
+	}
+
+	next := make(map[string]struct{}, len(desired))
+	for path := range desired {
+		next[path] = struct{}{}
+	}
+	e.activeCgroups = next
+	e.cgroupsAttached += int64(added)
+	e.cgroupsDetached += int64(removed)
+
+	if obs := e.cfg.Observer; obs != nil {
+		if added > 0 {
+			obs.OnCgroupsAttached(added)
+		}
+		if removed > 0 {
+			obs.OnCgroupsDetached(removed)
+		}
+	}
+	return nil
 }
 
 func (e *engine) dispatchLoop(ctx context.Context, eventCh <-chan *events.Event) {
@@ -235,5 +254,7 @@ func (e *engine) Stats() EngineStats {
 		EventsDropped:   e.eventsDropped,
 		ActiveTargets:   len(e.activeCgroups),
 		ExporterFailure: e.exporterFailure,
+		CgroupsAttached: e.cgroupsAttached,
+		CgroupsDetached: e.cgroupsDetached,
 	}
 }

--- a/pkg/tracer/engine_test.go
+++ b/pkg/tracer/engine_test.go
@@ -15,14 +15,17 @@ import (
 // mockBackend is a minimal TracerBackend implementation that records
 // attach/start/stop activity for assertions.
 type mockBackend struct {
-	mu          sync.Mutex
-	attached    []string
-	started     bool
-	stopped     bool
-	startErr    error
-	attachErr   error
+	mu              sync.Mutex
+	active          map[string]struct{}
+	attachHistory   []string
+	setCalls        int
+	started         bool
+	stopped         bool
+	startErr        error
+	attachErr       error
+	setCgroupsErr   error
 	setContainerErr error
-	eventCh     chan<- *events.Event
+	eventCh         chan<- *events.Event
 }
 
 func (m *mockBackend) AttachToCgroup(path string) error {
@@ -31,7 +34,32 @@ func (m *mockBackend) AttachToCgroup(path string) error {
 	if m.attachErr != nil {
 		return m.attachErr
 	}
-	m.attached = append(m.attached, path)
+	if m.active == nil {
+		m.active = map[string]struct{}{}
+	}
+	m.active[path] = struct{}{}
+	m.attachHistory = append(m.attachHistory, path)
+	return nil
+}
+
+func (m *mockBackend) SetCgroups(targets []tracer.CgroupTarget) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.setCgroupsErr != nil {
+		return m.setCgroupsErr
+	}
+	m.setCalls++
+	next := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if t.CgroupPath == "" {
+			continue
+		}
+		next[t.CgroupPath] = struct{}{}
+		if _, was := m.active[t.CgroupPath]; !was {
+			m.attachHistory = append(m.attachHistory, t.CgroupPath)
+		}
+	}
+	m.active = next
 	return nil
 }
 
@@ -69,11 +97,25 @@ func (m *mockBackend) emit(t *testing.T, ev *events.Event) {
 	ch <- ev
 }
 
+// activePaths returns the current active set (after the most recent
+// SetCgroups call).
+func (m *mockBackend) activePaths() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.active))
+	for p := range m.active {
+		out = append(out, p)
+	}
+	return out
+}
+
+// attachedPaths returns the cumulative history of paths the backend has
+// seen attached at any point.
 func (m *mockBackend) attachedPaths() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]string, len(m.attached))
-	copy(out, m.attached)
+	out := make([]string, len(m.attachHistory))
+	copy(out, m.attachHistory)
 	return out
 }
 
@@ -162,25 +204,40 @@ func TestEngine_TargetAttachment(t *testing.T) {
 		{CgroupPath: "/sys/fs/cgroup/a", ContainerID: "a"},
 		{CgroupPath: "/sys/fs/cgroup/b", ContainerID: "b"},
 	}
-	waitUntil(t, 2*time.Second, func() bool { return len(backend.attachedPaths()) == 2 })
+	waitUntil(t, 2*time.Second, func() bool { return len(backend.activePaths()) == 2 })
 
-	// Add c, keep a; b removed — engine does not detach today (intra-run
-	// detach is future work) so b stays attached. But c must be attached.
 	targets <- tracer.TargetSet{
 		{CgroupPath: "/sys/fs/cgroup/a", ContainerID: "a"},
 		{CgroupPath: "/sys/fs/cgroup/c", ContainerID: "c"},
 	}
-	waitUntil(t, 2*time.Second, func() bool { return len(backend.attachedPaths()) == 3 })
+	waitUntil(t, 2*time.Second, func() bool {
+		ap := backend.activePaths()
+		return len(ap) == 2 && hasAll(ap, "/sys/fs/cgroup/a", "/sys/fs/cgroup/c")
+	})
 
-	paths := backend.attachedPaths()
-	want := map[string]bool{"/sys/fs/cgroup/a": true, "/sys/fs/cgroup/b": true, "/sys/fs/cgroup/c": true}
-	for _, p := range paths {
-		if !want[p] {
-			t.Errorf("unexpected attached path %q", p)
+	active := backend.activePaths()
+	if len(active) != 2 {
+		t.Errorf("expected active set of 2 after replace, got %d (%v)", len(active), active)
+	}
+	for _, p := range active {
+		if p == "/sys/fs/cgroup/b" {
+			t.Errorf("stale cgroup %q remained in active set after replace", p)
 		}
 	}
-	if len(paths) != 3 {
-		t.Errorf("expected 3 attaches, got %d (%v)", len(paths), paths)
+
+	history := backend.attachedPaths()
+	wantHistory := map[string]bool{"/sys/fs/cgroup/a": true, "/sys/fs/cgroup/b": true, "/sys/fs/cgroup/c": true}
+	for _, p := range history {
+		if !wantHistory[p] {
+			t.Errorf("unexpected path in attach history %q", p)
+		}
+	}
+	if len(history) != 3 {
+		t.Errorf("expected 3 paths in attach history, got %d (%v)", len(history), history)
+	}
+
+	if s := eng.Stats(); s.CgroupsDetached != 1 {
+		t.Errorf("CgroupsDetached=%d, want 1", s.CgroupsDetached)
 	}
 
 	cancel()
@@ -216,8 +273,6 @@ func TestEngine_EventDispatch(t *testing.T) {
 
 	waitUntil(t, 2*time.Second, func() bool { return len(backend.attachedPaths()) == 1 })
 
-	// Emit 10 events; ExportBatchSize=4 means 2 full batches flush inline
-	// and 2 events remain in the pending batch until shutdown flushes them.
 	for i := 0; i < 10; i++ {
 		backend.emit(t, &events.Event{Type: events.EventDNS})
 	}
@@ -290,6 +345,21 @@ func waitUntil(t *testing.T, d time.Duration, pred func() bool) {
 	}
 }
 
+// hasAll reports whether got contains every value in want (order- and
+// duplicate-insensitive).
+func hasAll(got []string, want ...string) bool {
+	have := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		have[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := have[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func containsSub(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {
@@ -303,8 +373,7 @@ func containsSub(s, sub string) bool {
 var _ = fmt.Sprint(tracer.Config{})
 
 // TestEngine_Stats asserts that Stats() reflects accumulated counters and
-// active target count. This is the metric surface agent mode will scrape
-// for per-CR status reporting, so the contract matters.
+// active target count.
 func TestEngine_Stats(t *testing.T) {
 	backend := &mockBackend{}
 	exp := &recordingExporter{name: "rec"}
@@ -313,7 +382,6 @@ func TestEngine_Stats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Zero-state snapshot is all zeros.
 	if s := eng.Stats(); s.EventsReceived != 0 || s.EventsExported != 0 || s.ActiveTargets != 0 {
 		t.Fatalf("pre-run stats non-zero: %+v", s)
 	}
@@ -354,9 +422,7 @@ func TestEngine_Stats(t *testing.T) {
 }
 
 // TestEngine_MultiExporterFanout asserts every registered exporter
-// receives every batch. Agent mode will compose per-CR exporters behind
-// the engine; a silent fan-out bug would mean one CR's exporter stops
-// getting events.
+// receives every batch.
 func TestEngine_MultiExporterFanout(t *testing.T) {
 	backend := &mockBackend{}
 	a := &recordingExporter{name: "a"}
@@ -389,7 +455,6 @@ func TestEngine_MultiExporterFanout(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Every exporter must have received identical event counts and been closed.
 	for _, ex := range []*recordingExporter{a, b, c} {
 		if ex.totalEvents() != 4 {
 			t.Errorf("%s: received %d, want 4", ex.name, ex.totalEvents())
@@ -402,7 +467,7 @@ func TestEngine_MultiExporterFanout(t *testing.T) {
 
 // TestEngine_ExporterFailureCounted ensures that when an exporter's
 // Export returns error, the engine continues pumping events and bumps
-// ExporterFailure. Exporter outage must not tear down the tracer.
+// ExporterFailure.
 func TestEngine_ExporterFailureCounted(t *testing.T) {
 	backend := &mockBackend{}
 	bad := &recordingExporter{name: "bad", exportErr: errors.New("broken")}
@@ -425,7 +490,6 @@ func TestEngine_ExporterFailureCounted(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		backend.emit(t, &events.Event{Type: events.EventDNS})
 	}
-	// Good exporter still gets all events; bad one has failure count.
 	waitUntil(t, 2*time.Second, func() bool { return good.totalEvents() == 4 })
 	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ExporterFailure > 0 })
 
@@ -438,11 +502,11 @@ func TestEngine_ExporterFailureCounted(t *testing.T) {
 	}
 }
 
-// TestEngine_AttachErrorDoesNotAbortRun ensures that a backend attach
-// failure for one cgroup does not prevent the engine from processing
-// later target sets (the error is tracked, not fatal).
+// TestEngine_AttachErrorDoesNotAbortRun ensures that a backend
+// SetCgroups failure does not prevent the engine from processing later
+// target sets
 func TestEngine_AttachErrorDoesNotAbortRun(t *testing.T) {
-	backend := &mockBackend{attachErr: errors.New("attach broken")}
+	backend := &mockBackend{setCgroupsErr: errors.New("attach broken")}
 	exp := &recordingExporter{name: "x"}
 	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{})
 	if err != nil {
@@ -458,11 +522,9 @@ func TestEngine_AttachErrorDoesNotAbortRun(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(ctx, targets) }()
 
-	// Recovery: clear the attach error and push a second snapshot. The
-	// engine must still process it.
 	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ExporterFailure > 0 })
 	backend.mu.Lock()
-	backend.attachErr = nil
+	backend.setCgroupsErr = nil
 	backend.mu.Unlock()
 
 	targets <- tracer.TargetSet{{CgroupPath: "/will/succeed"}}
@@ -525,7 +587,6 @@ func TestEngine_EmptyTargetSetIsNoOp(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(ctx, targets) }()
 
-	// Let it settle.
 	time.Sleep(50 * time.Millisecond)
 	if s := eng.Stats(); s.ActiveTargets != 0 || s.ExporterFailure != 0 {
 		t.Errorf("empty TargetSet disturbed stats: %+v", s)
@@ -538,8 +599,7 @@ func TestEngine_EmptyTargetSetIsNoOp(t *testing.T) {
 }
 
 // TestEngine_ConcurrentTargetUpdates is a smoke test for the race
-// detector. Run with `go test -race`; any data race in applyTargets'
-// bookkeeping will fire.
+// detector.
 func TestEngine_ConcurrentTargetUpdates(t *testing.T) {
 	backend := &mockBackend{}
 	eng, err := tracer.NewEngine(backend, []tracer.Exporter{&recordingExporter{name: "x"}}, tracer.Config{})
@@ -554,7 +614,6 @@ func TestEngine_ConcurrentTargetUpdates(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(ctx, targets) }()
 
-	// Multiple producers hammer the engine with overlapping target sets.
 	producers := 4
 	perProducer := 25
 	var wg sync.WaitGroup
@@ -573,7 +632,7 @@ func TestEngine_ConcurrentTargetUpdates(t *testing.T) {
 	wg.Wait()
 
 	waitUntil(t, 3*time.Second, func() bool {
-		return eng.Stats().ActiveTargets >= producers*perProducer/2
+		return eng.Stats().CgroupsAttached >= int64(producers*perProducer/2)
 	})
 
 	cancel()
@@ -584,4 +643,201 @@ func TestEngine_ConcurrentTargetUpdates(t *testing.T) {
 
 func fmtPath(a, b int) string {
 	return fmt.Sprintf("/c/%d/%d", a, b)
+}
+
+// TestEngine_EmptySnapshotDetachesAll asserts that an empty TargetSet
+// arriving after a non-empty one fully detaches the previously active
+// cgroups.
+func TestEngine_EmptySnapshotDetachesAll(t *testing.T) {
+	backend := &mockBackend{}
+	exp := &recordingExporter{name: "x"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 2)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/c/a"},
+		{CgroupPath: "/c/b"},
+	}
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ActiveTargets == 2 })
+
+	targets <- tracer.TargetSet{}
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ActiveTargets == 0 })
+
+	if active := backend.activePaths(); len(active) != 0 {
+		t.Errorf("backend still has active paths after empty snapshot: %v", active)
+	}
+	if s := eng.Stats(); s.CgroupsDetached != 2 {
+		t.Errorf("CgroupsDetached=%d, want 2", s.CgroupsDetached)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// TestEngine_PodRecreateRotatesCgroup simulates the pod delete-and-recreate
+// scenario the user originally flagged: same pod name, different cgroup
+// path.
+func TestEngine_PodRecreateRotatesCgroup(t *testing.T) {
+	backend := &mockBackend{}
+	exp := &recordingExporter{name: "x"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 2)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{
+		{PodName: "web", CgroupPath: "/cg/pod-uid-1"},
+	}
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ActiveTargets == 1 })
+
+	targets <- tracer.TargetSet{
+		{PodName: "web", CgroupPath: "/cg/pod-uid-2"},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		ap := backend.activePaths()
+		return len(ap) == 1 && ap[0] == "/cg/pod-uid-2"
+	})
+
+	if s := eng.Stats(); s.CgroupsAttached != 2 || s.CgroupsDetached != 1 {
+		t.Errorf("attach/detach counters wrong: %+v", s)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// recordingObserver captures observer callbacks for assertion.
+type recordingObserver struct {
+	mu                sync.Mutex
+	attachedTotal     int
+	detachedTotal     int
+	attachedCallbacks int
+	detachedCallbacks int
+}
+
+func (r *recordingObserver) OnCgroupsAttached(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.attachedTotal += n
+	r.attachedCallbacks++
+}
+
+func (r *recordingObserver) OnCgroupsDetached(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.detachedTotal += n
+	r.detachedCallbacks++
+}
+
+func (r *recordingObserver) snapshot() (attachedTotal, detachedTotal, attachedCalls, detachedCalls int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.attachedTotal, r.detachedTotal, r.attachedCallbacks, r.detachedCallbacks
+}
+
+// TestEngine_ObserverNotifiedOnChurn asserts the optional EngineObserver
+// is fed only when the active set actually changes.
+func TestEngine_ObserverNotifiedOnChurn(t *testing.T) {
+	backend := &mockBackend{}
+	obs := &recordingObserver{}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{&recordingExporter{name: "x"}}, tracer.Config{
+		Observer: obs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 4)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{{CgroupPath: "/c/a"}, {CgroupPath: "/c/b"}}
+	waitUntil(t, 2*time.Second, func() bool {
+		a, _, _, _ := obs.snapshot()
+		return a == 2
+	})
+
+	targets <- tracer.TargetSet{{CgroupPath: "/c/a"}, {CgroupPath: "/c/b"}}
+	time.Sleep(50 * time.Millisecond)
+	a, d, ac, dc := obs.snapshot()
+	if a != 2 || d != 0 || ac != 1 || dc != 0 {
+		t.Errorf("idempotent re-send disturbed observer: attached=%d detached=%d ac=%d dc=%d", a, d, ac, dc)
+	}
+
+	targets <- tracer.TargetSet{{CgroupPath: "/c/a"}, {CgroupPath: "/c/c"}}
+	waitUntil(t, 2*time.Second, func() bool {
+		_, dt, _, _ := obs.snapshot()
+		return dt == 1
+	})
+	a, d, _, _ = obs.snapshot()
+	if a != 3 || d != 1 {
+		t.Errorf("after churn: attached=%d detached=%d, want 3/1", a, d)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// TestEngine_BackendSetCgroupsErrorPreservesActiveSet asserts that when
+// SetCgroups fails, the engine does NOT clobber its previous active set
+// — the next snapshot retry can still converge.
+func TestEngine_BackendSetCgroupsErrorPreservesActiveSet(t *testing.T) {
+	backend := &mockBackend{}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{&recordingExporter{name: "x"}}, tracer.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 2)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{{CgroupPath: "/c/a"}, {CgroupPath: "/c/b"}}
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ActiveTargets == 2 })
+
+	backend.mu.Lock()
+	backend.setCgroupsErr = errors.New("transient kernel hiccup")
+	backend.mu.Unlock()
+
+	targets <- tracer.TargetSet{{CgroupPath: "/c/c"}}
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ExporterFailure > 0 })
+
+	// Active set must still be {a, b} — failed replace did not poison
+	// engine state.
+	if s := eng.Stats(); s.ActiveTargets != 2 {
+		t.Errorf("ActiveTargets=%d after failed replace, want 2", s.ActiveTargets)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 }

--- a/pkg/tracer/types.go
+++ b/pkg/tracer/types.go
@@ -1,21 +1,6 @@
 // Package tracer defines the stable boundary between podtrace's three
 // operational modes (CLI, agent DaemonSet, session Job) and the eBPF
 // tracing core implemented under internal/ebpf.
-//
-// The boundary is narrow on purpose:
-//
-//   - a Target describes one pod-level attachment site (cgroup + metadata),
-//   - a TargetSet is the full set of sites the tracer should currently
-//     attach to,
-//   - an Exporter consumes events,
-//   - an Engine orchestrates a TracerBackend over a stream of TargetSets
-//     and dispatches events to a set of Exporters.
-//
-// Legacy CLI, agent, and job modes all drive the same Engine. They differ
-// only in who produces the TargetSet stream (CLI: flags → informer,
-// agent: PodTrace CR informer, job: flags derived from a
-// PodTraceSession). The eBPF core and the Exporter implementations are
-// identical across modes.
 package tracer
 
 import (
@@ -28,85 +13,61 @@ import (
 // field is populated by the producer of the target stream (CLI target
 // registry, CR-backed agent, or session Job) and is otherwise opaque to
 // the Engine.
-//
-// The CgroupPath field is load-bearing: attachment is always cgroup-based.
-// ContainerID and pod-level metadata are carried for exporter enrichment
-// and for status reporting back to Kubernetes resources.
 type Target struct {
-	// PodName and Namespace identify the Kubernetes pod.
 	PodName   string
 	Namespace string
 
-	// ContainerID is the short (CRI-normalized) container identifier.
 	ContainerID string
 
-	// ContainerName is the spec container name inside the pod.
 	ContainerName string
 
-	// CgroupPath is the absolute cgroup v2 path the eBPF program will be
-	// attached to. Must be validated by the producer against the container
-	// it is supposed to represent.
 	CgroupPath string
 
-	// Labels is a shallow copy of pod labels, used for exporter enrichment.
-	// May be nil.
 	Labels map[string]string
 
-	// PodIP is the pod's primary IP at the time the target was resolved.
-	// May be empty when the pod has not yet been assigned an address.
 	PodIP string
 
-	// OwnerKind / OwnerName identify the first controller owner reference
-	// (Deployment, StatefulSet, DaemonSet, Job, …) — used for correlation
-	// in exporters and in CR status.
 	OwnerKind string
 	OwnerName string
 }
 
 // TargetSet is the complete set of Targets the tracer should currently be
-// attached to. It is the unit of update on the target stream: each tick
-// of the stream is a full snapshot, not a delta. This is the simplest
-// representation to reason about under concurrent producers (CRs merging
-// with pod informers, for instance) and lets the tracer diff against
-// prior state in one place.
+// attached to.
 type TargetSet []Target
 
 // Exporter consumes events produced by the tracer core. Implementations
 // must be safe for concurrent use by the Engine's dispatch loop.
-//
-// Close is called once, during Engine shutdown, and must release any
-// network resources. Export must be non-blocking in the common case and
-// should buffer internally; returning an error tells the Engine to count
-// the events as dropped but not to stop the pipeline.
 type Exporter interface {
-	// Name returns a short, stable identifier for logging and metrics.
 	Name() string
 
-	// Export forwards a batch of events. Implementations must not retain
-	// the slice beyond the call; callers may reuse the underlying array.
 	Export(ctx context.Context, batch []*events.Event) error
 
-	// Close flushes any pending exports and releases resources.
 	Close(ctx context.Context) error
 }
 
+// CgroupTarget is one attachment site in a backend filter snapshot.
+type CgroupTarget struct {
+	CgroupPath  string
+	ContainerID string
+}
+
 // TracerBackend is the minimal surface an Engine needs from the eBPF
-// tracing core. internal/ebpf/tracer.TracerInterface satisfies it; an
-// adapter is provided in this package.
+// tracing core.
 type TracerBackend interface {
-	// AttachToCgroup attaches eBPF programs to the given cgroup v2 path.
-	// Idempotent — calling twice with the same path is a no-op.
+	SetCgroups(targets []CgroupTarget) error
+
 	AttachToCgroup(cgroupPath string) error
 
-	// SetContainerID associates the current attachment batch with a
-	// container ID, used by the core for per-container filtering.
 	SetContainerID(containerID string) error
 
-	// Start begins streaming events into the supplied channel. Start must
-	// return once the stream is wired; the long-lived work happens in
-	// goroutines owned by the backend and terminates when ctx is done.
 	Start(ctx context.Context, eventChan chan<- *events.Event) error
 
-	// Stop flushes and detaches. Safe to call multiple times.
 	Stop() error
+}
+
+// EngineObserver is an optional hook the Engine notifies when the
+// active target set changes.
+type EngineObserver interface {
+	OnCgroupsAttached(n int)
+	OnCgroupsDetached(n int)
 }


### PR DESCRIPTION
## Summary


- Replace the engine's grow-only `AttachToCgroup` flow with a snapshot-shaped `SetCgroups([]CgroupTarget)` contract on `TracerBackend`/`TracerInterface`, so the engine reconciles the backend's filter set against each `TargetSet` snapshot, added cgroups attach, removed cgroups detach, no drift on pod churn.
- Make the underlying `*Tracer.targetCgroupIDs` lock-free for the event-reader hot path by storing it as `atomic.Pointer[map[uint64]struct{}]` and serializing writers (engine reconciles + the auto-disable branch in the event loop) under a new `cgroupWriteMu`; fixes a `concurrent map read and map write` panic that surfaced as soon as the new contract started firing `SetCgroups` on every reconcile tick.
- Engine `applyTargets` is now idempotent, when the desired snapshot equals the active set, no backend call is made, and exposes attach/detach deltas via a new optional `EngineObserver` hook plus `EngineStats.CgroupsAttached/CgroupsDetached`.
- New Prometheus counters `podtrace_agent_cgroups_attached_total` / `podtrace_agent_cgroups_detached_total` are wired into the agent via a `Metrics.EngineObserver()` adapter.

## Why this matters

Cgroup inode IDs are recycled by the kernel after a pod is deleted. The previous engine never pruned its filter set, so a stale ID could collide with an unrelated new pod and silently start tracing it. This change ties the in-kernel filter map's lifetime to the target snapshot.