### PR TITLE
test: enforce OTLP-only agent exporter contract with golden tests

### DIFF
--- a/api/v1alpha1/exporterconfig_types.go
+++ b/api/v1alpha1/exporterconfig_types.go
@@ -61,13 +61,24 @@ type OTLPHeader struct {
 }
 
 // JaegerExporter configures the Jaeger exporter.
+//
+// Agent mode ships spans to Jaeger over OTLP/HTTP, so the endpoint must
+// point at Jaeger's OTLP receiver (port 4318 by default), not the legacy
+// Thrift collector endpoint. See docs/tracing-exporters.md.
 type JaegerExporter struct {
-	// Endpoint, e.g. "http://jaeger-collector.observability:14268/api/traces".
+	// Endpoint of Jaeger's OTLP/HTTP receiver, e.g.
+	// "jaeger-collector.observability:4318".
 	// +kubebuilder:validation:Required
 	Endpoint string `json:"endpoint"`
 }
 
 // ZipkinExporter configures the Zipkin exporter.
+//
+// Direct export to Zipkin is not supported in agent mode (the upstream
+// OTel SDK Zipkin exporter is deprecated). To route spans to Zipkin,
+// deploy an OpenTelemetry Collector with the 'zipkin' exporter and
+// configure podtrace with type=otlp pointing at the Collector. See
+// docs/tracing-exporters.md.
 type ZipkinExporter struct {
 	// Endpoint, e.g. "http://zipkin.observability:9411/api/v2/spans".
 	// +kubebuilder:validation:Required

--- a/deploy/charts/podtrace/Chart.yaml
+++ b/deploy/charts/podtrace/Chart.yaml
@@ -1,19 +1,19 @@
 apiVersion: v2
 name: podtrace
 description: |
-  Podtrace — eBPF-based Kubernetes pod observability and diagnostics.
+  Podtrace — a lightweight yet powerful eBPF-driven diagnostic tool for
+  Kubernetes applications. It delivers full-stack observability from
+  kernel events to application-layer behavior, activated on demand with
+  no prior configuration or instrumentation.
 
-  Installs the podtrace operator and its CustomResourceDefinitions. The
-  operator reconciles PodTrace, PodTraceSession, PodTraceSchedule,
-  ExporterConfig, and TracerConfig resources, and rolls out the
-  podtrace-agent DaemonSet on demand when a TracerConfig is created.
+  This chart installs the podtrace operator, its v1alpha1 CRDs
+  (PodTrace, PodTraceSession, PodTraceSchedule, ExporterConfig,
+  TracerConfig), and rolls out the podtrace-agent DaemonSet on demand
+  when a TracerConfig is created.
 type: application
 kubeVersion: ">=1.28.0-0"
 
-# chart version — bumped per chart change, decoupled from appVersion.
-version: 0.1.1
-# appVersion tracks the podtrace binary release this chart targets.
-# Managed by release-please via the marker below.
+version: 0.2.0
 appVersion: "0.11.11" # x-release-please-version
 
 keywords:
@@ -37,5 +37,7 @@ icon: https://raw.githubusercontent.com/gma1k/podtrace/main/assets/podtrace-logo
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Initial chart with v1alpha1 CRDs (PodTrace, PodTraceSession, ExporterConfig, TracerConfig) and podtrace-system namespace scaffolding."
+      description: "values.schema.json: chart values are now validated by JSON Schema at install/upgrade time."
+    - kind: changed
+      description: "Chart description rewritten to mirror the project README."
   artifacthub.io/category: monitoring-logging

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_exporterconfigs.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_exporterconfigs.yaml
@@ -93,10 +93,17 @@ spec:
                 - apiKeySecretRef
                 type: object
               jaeger:
-                description: JaegerExporter configures the Jaeger exporter.
+                description: |-
+                  JaegerExporter configures the Jaeger exporter.
+
+                  Agent mode ships spans to Jaeger over OTLP/HTTP, so the endpoint must
+                  point at Jaeger's OTLP receiver (port 4318 by default), not the legacy
+                  Thrift collector endpoint. See docs/tracing-exporters.md.
                 properties:
                   endpoint:
-                    description: Endpoint, e.g. "http://jaeger-collector.observability:14268/api/traces".
+                    description: |-
+                      Endpoint of Jaeger's OTLP/HTTP receiver, e.g.
+                      "jaeger-collector.observability:4318".
                     type: string
                 required:
                 - endpoint
@@ -198,7 +205,14 @@ spec:
                 - datadog
                 type: string
               zipkin:
-                description: ZipkinExporter configures the Zipkin exporter.
+                description: |-
+                  ZipkinExporter configures the Zipkin exporter.
+
+                  Direct export to Zipkin is not supported in agent mode (the upstream
+                  OTel SDK Zipkin exporter is deprecated). To route spans to Zipkin,
+                  deploy an OpenTelemetry Collector with the 'zipkin' exporter and
+                  configure podtrace with type=otlp pointing at the Collector. See
+                  docs/tracing-exporters.md.
                 properties:
                   endpoint:
                     description: Endpoint, e.g. "http://zipkin.observability:9411/api/v2/spans".

--- a/docs/crd-exporterconfig.md
+++ b/docs/crd-exporterconfig.md
@@ -48,10 +48,12 @@ supported per OTLP exporter.
 spec:
   type: jaeger
   jaeger:
-    endpoint: http://jaeger-collector.observability:14268/api/traces
+    endpoint: jaeger-collector.observability:4318
 ```
 
-No credentials. Bundle is ConfigMap-only.
+Agent mode ships to Jaeger's **OTLP/HTTP receiver** (port 4318 by
+default), not the legacy Thrift `/api/traces` endpoint. Jaeger 1.35+
+ships an OTLP receiver out of the box. No credentials.
 
 ### Zipkin
 
@@ -62,22 +64,29 @@ spec:
     endpoint: http://zipkin.observability:9411/api/v2/spans
 ```
 
-No credentials. Bundle is ConfigMap-only.
+Direct Zipkin export **is not supported in agent mode**. The upstream
+OTel SDK Zipkin exporter is deprecated. To route spans to Zipkin,
+deploy an OpenTelemetry Collector with the `zipkin` exporter and
+configure podtrace with `type: otlp` pointing at the Collector. See
+[Agent-mode exporter support](./tracing-exporters.md#agent-mode-exporter-support).
 
-### Splunk HEC
+### Splunk
 
 ```yaml
 spec:
   type: splunk
   splunk:
-    endpoint: https://splunk.example.com:8088/services/collector
+    endpoint: splunk-otel-collector.splunk:4318
     tokenSecretRef:
-      name: splunk-hec-token
+      name: splunk-access-token
       key: token
 ```
 
-The bundle's companion Secret carries the resolved HEC token under the
-`credential` key.
+Agent mode ships to the **Splunk OpenTelemetry Collector** over
+OTLP/HTTP. The token in `tokenSecretRef` is forwarded as the
+`X-SF-TOKEN` header. Direct HEC (`:8088/services/collector`) is not
+the agent's wire format; deploy the Splunk OTel Collector and route to
+its OTLP port instead.
 
 ### DataDog
 
@@ -85,13 +94,17 @@ The bundle's companion Secret carries the resolved HEC token under the
 spec:
   type: datadog
   datadog:
-    site: datadoghq.com           # or datadoghq.eu, etc.
+    endpoint: datadog-agent.datadog:4318  # optional; defaults to this
+    site: datadoghq.com                    # or datadoghq.eu, etc.
     apiKeySecretRef:
       name: dd-api-key
       key: api_key
 ```
 
-The companion Secret carries the resolved API key under `credential`.
+Agent mode ships to the **DataDog Agent's OTLP intake**. Enable the
+OTLP receiver in your Datadog Agent Helm values (the receiver is off
+by default on older Agent versions). The API key in
+`apiKeySecretRef` is forwarded as the `DD-API-KEY` header.
 
 ## Optional fields shared by all types
 

--- a/docs/tracing-exporters.md
+++ b/docs/tracing-exporters.md
@@ -18,6 +18,28 @@ For Zipkin: the agent returns a structured error explaining the OTel Collector p
 
 CLI / one-shot diagnose mode (`podtrace diagnose`) continues to support every backend including direct Zipkin, since that path uses its own hand-rolled exporters rather than the agent's SDK-based pipeline.
 
+### OTLP-only in agent mode
+
+The continuous DaemonSet path commits to one wire format on purpose:
+
+- **One transport to maintain.** Every backend listed above offers a
+  first-class OTLP receiver today, either natively (Jaeger 1.35+) or
+  through a vendor-supplied Collector distribution (Splunk OpenTelemetry
+  Collector, Datadog Agent OTLP intake). Speaking OTLP everywhere means
+  one client library, one set of golden tests, and one upgrade path.
+- **Vendors are deprecating their native formats.** Jaeger Thrift is on
+  the upstream deprecation path; the OTel SDK's Zipkin exporter is
+  already scheduled for removal. Building native parity in the agent
+  would be investing in formats whose owners are moving on.
+- **Auth and tenant routing are header concerns, not protocol
+  concerns.** `DD-API-KEY`, `X-SF-TOKEN`, and arbitrary `headers[]`
+  cover every backend's authentication model without per-backend wire
+  code in the agent.
+
+If your environment can't run a Collector or vendor Agent (air-gapped,
+strict footprint constraints), use CLI/diagnose mode for one-shot
+captures, it speaks each backend's native protocol directly.
+
 ## Table of Contents
 
 - [OpenTelemetry (OTLP)](#opentelemetry-otlp)

--- a/internal/agent/exporter_loader_test.go
+++ b/internal/agent/exporter_loader_test.go
@@ -122,39 +122,72 @@ func TestBuildExporter_OTLP(t *testing.T) {
 	_ = exp.Close(ctx)
 }
 
-func TestBuildExporter_OTLPLikeTypesBuildSuccessfully(t *testing.T) {
-	cases := []struct {
-		ty       bundle.Type
-		endpoint string
-	}{
-		{bundle.TypeJaeger, "jaeger-collector:4318"},
-		{bundle.TypeDataDog, "datadog-agent:4318"},
-		{bundle.TypeSplunk, "splunk-otel-collector:4318"},
+func TestBuildExporter_Jaeger(t *testing.T) {
+	p := &BundlePayload{
+		Type:     bundle.TypeJaeger,
+		Endpoint: "jaeger-collector.observability:4318",
+		Insecure: true,
 	}
-	for _, tc := range cases {
-		t.Run(string(tc.ty), func(t *testing.T) {
-			p := &BundlePayload{
-				Type:     tc.ty,
-				Endpoint: tc.endpoint,
-				Insecure: true,
-			}
-			exp, err := BuildExporter(p, CRKey{"ns", "cr"})
-			if err != nil {
-				t.Fatalf("expected exporter to build, got: %v", err)
-			}
-			if exp == nil {
-				t.Fatal("nil exporter")
-			}
-			// The exporter's Name() should mention the backend type so
-			// log lines and Degraded conditions are attributable.
-			if !strings.Contains(exp.Name(), string(tc.ty)) {
-				t.Errorf("Name() = %q; expected to contain %q", exp.Name(), tc.ty)
-			}
-			ctx, cancel := contextWithTimeout(1)
-			defer cancel()
-			_ = exp.Close(ctx)
-		})
+	exp, err := BuildExporter(p, CRKey{"ns", "cr"})
+	if err != nil {
+		t.Fatalf("BuildExporter: %v", err)
 	}
+	if exp == nil {
+		t.Fatal("nil exporter")
+	}
+	if !strings.Contains(exp.Name(), "jaeger") {
+		t.Errorf("Name() = %q; expected to contain %q", exp.Name(), "jaeger")
+	}
+	ctx, cancel := contextWithTimeout(1)
+	defer cancel()
+	_ = exp.Close(ctx)
+}
+
+func TestBuildExporter_DataDog(t *testing.T) {
+	p := &BundlePayload{
+		Type:       bundle.TypeDataDog,
+		Endpoint:   "datadog-agent.datadog:4318",
+		Site:       "datadoghq.com",
+		Insecure:   true,
+		HeaderName: "DD-API-KEY",
+		Credential: []byte("dd-api-key-redacted"),
+	}
+	exp, err := BuildExporter(p, CRKey{"ns", "cr"})
+	if err != nil {
+		t.Fatalf("BuildExporter: %v", err)
+	}
+	if exp == nil {
+		t.Fatal("nil exporter")
+	}
+	if !strings.Contains(exp.Name(), "datadog") {
+		t.Errorf("Name() = %q; expected to contain %q", exp.Name(), "datadog")
+	}
+	ctx, cancel := contextWithTimeout(1)
+	defer cancel()
+	_ = exp.Close(ctx)
+}
+
+func TestBuildExporter_Splunk(t *testing.T) {
+	p := &BundlePayload{
+		Type:       bundle.TypeSplunk,
+		Endpoint:   "splunk-otel-collector.splunk:4318",
+		Insecure:   true,
+		HeaderName: "X-SF-TOKEN",
+		Credential: []byte("splunk-token-redacted"),
+	}
+	exp, err := BuildExporter(p, CRKey{"ns", "cr"})
+	if err != nil {
+		t.Fatalf("BuildExporter: %v", err)
+	}
+	if exp == nil {
+		t.Fatal("nil exporter")
+	}
+	if !strings.Contains(exp.Name(), "splunk") {
+		t.Errorf("Name() = %q; expected to contain %q", exp.Name(), "splunk")
+	}
+	ctx, cancel := contextWithTimeout(1)
+	defer cancel()
+	_ = exp.Close(ctx)
 }
 
 func TestBuildExporter_ZipkinReturnsHelpfulError(t *testing.T) {

--- a/internal/agent/sdk_event_exporter_test.go
+++ b/internal/agent/sdk_event_exporter_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/exporter/bundle"
 )
 
 type captureServer struct {
@@ -23,11 +25,13 @@ type capturedReq struct {
 	path    string
 	method  string
 	headers http.Header
+	body    []byte
 }
 
 func newCaptureServer() *captureServer {
 	cs := &captureServer{}
 	cs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
 		cs.mu.Lock()
 		defer cs.mu.Unlock()
 		cs.hits++
@@ -35,10 +39,29 @@ func newCaptureServer() *captureServer {
 			path:    r.URL.Path,
 			method:  r.Method,
 			headers: r.Header.Clone(),
+			body:    body,
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	return cs
+}
+
+func (cs *captureServer) lastPath() string {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.lastReq.path
+}
+
+func (cs *captureServer) lastMethod() string {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.lastReq.method
+}
+
+func (cs *captureServer) lastBodyLen() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return len(cs.lastReq.body)
 }
 
 func (cs *captureServer) endpointHostPort() string {
@@ -160,6 +183,159 @@ func TestSDKEventExporter_SplunkAppliesTokenHeader(t *testing.T) {
 	if got := cs.lastHeader("X-Sf-Token"); got != "hec-token" {
 		t.Errorf("X-SF-TOKEN header = %q, want %q", got, "hec-token")
 	}
+}
+
+// TestSDKEventExporter_GoldenOTLPWire is the golden-payload assertion for
+// the agent's OTLP-only design.
+func TestSDKEventExporter_GoldenOTLPWire(t *testing.T) {
+	cases := []struct {
+		name          string
+		build         func(CRKey, *BundlePayload) (interface {
+			Export(context.Context, []*events.Event) error
+			Close(context.Context) error
+			Name() string
+		}, error)
+		headerName  string
+		credential  string
+		extraAssert func(t *testing.T, cs *captureServer)
+	}{
+		{
+			name: "otlp",
+			build: func(k CRKey, b *BundlePayload) (interface {
+				Export(context.Context, []*events.Event) error
+				Close(context.Context) error
+				Name() string
+			}, error) {
+				return newOTLPEventExporter(k, b)
+			},
+		},
+		{
+			name: "jaeger",
+			build: func(k CRKey, b *BundlePayload) (interface {
+				Export(context.Context, []*events.Event) error
+				Close(context.Context) error
+				Name() string
+			}, error) {
+				return newJaegerEventExporter(k, b)
+			},
+		},
+		{
+			name: "datadog",
+			build: func(k CRKey, b *BundlePayload) (interface {
+				Export(context.Context, []*events.Event) error
+				Close(context.Context) error
+				Name() string
+			}, error) {
+				return newDataDogEventExporter(k, b)
+			},
+			headerName: "DD-API-KEY",
+			credential: "dd-api-key-golden",
+			extraAssert: func(t *testing.T, cs *captureServer) {
+				if got := cs.lastHeader("Dd-Api-Key"); got != "dd-api-key-golden" {
+					t.Errorf("DD-API-KEY = %q, want %q", got, "dd-api-key-golden")
+				}
+			},
+		},
+		{
+			name: "splunk",
+			build: func(k CRKey, b *BundlePayload) (interface {
+				Export(context.Context, []*events.Event) error
+				Close(context.Context) error
+				Name() string
+			}, error) {
+				return newSplunkEventExporter(k, b)
+			},
+			headerName: "X-SF-TOKEN",
+			credential: "splunk-token-golden",
+			extraAssert: func(t *testing.T, cs *captureServer) {
+				if got := cs.lastHeader("X-Sf-Token"); got != "splunk-token-golden" {
+					t.Errorf("X-SF-TOKEN = %q, want %q", got, "splunk-token-golden")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := newCaptureServer()
+			defer cs.close()
+
+			b := &BundlePayload{
+				Type:       bundleType(tc.name),
+				Endpoint:   cs.endpointHostPort(),
+				Insecure:   true,
+				HeaderName: tc.headerName,
+				Credential: []byte(tc.credential),
+			}
+			exp, err := tc.build(CRKey{"ns", "cr"}, b)
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			sendOneEventAndShutdown(t, exp)
+
+			if cs.hitCount() == 0 {
+				t.Fatal("captureServer received no request")
+			}
+			if got := cs.lastPath(); got != "/v1/traces" {
+				t.Errorf("path = %q, want %q (proves OTLP/HTTP wire)", got, "/v1/traces")
+			}
+			if got := cs.lastMethod(); got != http.MethodPost {
+				t.Errorf("method = %q, want POST", got)
+			}
+			if got := cs.lastHeader("Content-Type"); got != "application/x-protobuf" {
+				t.Errorf("Content-Type = %q, want application/x-protobuf", got)
+			}
+			if cs.lastBodyLen() == 0 {
+				t.Error("body is empty; expected serialized span data")
+			}
+			if tc.extraAssert != nil {
+				tc.extraAssert(t, cs)
+			}
+		})
+	}
+}
+
+// TestSDKEventExporter_LiteralHeadersPropagate confirms that
+// bundle.Headers reach the receiver.
+func TestSDKEventExporter_LiteralHeadersPropagate(t *testing.T) {
+	cs := newCaptureServer()
+	defer cs.close()
+
+	b := &BundlePayload{
+		Type:     bundle.TypeOTLP,
+		Endpoint: cs.endpointHostPort(),
+		Insecure: true,
+		Headers: map[string]string{
+			"X-Env":    "prod",
+			"X-Tenant": "team-a",
+		},
+	}
+	exp, err := newOTLPEventExporter(CRKey{"ns", "cr"}, b)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	sendOneEventAndShutdown(t, exp)
+
+	if got := cs.lastHeader("X-Env"); got != "prod" {
+		t.Errorf("X-Env = %q, want prod", got)
+	}
+	if got := cs.lastHeader("X-Tenant"); got != "team-a" {
+		t.Errorf("X-Tenant = %q, want team-a", got)
+	}
+}
+
+func bundleType(name string) bundle.Type {
+	switch name {
+	case "otlp":
+		return bundle.TypeOTLP
+	case "jaeger":
+		return bundle.TypeJaeger
+	case "datadog":
+		return bundle.TypeDataDog
+	case "splunk":
+		return bundle.TypeSplunk
+	}
+	return bundle.Type(name)
 }
 
 func TestSDKEventExporter_NameIncludesBackend(t *testing.T) {


### PR DESCRIPTION
Lock in OTLP-only as the agent's exporter contract and back it with tests. No runtime changes, this tightens docs and adds golden tests around code that already ships.
Chart bumped `0.1.1` to `0.2.0` for new description and the unreleased `values.schema.json`.
