### PR TITLE
feat: rolling-window error_rate detector and selective probe attach

### DIFF
--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -152,6 +152,19 @@ func (a *ebpfBackendAdapter) Stop() error {
 	return a.tr.Stop()
 }
 
+// SetEnabledCategories implements the optional pkg/tracer.CategoryGateable
+// interface by delegating to the eBPF tracer's runtime probe-group gate.
+func (a *ebpfBackendAdapter) SetEnabledCategories(categories []string) error {
+	type categoryGateable interface {
+		SetEnabledCategories([]string) error
+	}
+	g, ok := a.tr.(categoryGateable)
+	if !ok {
+		return nil
+	}
+	return g.SetEnabledCategories(categories)
+}
+
 func noopBackendFactory() (tracer.TracerBackend, error) {
 	return agent.NewNoopBackend(), nil
 }

--- a/docs/crd-podtrace.md
+++ b/docs/crd-podtrace.md
@@ -5,13 +5,12 @@ operator creates an exporter bundle in `podtrace-system`, the agent
 DaemonSet matches the selector, and per-node status entries roll up into
 the CR's `.status.nodeStatus` array.
 
-> **Current status (honest):** The control plane is fully functional —
-> matching, bundle sync, multi-CR merging, per-node status writes all
-> work. **Event emission to the configured exporter is stubbed** in the
-> agent's continuous path (NoopBackend); no spans reach the exporter
-> today. For a working end-to-end trace including event flow, use
-> [PodTraceSession](crd-podtracesession.md). The plumbing for real
-> events through this path is upcoming work.
+The agent loads the real eBPF backend by default and emits one
+OpenTelemetry span per kernel event to the configured exporter. A
+no-op backend remains available for clusters where loading eBPF
+programs is undesirable — opt in by passing `--backend=noop` to the
+agent (DaemonSet-template override; production deployments leave this
+unset).
 
 ## Minimal example
 
@@ -146,11 +145,17 @@ the same namespace. Cross-namespace exporter references are not allowed.
 exporter bundle in `podtrace-system`. Likely a missing user-namespace
 Secret referenced by the ExporterConfig. Check the operator log.
 
-**Events stay at zero:** Expected today — see status note at the top.
-For real eBPF-active tracing, use a [PodTraceSession](crd-podtracesession.md).
+**Events stay at zero:** The agent matched no pods, the matched pods
+generate no kernel events of the configured `filters`, or
+`podtrace_agent_backend_degraded` is non-zero on the agent's node
+(check `kubectl -n podtrace-system logs daemonset/podtrace-agent` for
+the failure reason). The continuous CR uses the real eBPF backend by
+default — confirm with
+`kubectl -n podtrace-system get ds podtrace-agent -o jsonpath='{.spec.template.spec.containers[0].args}'`
+that `--backend=noop` is not present.
 
 ## Related
 
-- [crd-podtracesession.md](crd-podtracesession.md) — bounded diagnose CR (the live event path)
+- [crd-podtracesession.md](crd-podtracesession.md) — bounded diagnose CR for one-shot traces
 - [crd-exporterconfig.md](crd-exporterconfig.md) — exporter setup
 - [operator.md](operator.md) — operator architecture

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,7 +37,7 @@ CLI strengths the CRDs don't replace:
 ```
 
 ```yaml
-# Continuous CR equivalent (control plane only today; events stubbed)
+# Continuous CR equivalent — events flow through the agent to the exporter
 apiVersion: podtrace.io/v1alpha1
 kind: ExporterConfig
 metadata: { name: my-otlp, namespace: my-app }
@@ -234,11 +234,12 @@ workload owner cannot exceed the platform-owner cap, and vice versa.
 The resolved value is surfaced on `status.policy.effectiveSampleRate`;
 inspect it there rather than inferring from `spec` alone.
 
-**`PodTrace` events are not yet flowing through the agent.** Continuous
-realtime tracing via the CR has working control-plane plumbing
-(matching, status, RBAC) but events are stubbed (`NoopBackend`). For
-real eBPF flow today, use `PodTraceSession` (works end-to-end) or stay
-on the CLI.
+**`PodTrace` events flow end-to-end through the agent.** Continuous
+realtime tracing via the CR is wired through the real eBPF backend by
+default — events from matched pods become OpenTelemetry spans on the
+configured exporter, with sampling, filters, and per-event threshold
+tagging applied per `spec.policy`. A `--backend=noop` flag exists for
+debugging on clusters where eBPF cannot be loaded.
 
 ## Related
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -147,22 +147,17 @@ no-op rather than a hard install failure.
 
 ## Current limits (where we are vs the long-term shape)
 
-Two limits to be honest about:
+One limit to be honest about:
 
-1. **Continuous PodTrace events are not yet emitted to exporters.** The
-   agent's continuous-tracing path uses a `NoopBackend` today; the control
-   plane (matching, bundle sync, status writes, multi-CR merge) all works
-   and is observable, but events do not flow through the agent to the
-   configured exporter. Phase 5+ work plumbs the same eBPF stack the
-   session Job already runs into the agent's event loop.
-2. **`spec.reportRef.objectStore` is reserved.** The CRD schema accepts an
-   `objectStore` sink field (S3/GCS/Azure) so clients can adopt it ahead
-   of the upload path going live. The validating webhook rejects sessions
-   that set it today — Phase 7+ work.
+- **`spec.reportRef.objectStore` is reserved.** The CRD schema accepts an
+  `objectStore` sink field (S3/GCS/Azure) so clients can adopt it ahead
+  of the upload path going live. The validating webhook rejects sessions
+  that set it today — Phase 7+ work.
 
-For real eBPF-active tracing today, use [PodTraceSession](crd-podtracesession.md)
-(Phase 4 — works end-to-end with summary + reportRef artifacts) or the
-standalone [CLI binary](usage.md).
+Both [PodTrace](crd-podtrace.md) (continuous) and
+[PodTraceSession](crd-podtracesession.md) (bounded) drive the real eBPF
+backend by default, with events surfacing as OpenTelemetry spans on the
+configured exporter.
 
 ## Going further
 

--- a/internal/agent/error_rate_detector.go
+++ b/internal/agent/error_rate_detector.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"sync"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/safeconv"
+)
+
+// Tunables for the per-CR rolling error-rate detector.
+const (
+	errorRateWindowSeconds = 60
+	errorRateMinSampleSize = 20
+)
+
+// errorRateDetector evaluates a per-CR error-rate threshold over a
+// rolling N-second window of buckets.
+type errorRateDetector struct {
+	mu      sync.Mutex
+	buckets [errorRateWindowSeconds]errorRateBucket
+
+	threshold int32
+
+	breached bool
+	nowFn    func() time.Time
+}
+
+// errorRateBucket holds the (total, errors) counts for one wall-clock
+// second.
+type errorRateBucket struct {
+	second uint64
+	total  int64
+	errors int64
+}
+
+func newErrorRateDetector(thresholdPercent int32) *errorRateDetector {
+	return &errorRateDetector{
+		threshold: thresholdPercent,
+		nowFn:     time.Now,
+	}
+}
+
+// setThreshold updates the configured threshold percentage without
+// disturbing the window state.
+func (d *errorRateDetector) setThreshold(thresholdPercent int32) {
+	d.mu.Lock()
+	d.threshold = thresholdPercent
+	d.mu.Unlock()
+}
+
+// Observe records one event and returns true iff this event caused a
+// "below-threshold to above-threshold" transition.
+func (d *errorRateDetector) Observe(isError bool) (justBreached bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := d.nowFn()
+	sec := safeconv.Int64ToUint64(now.Unix())
+	idx := int(sec % errorRateWindowSeconds)
+
+	b := &d.buckets[idx]
+	if b.second != sec {
+		b.second = sec
+		b.total = 0
+		b.errors = 0
+	}
+	b.total++
+	if isError {
+		b.errors++
+	}
+
+	var cutoff uint64
+	if sec+1 > errorRateWindowSeconds {
+		cutoff = sec + 1 - errorRateWindowSeconds
+	}
+	var total, errors int64
+	for i := range d.buckets {
+		bb := &d.buckets[i]
+		if bb.second >= cutoff && bb.second <= sec {
+			total += bb.total
+			errors += bb.errors
+		}
+	}
+
+	if total < errorRateMinSampleSize {
+		if d.breached {
+			d.breached = false
+		}
+		return false
+	}
+
+	above := errors*100 > total*int64(d.threshold)
+	if above && !d.breached {
+		d.breached = true
+		return true
+	}
+	if !above && d.breached {
+		d.breached = false
+	}
+	return false
+}
+
+// IsBreached returns the detector's current breach state without
+// modifying it.
+func (d *errorRateDetector) IsBreached() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.breached
+}

--- a/internal/agent/error_rate_detector_test.go
+++ b/internal/agent/error_rate_detector_test.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock advances only when the test asks it to, so detector tests
+// stay deterministic regardless of CI load.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Unix(1_700_000_000, 0)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func newTestDetector(t *testing.T, threshold int32) (*errorRateDetector, *fakeClock) {
+	t.Helper()
+	clk := newFakeClock()
+	d := newErrorRateDetector(threshold)
+	d.nowFn = clk.Now
+	return d, clk
+}
+
+// TestErrorRateDetector_BelowMinSampleSizeNeverBreaches guards the
+// startup-noise contract: a CR that sees one error in its first second
+// must not breach a 50% threshold.
+func TestErrorRateDetector_BelowMinSampleSizeNeverBreaches(t *testing.T) {
+	d, _ := newTestDetector(t, 50)
+	for i := 0; i < errorRateMinSampleSize-1; i++ {
+		if got := d.Observe(true); got {
+			t.Fatalf("observation %d: unexpected breach below min sample size", i)
+		}
+	}
+}
+
+// TestErrorRateDetector_EdgeTriggeredBreach pins the "one signal per
+// transition" contract, sustained breach must not produce repeated
+// edge signals.
+func TestErrorRateDetector_EdgeTriggeredBreach(t *testing.T) {
+	d, _ := newTestDetector(t, 10)
+	// 20 events, all errors → rate = 100% > 10% threshold.
+	edges := 0
+	for i := 0; i < errorRateMinSampleSize+5; i++ {
+		if d.Observe(true) {
+			edges++
+		}
+	}
+	if edges != 1 {
+		t.Errorf("expected exactly one breach edge, got %d", edges)
+	}
+}
+
+// TestErrorRateDetector_RateBelowThresholdNoBreach ensures the
+// arithmetic correctly compares against the threshold.
+func TestErrorRateDetector_RateBelowThresholdNoBreach(t *testing.T) {
+	d, _ := newTestDetector(t, 30)
+	// 30 events: 5 errors, 25 successes to rate ≈ 16.7%, below 30%.
+	for i := 0; i < 5; i++ {
+		if d.Observe(true) {
+			t.Fatalf("event %d: unexpected breach", i)
+		}
+	}
+	for i := 0; i < 25; i++ {
+		if d.Observe(false) {
+			t.Fatalf("event %d (success): unexpected breach", i)
+		}
+	}
+	if d.IsBreached() {
+		t.Error("detector should not be in breached state")
+	}
+}
+
+// TestErrorRateDetector_WindowExpiresClearsBreach asserts that old
+// buckets fall out of the window.
+func TestErrorRateDetector_WindowExpiresClearsBreach(t *testing.T) {
+	d, clk := newTestDetector(t, 10)
+	for i := 0; i < errorRateMinSampleSize+5; i++ {
+		d.Observe(true)
+	}
+	if !d.IsBreached() {
+		t.Fatal("expected breach after error burst")
+	}
+
+	clk.Advance(time.Duration(errorRateWindowSeconds+1) * time.Second)
+	d.Observe(false)
+	if d.IsBreached() {
+		t.Error("breach should clear after window expiry")
+	}
+}
+
+// TestErrorRateDetector_ThresholdUpdatePreservesWindow guards the
+// "bundle rotation does not lose window state" property: changing the
+// threshold while the detector is healthy must keep buckets in place.
+func TestErrorRateDetector_ThresholdUpdatePreservesWindow(t *testing.T) {
+	d, _ := newTestDetector(t, 100) // threshold so high nothing breaches
+	for i := 0; i < errorRateMinSampleSize; i++ {
+		d.Observe(true)
+	}
+	if d.IsBreached() {
+		t.Fatal("100% threshold means errors=total is at-not-above; should not breach")
+	}
+
+	d.setThreshold(10)
+	if !d.Observe(true) {
+		t.Error("expected breach edge after threshold tighten on existing window")
+	}
+}
+
+// TestErrorRateDetector_BucketRollover exercises the
+// ring-modulo-window-seconds index reset when the clock wraps a full
+// minute and the same slot is revisited with a newer second.
+func TestErrorRateDetector_BucketRollover(t *testing.T) {
+	d, clk := newTestDetector(t, 10)
+	// 20 errors at t=0.
+	for i := 0; i < 20; i++ {
+		d.Observe(true)
+	}
+	clk.Advance(time.Duration(errorRateWindowSeconds) * time.Second)
+	for i := 0; i < 20; i++ {
+		d.Observe(false)
+	}
+	if d.IsBreached() {
+		t.Error("breach should clear when window fully rolls over with successes")
+	}
+}
+
+// TestErrorRateDetector_ConcurrentObserveSafe is a smoke test for the
+// internal mutex.
+func TestErrorRateDetector_ConcurrentObserveSafe(t *testing.T) {
+	d, _ := newTestDetector(t, 50)
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				d.Observe(true)
+			}
+		}()
+	}
+	wg.Wait()
+	if !d.IsBreached() {
+		t.Error("8 goroutines × 200 errors should produce a breach")
+	}
+}
+
+// TestErrorRateDetector_QuietPeriodClearsLatentBreach pins the
+// "breach holds during sustained activity, clears during quiet" path.
+func TestErrorRateDetector_QuietPeriodClearsLatentBreach(t *testing.T) {
+	d, clk := newTestDetector(t, 10)
+	for i := 0; i < errorRateMinSampleSize+5; i++ {
+		d.Observe(true)
+	}
+	if !d.IsBreached() {
+		t.Fatal("expected breach")
+	}
+	clk.Advance(time.Duration(errorRateWindowSeconds+1) * time.Second)
+	d.Observe(false)
+	if d.IsBreached() {
+		t.Error("breach should clear when windowed total drops below min sample")
+	}
+}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -26,6 +26,11 @@ type Metrics struct {
 	EffectiveSampleRate *prometheus.GaugeVec
 	PolicyGeneration    *prometheus.GaugeVec
 
+	ErrorRateBreached *prometheus.CounterVec
+
+	detectorsMu sync.Mutex
+	detectors   map[CRKey]*errorRateDetector
+
 	EnrichmentLookups       *prometheus.CounterVec
 	EnrichmentCacheSize     prometheus.Gauge
 	EnrichmentSnapshots     prometheus.Counter
@@ -123,6 +128,12 @@ func NewMetrics() *Metrics {
 			Name:      "policy_generation",
 			Help:      "metadata.generation of the source PodTrace at the time the agent loaded its bundle. Compare to .metadata.generation on the CR to verify propagation.",
 		}, []string{"cr_namespace", "cr_name"}),
+		ErrorRateBreached: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "error_rate_breached_total",
+			Help:      "Edges where a CR's rolling-window error rate transitioned from below to above its configured spec.thresholds.errorRatePercent. One increment per transition (edge-triggered), so a sustained breach does not inflate this counter.",
+		}, []string{"cr_namespace", "cr_name"}),
+		detectors: map[CRKey]*errorRateDetector{},
 		lastEvents:  map[CRKey]int64{},
 		lastDropped: map[CRKey]int64{},
 	}
@@ -132,8 +143,43 @@ func NewMetrics() *Metrics {
 		m.EnrichmentLookups, m.EnrichmentCacheSize, m.EnrichmentSnapshots,
 		m.EnrichmentOwnerResolved,
 		m.ThresholdTripped, m.EffectiveSampleRate, m.PolicyGeneration,
+		m.ErrorRateBreached,
 	)
 	return m
+}
+
+// ObserveErrorRate feeds one event into the per-CR rolling-window
+// error-rate detector.
+func (m *Metrics) ObserveErrorRate(cr CRKey, thresholdPercent int32, isError bool) (justBreached bool) {
+	if m == nil {
+		return false
+	}
+	m.detectorsMu.Lock()
+	d, ok := m.detectors[cr]
+	if !ok {
+		d = newErrorRateDetector(thresholdPercent)
+		m.detectors[cr] = d
+	} else {
+		d.setThreshold(thresholdPercent)
+	}
+	m.detectorsMu.Unlock()
+
+	justBreached = d.Observe(isError)
+	if justBreached && m.ErrorRateBreached != nil {
+		m.ErrorRateBreached.WithLabelValues(cr.Namespace, cr.Name).Inc()
+	}
+	return justBreached
+}
+
+// dropErrorRateDetector removes the per-CR detector when a CR is no
+// longer scheduled on this node.
+func (m *Metrics) dropErrorRateDetector(cr CRKey) {
+	if m == nil {
+		return
+	}
+	m.detectorsMu.Lock()
+	delete(m.detectors, cr)
+	m.detectorsMu.Unlock()
 }
 
 // RecordThresholdTripped bumps the per-CR-per-kind counter once for an
@@ -177,6 +223,10 @@ func (m *Metrics) dropPolicyMetrics(cr CRKey) {
 	if m.ThresholdTripped != nil {
 		m.ThresholdTripped.DeletePartialMatch(lbls)
 	}
+	if m.ErrorRateBreached != nil {
+		m.ErrorRateBreached.DeletePartialMatch(lbls)
+	}
+	m.dropErrorRateDetector(cr)
 }
 
 // RefreshFromEnricher emits the deltas from the enricher's atomic

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -46,6 +47,8 @@ type AgentReconciler struct {
 	PodAttributor func(pods []*corev1.Pod) []PodCgroupEntry
 
 	Enricher *PodEnricher
+
+	CategoryGate func(categories []string) error
 
 	exporterCacheMu sync.Mutex
 	exporterCache   map[CRKey]cachedExporter
@@ -207,6 +210,14 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	r.Router.Publish(rules)
+
+	if r.CategoryGate != nil {
+		categories := unionCategoriesFromRules(rules)
+		if err := r.CategoryGate(categories); err != nil {
+			logger.V(1).Info("category gate apply failed",
+				"error", err, "categories", categories)
+		}
+	}
 
 	targets := buildTargetSet(rules, localPods, podEntries)
 	select {
@@ -613,6 +624,45 @@ func bundlePolicyGeneration(b *BundlePayload) int64 {
 		return 0
 	}
 	return b.PolicyGeneration
+}
+
+// unionCategoriesFromRules returns the sorted, deduplicated union of
+// CRD-filter category strings (dns/net/fs/cpu/proc) across every active
+// CRRule.
+func unionCategoriesFromRules(rules []CRRule) []string {
+	seen := make(map[string]struct{}, len(rules))
+	for _, r := range rules {
+		if r.Err != nil {
+			continue
+		}
+		if len(r.Policy.Filters) == 0 {
+			for _, c := range knownFilterCategories() {
+				seen[c] = struct{}{}
+			}
+			break
+		}
+		for _, c := range r.Policy.Filters {
+			seen[c] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for c := range seen {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// knownFilterCategories returns the canonical list of CRD filter
+// category strings, in stable order.
+func knownFilterCategories() []string {
+	return []string{
+		string(podtracev1alpha1.FilterDNS),
+		string(podtracev1alpha1.FilterNet),
+		string(podtracev1alpha1.FilterFS),
+		string(podtracev1alpha1.FilterCPU),
+		string(podtracev1alpha1.FilterProc),
+	}
 }
 
 // filtersToSet converts the CRD's EventFilter list into the

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -22,9 +22,6 @@ import (
 	"github.com/podtrace/podtrace/pkg/tracer"
 )
 
-// fakeExporter is a tracer.Exporter that records every Export call and
-// surfaces a Close counter so we can assert the reconciler's
-// release/reap paths properly free downstream resources.
 type fakeExporter struct {
 	mu      sync.Mutex
 	name    string
@@ -58,8 +55,6 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-// makeBundleCM produces a managed ConfigMap whose name matches the
-// PodTrace UID so LoadBundle finds it.
 func makeBundleCM(systemNS string, uid types.UID, rv string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -132,7 +127,6 @@ func TestPodChangePredicates(t *testing.T) {
 		t.Error("Generic predicate should reject events")
 	}
 
-	// UpdateFunc: same labels + same state → false; different labels → true; different state → true.
 	old := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "1"}},
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
@@ -154,17 +148,11 @@ func TestPodChangePredicates(t *testing.T) {
 		t.Error("state-change Update should pass")
 	}
 
-	// Non-Pod ObjectOld/New → false.
 	if p.Update(event.UpdateEvent{ObjectOld: &corev1.ConfigMap{}, ObjectNew: &corev1.Pod{}}) {
 		t.Error("non-Pod Update should be rejected")
 	}
 }
 
-// TestReconcile_HappyPath runs the reconcile loop end-to-end against a
-// fake controller-runtime client. It seeds two pods on the local node,
-// one PodTrace selecting them by label, and a bundle ConfigMap. The
-// injected ExporterBuilder returns a fakeExporter and the injected
-// CgroupResolver maps each pod to a synthetic ID.
 func TestReconcile_HappyPath(t *testing.T) {
 	const node, sysNS, ns = "node-1", "podtrace-system", "default"
 	uid := types.UID("uid-1")
@@ -245,7 +233,6 @@ func TestReconcile_HappyPath(t *testing.T) {
 		t.Errorf("BundleRevision = %q, want 10", rules[0].BundleRevision)
 	}
 
-	// TargetsCh should have received a (possibly empty) set.
 	select {
 	case <-r.TargetsCh:
 	default:
@@ -263,9 +250,6 @@ func TestReconcile_HappyPath(t *testing.T) {
 	}
 }
 
-// TestReconcile_BundleRotationRebuildsExporter changes the ConfigMap
-// ResourceVersion between reconciles and asserts the cached exporter
-// is closed and a fresh one is built.
 func TestReconcile_BundleRotationRebuildsExporter(t *testing.T) {
 	const node, sysNS, ns = "node-1", "podtrace-system", "default"
 	uid := types.UID("uid-1")
@@ -311,7 +295,6 @@ func TestReconcile_BundleRotationRebuildsExporter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Bump RV via Update (fake client auto-increments ResourceVersion).
 	var current corev1.ConfigMap
 	if err := c.Get(context.Background(), types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, &current); err != nil {
 		t.Fatalf("get: %v", err)
@@ -338,9 +321,6 @@ func TestReconcile_BundleRotationRebuildsExporter(t *testing.T) {
 	}
 }
 
-// TestReconcile_PausedCRSkipped covers the early-continue branch that
-// drops paused CRs from the active rule set without consulting the
-// bundle.
 func TestReconcile_PausedCRSkipped(t *testing.T) {
 	const node, sysNS, ns = "node-1", "podtrace-system", "default"
 	pt := &podtracev1alpha1.PodTrace{
@@ -385,9 +365,6 @@ func TestReconcile_PausedCRSkipped(t *testing.T) {
 	}
 }
 
-// TestReconcile_NoMatchedPodsReleasesExporter exercises the
-// match-empty branch: the cached exporter for that CR must be closed
-// and removed.
 func TestReconcile_NoMatchedPodsReleasesExporter(t *testing.T) {
 	const node, sysNS, ns = "node-1", "podtrace-system", "default"
 	uid := types.UID("uid-empty")
@@ -429,9 +406,6 @@ func TestReconcile_NoMatchedPodsReleasesExporter(t *testing.T) {
 	}
 }
 
-// TestReconcile_BundleNotFoundIsNonFatal verifies that a missing
-// bundle ConfigMap (e.g. the operator hasn't synced it yet) returns
-// without error and without publishing a rule for the affected CR.
 func TestReconcile_BundleNotFoundIsNonFatal(t *testing.T) {
 	const node, sysNS, ns = "node-1", "podtrace-system", "default"
 	pt := &podtracev1alpha1.PodTrace{
@@ -447,8 +421,6 @@ func TestReconcile_BundleNotFoundIsNonFatal(t *testing.T) {
 		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(pt, pod).Build()
-	// No bundle ConfigMap → LoadBundle returns NotFound which the
-	// reconciler must treat as transient.
 
 	r := &AgentReconciler{
 		Client: c, NodeName: node, SystemNamespace: sysNS,
@@ -476,14 +448,6 @@ func TestReconcile_BundleNotFoundIsNonFatal(t *testing.T) {
 	}
 }
 
-// TestReconcile_ExporterBuilderErrorIsNonFatal: builder failure logs
-// and continues; no rule is published for that CR.
-// TestReconcile_ExporterBuilderErrorPublishesTombstone covers the
-// agent's failure-visibility contract for the most common case: a
-// bundle the agent does not know how to build (e.g. unsupported
-// exporter type). The reconcile must not crash, must publish a
-// tombstone rule (so the status writer can surface the cause on
-// NodeStatus.Message), and must not cache the failed exporter.
 func TestReconcile_ExporterBuilderErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-err")
@@ -548,10 +512,6 @@ func TestReconcile_ExporterBuilderErrorPublishesTombstone(t *testing.T) {
 	}
 }
 
-// TestReconcile_CgroupResolverErrorPublishesTombstone: resolver failure
-// produces a tombstone rule that carries the wrapped error and a nil
-// exporter. CgroupIDs is empty because resolution failed before we
-// could obtain them.
 func TestReconcile_CgroupResolverErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-cgerr")
@@ -601,10 +561,6 @@ func TestReconcile_CgroupResolverErrorPublishesTombstone(t *testing.T) {
 	}
 }
 
-// TestReconcile_BundleLoadErrorPublishesTombstone covers the non-
-// NotFound bundle load failure path: a real apiserver / network error
-// must tombstone the rule, but NotFound (operator hasn't synced yet)
-// must stay a silent skip — see TestReconcile_BundleNotFoundIsNonFatal.
 func TestReconcile_BundleLoadErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-bundle-err")
@@ -662,10 +618,6 @@ func TestReconcile_BundleLoadErrorPublishesTombstone(t *testing.T) {
 	}
 }
 
-// TestReconcile_MatchPodsErrorPublishesTombstone covers the defensive
-// tombstone for selector evaluation. The webhook normally catches bad
-// label selectors at admission; this test verifies the agent's belt-
-// and-braces behaviour when an invalid selector somehow reaches it.
 func TestReconcile_MatchPodsErrorPublishesTombstone(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	uid := types.UID("uid-match-err")
@@ -714,9 +666,6 @@ func TestReconcile_MatchPodsErrorPublishesTombstone(t *testing.T) {
 	}
 }
 
-// TestReconcile_ReapsExportersForDeletedCRs seeds a stale cached
-// exporter with a key that no longer corresponds to any CR; the
-// reaper must close and drop it.
 func TestReconcile_ReapsExportersForDeletedCRs(t *testing.T) {
 	const node, sysNS, ns = "n", "ns-sys", "default"
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
@@ -743,9 +692,6 @@ func TestReconcile_ReapsExportersForDeletedCRs(t *testing.T) {
 	}
 }
 
-// TestReconcile_TargetsChannelKeepLatest stresses the keep-latest
-// fallback by calling Reconcile against a 1-buffer channel that no
-// consumer is draining. Two reconciles must succeed.
 func TestReconcile_TargetsChannelKeepLatest(t *testing.T) {
 	const node, sysNS, ns = "n", "s", "default"
 	uid := types.UID("uid-ch")
@@ -783,8 +729,6 @@ func TestReconcile_TargetsChannelKeepLatest(t *testing.T) {
 	}
 }
 
-// TestEnqueueAllPodTraces returns one request per existing PodTrace,
-// regardless of the triggering object.
 func TestEnqueueAllPodTraces(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(
 		&podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns1"}},
@@ -797,21 +741,18 @@ func TestEnqueueAllPodTraces(t *testing.T) {
 	}
 }
 
-// TestEnqueueOnBundleChange filters out non-bundle ConfigMaps.
 func TestEnqueueOnBundleChange(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(
 		&podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
 	).Build()
 	r := &AgentReconciler{Client: c}
 
-	// Unmanaged ConfigMap → 0 requests.
 	if got := r.enqueueOnBundleChange(context.Background(), &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns"},
 	}); len(got) != 0 {
 		t.Errorf("unmanaged CM enqueued %d", len(got))
 	}
 
-	// Managed but wrong component → 0 requests.
 	if got := r.enqueueOnBundleChange(context.Background(), &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "x", Namespace: "ns",
@@ -824,7 +765,6 @@ func TestEnqueueOnBundleChange(t *testing.T) {
 		t.Errorf("wrong-component CM enqueued %d", len(got))
 	}
 
-	// Bundle CM → enqueues all PodTraces.
 	got := r.enqueueOnBundleChange(context.Background(), &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "x", Namespace: "ns",
@@ -839,7 +779,6 @@ func TestEnqueueOnBundleChange(t *testing.T) {
 	}
 }
 
-// TestObtainAndReleaseExporter exercises cache miss → hit → bundle-RV change.
 func TestObtainAndReleaseExporter(t *testing.T) {
 	calls := 0
 	r := &AgentReconciler{
@@ -851,12 +790,10 @@ func TestObtainAndReleaseExporter(t *testing.T) {
 	}
 	key := CRKey{Namespace: "ns", Name: "pt"}
 
-	// Miss.
 	exp1, err := r.obtainExporter(key, &BundlePayload{ResourceVer: "1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Hit (same RV).
 	exp2, err := r.obtainExporter(key, &BundlePayload{ResourceVer: "1"})
 	if err != nil {
 		t.Fatal(err)
@@ -868,7 +805,6 @@ func TestObtainAndReleaseExporter(t *testing.T) {
 		t.Errorf("calls = %d, want 1", calls)
 	}
 
-	// Rotation.
 	exp3, err := r.obtainExporter(key, &BundlePayload{ResourceVer: "2"})
 	if err != nil {
 		t.Fatal(err)
@@ -879,12 +815,10 @@ func TestObtainAndReleaseExporter(t *testing.T) {
 	if calls != 2 {
 		t.Errorf("calls = %d, want 2", calls)
 	}
-	// The old exporter must have been closed.
 	if exp1.(*fakeExporter).Closes() != 1 {
 		t.Errorf("old exporter Close count = %d, want 1", exp1.(*fakeExporter).Closes())
 	}
 
-	// Release.
 	r.releaseExporter(key)
 	if _, ok := r.exporterCache[key]; ok {
 		t.Error("releaseExporter did not remove the entry")
@@ -892,12 +826,9 @@ func TestObtainAndReleaseExporter(t *testing.T) {
 	if exp3.(*fakeExporter).Closes() != 1 {
 		t.Errorf("released exporter Close count = %d, want 1", exp3.(*fakeExporter).Closes())
 	}
-	// Releasing an absent key is a no-op.
 	r.releaseExporter(key)
 }
 
-// TestObtainExporter_BuildErrorPropagates verifies builder errors are
-// surfaced and nothing is cached on failure.
 func TestObtainExporter_BuildErrorPropagates(t *testing.T) {
 	r := &AgentReconciler{
 		exporterCache: map[CRKey]cachedExporter{},
@@ -914,8 +845,6 @@ func TestObtainExporter_BuildErrorPropagates(t *testing.T) {
 	}
 }
 
-// TestReapStaleExporters exercises both the no-op-when-active path and
-// the close-on-stale path.
 func TestReapStaleExporters(t *testing.T) {
 	a := &fakeExporter{name: "a"}
 	b := &fakeExporter{name: "b"}
@@ -938,8 +867,6 @@ func TestReapStaleExporters(t *testing.T) {
 	}
 }
 
-// TestCgroupIDFromPath_Errors covers the bad-path branch (Stat failure)
-// and a happy path resolved against the test's own working directory.
 func TestCgroupIDFromPath_Errors(t *testing.T) {
 	if _, err := cgroupIDFromPath("/non/existent/path/should/not/exist"); err == nil {
 		t.Error("expected error for missing path")
@@ -954,8 +881,6 @@ func TestCgroupIDFromPath_Errors(t *testing.T) {
 	}
 }
 
-// TestCgroupPathForPod_NoMatch covers the all-candidates-miss branch
-// by passing a synthetic UID that cannot exist on the host.
 func TestCgroupPathForPod_NoMatch(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -968,9 +893,6 @@ func TestCgroupPathForPod_NoMatch(t *testing.T) {
 	}
 }
 
-// TestResolveCgroupIDs_SkipsUnresolvable confirms that pods whose
-// cgroup paths cannot be resolved are silently dropped (the next
-// reconcile picks them up).
 func TestResolveCgroupIDs_SkipsUnresolvable(t *testing.T) {
 	pods := []*corev1.Pod{
 		{
@@ -989,25 +911,17 @@ func TestResolveCgroupIDs_SkipsUnresolvable(t *testing.T) {
 	}
 }
 
-// TestBuildTargetSet_Deduplicates verifies the seen-cgroup-id guard
-// keeps the same target out of the output twice.
 func TestBuildTargetSet_Deduplicates(t *testing.T) {
 	rules := []CRRule{
 		{CgroupIDs: map[uint64]struct{}{1: {}, 2: {}}},
 		{CgroupIDs: map[uint64]struct{}{2: {}, 3: {}}},
 	}
-	// Empty pod list: every cgroup ID is "unmatched", so the result is empty
-	// — but the function must not panic and dedup must not crash on overlap.
 	out := buildTargetSet(rules, nil, nil)
 	if len(out) != 0 {
 		t.Errorf("expected empty output, got %+v", out)
 	}
 }
 
-// TestPolicySnapshotFromBundle_FullRoundTrip pins the operator→bundle
-// →agent path: a bundle populated by the operator with effective
-// sample, filters, thresholds, and generation surfaces in a
-// PolicySnapshot the router carries on every CRRule.
 func TestPolicySnapshotFromBundle_FullRoundTrip(t *testing.T) {
 	five := int32(5)
 	twenty := int32(20)
@@ -1048,8 +962,69 @@ func TestPolicySnapshotFromBundle_FullRoundTrip(t *testing.T) {
 	}
 }
 
-// TestPolicySnapshotFromBundle_NilSafe documents the agent contract:
-// a nil bundle yields a zero-value snapshot, never panics.
+func TestUnionCategoriesFromRules_NoFilterWidensToAll(t *testing.T) {
+	rules := []CRRule{
+		{Key: CRKey{Namespace: "ns", Name: "a"}, Policy: PolicySnapshot{Filters: []string{"dns"}}},
+		{Key: CRKey{Namespace: "ns", Name: "b"}, Policy: PolicySnapshot{}},
+	}
+	got := unionCategoriesFromRules(rules)
+	want := []string{"cpu", "dns", "fs", "net", "proc"}
+	if !equalStrings(got, want) {
+		t.Errorf("union = %v, want %v", got, want)
+	}
+}
+
+func TestUnionCategoriesFromRules_SortedDeduped(t *testing.T) {
+	rules := []CRRule{
+		{Key: CRKey{Namespace: "ns", Name: "a"}, Policy: PolicySnapshot{Filters: []string{"net", "fs"}}},
+		{Key: CRKey{Namespace: "ns", Name: "b"}, Policy: PolicySnapshot{Filters: []string{"fs", "dns"}}},
+		{Key: CRKey{Namespace: "ns", Name: "c"}, Policy: PolicySnapshot{Filters: []string{"net"}}},
+	}
+	got := unionCategoriesFromRules(rules)
+	want := []string{"dns", "fs", "net"}
+	if !equalStrings(got, want) {
+		t.Errorf("union = %v, want %v", got, want)
+	}
+}
+
+func TestUnionCategoriesFromRules_SkipsErroredRules(t *testing.T) {
+	rules := []CRRule{
+		{Key: CRKey{Namespace: "ns", Name: "ok"}, Policy: PolicySnapshot{Filters: []string{"dns"}}},
+		{
+			Key:    CRKey{Namespace: "ns", Name: "bad"},
+			Policy: PolicySnapshot{Filters: []string{"net", "fs"}},
+			Err:    errors.New("bundle load failed"),
+		},
+	}
+	got := unionCategoriesFromRules(rules)
+	want := []string{"dns"}
+	if !equalStrings(got, want) {
+		t.Errorf("errored rule must not contribute: got %v want %v", got, want)
+	}
+}
+
+func TestUnionCategoriesFromRules_EmptyRulesEmptyUnion(t *testing.T) {
+	got := unionCategoriesFromRules(nil)
+	if got == nil {
+		t.Fatal("union must return a non-nil slice so the gate can act on it")
+	}
+	if len(got) != 0 {
+		t.Errorf("union = %v, want []", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestPolicySnapshotFromBundle_NilSafe(t *testing.T) {
 	snap := policySnapshotFromBundle(nil)
 	if snap.EffectiveSamplePercent != nil ||

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -31,38 +31,23 @@ import (
 )
 
 // Options configure a single agent run. Defaults are applied by
-// DefaultOptions; callers override only what the CLI flags customised.
+// DefaultOptions.
 type Options struct {
-	// NodeName is the node this agent runs on. Required — comes from
-	// $NODE_NAME via the DaemonSet's downward API.
 	NodeName string
 
-	// SystemNamespace is where exporter bundles live (and where
-	// podtrace-system resources are reconciled by the operator).
 	SystemNamespace string
 
-	// TracerConfigName lets the agent read infra defaults (currently
-	// unused; reserved for bundle cache invalidation policies).
 	TracerConfigName string
 
 	MetricsAddr string
 	HealthAddr  string
 
-	// StatusReportInterval overrides the default 30s cadence. Tests set
-	// this short; production leaves it at zero for the default.
 	StatusReportInterval time.Duration
 
-	// BackendFactory produces the TracerBackend the Engine will drive.
-	// When nil, the agent falls back to a noop backend and logs a
-	// one-line warning: the DaemonSet pod stays Ready so operators can
-	// inspect it via kubectl, but no kernel-space tracing happens.
-	// Tests inject a fake backend through this hook.
 	BackendFactory func() (tracer.TracerBackend, error)
 }
 
-// DefaultOptions returns production defaults. NodeName and
-// SystemNamespace are NOT defaulted because they have no reasonable
-// static value — the CLI validates both.
+// DefaultOptions returns production defaults.
 func DefaultOptions() Options {
 	return Options{
 		MetricsAddr: ":9090",
@@ -86,13 +71,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
-		// LeaderElection OFF: each agent acts on its own node only, no
-		// coordination needed across DaemonSet replicas.
 		LeaderElection: false,
-		// Pod cache is filtered to this node; the bundle ConfigMap/Secret
-		// caches are filtered to the system namespace. PodTrace is
-		// watched cluster-wide — that's the cross-namespace resource we
-		// cannot narrow.
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Pod{}: {
@@ -106,9 +85,6 @@ func Run(ctx context.Context, opts Options) error {
 				},
 			},
 		},
-		// Metrics are served on the agent's own registry (not
-		// controller-runtime's default) so the Prometheus scrape
-		// surface is deterministic — see Metrics.NewMetrics.
 		Metrics: metricsserver.Options{BindAddress: "0"},
 	})
 	if err != nil {
@@ -146,7 +122,8 @@ func Run(ctx context.Context, opts Options) error {
 		Router:          router,
 		TargetsCh:       targetsCh,
 		Metrics:         metrics,
-		Enricher: enricher,
+		Enricher:        enricher,
+		CategoryGate:    makeCategoryGate(backend),
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup reconciler: %w", err)
@@ -170,8 +147,6 @@ func Run(ctx context.Context, opts Options) error {
 	g.Go(func() error { return probes.Run(gctx) })
 	g.Go(func() error { return serveMetrics(gctx, opts.MetricsAddr, metrics, logger) })
 
-	// Mark ready once informers have synced — the manager's cache
-	// Start is async, so we wait here. Until then /readyz returns 503.
 	g.Go(func() error {
 		if !mgr.GetCache().WaitForCacheSync(gctx) {
 			return errors.New("informer cache sync failed")
@@ -206,14 +181,6 @@ func newAgentScheme() (*runtime.Scheme, error) {
 }
 
 // buildBackend returns the TracerBackend for the agent.
-//
-// Production: the CLI always sets BackendFactory (see cmd/podtrace/agent.go
-// where the --backend flag selects between the real eBPF tracer and an
-// explicit noop). A non-nil factory that returns an error is NOT fatal:
-// the agent falls back to the noop backend so the pod stays Ready, the
-// underlying error surfaces on PodTrace.status.nodeStatus.message via
-// StatusWriter.BackendErr, and `kubectl describe pod` keeps showing the
-// real cause. CrashLoopBackOff would hide that.
 func buildBackend(opts Options, logger logr.Logger) (tracer.TracerBackend, error) {
 	if opts.BackendFactory == nil {
 		logger.Info("no BackendFactory supplied — using noop backend (library/test mode; production binaries always set this)")
@@ -258,10 +225,20 @@ func serveMetrics(ctx context.Context, addr string, metrics *Metrics, logger log
 	return nil
 }
 
-// NoopBackend is the default TracerBackend when none is injected. It
-// accepts every Attach/SetContainerID call and never produces events,
-// so the agent's routing + status machinery is exercised end-to-end
-// without requiring a privileged eBPF load.
+// makeCategoryGate returns a closure suitable for
+// AgentReconciler.CategoryGate.
+func makeCategoryGate(backend tracer.TracerBackend) func(categories []string) error {
+	if backend == nil {
+		return nil
+	}
+	gate, ok := backend.(tracer.CategoryGateable)
+	if !ok {
+		return nil
+	}
+	return gate.SetEnabledCategories
+}
+
+// NoopBackend is the default TracerBackend when none is injected.
 type NoopBackend struct {
 	mu       sync.Mutex
 	eventCh  chan<- *events.Event
@@ -313,7 +290,7 @@ func (b *NoopBackend) Stop() error {
 }
 
 // Inject lets tests push synthetic events through the backend's
-// channel. Returns false if Start has not yet been called.
+// channel.
 func (b *NoopBackend) Inject(ev *events.Event) bool {
 	b.mu.Lock()
 	ch := b.eventCh

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -25,7 +26,6 @@ import (
 	"github.com/podtrace/podtrace/pkg/tracer"
 )
 
-// ─── Options + DefaultOptions + validate ─────────────────────────────
 
 func TestDefaultOptions_NonEmptyAddrs(t *testing.T) {
 	o := DefaultOptions()
@@ -70,7 +70,6 @@ func TestRun_RejectsInvalidOptions(t *testing.T) {
 	}
 }
 
-// ─── newAgentScheme ───────────────────────────────────────────────────
 
 func TestNewAgentScheme_RegistersBothAPIs(t *testing.T) {
 	s, err := newAgentScheme()
@@ -85,7 +84,6 @@ func TestNewAgentScheme_RegistersBothAPIs(t *testing.T) {
 	}
 }
 
-// ─── buildBackend ────────────────────────────────────────────────────
 
 type fakeBackend struct{ name string }
 
@@ -132,8 +130,6 @@ func TestBuildBackend_FactoryErrorFallsBackToNoop(t *testing.T) {
 	}
 }
 
-// TestNewNoopBackend_ExportedConstructor guards the public surface the
-// CLI relies on for `--backend=noop`.
 func TestNewNoopBackend_ExportedConstructor(t *testing.T) {
 	b := NewNoopBackend()
 	if b == nil {
@@ -144,7 +140,6 @@ func TestNewNoopBackend_ExportedConstructor(t *testing.T) {
 	}
 }
 
-// ─── NoopBackend ─────────────────────────────────────────────────────
 
 func TestNoopBackend_BasicLifecycle(t *testing.T) {
 	b := newNoopBackend()
@@ -160,7 +155,6 @@ func TestNoopBackend_BasicLifecycle(t *testing.T) {
 	if err := b.SetContainerID("abc"); err != nil {
 		t.Fatal(err)
 	}
-	// Inject before Start: must report not-started.
 	if b.Inject(&events.Event{}) {
 		t.Error("Inject should return false before Start")
 	}
@@ -187,7 +181,6 @@ func TestNoopBackend_BasicLifecycle(t *testing.T) {
 	}
 }
 
-// ─── serveMetrics ────────────────────────────────────────────────────
 
 func TestServeMetrics_EmptyAddrIsNoop(t *testing.T) {
 	if err := serveMetrics(context.Background(), "", NewMetrics(), logr.Discard()); err != nil {
@@ -244,7 +237,6 @@ func TestServeMetrics_ServesAndShutsDown(t *testing.T) {
 	}
 }
 
-// ─── otlp_event_exporter ─────────────────────────────────────────────
 
 func TestNormalizeOTLPEndpoint(t *testing.T) {
 	cases := []struct {
@@ -277,7 +269,6 @@ func TestEventTypeString(t *testing.T) {
 	if got := eventTypeString(events.EventConnect); got != "net.connect" {
 		t.Errorf("Connect = %q, want net.connect", got)
 	}
-	// Unknown type falls back to "event_<N>".
 	got := eventTypeString(events.EventType(9999))
 	if !strings.HasPrefix(got, "event_") {
 		t.Errorf("unknown type = %q, want event_NNNN", got)
@@ -305,9 +296,6 @@ func TestNewOTLPEventExporter_RejectsBadEndpoint(t *testing.T) {
 	}
 }
 
-// TestNewOTLPEventExporter_RoundTrip drives the full exporter against a
-// local httptest server. We don't decode the OTLP payload — only assert
-// that Export delivers a request before Close, exercising Name/Export/Close.
 func TestNewOTLPEventExporter_RoundTrip(t *testing.T) {
 	hits := make(chan struct{}, 16)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -324,7 +312,7 @@ func TestNewOTLPEventExporter_RoundTrip(t *testing.T) {
 		Type:     bundle.TypeOTLP,
 		Endpoint: host,
 		Insecure: true,
-		Sample:   0.5, // covers the TraceIDRatioBased branch
+		Sample:   0.5,
 	})
 	if err != nil {
 		t.Fatalf("newOTLPEventExporter: %v", err)
@@ -338,8 +326,6 @@ func TestNewOTLPEventExporter_RoundTrip(t *testing.T) {
 		_ = exp.Close(ctx)
 	}()
 
-	// Emit a batch — span gets queued by the batcher; Force-flush via Close
-	// in defer above sends it before we return.
 	if err := exp.Export(context.Background(), []*events.Event{
 		{Type: events.EventDNS, Target: "example.com", Timestamp: uint64(time.Now().UnixNano())},
 		{Type: events.EventConnect, PID: 42},
@@ -347,7 +333,6 @@ func TestNewOTLPEventExporter_RoundTrip(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Export: %v", err)
 	}
-	// Empty batch is a fast no-op.
 	if err := exp.Export(context.Background(), nil); err != nil {
 		t.Errorf("nil batch: %v", err)
 	}
@@ -368,7 +353,6 @@ func TestNewOTLPEventExporter_HeadersAndCredential(t *testing.T) {
 	_ = exp.Close(context.Background())
 }
 
-// ─── status_writer ────────────────────────────────────────────────────
 
 func TestStatusWriter_EmitOnce_NoRulesIsNoop(t *testing.T) {
 	router := NewRouter(nil)
@@ -379,8 +363,6 @@ func TestStatusWriter_EmitOnce_NoRulesIsNoop(t *testing.T) {
 	}
 }
 
-// recordingPatcher captures Status().Patch invocations because the
-// controller-runtime fake client does not implement Server-Side Apply.
 type recordingPatcher struct {
 	mu    sync.Mutex
 	calls []recordedPatch
@@ -489,8 +471,6 @@ func TestStatusWriter_EmitOnce_ReadyNilDefaultsTrue(t *testing.T) {
 	}
 }
 
-// TestStatusWriter_Run_StopsOnContextCancel proves Run returns nil on
-// context cancellation.
 func TestStatusWriter_Run_StopsOnContextCancel(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
 	w := &StatusWriter{
@@ -517,8 +497,6 @@ func TestStatusWriter_Run_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestStatusWriter_Run_PatchErrorIsLoggedNotFatal(t *testing.T) {
-	// Force the patch to error so emitOnce reports a per-tick failure;
-	// Run must keep going and exit cleanly only on context cancellation.
 	router := NewRouter(nil)
 	router.Publish([]CRRule{{Key: CRKey{Namespace: "ns", Name: "missing"}}})
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
@@ -542,7 +520,6 @@ func TestStatusWriter_Run_PatchErrorIsLoggedNotFatal(t *testing.T) {
 	}
 }
 
-// ─── ComputeNodeReport ───────────────────────────────────────────────
 
 func TestComputeNodeReport_AggregatesUniqueCgroups(t *testing.T) {
 	router := NewRouter(nil)
@@ -565,22 +542,18 @@ func TestComputeNodeReport_AggregatesUniqueCgroups(t *testing.T) {
 	}
 }
 
-// ─── convert.go ──────────────────────────────────────────────────────
 
 func TestSafeUint64ToInt64(t *testing.T) {
 	if got := safeUint64ToInt64(42); got != 42 {
 		t.Errorf("small = %d, want 42", got)
 	}
-	// Just below the int64 cap.
 	if got := safeUint64ToInt64(uint64(int64(1)<<62) + 1); got <= 0 {
 		t.Errorf("under-cap got %d, want positive", got)
 	}
-	// Exactly maxInt64 — should pass through.
 	max := uint64(int64(^uint64(0) >> 1))
 	if got := safeUint64ToInt64(max); int64(got) != int64(max) {
 		t.Errorf("maxint64 conversion lossy: got %d", got)
 	}
-	// Over the cap (top bit set) → clamp to maxint64 (positive, no wrap).
 	huge := uint64(1) << 63 // exactly the wrap-point
 	if got := safeUint64ToInt64(huge); got <= 0 {
 		t.Errorf("over-cap should clamp to positive maxint64, got %d", got)
@@ -596,7 +569,6 @@ func TestLenToInt32(t *testing.T) {
 	}
 }
 
-// ─── ResolveNodeName: hostname fallback ──────────────────────────────
 
 func TestResolveNodeName_HostnameFallback(t *testing.T) {
 	t.Setenv("NODE_NAME", "")
@@ -606,8 +578,6 @@ func TestResolveNodeName_HostnameFallback(t *testing.T) {
 	}
 }
 
-// guard that StatusWriter.patchCRStatus uses the SSA path with
-// a deterministic field manager.
 var _ = sync.Mutex{}
 
 func TestRouter_NameAndStats(t *testing.T) {
@@ -617,5 +587,48 @@ func TestRouter_NameAndStats(t *testing.T) {
 	}
 	if r.Stats() == nil {
 		t.Error("Stats() should never be nil")
+	}
+}
+
+type fakeGateableBackend struct {
+	*NoopBackend
+	mu       sync.Mutex
+	captured [][]string
+	err      error
+}
+
+func (f *fakeGateableBackend) SetEnabledCategories(categories []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.captured = append(f.captured, append([]string(nil), categories...))
+	return f.err
+}
+
+func TestMakeCategoryGate_BackendImplementsGateable(t *testing.T) {
+	b := &fakeGateableBackend{NoopBackend: NewNoopBackend()}
+	gate := makeCategoryGate(b)
+	if gate == nil {
+		t.Fatal("gate must be non-nil for gateable backend")
+	}
+	if err := gate([]string{"dns", "net"}); err != nil {
+		t.Fatalf("gate: %v", err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.captured) != 1 || !reflect.DeepEqual(b.captured[0], []string{"dns", "net"}) {
+		t.Errorf("captured = %v, want [[dns net]]", b.captured)
+	}
+}
+
+func TestMakeCategoryGate_BackendDoesNotImplementGateableReturnsNil(t *testing.T) {
+	gate := makeCategoryGate(NewNoopBackend())
+	if gate != nil {
+		t.Error("gate should be nil for non-gateable backend")
+	}
+}
+
+func TestMakeCategoryGate_NilBackendReturnsNil(t *testing.T) {
+	if gate := makeCategoryGate(nil); gate != nil {
+		t.Error("nil backend must produce nil gate")
 	}
 }

--- a/internal/agent/sdk_event_exporter.go
+++ b/internal/agent/sdk_event_exporter.go
@@ -201,12 +201,22 @@ func (e *sdkEventExporter) appendThresholdAttributes(attrs []attribute.KeyValue,
 			e.recordTrip("rtt_spike")
 		}
 	}
-	if t.ErrorRatePercent != nil && ev.Error != 0 {
-		attrs = append(attrs,
-			attribute.Bool("podtrace.threshold.error_rate.observed", true),
-			attribute.Int64("podtrace.threshold.error_rate.percent", int64(*t.ErrorRatePercent)),
-		)
-		e.recordTrip("error_rate")
+	if t.ErrorRatePercent != nil {
+		isErr := ev.Error != 0
+		if isErr {
+			attrs = append(attrs,
+				attribute.Bool("podtrace.threshold.error_rate.observed", true),
+				attribute.Int64("podtrace.threshold.error_rate.percent", int64(*t.ErrorRatePercent)),
+			)
+			e.recordTrip("error_rate")
+		}
+		if e.metrics != nil {
+			if justBreached := e.metrics.ObserveErrorRate(e.cr, *t.ErrorRatePercent, isErr); justBreached {
+				attrs = append(attrs,
+					attribute.Bool("podtrace.threshold.error_rate.breached", true),
+				)
+			}
+		}
 	}
 	return attrs
 }

--- a/internal/agent/sdk_event_exporter_test.go
+++ b/internal/agent/sdk_event_exporter_test.go
@@ -534,6 +534,99 @@ func TestSDKEventExporter_EffectiveSampleRateGauge(t *testing.T) {
 	}
 }
 
+// TestSDKEventExporter_ErrorRateRollingWindowBreach exercises the
+// end-to-end: configure an error_rate threshold, push enough
+// error events to cross the rolling-window threshold, and assert the
+// per-CR error_rate_breached_total counter increments exactly once
+// (edge-triggered) regardless of how many error events follow.
+func TestSDKEventExporter_ErrorRateRollingWindowBreach(t *testing.T) {
+	errPct := int32(10)
+	b := &bundle.Payload{
+		Type:     bundle.TypeOTLP,
+		Endpoint: "x:4318",
+		Insecure: true,
+		Thresholds: &bundle.Thresholds{
+			ErrorRatePercent: &errPct,
+		},
+	}
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+	m := NewMetrics()
+
+	exp, err := newSDKEventExporter("otlp", cr, b, &noopSpanExporter{}, withMetrics(m))
+	if err != nil {
+		t.Fatalf("newSDKEventExporter: %v", err)
+	}
+	defer func() { _ = exp.Close(context.Background()) }()
+
+	batch := make([]*events.Event, 30)
+	for i := range batch {
+		batch[i] = &events.Event{
+			Type:      events.EventTCPSend,
+			Timestamp: uint64(time.Now().UnixNano()),
+			Error:     -5,
+		}
+	}
+	if err := exp.Export(context.Background(), batch); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	got := counterValue(t, m.ErrorRateBreached, prometheus.Labels{
+		"cr_namespace": cr.Namespace,
+		"cr_name":      cr.Name,
+	})
+	if got != 1 {
+		t.Errorf("error_rate_breached_total = %v, want 1 (edge-triggered)", got)
+	}
+
+	// Hammering the same exporter with more error events stays at 1.
+	if err := exp.Export(context.Background(), batch); err != nil {
+		t.Fatalf("Export 2: %v", err)
+	}
+	got = counterValue(t, m.ErrorRateBreached, prometheus.Labels{
+		"cr_namespace": cr.Namespace,
+		"cr_name":      cr.Name,
+	})
+	if got != 1 {
+		t.Errorf("sustained breach should not double-count, got %v", got)
+	}
+}
+
+// TestSDKEventExporter_ErrorRateBelowMinSampleNoBreach guards the
+// startup-noise contract end-to-end: a single error event with an
+// active error_rate policy must not breach.
+func TestSDKEventExporter_ErrorRateBelowMinSampleNoBreach(t *testing.T) {
+	errPct := int32(10)
+	b := &bundle.Payload{
+		Type:     bundle.TypeOTLP,
+		Endpoint: "x:4318",
+		Insecure: true,
+		Thresholds: &bundle.Thresholds{
+			ErrorRatePercent: &errPct,
+		},
+	}
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+	m := NewMetrics()
+
+	exp, err := newSDKEventExporter("otlp", cr, b, &noopSpanExporter{}, withMetrics(m))
+	if err != nil {
+		t.Fatalf("newSDKEventExporter: %v", err)
+	}
+	defer func() { _ = exp.Close(context.Background()) }()
+
+	if err := exp.Export(context.Background(), []*events.Event{
+		{Type: events.EventTCPSend, Error: -5},
+		{Type: events.EventTCPSend, Error: -5},
+	}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if got := counterValue(t, m.ErrorRateBreached, prometheus.Labels{
+		"cr_namespace": cr.Namespace,
+		"cr_name":      cr.Name,
+	}); got != 0 {
+		t.Errorf("expected no breach below min sample, got %v", got)
+	}
+}
+
 // TestSDKEventExporter_NoThresholdsNoMetricChurn ensures the
 // nil-thresholds fast-path doesn't accidentally tag spans or bump
 // counters — important because most CRs won't set thresholds.

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -62,8 +62,52 @@ func attachKprobe(progName, symbol string, prog *ebpf.Program) (link.Link, error
 	return link.Kprobe(symbol, prog, nil)
 }
 
+// AttachProbes attaches every probe whose program is present in the
+// collection and returns a flat slice of the resulting links.
 func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
-	var links []link.Link
+	groups, err := AttachProbesByGroup(coll)
+	if err != nil {
+		return nil, err
+	}
+	return flattenGroupedLinks(groups), nil
+}
+
+// flattenGroupedLinks concatenates a group→links map into a single
+// slice.
+func flattenGroupedLinks(groups map[ProbeGroup][]link.Link) []link.Link {
+	var out []link.Link
+	for _, g := range allProbeGroups() {
+		out = append(out, groups[g]...)
+	}
+	return out
+}
+
+// allProbeGroups returns the canonical ordering of probe groups. New
+// groups added to groups.go must be added here too.
+func allProbeGroups() []ProbeGroup {
+	return []ProbeGroup{
+		GroupNetwork, GroupFileSystem, GroupDatabase, GroupTLS,
+		GroupMemory, GroupCPU, GroupPool, GroupCache,
+		GroupMessaging, GroupFastCGI,
+	}
+}
+
+// AttachProbesByGroup performs the same attach work as AttachProbes but
+// returns the resulting links bucketed by the ProbeGroup each program
+// belongs to.
+func AttachProbesByGroup(coll *ebpf.Collection) (map[ProbeGroup][]link.Link, error) {
+	groups := map[ProbeGroup][]link.Link{}
+	appendLink := func(progName string, l link.Link) {
+		g := GroupForProbe(progName)
+		groups[g] = append(groups[g], l)
+	}
+	closeAll := func() {
+		for _, ls := range groups {
+			for _, l := range ls {
+				_ = l.Close()
+			}
+		}
+	}
 
 	// --- Mandatory kprobes: all must attach or we return an error. ---
 	for progName, symbol := range mandatoryProbes {
@@ -76,9 +120,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 
 		l, err := attachKprobe(progName, symbol, prog)
 		if err != nil {
-			for _, existing := range links {
-				_ = existing.Close()
-			}
+			closeAll()
 			return nil, fmt.Errorf(
 				"%w\n\n"+
 					"Hint: mandatory kprobe %q could not attach to kernel symbol %q.\n"+
@@ -89,7 +131,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 					"  • On OpenShift ensure the pod SCC allows CAP_BPF and CAP_SYS_ADMIN",
 				NewProbeAttachError(progName, err), progName, symbol, symbol, kernelVersionString())
 		}
-		links = append(links, l)
+		appendLink(progName, l)
 		logger.Debug("Mandatory probe attached", zap.String("prog", progName), zap.String("symbol", symbol))
 	}
 
@@ -109,7 +151,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				zap.String("prog", progName), zap.String("symbol", symbol), zap.Error(err))
 			continue
 		}
-		links = append(links, l)
+		appendLink(progName, l)
 		logger.Debug("Optional probe attached", zap.String("prog", progName), zap.String("symbol", symbol))
 	}
 
@@ -125,7 +167,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Info("CPU/scheduling tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_sched_switch", tp)
 		}
 	}
 
@@ -136,7 +178,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Debug("TCP state tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_tcp_set_state", tp)
 		}
 	}
 
@@ -147,7 +189,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Info("TCP retransmission tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_tcp_retransmit_skb", tp)
 		}
 	}
 
@@ -158,7 +200,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Info("Network device error tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_net_dev_xmit", tp)
 		}
 	}
 
@@ -169,7 +211,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Info("Page fault tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_page_fault_user", tp)
 		}
 	}
 
@@ -180,7 +222,7 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Debug("OOM kill tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_oom_kill_process", tp)
 		}
 	}
 
@@ -191,11 +233,11 @@ func AttachProbes(coll *ebpf.Collection) ([]link.Link, error) {
 				logger.Info("Process fork tracking unavailable", zap.Error(err))
 			}
 		} else {
-			links = append(links, tp)
+			appendLink("tracepoint_sched_process_fork", tp)
 		}
 	}
 
-	return links, nil
+	return groups, nil
 }
 
 func AttachDNSProbes(coll *ebpf.Collection, containerID string) []link.Link {

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 
 	"github.com/podtrace/podtrace/internal/config"
 )
@@ -133,6 +134,44 @@ func TestAttachProbes_EmptyCollection(t *testing.T) {
 	}
 	if links != nil {
 		t.Logf("AttachProbes returned %d links", len(links))
+	}
+}
+
+func TestAttachProbesByGroup_EmptyCollectionEmptyMap(t *testing.T) {
+	coll := &ebpf.Collection{Programs: make(map[string]*ebpf.Program)}
+	groups, err := AttachProbesByGroup(coll)
+	if err != nil {
+		t.Fatalf("AttachProbesByGroup: %v", err)
+	}
+	if groups == nil {
+		t.Fatal("groups map must be non-nil even when no programs attached")
+	}
+	if len(groups) != 0 {
+		t.Errorf("expected empty groups map for empty collection, got %v", groups)
+	}
+}
+
+func TestAllProbeGroups_StableOrdering(t *testing.T) {
+	got := allProbeGroups()
+	want := []ProbeGroup{
+		GroupNetwork, GroupFileSystem, GroupDatabase, GroupTLS,
+		GroupMemory, GroupCPU, GroupPool, GroupCache,
+		GroupMessaging, GroupFastCGI,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("allProbeGroups length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("allProbeGroups[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFlattenGroupedLinks_EmptyMap(t *testing.T) {
+	got := flattenGroupedLinks(map[ProbeGroup][]link.Link{})
+	if got != nil {
+		t.Errorf("flatten of empty map = %v, want nil", got)
 	}
 }
 

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -70,6 +70,8 @@ type Tracer struct {
 	links                    []link.Link
 	probeGroupsMu            sync.Mutex
 	probeGroups              map[probes.ProbeGroup][]link.Link
+
+	intentionallyDisabled map[probes.ProbeGroup]struct{}
 	reader                   *ringbuf.Reader
 	filter                   *filter.CgroupFilter
 	containerID              string
@@ -205,10 +207,14 @@ func NewTracer() (*Tracer, error) {
 		}
 	}
 
-	links, err := probes.AttachProbes(coll)
+	probeGroups, err := probes.AttachProbesByGroup(coll)
 	if err != nil {
 		coll.Close()
 		return nil, err
+	}
+	var links []link.Link
+	for _, ls := range probeGroups {
+		links = append(links, ls...)
 	}
 
 	rd, err := ringbuf.NewReader(coll.Maps["events"])
@@ -226,7 +232,8 @@ func NewTracer() (*Tracer, error) {
 	t := &Tracer{
 		collection:               coll,
 		links:                    links,
-		probeGroups:              make(map[probes.ProbeGroup][]link.Link),
+		probeGroups:              probeGroups,
+		intentionallyDisabled:    map[probes.ProbeGroup]struct{}{},
 		reader:                   rd,
 		filter:                   filter.NewCgroupFilter(),
 		processNameCache:         processCache,
@@ -933,6 +940,118 @@ func (t *Tracer) ActiveProbeGroups() []probes.ProbeGroup {
 	return result
 }
 
+// SetEnabledCategories disables probe groups whose CRD-filter categories
+// are absent from `categories`. This is the kernel-side counterpart to
+// the Router's per-event userspace filtering — when no CR on this node
+// asks for a category, the corresponding kprobes can stay un-attached,
+// saving the per-event kernel overhead.
+//
+// Semantics:
+//
+//   - `categories == nil` is a sentinel: "do not gate anything" — the
+//     bootstrap default before the agent has observed any CRs. Calling
+//     with nil is a no-op so a freshly-started agent does not strip the
+//     default attach set out from under in-flight events.
+//   - An empty (non-nil) slice means "no CR needs any category here",
+//     and disables every gateable group.
+//   - Currently this is detach-only: groups newly absent from the
+//     active set are closed; groups newly present in the active set
+//     but previously closed are NOT re-attached. A warning is logged
+//     so operators know to restart the agent to pick up the new
+//     category. Hot re-attach is a separate change because the
+//     attach-while-events-flow race is non-trivial.
+//
+// SetEnabledCategories is safe to call concurrently with event
+// processing — only the probeGroups map is mutated, under its mutex.
+func (t *Tracer) SetEnabledCategories(categories []string) error {
+	if categories == nil {
+		return nil
+	}
+	wanted := make(map[string]struct{}, len(categories))
+	for _, c := range categories {
+		wanted[c] = struct{}{}
+	}
+
+	t.probeGroupsMu.Lock()
+	active := make([]probes.ProbeGroup, 0, len(t.probeGroups))
+	for g := range t.probeGroups {
+		active = append(active, g)
+	}
+	t.probeGroupsMu.Unlock()
+
+	for _, g := range active {
+		if probeGroupNeededBy(g, wanted) {
+			continue
+		}
+		if err := t.DisableProbeGroup(g); err != nil {
+			logger.Warn("SetEnabledCategories: disable failed",
+				zap.String("group", string(g)), zap.Error(err))
+			continue
+		}
+		t.probeGroupsMu.Lock()
+		if t.intentionallyDisabled == nil {
+			t.intentionallyDisabled = map[probes.ProbeGroup]struct{}{}
+		}
+		t.intentionallyDisabled[g] = struct{}{}
+		t.probeGroupsMu.Unlock()
+	}
+
+	for c := range wanted {
+		needs := groupsNeededFor(c)
+		for _, g := range needs {
+			t.probeGroupsMu.Lock()
+			_, disabled := t.intentionallyDisabled[g]
+			t.probeGroupsMu.Unlock()
+			if disabled {
+				logger.Warn("SetEnabledCategories: category needs a group that is currently detached; restart agent to re-attach",
+					zap.String("category", c), zap.String("group", string(g)))
+			}
+		}
+	}
+	return nil
+}
+
+// probeGroupNeededBy reports whether a group should stay attached
+// given the set of categories currently desired by some active CR.
+func probeGroupNeededBy(g probes.ProbeGroup, wanted map[string]struct{}) bool {
+	needs, gated := groupCategoryNeeds[g]
+	if !gated {
+		return true // not gateable by category
+	}
+	for _, c := range needs {
+		if _, ok := wanted[c]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// groupsNeededFor returns the probe groups required to surface a
+// given CRD category.
+func groupsNeededFor(category string) []probes.ProbeGroup {
+	var out []probes.ProbeGroup
+	for g, needs := range groupCategoryNeeds {
+		for _, c := range needs {
+			if c == category {
+				out = append(out, g)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// groupCategoryNeeds maps each probe group to the CRD filter
+// categories that require it.
+var groupCategoryNeeds = map[probes.ProbeGroup][]string{
+	probes.GroupNetwork:    {"net"},
+	probes.GroupFileSystem: {"fs"},
+	probes.GroupCPU:        {"cpu", "proc"},
+	probes.GroupMemory:     {"proc"},
+	probes.GroupFastCGI:    {"net"},
+	probes.GroupTLS: {"dns", "cpu"},
+}
+
 // DisableProbeGroup closes all links associated with the given group.
 func (t *Tracer) DisableProbeGroup(g probes.ProbeGroup) error {
 	t.probeGroupsMu.Lock()
@@ -966,7 +1085,6 @@ func (t *Tracer) serveManagementAPI(ctx context.Context, port int) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"active_groups": strs})
 	})
 	mux.HandleFunc("/probes/", func(w http.ResponseWriter, r *http.Request) {
-		// Expect /probes/{group}/disable
 		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/probes/"), "/")
 		if len(parts) != 2 || r.Method != http.MethodPost {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -986,7 +1104,6 @@ func (t *Tracer) serveManagementAPI(ctx context.Context, port int) {
 		}
 	})
 
-	// Wire profiling endpoints when a controller has been registered.
 	if t.profilingCtrl != nil {
 		mux.HandleFunc("/profile/start", t.profilingCtrl.HTTPStart)
 		mux.HandleFunc("/profile/status", t.profilingCtrl.HTTPStatus)

--- a/internal/ebpf/tracer/tracer_test.go
+++ b/internal/ebpf/tracer/tracer_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/podtrace/podtrace/internal/sysfs"
 )
 
-// useCgroupBase points the cgroup root at dir for the duration of the
-// test. Required because sysfs.CgroupReadFile rejects paths outside
-// config.CgroupBasePath.
 func useCgroupBase(t *testing.T, dir string) {
 	t.Helper()
 	original := config.CgroupBasePath
@@ -54,11 +51,6 @@ func TestTracer_AttachToCgroup(t *testing.T) {
 	}
 }
 
-// TestTracer_AttachToCgroup_IsAdditive locks in the per-cgroup contract
-// used by the agent's engine: calling AttachToCgroup multiple times
-// must accumulate paths, not replace them. The original implementation
-// silently dropped earlier attachments on every new call, breaking
-// continuous-trace event flow once a PodTrace matched more than one pod.
 func TestTracer_AttachToCgroup_IsAdditive(t *testing.T) {
 	tr := &Tracer{filter: filter.NewCgroupFilter()}
 
@@ -82,10 +74,6 @@ func TestTracer_AttachToCgroup_IsAdditive(t *testing.T) {
 	}
 }
 
-// TestTracer_AttachToCgroup_IdempotentOnRepeat asserts that re-calling
-// AttachToCgroup with the same path is a no-op rather than a duplicate
-// entry. The agent's engine relies on this when a workload survives
-// across reconciles.
 func TestTracer_AttachToCgroup_IdempotentOnRepeat(t *testing.T) {
 	tr := &Tracer{filter: filter.NewCgroupFilter()}
 	const p = "/sys/fs/cgroup/dup"
@@ -99,9 +87,6 @@ func TestTracer_AttachToCgroup_IdempotentOnRepeat(t *testing.T) {
 	}
 }
 
-// TestTracer_AttachToCgroups_Replaces preserves the session-Job bulk
-// contract: passing the full set as one call replaces whatever was
-// there before.
 func TestTracer_AttachToCgroups_Replaces(t *testing.T) {
 	tr := &Tracer{filter: filter.NewCgroupFilter()}
 	if err := tr.AttachToCgroup("/sys/fs/cgroup/old"); err != nil {
@@ -1765,7 +1750,6 @@ func TestTracer_Start_PathCacheCleanupGoroutine(t *testing.T) {
 
 
 
-// ─── roundUpPow2 ─────────────────────────────────────────────────────────────
 
 func TestRoundUpPow2_BelowMin(t *testing.T) {
 	for _, n := range []uint32{0, 1, 100, 4095} {
@@ -1803,7 +1787,6 @@ func TestRoundUpPow2_NonPowers(t *testing.T) {
 	}
 }
 
-// ─── isCgroupV2Base ──────────────────────────────────────────────────────────
 
 func TestIsCgroupV2Base_Exists(t *testing.T) {
 	dir := t.TempDir()
@@ -1828,7 +1811,6 @@ func TestIsCgroupV2Base_EmptyPath(t *testing.T) {
 	}
 }
 
-// ─── getCgroupIDFromPath ──────────────────────────────────────────────────────
 
 func TestGetCgroupIDFromPath_ValidPath(t *testing.T) {
 	dir := t.TempDir()
@@ -1848,7 +1830,6 @@ func TestGetCgroupIDFromPath_NonExistent(t *testing.T) {
 	}
 }
 
-// ─── readFirstPIDFromCgroupProcs ─────────────────────────────────────────────
 
 func TestReadFirstPIDFromCgroupProcs_Valid(t *testing.T) {
 	base := t.TempDir()
@@ -1907,11 +1888,9 @@ func TestReadFirstPIDFromCgroupProcs_LeadingBlankLines(t *testing.T) {
 	}
 }
 
-// ─── AttachToCgroup additional paths ─────────────────────────────────────────
 
 func TestAttachToCgroup_EmptyPath(t *testing.T) {
 	tr := &Tracer{filter: filter.NewCgroupFilter()}
-	// Empty path is rejected with "no valid cgroup paths provided" in this codebase.
 	_ = tr.AttachToCgroup("")
 }
 
@@ -1973,14 +1952,12 @@ func TestAttachToCgroup_PreserveExistingPID(t *testing.T) {
 	}
 }
 
-// ─── pollBPFMapUtilization ────────────────────────────────────────────────────
 
 func TestPollBPFMapUtilization_NilCollection(t *testing.T) {
 	tr := &Tracer{collection: nil}
 	tr.pollBPFMapUtilization() // must not panic
 }
 
-// ─── ActiveProbeGroups / DisableProbeGroup ────────────────────────────────────
 
 func TestActiveProbeGroups_Empty(t *testing.T) {
 	tr := &Tracer{probeGroups: make(map[probes.ProbeGroup][]link.Link)}
@@ -2000,6 +1977,105 @@ func TestActiveProbeGroups_WithGroups(t *testing.T) {
 	}
 }
 
+func TestSetEnabledCategories_NilSentinelIsNoop(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{
+		probes.GroupNetwork:    nil,
+		probes.GroupFileSystem: nil,
+	}}
+	if err := tr.SetEnabledCategories(nil); err != nil {
+		t.Fatalf("nil sentinel: %v", err)
+	}
+	if _, ok := tr.probeGroups[probes.GroupNetwork]; !ok {
+		t.Error("nil sentinel must not detach GroupNetwork")
+	}
+	if _, ok := tr.probeGroups[probes.GroupFileSystem]; !ok {
+		t.Error("nil sentinel must not detach GroupFileSystem")
+	}
+}
+
+func TestSetEnabledCategories_DetachesUnneededGroups(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{
+		probes.GroupNetwork:    nil,
+		probes.GroupFileSystem: nil,
+		probes.GroupCPU:        nil,
+	}}
+	if err := tr.SetEnabledCategories([]string{"fs"}); err != nil {
+		t.Fatalf("gate: %v", err)
+	}
+	if _, ok := tr.probeGroups[probes.GroupFileSystem]; !ok {
+		t.Error("GroupFileSystem must stay attached for category=fs")
+	}
+}
+
+func TestSetEnabledCategories_NonGateableGroupsUnaffected(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{
+		probes.GroupDatabase:  nil,
+		probes.GroupCache:     nil,
+		probes.GroupMessaging: nil,
+		probes.GroupPool:      nil,
+	}}
+	if err := tr.SetEnabledCategories([]string{}); err != nil {
+		t.Fatalf("gate: %v", err)
+	}
+	for _, g := range []probes.ProbeGroup{
+		probes.GroupDatabase, probes.GroupCache,
+		probes.GroupMessaging, probes.GroupPool,
+	} {
+		if _, ok := tr.probeGroups[g]; !ok {
+			t.Errorf("non-gateable group %s must not be detached by empty category set", g)
+		}
+	}
+}
+
+func TestSetEnabledCategories_WarnsOnlyForIntentionallyDisabled(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{
+		probes.GroupFileSystem: nil,
+	}}
+	if err := tr.SetEnabledCategories([]string{"dns"}); err != nil {
+		t.Fatalf("gate round 1: %v", err)
+	}
+	if tr.intentionallyDisabled == nil {
+		t.Fatal("intentionallyDisabled must be initialised after a detach")
+	}
+	if _, ok := tr.intentionallyDisabled[probes.GroupFileSystem]; !ok {
+		t.Error("GroupFileSystem should be tracked as intentionally disabled")
+	}
+	if _, ok := tr.intentionallyDisabled[probes.GroupTLS]; ok {
+		t.Error("GroupTLS never attached — must NOT be tracked as intentionally disabled")
+	}
+	if err := tr.SetEnabledCategories([]string{"fs", "dns"}); err != nil {
+		t.Fatalf("gate round 2: %v", err)
+	}
+	if _, ok := tr.intentionallyDisabled[probes.GroupFileSystem]; !ok {
+		t.Error("FS must stay in intentionallyDisabled until agent restart")
+	}
+	if _, ok := tr.intentionallyDisabled[probes.GroupTLS]; ok {
+		t.Error("GroupTLS still must not be in intentionallyDisabled")
+	}
+}
+
+func TestGroupCategoryNeeds_CoversEveryCategory(t *testing.T) {
+	covered := map[string]bool{}
+	for _, needs := range groupCategoryNeeds {
+		for _, c := range needs {
+			covered[c] = true
+		}
+	}
+	for _, c := range []string{"dns", "net", "fs", "cpu", "proc"} {
+		if !covered[c] {
+			t.Errorf("CRD category %q has no probe group in groupCategoryNeeds", c)
+		}
+	}
+}
+
+func TestGroupsNeededFor_RoundTrip(t *testing.T) {
+	for _, c := range []string{"dns", "net", "fs", "cpu", "proc"} {
+		if got := groupsNeededFor(c); len(got) == 0 {
+			t.Errorf("groupsNeededFor(%q) returned nothing — category cannot be re-attached", c)
+		}
+	}
+}
+
 func TestDisableProbeGroup_NotPresent(t *testing.T) {
 	tr := &Tracer{probeGroups: make(map[probes.ProbeGroup][]link.Link)}
 	if err := tr.DisableProbeGroup(probes.GroupNetwork); err != nil {
@@ -2009,18 +2085,15 @@ func TestDisableProbeGroup_NotPresent(t *testing.T) {
 
 func TestDisableProbeGroup_EmptyLinks(t *testing.T) {
 	tr := &Tracer{probeGroups: make(map[probes.ProbeGroup][]link.Link)}
-	// nil slice → len == 0 → DisableProbeGroup returns early without deleting.
 	tr.probeGroups[probes.GroupDatabase] = nil
 	if err := tr.DisableProbeGroup(probes.GroupDatabase); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	// Group is still present because len(links)==0 causes early return.
 	if _, ok := tr.probeGroups[probes.GroupDatabase]; !ok {
 		t.Error("expected group to still be present when links slice is nil")
 	}
 }
 
-// ─── serveManagementAPI via fake mux ─────────────────────────────────────────
 
 func TestServeManagementAPI_GetProbes(t *testing.T) {
 	tr := &Tracer{probeGroups: make(map[probes.ProbeGroup][]link.Link)}
@@ -2145,19 +2218,16 @@ func TestServeManagementAPI_BadPathMethod(t *testing.T) {
 	}
 }
 
-// ─── serveManagementAPI real HTTP server (coverage for the actual function) ──
 
 func TestServeManagementAPI_RealServer_ContextCancel(t *testing.T) {
 	tr := &Tracer{probeGroups: make(map[probes.ProbeGroup][]link.Link)}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled — server should exit quickly
+	cancel()
 
-	// port=0 causes bind to fail → ListenAndServe returns immediately
 	tr.serveManagementAPI(ctx, 0)
 }
 
-// ─── Stop with processNameCache and pathCache ─────────────────────────────────
 
 func TestStop_WithCaches(t *testing.T) {
 	tr := &Tracer{
@@ -2173,19 +2243,14 @@ func TestStop_WithCaches(t *testing.T) {
 	}
 }
 
-// ─── getProcessNameQuick — cache miss with non-existent PID ──────────────────
 
 func TestGetProcessNameQuick_NonExistentPID(t *testing.T) {
 	tr := &Tracer{processNameCache: cache.NewLRUCache(16, time.Minute)}
-	// PID 55555 almost certainly doesn't exist on the test host.
 	result := tr.getProcessNameQuick(55555)
-	_ = result // just ensure no panic
+	_ = result
 }
 
-// ─── serveManagementAPI real integration test ─────────────────────────────────
 
-// TestServeManagementAPI_Integration starts the actual serveManagementAPI on a
-// free port and exercises the /probes and /probes/{group}/disable endpoints.
 func TestServeManagementAPI_Integration(t *testing.T) {
 	// Find a free port by opening a listener and closing it.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -2205,7 +2270,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		tr.serveManagementAPI(ctx, port)
 	}()
 
-	// Wait up to 500ms for the server to be ready.
 	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
 	var ready bool
 	for i := 0; i < 50; i++ {
@@ -2223,7 +2287,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		t.Skip("management API server not ready in time")
 	}
 
-	// GET /probes → 200 with active_groups.
 	resp, err := http.Get(addr + "/probes")
 	if err != nil {
 		t.Fatalf("GET /probes: %v", err)
@@ -2234,7 +2297,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		t.Errorf("GET /probes: expected 200, got %d: %s", resp.StatusCode, body)
 	}
 
-	// POST /probes → 405 method not allowed.
 	resp2, err := http.Post(addr+"/probes", "application/json", nil)
 	if err != nil {
 		t.Fatalf("POST /probes: %v", err)
@@ -2244,7 +2306,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		t.Errorf("POST /probes: expected 405, got %d", resp2.StatusCode)
 	}
 
-	// POST /probes/network/disable → 204 (group present but no links).
 	resp3, err := http.Post(addr+"/probes/network/disable", "application/json", nil)
 	if err != nil {
 		t.Fatalf("POST /probes/network/disable: %v", err)
@@ -2254,7 +2315,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		t.Errorf("POST /probes/network/disable: expected 204, got %d", resp3.StatusCode)
 	}
 
-	// POST /probes/network/enable → 400 unknown action.
 	resp4, err := http.Post(addr+"/probes/network/enable", "application/json", nil)
 	if err != nil {
 		t.Fatalf("POST /probes/network/enable: %v", err)
@@ -2264,7 +2324,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 		t.Errorf("POST /probes/network/enable: expected 400, got %d", resp4.StatusCode)
 	}
 
-	// GET /probes/network/disable → 404 (GET not POST).
 	resp5, err := http.Get(addr + "/probes/network/disable")
 	if err != nil {
 		t.Fatalf("GET /probes/network/disable: %v", err)
@@ -2282,7 +2341,6 @@ func TestServeManagementAPI_Integration(t *testing.T) {
 	}
 }
 
-// ─── misc format helpers ───────────────────────────────────────────────────────
 
 // Verify that the fmt import is used so the file compiles without "imported and not used".
 var _ = fmt.Sprintf

--- a/pkg/tracer/types.go
+++ b/pkg/tracer/types.go
@@ -71,3 +71,10 @@ type EngineObserver interface {
 	OnCgroupsAttached(n int)
 	OnCgroupsDetached(n int)
 }
+
+// CategoryGateable is an optional capability a TracerBackend can
+// implement to support kernel-side gating of probe groups by CRD
+// filter category.
+type CategoryGateable interface {
+	SetEnabledCategories(categories []string) error
+}


### PR DESCRIPTION
- **error-rate detector** — rolling-window per-CR detector that fires an edge signal on "below to above threshold"  transitions. Surfaces a new `podtrace_agent_error_rate_breached_total` counter and a `podtrace.threshold.error_rate.breached=true` span attribute on the edge event. Phase A (per-event `observed` tag) keeps working unchanged.
- **Selective probe attach** — kernel-side counterpart to the Router's per-event userspace filter. When the union of `spec.filters` across active CRs on a node is a strict subset of the known categories, the Tracer detaches the probe groups it doesn't need (`filesystem`, `cpu`, etc.), saving per-event kernel overhead.
- **Stale doc cleanup** — `crd-podtrace.md`, `migration.md`, `operator.md` no longer claim continuous PodTrace events are stubbed in NoopBackend; the agent has driven the real eBPF backend by default.
