### PR TITLE
chore(charts): add artifacthub-repo.yml for Verified Publisher

### DIFF
--- a/deploy/charts/podtrace/Chart.yaml
+++ b/deploy/charts/podtrace/Chart.yaml
@@ -32,7 +32,7 @@ maintainers:
   - name: podtrace maintainers
     url: https://github.com/gma1k/podtrace
 
-icon: https://raw.githubusercontent.com/gma1k/podtrace/main/assets/logo.png
+icon: https://raw.githubusercontent.com/gma1k/podtrace/main/assets/podtrace-logo.png
 
 annotations:
   artifacthub.io/changes: |

--- a/deploy/charts/podtrace/artifacthub-repo.yml
+++ b/deploy/charts/podtrace/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: 1f5ac490-0036-4f02-801a-8f217df6c19d
+owners:
+  - name: Ghassan Malke
+    email: ghassan+podtrace@malke.nl


### PR DESCRIPTION
Register Podtrace Helm chart on Artifact Hub as a Verified Publisher.
