### PR TITLE
feat(agent): attach k8s pod and workload context to exported spans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ else
 endif
 
 LIBBPF_INCLUDE ?= /usr/include
-BPF_CFLAGS = -O2 -g -target bpf $(BPF_ARCH_DEFINE) -mcpu=$(BPF_MCPU) -I$(LIBBPF_INCLUDE) -I$(BPF_GEN_DIR)
+BPF_CFLAGS = -O2 -g -target bpf $(BPF_ARCH_DEFINE) -mcpu=$(BPF_MCPU) \
+	-Wno-missing-declarations \
+	-I$(LIBBPF_INCLUDE) -I$(BPF_GEN_DIR)
 
 all: check-go build
 

--- a/internal/agent/enricher.go
+++ b/internal/agent/enricher.go
@@ -1,0 +1,240 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// PodEnricher maps kernel cgroup inode IDs to a frozen, six-attribute
+// Kubernetes metadata bundle used to enrich exported spans.
+type PodEnricher struct {
+	mu    sync.RWMutex
+	byCgroup map[uint64]events.K8sMetadata
+
+	hits           atomic.Int64
+	misses         atomic.Int64
+	snapshots      atomic.Int64
+	ownerResolved  atomic.Int64
+	ownerOrphaned  atomic.Int64
+}
+
+// NewPodEnricher returns an empty enricher.
+func NewPodEnricher() *PodEnricher {
+	return &PodEnricher{
+		byCgroup: map[uint64]events.K8sMetadata{},
+	}
+}
+
+// Lookup returns the metadata for cgroupID and whether it was found.
+func (e *PodEnricher) Lookup(cgroupID uint64) (events.K8sMetadata, bool) {
+	if e == nil {
+		return events.K8sMetadata{}, false
+	}
+	e.mu.RLock()
+	meta, ok := e.byCgroup[cgroupID]
+	e.mu.RUnlock()
+	if ok {
+		e.hits.Add(1)
+	} else {
+		e.misses.Add(1)
+	}
+	return meta, ok
+}
+
+// Snapshot atomically replaces the cache with metas.
+func (e *PodEnricher) Snapshot(entries []PodCgroupEntry) {
+	if e == nil {
+		return
+	}
+	next := make(map[uint64]events.K8sMetadata, len(entries))
+	seenPods := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry.Pod == nil {
+			continue
+		}
+		next[entry.CgroupID] = buildK8sMetadata(entry)
+
+		// Owner resolution is tallied once per unique pod (UID), not
+		// once per entry — a pod with N container cgroups must not
+		// inflate the counter N-fold. Pods with no UID (synthetic
+		// test fixtures) are skipped for the counter only.
+		uid := string(entry.Pod.UID)
+		if uid == "" {
+			continue
+		}
+		if _, dup := seenPods[uid]; dup {
+			continue
+		}
+		seenPods[uid] = struct{}{}
+		if controllerOwnerRef(entry.Pod.OwnerReferences) == nil {
+			e.ownerOrphaned.Add(1)
+		} else {
+			e.ownerResolved.Add(1)
+		}
+	}
+	e.mu.Lock()
+	e.byCgroup = next
+	e.mu.Unlock()
+	e.snapshots.Add(1)
+}
+
+// Size returns the number of cached cgroup IDs. Used by the metrics
+// refresh path and tests.
+func (e *PodEnricher) Size() int {
+	if e == nil {
+		return 0
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.byCgroup)
+}
+
+// EnricherStats is the read-only snapshot the metrics path consumes.
+type EnricherStats struct {
+	Hits          int64
+	Misses        int64
+	Snapshots     int64
+	OwnerResolved int64
+	OwnerOrphaned int64
+	CacheSize     int
+}
+
+// Stats returns the counters atomically. Safe to call concurrently
+// with Lookup and Snapshot.
+func (e *PodEnricher) Stats() EnricherStats {
+	if e == nil {
+		return EnricherStats{}
+	}
+	return EnricherStats{
+		Hits:          e.hits.Load(),
+		Misses:        e.misses.Load(),
+		Snapshots:     e.snapshots.Load(),
+		OwnerResolved: e.ownerResolved.Load(),
+		OwnerOrphaned: e.ownerOrphaned.Load(),
+		CacheSize:     e.Size(),
+	}
+}
+
+// enrichBatch stamps each event in batch with its matching
+// K8sMetadata.
+func enrichBatch(e *PodEnricher, batch []*events.Event) {
+	if e == nil {
+		return
+	}
+	var memo map[uint64]*events.K8sMetadata
+	for _, ev := range batch {
+		if ev == nil || ev.K8s != nil {
+			continue
+		}
+		if memo == nil {
+			memo = make(map[uint64]*events.K8sMetadata, 8)
+		}
+		if cached, ok := memo[ev.CgroupID]; ok {
+			ev.K8s = cached
+			continue
+		}
+		meta, found := e.Lookup(ev.CgroupID)
+		if !found {
+			memo[ev.CgroupID] = nil
+			continue
+		}
+		m := meta
+		memo[ev.CgroupID] = &m
+		ev.K8s = &m
+	}
+}
+
+// PodCgroupEntry is the unit of input to PodEnricher.Snapshot.
+type PodCgroupEntry struct {
+	CgroupID      uint64
+	CgroupPath    string
+	Pod           *corev1.Pod
+	ContainerName string
+	ContainerID   string
+}
+
+// buildK8sMetadata projects a PodCgroupEntry onto the frozen v1
+// metadata schema.
+func buildK8sMetadata(entry PodCgroupEntry) events.K8sMetadata {
+	pod := entry.Pod
+	meta := events.K8sMetadata{
+		Namespace:     pod.Namespace,
+		PodName:       pod.Name,
+		PodUID:        string(pod.UID),
+		NodeName:      pod.Spec.NodeName,
+		ContainerName: entry.ContainerName,
+	}
+	kind, name := resolveWorkload(pod)
+	meta.WorkloadKind = kind
+	meta.WorkloadName = name
+	return meta
+}
+
+// resolveWorkload walks pod.OwnerReferences and returns the
+// (kind, name) of the workload that ultimately produced this pod.
+func resolveWorkload(pod *corev1.Pod) (kind, name string) {
+	owner := controllerOwnerRef(pod.OwnerReferences)
+	if owner == nil {
+		return "Pod", pod.Name
+	}
+	if owner.Kind == "ReplicaSet" {
+		if deployment, ok := deploymentFromReplicaSet(owner.Name); ok {
+			return "Deployment", deployment
+		}
+		return "ReplicaSet", owner.Name
+	}
+	return owner.Kind, owner.Name
+}
+
+// controllerOwnerRef returns the OwnerReference flagged as the
+// controller.
+func controllerOwnerRef(refs []metav1.OwnerReference) *metav1.OwnerReference {
+	for i := range refs {
+		ref := &refs[i]
+		if ref.Controller != nil && *ref.Controller {
+			return ref
+		}
+	}
+	return nil
+}
+
+// deploymentFromReplicaSet strips the kubernetes-controller-manager
+// pod-template-hash suffix from a ReplicaSet name.
+func deploymentFromReplicaSet(rsName string) (string, bool) {
+	idx := strings.LastIndex(rsName, "-")
+	if idx < 1 || idx == len(rsName)-1 {
+		return "", false
+	}
+	suffix := rsName[idx+1:]
+	if !isPodTemplateHash(suffix) {
+		return "", false
+	}
+	return rsName[:idx], true
+}
+
+// isPodTemplateHash matches the alphabet kube-controller-manager
+// uses for the ReplicaSet pod-template-hash suffix.
+func isPodTemplateHash(s string) bool {
+	if len(s) < 5 || len(s) > 12 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c == 'b', c == 'c', c == 'd':
+		case c == 'f', c == 'g', c == 'h':
+		case c == 'j', c == 'k', c == 'm', c == 'n':
+		case c >= 'p' && c <= 't':
+		case c == 'v', c == 'w', c == 'x', c == 'y', c == 'z':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/enricher_bench_test.go
+++ b/internal/agent/enricher_bench_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// BenchmarkEnricherLookup measures the raw hot-path cost of a
+// PodEnricher.Lookup.
+func BenchmarkEnricherLookup(b *testing.B) {
+	e := NewPodEnricher()
+	entries := makeBenchEntries(64)
+	e.Snapshot(entries)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.Lookup(uint64(i % 64))
+	}
+}
+
+// BenchmarkEnrichBatch covers the production hot path: enrichBatch is
+// what Router.Export calls once per batch.
+func BenchmarkEnrichBatch(b *testing.B) {
+	e := NewPodEnricher()
+	entries := makeBenchEntries(8)
+	e.Snapshot(entries)
+
+	const batchSize = 128
+	batch := make([]*events.Event, batchSize)
+	for i := range batch {
+		batch[i] = &events.Event{CgroupID: uint64(i % 8)}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := range batch {
+			batch[j].K8s = nil
+		}
+		enrichBatch(e, batch)
+	}
+}
+
+// BenchmarkRouterExportWithEnricher exercises the full per-event path
+// (filter match + enrichment + delivery) so the cost of enrichment
+// can be compared against BenchmarkRouterExportWithoutEnricher below.
+func BenchmarkRouterExportWithEnricher(b *testing.B) {
+	r, _ := newBenchRouter(b, true)
+	batch := newBenchBatch(128)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := range batch {
+			batch[j].K8s = nil
+		}
+		_ = r.Export(context.Background(), batch)
+	}
+}
+
+// BenchmarkRouterExportWithoutEnricher is the control case: same
+// batch, same router shape, no enricher attached.
+func BenchmarkRouterExportWithoutEnricher(b *testing.B) {
+	r, _ := newBenchRouter(b, false)
+	batch := newBenchBatch(128)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j := range batch {
+			batch[j].K8s = nil
+		}
+		_ = r.Export(context.Background(), batch)
+	}
+}
+
+// makeBenchEntries produces n PodCgroupEntry values bound to n
+// distinct pods so the owner resolution and metadata-build paths
+// exercise realistic data shapes.
+func makeBenchEntries(n int) []PodCgroupEntry {
+	tc := true
+	out := make([]PodCgroupEntry, 0, n)
+	for i := 0; i < n; i++ {
+		uid := types.UID(uidFor(i))
+		out = append(out, PodCgroupEntry{
+			CgroupID:      uint64(i),
+			ContainerName: "app",
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pod-" + uidFor(i),
+					UID:       uid,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "web-7d8c9c", Controller: &tc},
+					},
+				},
+				Spec: corev1.PodSpec{NodeName: "node-1"},
+			},
+		})
+	}
+	return out
+}
+
+func newBenchRouter(b *testing.B, withEnricher bool) (*Router, *PodEnricher) {
+	b.Helper()
+	r := NewRouter(nil)
+	var enricher *PodEnricher
+	if withEnricher {
+		enricher = NewPodEnricher()
+		enricher.Snapshot(makeBenchEntries(8))
+		r = r.WithEnricher(enricher)
+	}
+	r.Publish([]CRRule{{
+		Key:       CRKey{Namespace: "ns", Name: "cr"},
+		CgroupIDs: cgroupSet(0, 1, 2, 3, 4, 5, 6, 7),
+		Filters:   map[events.EventType]struct{}{events.EventDNS: {}},
+		Exporter:  &nullExporter{},
+	}})
+	return r, enricher
+}
+
+func newBenchBatch(n int) []*events.Event {
+	out := make([]*events.Event, n)
+	for i := range out {
+		out[i] = &events.Event{CgroupID: uint64(i % 8), Type: events.EventDNS}
+	}
+	return out
+}
+
+func cgroupSet(ids ...uint64) map[uint64]struct{} {
+	out := make(map[uint64]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// nullExporter discards every event — it's the "no work past the
+// router" baseline so the benchmark isolates router+enrichment cost.
+type nullExporter struct{}
+
+func (nullExporter) Name() string                                          { return "null" }
+func (nullExporter) Export(_ context.Context, batch []*events.Event) error { return nil }
+func (nullExporter) Close(_ context.Context) error                         { return nil }
+
+func uidFor(i int) string {
+	const hex = "0123456789abcdef"
+	// 16-char synthetic UID; uniqueness is what we care about.
+	out := make([]byte, 16)
+	for j := range out {
+		out[j] = hex[(i+j)%16]
+	}
+	return string(out)
+}

--- a/internal/agent/enricher_integration_test.go
+++ b/internal/agent/enricher_integration_test.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// TestEnricher_FullPipeline drives Reconcile → enricher.Snapshot →
+// Router.Export to exporter receives ev.K8s.
+func TestEnricher_FullPipeline(t *testing.T) {
+	const node, sysNS, ns = "n-1", "podtrace-system", "default"
+	uid := types.UID("uid-enrich")
+	tcontroller := true
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: uid},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "x"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-7d8c9c-abcde", Namespace: ns, UID: "pod-uid-1",
+			Labels: map[string]string{"app": "web"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-7d8c9c", Controller: &tcontroller},
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+	}
+	cm := makeBundleCM(sysNS, uid, "1")
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(pt, pod, cm).Build()
+
+	const cgID uint64 = 4242
+	exp := &fakeExporter{name: "fx"}
+	enricher := NewPodEnricher()
+
+	r := &AgentReconciler{
+		Client:          c,
+		NodeName:        node,
+		SystemNamespace: sysNS,
+		Router:          NewRouter(nil).WithEnricher(enricher),
+		Metrics:         NewMetrics(),
+		TargetsCh:       make(chan tracer.TargetSet, 4),
+		Enricher:        enricher,
+		ExporterBuilder: func(_ *BundlePayload, _ CRKey) (tracer.Exporter, error) {
+			return exp, nil
+		},
+		CgroupResolver: func(pods []*corev1.Pod) (map[uint64]struct{}, error) {
+			out := map[uint64]struct{}{}
+			for range pods {
+				out[cgID] = struct{}{}
+			}
+			return out, nil
+		},
+		PodAttributor: func(pods []*corev1.Pod) []PodCgroupEntry {
+			out := make([]PodCgroupEntry, 0, len(pods))
+			for _, p := range pods {
+				out = append(out, PodCgroupEntry{
+					CgroupID:      cgID,
+					Pod:           p,
+					ContainerName: "app",
+					ContainerID:   "containerd://deadbeef",
+				})
+			}
+			return out
+		},
+		exporterCache: map[CRKey]cachedExporter{},
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: "pt"},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	meta, ok := enricher.Lookup(cgID)
+	if !ok {
+		t.Fatal("enricher cache miss for known cgroup")
+	}
+	want := events.K8sMetadata{
+		Namespace:     ns,
+		PodName:       "web-7d8c9c-abcde",
+		PodUID:        "pod-uid-1",
+		NodeName:      node,
+		ContainerName: "app",
+		WorkloadKind:  "Deployment",
+		WorkloadName:  "web",
+	}
+	if meta != want {
+		t.Errorf("enricher meta = %+v, want %+v", meta, want)
+	}
+
+	captured := &capturingExporter{}
+	r.Router.Publish([]CRRule{{
+		Key:       CRKey{Namespace: ns, Name: "pt"},
+		CgroupIDs: map[uint64]struct{}{cgID: {}},
+		Filters:   map[events.EventType]struct{}{events.EventDNS: {}},
+		Exporter:  captured,
+	}})
+
+	batch := []*events.Event{
+		{CgroupID: cgID, Type: events.EventDNS, Target: "example.com"},
+		{CgroupID: cgID, Type: events.EventDNS, Target: "example.org"},
+		{CgroupID: 99, Type: events.EventDNS}, // miss; not routed
+	}
+	if err := r.Router.Export(context.Background(), batch); err != nil {
+		t.Fatalf("Router.Export: %v", err)
+	}
+
+	got := captured.Snapshot()
+	if len(got) != 2 {
+		t.Fatalf("exporter received %d events, want 2", len(got))
+	}
+	for i, ev := range got {
+		if ev.K8s == nil {
+			t.Errorf("event %d: K8s pointer is nil", i)
+			continue
+		}
+		if *ev.K8s != want {
+			t.Errorf("event %d: K8s = %+v, want %+v", i, *ev.K8s, want)
+		}
+	}
+	if got[0].K8s != got[1].K8s {
+		t.Error("two events with the same cgroup must share the K8s pointer")
+	}
+
+	stats := enricher.Stats()
+	if stats.Hits < 1 {
+		t.Errorf("expected >=1 enricher hit, got %d", stats.Hits)
+	}
+	if stats.Misses < 1 {
+		t.Errorf("expected >=1 enricher miss, got %d", stats.Misses)
+	}
+	if stats.OwnerResolved != 1 {
+		t.Errorf("OwnerResolved = %d, want 1", stats.OwnerResolved)
+	}
+}
+
+// capturingExporter records every event it sees so the integration
+// test can assert on ev.K8s after the router runs.
+type capturingExporter struct {
+	events []*events.Event
+}
+
+func (e *capturingExporter) Name() string { return "capture" }
+func (e *capturingExporter) Export(_ context.Context, batch []*events.Event) error {
+	e.events = append(e.events, batch...)
+	return nil
+}
+func (e *capturingExporter) Close(_ context.Context) error { return nil }
+func (e *capturingExporter) Snapshot() []*events.Event {
+	out := make([]*events.Event, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+// TestEnricher_TargetSetPopulatesOwner verifies the second
+// improvement: buildTargetSet now populates OwnerKind / OwnerName /
+// ContainerName fields on tracer.Target objects (previously left
+// zero), so the tracer engine can attach to containers with stable
+// identity attributes available downstream.
+func TestEnricher_TargetSetPopulatesOwner(t *testing.T) {
+	tcontroller := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "web-7d8c9c-x", Namespace: "ns", UID: "pod-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-7d8c9c", Controller: &tcontroller},
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: "n"},
+		Status: corev1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	rules := []CRRule{{CgroupIDs: map[uint64]struct{}{1: {}}}}
+	entries := []PodCgroupEntry{
+		{CgroupID: 1, Pod: pod, ContainerName: "app", ContainerID: "abc",
+			CgroupPath: "/sys/fs/cgroup/x"},
+	}
+	out := buildTargetSet(rules, []*corev1.Pod{pod}, entries)
+	if len(out) != 1 {
+		t.Fatalf("want 1 target, got %d", len(out))
+	}
+	tgt := out[0]
+	if tgt.OwnerKind != "Deployment" || tgt.OwnerName != "web" {
+		t.Errorf("OwnerKind/Name = %q/%q, want Deployment/web", tgt.OwnerKind, tgt.OwnerName)
+	}
+	if tgt.ContainerName != "app" || tgt.ContainerID != "abc" {
+		t.Errorf("Container fields wrong: %+v", tgt)
+	}
+	if tgt.PodIP != "10.0.0.2" {
+		t.Errorf("PodIP = %q, want 10.0.0.2", tgt.PodIP)
+	}
+}

--- a/internal/agent/enricher_test.go
+++ b/internal/agent/enricher_test.go
@@ -1,0 +1,340 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// Owner-walk tests document the v1 contract for resolveWorkload: the
+// only rollup is ReplicaSet to Deployment, every other controller kind
+// is reported as-is, and pods with no controller owner degrade to
+// kind=Pod.
+func TestResolveWorkload(t *testing.T) {
+	tcontroller := true
+	notController := false
+
+	cases := []struct {
+		name     string
+		pod      *corev1.Pod
+		wantKind string
+		wantName string
+	}{
+		{
+			name: "no owners → orphan pod degrades to Pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "lonely"},
+			},
+			wantKind: "Pod",
+			wantName: "lonely",
+		},
+		{
+			name: "owner ref present but not controller → orphan",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "free-pod",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "rs-7d8c9c", Controller: &notController},
+					},
+				},
+			},
+			wantKind: "Pod",
+			wantName: "free-pod",
+		},
+		{
+			name: "ReplicaSet with valid hash suffix rolls up to Deployment",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-1",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "shopping-cart-7d8c9c", Controller: &tcontroller},
+					},
+				},
+			},
+			wantKind: "Deployment",
+			wantName: "shopping-cart",
+		},
+		{
+			name: "ReplicaSet without recognisable hash → no rollup",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p-2",
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "ReplicaSet", Name: "rs-without-hash", Controller: &tcontroller},
+					},
+				},
+			},
+			wantKind: "ReplicaSet",
+			wantName: "rs-without-hash",
+		},
+		{
+			name: "StatefulSet → reported as-is",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "StatefulSet", Name: "kafka", Controller: &tcontroller},
+					},
+				},
+			},
+			wantKind: "StatefulSet",
+			wantName: "kafka",
+		},
+		{
+			name: "DaemonSet → reported as-is",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "DaemonSet", Name: "fluentd", Controller: &tcontroller},
+					},
+				},
+			},
+			wantKind: "DaemonSet",
+			wantName: "fluentd",
+		},
+		{
+			name: "Job → reported as-is",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Job", Name: "nightly-backup-29543", Controller: &tcontroller},
+					},
+				},
+			},
+			wantKind: "Job",
+			wantName: "nightly-backup-29543",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, name := resolveWorkload(tc.pod)
+			if kind != tc.wantKind || name != tc.wantName {
+				t.Errorf("resolveWorkload = (%q, %q), want (%q, %q)",
+					kind, name, tc.wantKind, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestDeploymentFromReplicaSet pins the suffix-trim behaviour.
+func TestDeploymentFromReplicaSet(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"shopping-cart-7d8c9c", "shopping-cart", true},
+		{"webapp-58b6f7c9d4", "webapp", true},
+		{"a-bcdfg", "a", true},
+		{"single", "", false},
+		{"trailing-", "", false},
+		{"my-rs-prod", "", false},
+		{"deploy-toolong-suffixabcdefgh", "", false},
+		{"deploy-9c", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := deploymentFromReplicaSet(tc.in)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("deploymentFromReplicaSet(%q) = (%q, %v), want (%q, %v)",
+					tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestEnricher_LookupHitAndMiss covers the documented behaviour: an
+// unseen cgroup ID is a miss (zero value, false), a snapshotted one
+// is a hit, and counters move in the right direction.
+func TestEnricher_LookupHitAndMiss(t *testing.T) {
+	e := NewPodEnricher()
+
+	if _, ok := e.Lookup(42); ok {
+		t.Fatal("empty enricher must miss every lookup")
+	}
+	if s := e.Stats(); s.Hits != 0 || s.Misses != 1 {
+		t.Errorf("after one miss: hits=%d misses=%d (want 0/1)", s.Hits, s.Misses)
+	}
+
+	pod := newPodWithOwner("ns", "p", "u1", "n", "Deployment", "web", "web-7d8c9c")
+	e.Snapshot([]PodCgroupEntry{
+		{CgroupID: 42, Pod: pod, ContainerName: "app"},
+	})
+
+	meta, ok := e.Lookup(42)
+	if !ok {
+		t.Fatal("after snapshot, cgroup 42 must hit")
+	}
+	want := events.K8sMetadata{
+		Namespace:     "ns",
+		PodName:       "p",
+		PodUID:        "u1",
+		NodeName:      "n",
+		ContainerName: "app",
+		WorkloadKind:  "Deployment",
+		WorkloadName:  "web",
+	}
+	if meta != want {
+		t.Errorf("Lookup metadata = %+v, want %+v", meta, want)
+	}
+}
+
+// TestEnricher_SnapshotEvicts is the critical correctness guarantee:
+// after a pod delete the cache must not serve stale metadata for the
+// reused cgroup ID.
+func TestEnricher_SnapshotEvicts(t *testing.T) {
+	e := NewPodEnricher()
+	first := newPodWithOwner("ns", "old", "u-old", "n", "Deployment", "web", "web-aaaaaa")
+	second := newPodWithOwner("ns", "new", "u-new", "n", "Deployment", "api", "api-bbbbbb")
+
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 9001, Pod: first}})
+	if meta, _ := e.Lookup(9001); meta.PodUID != "u-old" {
+		t.Fatalf("first snapshot did not register: %+v", meta)
+	}
+
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 9001, Pod: second}})
+	meta, ok := e.Lookup(9001)
+	if !ok || meta.PodUID != "u-new" {
+		t.Errorf("reused cgroup must return new pod's metadata, got %+v ok=%v", meta, ok)
+	}
+
+	e.Snapshot([]PodCgroupEntry{})
+	if _, ok := e.Lookup(9001); ok {
+		t.Error("empty snapshot must evict every entry")
+	}
+}
+
+// TestEnricher_OrphanCountedSeparately verifies the owner-resolution
+// counter discriminates between resolved and orphaned pods.
+func TestEnricher_OrphanCountedSeparately(t *testing.T) {
+	e := NewPodEnricher()
+	owned := newPodWithOwner("ns", "p", "u", "n", "Deployment", "web", "web-aaaaaa")
+	orphan := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "static", UID: "uo"}}
+	e.Snapshot([]PodCgroupEntry{
+		{CgroupID: 1, Pod: owned},
+		{CgroupID: 2, Pod: orphan},
+	})
+	s := e.Stats()
+	if s.OwnerResolved != 1 || s.OwnerOrphaned != 1 {
+		t.Errorf("owner counters: resolved=%d orphaned=%d (want 1/1)", s.OwnerResolved, s.OwnerOrphaned)
+	}
+}
+
+// TestEnricher_NilSafe documents the explicit nil-safety guarantees:
+// nil enricher must never panic on Lookup, Snapshot, or Size, and
+// nil-pointer event-stamping is a no-op.
+func TestEnricher_NilSafe(t *testing.T) {
+	var e *PodEnricher
+	if _, ok := e.Lookup(1); ok {
+		t.Error("nil Lookup must miss")
+	}
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 1}})
+	if got := e.Size(); got != 0 {
+		t.Errorf("nil Size = %d, want 0", got)
+	}
+	enrichBatch(nil, []*events.Event{{CgroupID: 1}})
+}
+
+// TestEnrichBatch_PointerSharedAcrossEvents verifies the hot-path
+// memoization: events with the same cgroup ID get the same metadata
+// pointer rather than per-event copies.
+func TestEnrichBatch_PointerSharedAcrossEvents(t *testing.T) {
+	e := NewPodEnricher()
+	pod := newPodWithOwner("ns", "p", "u", "n", "Deployment", "web", "web-aaaaaa")
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 7, Pod: pod}})
+
+	batch := []*events.Event{
+		{CgroupID: 7},
+		{CgroupID: 7},
+		{CgroupID: 99},
+		{CgroupID: 7},
+	}
+	enrichBatch(e, batch)
+
+	if batch[0].K8s == nil || batch[1].K8s != batch[0].K8s || batch[3].K8s != batch[0].K8s {
+		t.Error("events sharing a cgroup ID must share the metadata pointer")
+	}
+	if batch[2].K8s != nil {
+		t.Errorf("miss must leave K8s nil, got %+v", batch[2].K8s)
+	}
+}
+
+// TestEnrichBatch_PreservesExistingK8s pins the contract that an
+// upstream producer (a future enricher in front of the router) can
+// stamp metadata before the router sees the event and the router
+// will not overwrite it.
+func TestEnrichBatch_PreservesExistingK8s(t *testing.T) {
+	e := NewPodEnricher()
+	pod := newPodWithOwner("ns", "p", "u-cache", "n", "Deployment", "web", "web-aaaaaa")
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 7, Pod: pod}})
+
+	pre := &events.K8sMetadata{PodUID: "u-upstream"}
+	batch := []*events.Event{{CgroupID: 7, K8s: pre}}
+	enrichBatch(e, batch)
+
+	if batch[0].K8s != pre {
+		t.Errorf("pre-stamped K8s must be preserved, got %+v", batch[0].K8s)
+	}
+}
+
+// TestEnricher_ConcurrentLookupSnapshot exercises the documented
+// thread-safety contract: many concurrent Lookups must coexist with
+// Snapshot writes without races (-race catches map mutation here).
+func TestEnricher_ConcurrentLookupSnapshot(t *testing.T) {
+	e := NewPodEnricher()
+	pod := newPodWithOwner("ns", "p", "u", "n", "Deployment", "web", "web-aaaaaa")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_, _ = e.Lookup(uint64(j % 64))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			entries := make([]PodCgroupEntry, 0, 32)
+			for j := 0; j < 32; j++ {
+				entries = append(entries, PodCgroupEntry{CgroupID: uint64(j), Pod: pod})
+			}
+			e.Snapshot(entries)
+		}
+	}()
+	wg.Wait()
+}
+
+// newPodWithOwner constructs a Pod whose OwnerReferences exercise the
+// ReplicaSet to Deployment rollup helper.
+func newPodWithOwner(namespace, podName, uid, node, ownerKind, deploymentName, rsName string) *corev1.Pod {
+	tc := true
+	if ownerKind == "Deployment" {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace, Name: podName, UID: types.UID(uid),
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "ReplicaSet", Name: rsName, Controller: &tc},
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: node},
+		}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: podName, UID: types.UID(uid),
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: ownerKind, Name: deploymentName, Controller: &tc},
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+}

--- a/internal/agent/k8s_attributes.go
+++ b/internal/agent/k8s_attributes.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// appendK8sAttributes appends the frozen v1 enrichment attribute set
+// to attrs and returns the extended slice.
+func appendK8sAttributes(attrs []attribute.KeyValue, meta *events.K8sMetadata) []attribute.KeyValue {
+	if meta == nil || meta.IsZero() {
+		return attrs
+	}
+	if meta.Namespace != "" {
+		attrs = append(attrs, semconv.K8SNamespaceName(meta.Namespace))
+	}
+	if meta.PodName != "" {
+		attrs = append(attrs, semconv.K8SPodName(meta.PodName))
+	}
+	if meta.PodUID != "" {
+		attrs = append(attrs, semconv.K8SPodUID(meta.PodUID))
+	}
+	if meta.NodeName != "" {
+		attrs = append(attrs, semconv.K8SNodeName(meta.NodeName))
+	}
+	if meta.ContainerName != "" {
+		attrs = append(attrs, semconv.K8SContainerName(meta.ContainerName))
+	}
+	attrs = appendWorkloadAttributes(attrs, meta.WorkloadKind, meta.WorkloadName)
+	return attrs
+}
+
+// appendWorkloadAttributes maps (kind, name) to the most specific
+// semconv key available.
+func appendWorkloadAttributes(attrs []attribute.KeyValue, kind, name string) []attribute.KeyValue {
+	if name == "" {
+		return attrs
+	}
+	switch kind {
+	case "Deployment":
+		attrs = append(attrs, semconv.K8SDeploymentName(name))
+	case "StatefulSet":
+		attrs = append(attrs, semconv.K8SStatefulSetName(name))
+	case "DaemonSet":
+		attrs = append(attrs, semconv.K8SDaemonSetName(name))
+	case "Job":
+		attrs = append(attrs, semconv.K8SJobName(name))
+	case "CronJob":
+		attrs = append(attrs, semconv.K8SCronJobName(name))
+	case "ReplicaSet":
+		attrs = append(attrs, semconv.K8SReplicaSetName(name))
+	case "Pod", "":
+	default:
+		attrs = append(attrs,
+			attribute.String("k8s.workload.kind", kind),
+			attribute.String("k8s.workload.name", name),
+		)
+	}
+	return attrs
+}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -22,9 +22,20 @@ type Metrics struct {
 	CgroupsAttached  prometheus.Counter
 	CgroupsDetached  prometheus.Counter
 
+	EnrichmentLookups       *prometheus.CounterVec
+	EnrichmentCacheSize     prometheus.Gauge
+	EnrichmentSnapshots     prometheus.Counter
+	EnrichmentOwnerResolved *prometheus.CounterVec
+
 	mu          sync.Mutex
 	lastEvents  map[CRKey]int64
 	lastDropped map[CRKey]int64
+
+	lastEnrichHits     int64
+	lastEnrichMisses   int64
+	lastEnrichSnaps    int64
+	lastOwnerResolved  int64
+	lastOwnerOrphaned  int64
 }
 
 // NewMetrics constructs the full metric surface and registers it
@@ -73,11 +84,70 @@ func NewMetrics() *Metrics {
 			Name:      "cgroups_detached_total",
 			Help:      "Cumulative cgroups removed from the tracer filter set (pod churn).",
 		}),
+		EnrichmentLookups: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "enrichment_lookups_total",
+			Help:      "Cgroup→k8s metadata lookups performed on the export hot path. Misses are events that arrived before the reconciler observed the pod; a sustained miss rate >1%% indicates the enricher is not keeping up with pod churn.",
+		}, []string{"result"}),
+		EnrichmentCacheSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "podtrace_agent",
+			Name:      "enrichment_cache_size",
+			Help:      "Cgroup IDs currently held by the k8s metadata cache. Roughly equals (local pods × (1 + containers per pod)).",
+		}),
+		EnrichmentSnapshots: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "enrichment_snapshots_total",
+			Help:      "Atomic replacements of the enrichment cache (one per Reconcile pass that observed pods).",
+		}),
+		EnrichmentOwnerResolved: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "enrichment_owner_resolution_total",
+			Help:      "Workload-owner resolution outcomes. result=resolved means OwnerReferences yielded a workload kind+name; result=orphaned means the pod had no controller ref and degraded to kind=Pod.",
+		}, []string{"result"}),
 		lastEvents:  map[CRKey]int64{},
 		lastDropped: map[CRKey]int64{},
 	}
-	reg.MustRegister(m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs, m.ReconcileTotal, m.BackendDegraded, m.CgroupsAttached, m.CgroupsDetached)
+	reg.MustRegister(
+		m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs,
+		m.ReconcileTotal, m.BackendDegraded, m.CgroupsAttached, m.CgroupsDetached,
+		m.EnrichmentLookups, m.EnrichmentCacheSize, m.EnrichmentSnapshots,
+		m.EnrichmentOwnerResolved,
+	)
 	return m
+}
+
+// RefreshFromEnricher emits the deltas from the enricher's atomic
+// counters to the Prometheus metric set.
+func (m *Metrics) RefreshFromEnricher(e *PodEnricher) {
+	if m == nil || e == nil {
+		return
+	}
+	stats := e.Stats()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if delta := stats.Hits - m.lastEnrichHits; delta > 0 {
+		m.EnrichmentLookups.WithLabelValues("hit").Add(float64(delta))
+	}
+	if delta := stats.Misses - m.lastEnrichMisses; delta > 0 {
+		m.EnrichmentLookups.WithLabelValues("miss").Add(float64(delta))
+	}
+	if delta := stats.Snapshots - m.lastEnrichSnaps; delta > 0 {
+		m.EnrichmentSnapshots.Add(float64(delta))
+	}
+	if delta := stats.OwnerResolved - m.lastOwnerResolved; delta > 0 {
+		m.EnrichmentOwnerResolved.WithLabelValues("resolved").Add(float64(delta))
+	}
+	if delta := stats.OwnerOrphaned - m.lastOwnerOrphaned; delta > 0 {
+		m.EnrichmentOwnerResolved.WithLabelValues("orphaned").Add(float64(delta))
+	}
+	m.lastEnrichHits = stats.Hits
+	m.lastEnrichMisses = stats.Misses
+	m.lastEnrichSnaps = stats.Snapshots
+	m.lastOwnerResolved = stats.OwnerResolved
+	m.lastOwnerOrphaned = stats.OwnerOrphaned
+
+	m.EnrichmentCacheSize.Set(float64(stats.CacheSize))
 }
 
 // Handler returns a promhttp.Handler bound to this Metrics' registry.

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -42,6 +42,10 @@ type AgentReconciler struct {
 
 	CgroupResolver func(pods []*corev1.Pod) (map[uint64]struct{}, error)
 
+	PodAttributor func(pods []*corev1.Pod) []PodCgroupEntry
+
+	Enricher *PodEnricher
+
 	exporterCacheMu sync.Mutex
 	exporterCache   map[CRKey]cachedExporter
 }
@@ -59,6 +63,9 @@ func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	if r.CgroupResolver == nil {
 		r.CgroupResolver = resolveCgroupIDs
+	}
+	if r.PodAttributor == nil {
+		r.PodAttributor = scanPodCgroups
 	}
 	r.exporterCache = map[CRKey]cachedExporter{}
 
@@ -182,9 +189,17 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	r.reapStaleExporters(activeKeys)
 
+	var podEntries []PodCgroupEntry
+	if r.PodAttributor != nil {
+		podEntries = r.PodAttributor(localPods)
+	}
+	if r.Enricher != nil {
+		r.Enricher.Snapshot(podEntries)
+	}
+
 	r.Router.Publish(rules)
 
-	targets := buildTargetSet(rules, localPods)
+	targets := buildTargetSet(rules, localPods, podEntries)
 	select {
 	case r.TargetsCh <- targets:
 	default:
@@ -200,6 +215,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if r.Metrics != nil {
 		r.Metrics.RefreshFromRouter(r.Router)
+		r.Metrics.RefreshFromEnricher(r.Enricher)
 	}
 
 	return ctrl.Result{}, nil
@@ -222,8 +238,7 @@ func (r *AgentReconciler) enqueueAllPodTraces(ctx context.Context, _ client.Obje
 
 // enqueueOnBundleChange handles ConfigMap watches: only bundle
 // ConfigMaps (with our managed-by label) produce reconcile requests,
-// and each such event enqueues every PodTrace (the bundle label tells
-// us which CR owns the bundle but the reconcile rebuilds all anyway).
+// and each such event enqueues every PodTrace.
 func (r *AgentReconciler) enqueueOnBundleChange(ctx context.Context, obj client.Object) []reconcile.Request {
 	if obj.GetLabels()[operator.LabelManagedBy] != operator.ManagedByValue {
 		return nil
@@ -290,31 +305,112 @@ func (r *AgentReconciler) reapStaleExporters(active map[CRKey]struct{}) {
 // resolveCgroupIDs maps each matched pod's cgroup path to its inode
 // number — the value the kernel stamps on every event.
 func resolveCgroupIDs(pods []*corev1.Pod) (map[uint64]struct{}, error) {
-	out := map[uint64]struct{}{}
+	entries := scanPodCgroups(pods)
+	out := make(map[uint64]struct{}, len(entries))
+	for _, e := range entries {
+		out[e.CgroupID] = struct{}{}
+	}
+	return out, nil
+}
+
+// scanPodCgroups walks the kubepods hierarchy once and emits one
+// PodCgroupEntry per (cgroup inode, pod, container) tuple.
+func scanPodCgroups(pods []*corev1.Pod) []PodCgroupEntry {
 	root := discoverKubepodsRoot()
+	if root == "" {
+		return nil
+	}
+	out := make([]PodCgroupEntry, 0, len(pods))
 	for _, p := range pods {
 		path := cgroupPathForPod(p, root)
 		if path == "" {
 			continue
 		}
 		if id, err := cgroupIDFromPath(path); err == nil {
-			out[id] = struct{}{}
+			out = append(out, PodCgroupEntry{
+				CgroupID:   id,
+				CgroupPath: path,
+				Pod:        p,
+			})
 		}
-		entries, err := os.ReadDir(path)
+		dirEntries, err := os.ReadDir(path)
 		if err != nil {
 			continue
 		}
-		for _, e := range entries {
+		statuses := containerStatusIndex(p)
+		for _, e := range dirEntries {
 			if !e.IsDir() {
 				continue
 			}
 			child := filepath.Join(path, e.Name())
-			if id, err := cgroupIDFromPath(child); err == nil {
-				out[id] = struct{}{}
+			id, err := cgroupIDFromPath(child)
+			if err != nil {
+				continue
 			}
+			containerName, containerID := identifyContainerCgroup(e.Name(), statuses)
+			out = append(out, PodCgroupEntry{
+				CgroupID:      id,
+				CgroupPath:    child,
+				Pod:           p,
+				ContainerName: containerName,
+				ContainerID:   containerID,
+			})
 		}
 	}
-	return out, nil
+	return out
+}
+
+// containerStatusIndex builds a containerID-prefix to container-name
+// lookup table from pod.status.containerStatuses.
+func containerStatusIndex(p *corev1.Pod) map[string]string {
+	out := map[string]string{}
+	add := func(name, rawID string) {
+		if name == "" || rawID == "" {
+			return
+		}
+		if i := strings.Index(rawID, "://"); i >= 0 {
+			rawID = rawID[i+3:]
+		}
+		if rawID == "" {
+			return
+		}
+		out[rawID] = name
+	}
+	for _, cs := range p.Status.ContainerStatuses {
+		add(cs.Name, cs.ContainerID)
+	}
+	for _, cs := range p.Status.InitContainerStatuses {
+		add(cs.Name, cs.ContainerID)
+	}
+	for _, cs := range p.Status.EphemeralContainerStatuses {
+		add(cs.Name, cs.ContainerID)
+	}
+	return out
+}
+
+// identifyContainerCgroup matches a container cgroup dir (e.g.
+// "cri-containerd-<id>.scope", "crio-<id>.scope", "docker-<id>.scope")
+// against the pod's containerStatuses index.
+func identifyContainerCgroup(dir string, statuses map[string]string) (name, id string) {
+	if len(statuses) == 0 {
+		return "", ""
+	}
+	trimmed := strings.TrimSuffix(dir, ".scope")
+	for _, prefix := range []string{"cri-containerd-", "crio-", "docker-", "containerd-"} {
+		if strings.HasPrefix(trimmed, prefix) {
+			trimmed = strings.TrimPrefix(trimmed, prefix)
+			break
+		}
+	}
+	if trimmed == "" {
+		return "", ""
+	}
+	for cid, cname := range statuses {
+		if strings.HasPrefix(cid, trimmed) || strings.HasPrefix(trimmed, cid) {
+			return cname, cid
+		}
+	}
+	return "", ""
 }
 
 // kubepodsRootCandidates lists the well-known cgroup directories
@@ -388,11 +484,20 @@ func cgroupIDFromPath(path string) (uint64, error) {
 	return sys.Ino, nil
 }
 
-// buildTargetSet turns the active rule set into a tracer.TargetSet.
-func buildTargetSet(rules []CRRule, pods []*corev1.Pod) tracer.TargetSet {
+// buildTargetSet turns the active rule set into a tracer.TargetSet,
+// using the pre-computed pod-cgroup attribution so that container,
+// owner-kind, and owner-name fields are populated alongside the
+// pod-level identifiers.
+func buildTargetSet(rules []CRRule, pods []*corev1.Pod, podEntries []PodCgroupEntry) tracer.TargetSet {
+	byCgroup := make(map[uint64]PodCgroupEntry, len(podEntries))
+	for _, e := range podEntries {
+		if existing, ok := byCgroup[e.CgroupID]; !ok || (existing.ContainerName == "" && e.ContainerName != "") {
+			byCgroup[e.CgroupID] = e
+		}
+	}
+
 	seen := map[uint64]struct{}{}
 	var out tracer.TargetSet
-	root := discoverKubepodsRoot()
 
 	for _, rule := range rules {
 		for id := range rule.CgroupIDs {
@@ -400,27 +505,49 @@ func buildTargetSet(rules []CRRule, pods []*corev1.Pod) tracer.TargetSet {
 				continue
 			}
 			seen[id] = struct{}{}
-			for _, p := range pods {
-				path := cgroupPathForPod(p, root)
-				if path == "" {
-					continue
-				}
-				pid, err := cgroupIDFromPath(path)
-				if err != nil || pid != id {
-					continue
-				}
+			if entry, ok := byCgroup[id]; ok {
+				kind, name := resolveWorkload(entry.Pod)
 				out = append(out, tracer.Target{
-					PodName:    p.Name,
-					Namespace:  p.Namespace,
-					CgroupPath: path,
-					Labels:     copyMap(p.Labels),
-					PodIP:      p.Status.PodIP,
+					PodName:       entry.Pod.Name,
+					Namespace:     entry.Pod.Namespace,
+					ContainerID:   entry.ContainerID,
+					ContainerName: entry.ContainerName,
+					CgroupPath:    entry.CgroupPath,
+					Labels:        copyMap(entry.Pod.Labels),
+					PodIP:         entry.Pod.Status.PodIP,
+					OwnerKind:     kind,
+					OwnerName:     name,
 				})
-				break
+				continue
 			}
+			fallbackLegacyTarget(&out, pods, id)
 		}
 	}
 	return out
+}
+
+// fallbackLegacyTarget reproduces the pre-enrichment buildTargetSet
+// walk for callers that did not populate PodAttributor.
+func fallbackLegacyTarget(out *tracer.TargetSet, pods []*corev1.Pod, id uint64) {
+	root := discoverKubepodsRoot()
+	for _, p := range pods {
+		path := cgroupPathForPod(p, root)
+		if path == "" {
+			continue
+		}
+		pid, err := cgroupIDFromPath(path)
+		if err != nil || pid != id {
+			continue
+		}
+		*out = append(*out, tracer.Target{
+			PodName:    p.Name,
+			Namespace:  p.Namespace,
+			CgroupPath: path,
+			Labels:     copyMap(p.Labels),
+			PodIP:      p.Status.PodIP,
+		})
+		return
+	}
 }
 
 // filtersToSet converts the CRD's EventFilter list into the

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -997,7 +997,7 @@ func TestBuildTargetSet_Deduplicates(t *testing.T) {
 	}
 	// Empty pod list: every cgroup ID is "unmatched", so the result is empty
 	// — but the function must not panic and dedup must not crash on overlap.
-	out := buildTargetSet(rules, nil)
+	out := buildTargetSet(rules, nil, nil)
 	if len(out) != 0 {
 		t.Errorf("expected empty output, got %+v", out)
 	}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -20,9 +20,10 @@ import (
 //     the tracer to the subset of CR exporters whose (cgroup, filter)
 //     tuple matches.
 type Router struct {
-	mu    sync.RWMutex
-	rules []CRRule
-	stats *perCRStats
+	mu       sync.RWMutex
+	rules    []CRRule
+	stats    *perCRStats
+	enricher *PodEnricher
 }
 
 // NewRouter constructs an empty Router. The stats argument is shared
@@ -36,6 +37,13 @@ func NewRouter(stats *perCRStats) *Router {
 		rules: nil,
 		stats: stats,
 	}
+}
+
+// WithEnricher returns a Router that stamps each forwarded event with
+// the matching K8sMetadata before delegating to the per-CR exporters.
+func (r *Router) WithEnricher(e *PodEnricher) *Router {
+	r.enricher = e
+	return r
 }
 
 func (r *Router) Publish(rules []CRRule) {
@@ -107,6 +115,7 @@ func (r *Router) Name() string { return "cr-router" }
 func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	r.mu.RLock()
 	rules := r.rules
+	enricher := r.enricher
 	r.mu.RUnlock()
 
 	if len(rules) == 0 || len(batch) == 0 {
@@ -117,6 +126,10 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	for i := range rules {
 		filtered[i] = filtered[i][:0]
 	}
+
+	// One lookup per event regardless of how many CRs (and exporters)
+	// claim it.
+	enrichBatch(enricher, batch)
 
 	for _, ev := range batch {
 		if ev == nil {

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -116,7 +116,8 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	stats := newPerCRStats()
-	router := NewRouter(stats)
+	enricher := NewPodEnricher()
+	router := NewRouter(stats).WithEnricher(enricher)
 	probes := NewProbeServer(opts.HealthAddr, 0)
 	metrics := NewMetrics()
 
@@ -146,6 +147,7 @@ func Run(ctx context.Context, opts Options) error {
 		TargetsCh:       targetsCh,
 		Metrics:         metrics,
 		ExporterBuilder: BuildExporter,
+		Enricher:        enricher,
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup reconciler: %w", err)

--- a/internal/agent/sdk_event_exporter.go
+++ b/internal/agent/sdk_event_exporter.go
@@ -89,7 +89,7 @@ func (e *sdkEventExporter) Export(ctx context.Context, batch []*events.Event) er
 		}
 
 		_, span := tr.Start(ctx, eventSpanName(ev), trace.WithTimestamp(startedAt))
-		span.SetAttributes(
+		attrs := []attribute.KeyValue{
 			attribute.String("podtrace.event.type", eventTypeString(ev.Type)),
 			attribute.Int64("podtrace.event.pid", int64(ev.PID)),
 			attribute.Int64("podtrace.event.cgroup_id", safeUint64ToInt64(ev.CgroupID)),
@@ -98,7 +98,9 @@ func (e *sdkEventExporter) Export(ctx context.Context, batch []*events.Event) er
 			attribute.Int64("podtrace.event.bytes", safeUint64ToInt64(ev.Bytes)),
 			attribute.Int64("podtrace.event.latency_ns", safeUint64ToInt64(ev.LatencyNS)),
 			attribute.Int("podtrace.event.error", int(ev.Error)),
-		)
+		}
+		attrs = appendK8sAttributes(attrs, ev.K8s)
+		span.SetAttributes(attrs...)
 		span.End(trace.WithTimestamp(endedAt))
 	}
 	return nil

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -86,6 +86,8 @@ type Event struct {
 	ParentSpanID string
 	TraceFlags   uint8
 	TraceState   string
+
+	K8s *K8sMetadata
 }
 
 func (e *Event) Latency() time.Duration {

--- a/internal/events/k8s_metadata.go
+++ b/internal/events/k8s_metadata.go
@@ -1,0 +1,31 @@
+package events
+
+// K8sMetadata is the frozen Kubernetes context attached to events
+// after agent-side enrichment.
+type K8sMetadata struct {
+	Namespace string
+
+	PodName string
+
+	PodUID string
+
+	NodeName string
+
+	ContainerName string
+
+	WorkloadKind string
+
+	WorkloadName string
+}
+
+// IsZero reports whether the metadata bundle contains no useful
+// information.
+func (m K8sMetadata) IsZero() bool {
+	return m.Namespace == "" &&
+		m.PodName == "" &&
+		m.PodUID == "" &&
+		m.NodeName == "" &&
+		m.ContainerName == "" &&
+		m.WorkloadKind == "" &&
+		m.WorkloadName == ""
+}


### PR DESCRIPTION
Adds Kubernetes context enrichment to every span the agent exports. Each event the eBPF core produces is now tagged with the namespace, pod, pod UID, node, container, and workload kind+name of the pod that produced it, so downstream OTLP backends can group, filter, and join on stable Kubernetes identity without a separate processor.