### PR TITLE
feat: surface objectStore upload reason, attempts, and retry logs

### DIFF
--- a/api/v1alpha1/podtracesession_types.go
+++ b/api/v1alpha1/podtracesession_types.go
@@ -9,6 +9,22 @@ import (
 // +kubebuilder:validation:Enum=Pending;Running;Completed;Failed
 type SessionState string
 
+// ReportFailureReason is the stable enum the operator stamps onto
+// status.reportFailureReason when an objectStore sidecar terminates
+// non-zero. Operators consume this for alerting and runbooks; the
+// free-text cause stays in conditions[type=ReportUploaded].message.
+// +kubebuilder:validation:Enum=InvalidURI;CredentialMissing;BucketNotFound;AccessDenied;NetworkTimeout;Unknown
+type ReportFailureReason string
+
+var (
+	ReportFailureReasonInvalidURI        = ReportFailureReason("InvalidURI")
+	ReportFailureReasonCredentialMissing = ReportFailureReason("CredentialMissing")
+	ReportFailureReasonBucketNotFound    = ReportFailureReason("BucketNotFound")
+	ReportFailureReasonAccessDenied      = ReportFailureReason("AccessDenied")
+	ReportFailureReasonNetworkTimeout    = ReportFailureReason("NetworkTimeout")
+	ReportFailureReasonUnknown           = ReportFailureReason("Unknown")
+)
+
 const (
 	SessionStatePending   SessionState = "Pending"
 	SessionStateRunning   SessionState = "Running"
@@ -19,55 +35,38 @@ const (
 // PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
 // reconciles this into one privileged Job per node hosting matched pods.
 type PodTraceSessionSpec struct {
-	// Selector picks target pods by label. Mutually exclusive with PodRefs.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
-	// PodRefs explicitly enumerates target pods.
 	// +optional
 	PodRefs []PodRef `json:"podRefs,omitempty"`
 
-	// NamespaceSelector scopes the Selector across namespaces. When unset
-	// the selector is evaluated within the session's own namespace only.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 
-	// ContainerName restricts tracing to a specific container.
 	// +optional
 	ContainerName string `json:"containerName,omitempty"`
 
-	// Duration is the total wall-clock time the session should run. Required.
-	// Format: Go duration, e.g. "30s", "5m". Maximum is enforced by the
-	// operator against TracerConfig.spec.session.maxDuration.
 	// +kubebuilder:validation:Required
 	Duration metav1.Duration `json:"duration"`
 
-	// Filters restricts the event categories captured. When empty, all are captured.
 	// +optional
 	Filters []EventFilter `json:"filters,omitempty"`
 
-	// ExporterRef names an ExporterConfig in the same namespace. Required.
 	// +kubebuilder:validation:Required
 	ExporterRef LocalObjectReference `json:"exporterRef"`
 
-	// Thresholds override the session's default anomaly-detection settings.
 	// +optional
 	Thresholds *Thresholds `json:"thresholds,omitempty"`
 
-	// SamplePercent sets the sampling rate for exported traces, 0-100.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
 	// +optional
 	SamplePercent *int32 `json:"samplePercent,omitempty"`
 
-	// ReportRef points at where the diagnose report summary should be persisted.
-	// If unset, only the exporter receives events and the session status
-	// retains a small inline summary.
 	// +optional
 	ReportRef *ReportReference `json:"reportRef,omitempty"`
 
-	// TTLSecondsAfterFinished cleans up the session resource after completion.
-	// If unset, the operator default applies.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
@@ -75,36 +74,28 @@ type PodTraceSessionSpec struct {
 
 // SessionJobRef describes a child Job created by the session reconciler.
 type SessionJobRef struct {
-	// Node the Job is pinned to. Unique within the array.
 	// +kubebuilder:validation:Required
 	Node string `json:"node"`
 
-	// Name of the Job resource.
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// Completed indicates whether the Job has finished (success or failure).
 	Completed bool `json:"completed"`
 
-	// EventCount is the number of events this Job's tracer reported.
 	// +optional
 	EventCount int64 `json:"eventCount,omitempty"`
 
-	// StartTime of the Job's pod.
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
-	// CompletionTime of the Job's pod, if finished.
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
-	// Message carries Job-level error text when Completed is true and the Job failed.
 	// +optional
 	Message string `json:"message,omitempty"`
 }
 
 // SessionSummary is a compact roll-up of what the session observed.
-// The full report is written to ReportRef, if set.
 type SessionSummary struct {
 	TotalEvents    int64 `json:"totalEvents"`
 	DNSEvents      int64 `json:"dnsEvents,omitempty"`
@@ -117,19 +108,15 @@ type SessionSummary struct {
 
 // PodTraceSessionStatus reflects the observed state of a PodTraceSession.
 type PodTraceSessionStatus struct {
-	// State is the high-level lifecycle state of the session.
 	// +optional
 	State SessionState `json:"state,omitempty"`
 
-	// StartTime is set when the first child Job enters Running.
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 
-	// CompletionTime is set when all child Jobs have finished.
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
-	// Jobs lists the per-node Job children managed by this session.
 	// +optional
 	// +patchMergeKey=node
 	// +patchStrategy=merge
@@ -137,22 +124,20 @@ type PodTraceSessionStatus struct {
 	// +listMapKey=node
 	Jobs []SessionJobRef `json:"jobs,omitempty" patchStrategy:"merge" patchMergeKey:"node"`
 
-	// Summary is a compact per-category event roll-up for this session.
 	// +optional
 	Summary *SessionSummary `json:"summary,omitempty"`
 
-	// TargetNamespaces is the sorted list of namespace names the operator
-	// resolved spec.namespaceSelector.
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
 
-	// ReportLocation is the resolved object URI of the uploaded session
-	// report when spec.reportRef.objectStore is set and the sidecar
-	// uploader has succeeded. Empty for ConfigMap/Secret sinks (the
-	// report lives at .spec.reportRef itself) and before upload completes.
 	// +optional
 	ReportLocation string `json:"reportLocation,omitempty"`
 
-	// Conditions is the latest available observations of session state.
+	// +optional
+	ReportFailureReason ReportFailureReason `json:"reportFailureReason,omitempty"`
+
+	// +optional
+	ReportAttempts int32 `json:"reportAttempts,omitempty"`
+
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -160,7 +145,6 @@ type PodTraceSessionStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ObservedGeneration is the most recent generation observed for this session.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// +optional

--- a/cmd/podtrace/report_uploader.go
+++ b/cmd/podtrace/report_uploader.go
@@ -24,6 +24,8 @@ const reportLocationFile = "/var/run/podtrace/report-location.txt"
 
 const terminationLogPath = "/dev/termination-log"
 
+var keyHintStateFile = "/var/run/podtrace/upload-key-hint.txt"
+
 func newReportUploaderCmd() *cobra.Command {
 	var (
 		reportFile     string
@@ -201,13 +203,46 @@ func loadObjectStoreCredentials() (map[string][]byte, error) {
 	return out, nil
 }
 
+// buildObjectKeyHint returns a stable per-session object-key suffix.
 func buildObjectKeyHint() string {
+	if existing, ok := readPersistedKeyHint(); ok {
+		return existing
+	}
+	hint := freshObjectKeyHint(time.Now)
+	persistKeyHint(hint)
+	return hint
+}
+
+func freshObjectKeyHint(nowFn func() time.Time) string {
 	pod := os.Getenv("HOSTNAME")
 	if pod == "" {
 		pod = "session"
 	}
-	stamp := time.Now().UTC().Format("2006-01-02T15-04-05Z")
+	stamp := nowFn().UTC().Format("2006-01-02T15-04-05Z")
 	return fmt.Sprintf("%s-%s.txt", pod, stamp)
+}
+
+// readPersistedKeyHint loads a previously-stored key suffix from the
+// state file in the shared volume.
+func readPersistedKeyHint() (string, bool) {
+	raw, err := hostfs.ReadFile(keyHintStateFile)
+	if err != nil {
+		return "", false
+	}
+	hint := strings.TrimSpace(string(raw))
+	if hint == "" {
+		return "", false
+	}
+	return hint, true
+}
+
+// persistKeyHint writes the key suffix to the state file. Failures
+// are logged but non-fatal: a sidecar that cannot persist the hint
+// will simply pick a fresh one on restart (duplicate object).
+func persistKeyHint(hint string) {
+	if err := hostfs.WriteFile(keyHintStateFile, []byte(hint), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: persist key hint: %v\n", err)
+	}
 }
 
 func writeResolvedLocation(uri string) error {

--- a/cmd/podtrace/report_uploader_test.go
+++ b/cmd/podtrace/report_uploader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -34,6 +35,79 @@ func TestWaitForFile_ContextCancelled(t *testing.T) {
 	}
 }
 
+func TestBuildObjectKeyHint_PersistsAcrossRestarts(t *testing.T) {
+	dir := t.TempDir()
+	origPath := keyHintStateFile
+	keyHintStateFile = filepath.Join(dir, "key-hint.txt")
+	t.Cleanup(func() { keyHintStateFile = origPath })
+
+	t.Setenv("HOSTNAME", "session-pod-abc")
+
+	first := buildObjectKeyHint()
+	if first == "" {
+		t.Fatal("first call returned empty hint")
+	}
+	if _, err := os.Stat(keyHintStateFile); err != nil {
+		t.Fatalf("state file not persisted: %v", err)
+	}
+
+	second := buildObjectKeyHint()
+	if second != first {
+		t.Errorf("hint changed across restarts: %q -> %q", first, second)
+	}
+
+	if third := buildObjectKeyHint(); third != first {
+		t.Errorf("hint changed on third call: %q -> %q", first, third)
+	}
+}
+
+func TestBuildObjectKeyHint_FreshSuffixFormat(t *testing.T) {
+	t.Setenv("HOSTNAME", "pod-xyz")
+	fixed := time.Date(2026, 5, 13, 12, 34, 56, 0, time.UTC)
+	got := freshObjectKeyHint(func() time.Time { return fixed })
+	want := "pod-xyz-2026-05-13T12-34-56Z.txt"
+	if got != want {
+		t.Errorf("freshObjectKeyHint = %q, want %q", got, want)
+	}
+}
+
+func TestBuildObjectKeyHint_EmptyHostname(t *testing.T) {
+	t.Setenv("HOSTNAME", "")
+	got := freshObjectKeyHint(func() time.Time { return time.Unix(0, 0).UTC() })
+	if !strings.HasPrefix(got, "session-") {
+		t.Errorf("missing HOSTNAME fallback, got %q", got)
+	}
+}
+
+func TestReadPersistedKeyHint_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	origPath := keyHintStateFile
+	keyHintStateFile = filepath.Join(dir, "key-hint.txt")
+	t.Cleanup(func() { keyHintStateFile = origPath })
+
+	if err := os.WriteFile(keyHintStateFile, []byte("  pod-1-2026-01-01T00-00-00Z.txt\n"), 0o644); err != nil {
+		t.Fatalf("seed state file: %v", err)
+	}
+	got, ok := readPersistedKeyHint()
+	if !ok || got != "pod-1-2026-01-01T00-00-00Z.txt" {
+		t.Errorf("readPersistedKeyHint = %q, ok=%v", got, ok)
+	}
+}
+
+func TestReadPersistedKeyHint_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	origPath := keyHintStateFile
+	keyHintStateFile = filepath.Join(dir, "key-hint.txt")
+	t.Cleanup(func() { keyHintStateFile = origPath })
+
+	if err := os.WriteFile(keyHintStateFile, []byte{}, 0o644); err != nil {
+		t.Fatalf("seed empty file: %v", err)
+	}
+	if _, ok := readPersistedKeyHint(); ok {
+		t.Error("empty state file should be treated as absent, but readPersistedKeyHint returned ok=true")
+	}
+}
+
 func TestUploadIfPresent_MissingFileIsNoop(t *testing.T) {
 	opts := reportUploaderOptions{
 		ReportFile:   "/no/such/path",
@@ -42,9 +116,6 @@ func TestUploadIfPresent_MissingFileIsNoop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// Missing report file must not attempt an upload (no Kubernetes
-	// client is available in unit tests); a nil return is the
-	// contract.
 	if err := uploadIfPresent(ctx, opts); err != nil {
 		t.Fatalf("missing file should be no-op, got: %v", err)
 	}
@@ -60,8 +131,6 @@ func TestRunReportUploader_TimeoutThenNoop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// With the wait timeout expiring first, uploadIfPresent is called
-	// with a missing file, which is a no-op. No error surfaces.
 	if err := runReportUploader(ctx, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
@@ -118,18 +118,12 @@ spec:
                       reconciles this into one privileged Job per node hosting matched pods.
                     properties:
                       containerName:
-                        description: ContainerName restricts tracing to a specific
-                          container.
                         type: string
                       duration:
-                        description: |-
-                          Duration is the total wall-clock time the session should run. Required.
-                          Format: Go duration, e.g. "30s", "5m". Maximum is enforced by the
-                          operator against TracerConfig.spec.session.maxDuration.
                         type: string
                       exporterRef:
-                        description: ExporterRef names an ExporterConfig in the same
-                          namespace. Required.
+                        description: LocalObjectReference references an object in
+                          the same namespace as the referent.
                         properties:
                           name:
                             type: string
@@ -137,8 +131,6 @@ spec:
                         - name
                         type: object
                       filters:
-                        description: Filters restricts the event categories captured.
-                          When empty, all are captured.
                         items:
                           description: EventFilter enumerates the event categories
                             podtrace can capture.
@@ -152,8 +144,9 @@ spec:
                         type: array
                       namespaceSelector:
                         description: |-
-                          NamespaceSelector scopes the Selector across namespaces. When unset
-                          the selector is evaluated within the session's own namespace only.
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -199,7 +192,6 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       podRefs:
-                        description: PodRefs explicitly enumerates target pods.
                         items:
                           description: PodRef references a specific pod by namespace/name.
                           properties:
@@ -217,9 +209,8 @@ spec:
                         type: array
                       reportRef:
                         description: |-
-                          ReportRef points at where the diagnose report summary should be persisted.
-                          If unset, only the exporter receives events and the session status
-                          retains a small inline summary.
+                          ReportReference describes where a session's diagnose report is persisted.
+                          Exactly one sink should be set.
                         properties:
                           configMap:
                             description: |-
@@ -295,15 +286,15 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       samplePercent:
-                        description: SamplePercent sets the sampling rate for exported
-                          traces, 0-100.
                         format: int32
                         maximum: 100
                         minimum: 0
                         type: integer
                       selector:
-                        description: Selector picks target pods by label. Mutually
-                          exclusive with PodRefs.
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -349,8 +340,8 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       thresholds:
-                        description: Thresholds override the session's default anomaly-detection
-                          settings.
+                        description: Thresholds control anomaly detection on the agent
+                          side.
                         properties:
                           errorRatePercent:
                             description: |-
@@ -376,9 +367,6 @@ spec:
                             type: integer
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          TTLSecondsAfterFinished cleans up the session resource after completion.
-                          If unset, the operator default applies.
                         format: int32
                         minimum: 0
                         type: integer

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -67,17 +67,12 @@ spec:
               reconciles this into one privileged Job per node hosting matched pods.
             properties:
               containerName:
-                description: ContainerName restricts tracing to a specific container.
                 type: string
               duration:
-                description: |-
-                  Duration is the total wall-clock time the session should run. Required.
-                  Format: Go duration, e.g. "30s", "5m". Maximum is enforced by the
-                  operator against TracerConfig.spec.session.maxDuration.
                 type: string
               exporterRef:
-                description: ExporterRef names an ExporterConfig in the same namespace.
-                  Required.
+                description: LocalObjectReference references an object in the same
+                  namespace as the referent.
                 properties:
                   name:
                     type: string
@@ -85,8 +80,6 @@ spec:
                 - name
                 type: object
               filters:
-                description: Filters restricts the event categories captured. When
-                  empty, all are captured.
                 items:
                   description: EventFilter enumerates the event categories podtrace
                     can capture.
@@ -100,8 +93,9 @@ spec:
                 type: array
               namespaceSelector:
                 description: |-
-                  NamespaceSelector scopes the Selector across namespaces. When unset
-                  the selector is evaluated within the session's own namespace only.
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -147,7 +141,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               podRefs:
-                description: PodRefs explicitly enumerates target pods.
                 items:
                   description: PodRef references a specific pod by namespace/name.
                   properties:
@@ -165,9 +158,8 @@ spec:
                 type: array
               reportRef:
                 description: |-
-                  ReportRef points at where the diagnose report summary should be persisted.
-                  If unset, only the exporter receives events and the session status
-                  retains a small inline summary.
+                  ReportReference describes where a session's diagnose report is persisted.
+                  Exactly one sink should be set.
                 properties:
                   configMap:
                     description: |-
@@ -243,15 +235,15 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               samplePercent:
-                description: SamplePercent sets the sampling rate for exported traces,
-                  0-100.
                 format: int32
                 maximum: 100
                 minimum: 0
                 type: integer
               selector:
-                description: Selector picks target pods by label. Mutually exclusive
-                  with PodRefs.
+                description: |-
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -297,8 +289,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               thresholds:
-                description: Thresholds override the session's default anomaly-detection
-                  settings.
+                description: Thresholds control anomaly detection on the agent side.
                 properties:
                   errorRatePercent:
                     description: |-
@@ -324,9 +315,6 @@ spec:
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: |-
-                  TTLSecondsAfterFinished cleans up the session resource after completion.
-                  If unset, the operator default applies.
                 format: int32
                 minimum: 0
                 type: integer
@@ -338,12 +326,9 @@ spec:
             description: PodTraceSessionStatus reflects the observed state of a PodTraceSession.
             properties:
               completionTime:
-                description: CompletionTime is set when all child Jobs have finished.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is the latest available observations of session
-                  state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -403,37 +388,25 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               jobs:
-                description: Jobs lists the per-node Job children managed by this
-                  session.
                 items:
                   description: SessionJobRef describes a child Job created by the
                     session reconciler.
                   properties:
                     completed:
-                      description: Completed indicates whether the Job has finished
-                        (success or failure).
                       type: boolean
                     completionTime:
-                      description: CompletionTime of the Job's pod, if finished.
                       format: date-time
                       type: string
                     eventCount:
-                      description: EventCount is the number of events this Job's tracer
-                        reported.
                       format: int64
                       type: integer
                     message:
-                      description: Message carries Job-level error text when Completed
-                        is true and the Job failed.
                       type: string
                     name:
-                      description: Name of the Job resource.
                       type: string
                     node:
-                      description: Node the Job is pinned to. Unique within the array.
                       type: string
                     startTime:
-                      description: StartTime of the Job's pod.
                       format: date-time
                       type: string
                   required:
@@ -446,8 +419,6 @@ spec:
                 - node
                 x-kubernetes-list-type: map
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  for this session.
                 format: int64
                 type: integer
               policy:
@@ -503,19 +474,32 @@ spec:
                         type: integer
                     type: object
                 type: object
-              reportLocation:
+              reportAttempts:
+                format: int32
+                type: integer
+              reportFailureReason:
                 description: |-
-                  ReportLocation is the resolved object URI of the uploaded session
-                  report when spec.reportRef.objectStore is set and the sidecar
-                  uploader has succeeded. Empty for ConfigMap/Secret sinks (the
-                  report lives at .spec.reportRef itself) and before upload completes.
+                  ReportFailureReason is the stable enum the operator stamps onto
+                  status.reportFailureReason when an objectStore sidecar terminates
+                  non-zero. Operators consume this for alerting and runbooks; the
+                  free-text cause stays in conditions[type=ReportUploaded].message.
+                enum:
+                - InvalidURI
+                - CredentialMissing
+                - BucketNotFound
+                - AccessDenied
+                - NetworkTimeout
+                - Unknown
+                type: string
+              reportLocation:
                 type: string
               startTime:
-                description: StartTime is set when the first child Job enters Running.
                 format: date-time
                 type: string
               state:
-                description: State is the high-level lifecycle state of the session.
+                description: |-
+                  SessionState represents the high-level lifecycle state of a
+                  PodTraceSession.
                 enum:
                 - Pending
                 - Running
@@ -523,8 +507,8 @@ spec:
                 - Failed
                 type: string
               summary:
-                description: Summary is a compact per-category event roll-up for this
-                  session.
+                description: SessionSummary is a compact roll-up of what the session
+                  observed.
                 properties:
                   cpuEvents:
                     format: int64
@@ -551,9 +535,6 @@ spec:
                 - totalEvents
                 type: object
               targetNamespaces:
-                description: |-
-                  TargetNamespaces is the sorted list of namespace names the operator
-                  resolved spec.namespaceSelector.
                 items:
                   type: string
                 type: array

--- a/docs/crd-podtracesession.md
+++ b/docs/crd-podtracesession.md
@@ -71,9 +71,9 @@ end of diagnose. Mutually exclusive with itself — exactly one of:
 
 | Field | What it produces |
 |---|---|
-| `configMap.name` | A ConfigMap in the session's namespace with `data["report.txt"]` populated. The CLI patches it via a per-session Role + RoleBinding scoped to that exact name. |
-| `secret.name` | A Secret in the session's namespace with `data["report.txt"]`. Use this when the report may carry sensitive data (private hostnames, paths, payloads). |
-| `objectStore` | **Reserved.** Schema accepts S3/GCS/Azure URIs ahead of upload-path delivery; webhook rejects these today. |
+| `configMap.name` | A ConfigMap in the session's namespace with `data["report.txt"]` populated. The CLI patches it via a per-session Role + RoleBinding scoped to that exact name. Capped at the etcd ConfigMap limit (~1MiB). |
+| `secret.name` | A Secret in the session's namespace with `data["report.txt"]`. Use this when the report may carry sensitive data (private hostnames, paths, payloads). Same size cap as ConfigMap. |
+| `objectStore` | Uploads to an S3-, GCS-, or Azure-Blob–compatible bucket via a [native sidecar](object-store-reports.md). The only sink that escapes the etcd object-size limit. Requires `TracerConfig.spec.session.sidecarUploader=true` and either ambient cloud credentials (IRSA / Workload Identity / Managed Identity) or an explicit `credentialsSecretRef`. |
 
 When `reportRef` is unset, only the exporter receives event spans and
 the session status keeps the small inline summary.
@@ -186,8 +186,9 @@ exfiltrate any sink other than its own.
   the upstream `ExporterConfig` does not retroactively change a
   Completed session's bundle.
 - **Webhook validation.** A webhook rejects `duration <= 0`, missing
-  `exporterRef`, both selector AND podRefs set, or
-  `reportRef.objectStore` set.
+  `exporterRef`, both selector AND podRefs set, or a malformed
+  `reportRef.objectStore.uri`. Well-formed objectStore URIs are
+  accepted — see [Object-store report sinks](object-store-reports.md).
 - **Webhook needs the operator running.** Sessions cannot be applied
   while the operator is down (webhook callout fails).
 - **Sample workloads.** A `pause:3.9` pod produces no events. Use

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -145,19 +145,12 @@ Both templates are gated on `monitoring.coreos.com/v1` being installed —
 flipping the toggle on a cluster without prometheus-operator is a silent
 no-op rather than a hard install failure.
 
-## Current limits (where we are vs the long-term shape)
-
-One limit to be honest about:
-
-- **`spec.reportRef.objectStore` is reserved.** The CRD schema accepts an
-  `objectStore` sink field (S3/GCS/Azure) so clients can adopt it ahead
-  of the upload path going live. The validating webhook rejects sessions
-  that set it today — Phase 7+ work.
-
 Both [PodTrace](crd-podtrace.md) (continuous) and
 [PodTraceSession](crd-podtracesession.md) (bounded) drive the real eBPF
 backend by default, with events surfacing as OpenTelemetry spans on the
-configured exporter.
+configured exporter. Session reports can also be uploaded directly to
+S3-, GCS-, or Azure-Blob–compatible object stores — see
+[Object-store report sinks](object-store-reports.md).
 
 ## Going further
 

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -62,6 +62,7 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err := cleanupPodTraceSessionChildren(ctx, r.Client, &session, r.SystemNamespace); err != nil {
 			return ctrl.Result{}, err
 		}
+		forgetReportObservations(session.Namespace, session.Name)
 		if removeFinalizer(&session) {
 			if err := r.Update(ctx, &session); err != nil {
 				if apierrors.IsConflict(err) {
@@ -195,10 +196,11 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		fmt.Sprintf("%d Job(s) on %d node(s)", len(jobs), len(targetNodes)))
 	r.setCondition(&session, ConditionDegraded, metav1.ConditionFalse, "Reconciled", "")
 
-	if uri, terminated, ok, err := harvestReportLocation(ctx, r.Client, &session, systemNS); err != nil {
+	if obs, err := harvestReportLocation(ctx, r.Client, &session, systemNS); err != nil {
 		logger.Error(err, "harvest report location")
 	} else {
-		applyReportUploadStatus(&session, uri, terminated, ok)
+		applyReportUploadStatus(&session, obs)
+		observeReportUploadMetrics(&session, obs)
 	}
 
 	if err := r.Status().Update(ctx, &session); err != nil {

--- a/internal/operator/podtracesession_metrics.go
+++ b/internal/operator/podtracesession_metrics.go
@@ -1,0 +1,130 @@
+package operator
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/internal/reportsink/objectstore"
+)
+
+// Session-objectStore Prometheus surface.
+var (
+	reportUploadAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "podtrace_operator",
+		Name:      "session_report_upload_attempts_total",
+		Help: "Terminal outcomes of the objectStore uploader sidecar. " +
+			"backend ∈ {s3,gs,azblob}, result ∈ {success,failure}, " +
+			"reason ∈ ReportFailureReason enum (empty when result=success). " +
+			"Compare rate(result=failure) vs rate(result=success) for an SLO; " +
+			"sum by (reason) to find the dominant failure mode.",
+	}, []string{"backend", "result", "reason"})
+
+	reportUploadDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "podtrace_operator",
+		Name:      "session_report_upload_duration_seconds",
+		Help: "Time from session start to terminal objectStore sidecar outcome. " +
+			"Buckets sized for typical small reports (under 100KB) with headroom " +
+			"for occasional slow tails. Use histogram_quantile(0.95, …) to track " +
+			"the long tail.",
+		Buckets: []float64{0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300, 600},
+	}, []string{"backend", "result"})
+
+	observed   = struct {
+		sync.Mutex
+		seen map[reportObservationKey]struct{}
+	}{seen: map[reportObservationKey]struct{}{}}
+)
+
+type reportObservationKey struct {
+	Namespace string
+	Name      string
+	Attempts  int32
+	Succeeded bool
+}
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(reportUploadAttempts, reportUploadDuration)
+}
+
+// observeReportUploadMetrics records one Prometheus observation per
+// terminal sidecar outcome. Safe to call on every reconcile: it
+// deduplicates against (namespace/name/attempts/succeeded) so repeated
+// calls for the same outcome only count once.
+func observeReportUploadMetrics(s *podtracev1alpha1.PodTraceSession, obs reportUploadObservation) {
+	if s == nil || s.Spec.ReportRef == nil || s.Spec.ReportRef.ObjectStore == nil {
+		return
+	}
+	if !obs.Terminated {
+		return
+	}
+	key := reportObservationKey{
+		Namespace: s.Namespace,
+		Name:      s.Name,
+		Attempts:  obs.Attempts,
+		Succeeded: obs.Succeeded,
+	}
+	observed.Lock()
+	if _, alreadyCounted := observed.seen[key]; alreadyCounted {
+		observed.Unlock()
+		return
+	}
+	observed.seen[key] = struct{}{}
+	observed.Unlock()
+
+	backend := backendFromURI(s.Spec.ReportRef.ObjectStore.URI)
+	result := "success"
+	reason := ""
+	if !obs.Succeeded {
+		result = "failure"
+		reason = string(classifyUploadFailure(obs.ResolvedURI))
+	}
+	reportUploadAttempts.WithLabelValues(backend, result, reason).Inc()
+
+	if duration := uploadDurationSeconds(s); duration > 0 {
+		reportUploadDuration.WithLabelValues(backend, result).Observe(duration)
+	}
+}
+
+// forgetReportObservations clears the dedup-set for a session when
+// the operator garbage-collects it. Bounded-memory hygiene so a
+// long-running operator does not retain entries for thousands of
+// completed sessions forever.
+func forgetReportObservations(namespace, name string) {
+	observed.Lock()
+	defer observed.Unlock()
+	for k := range observed.seen {
+		if k.Namespace == namespace && k.Name == name {
+			delete(observed.seen, k)
+		}
+	}
+}
+
+// backendFromURI extracts the scheme prefix for use as a metric
+// label. Falls back to "unknown" for malformed URIs so the label
+// cardinality stays bounded to the supported scheme set + 1.
+func backendFromURI(uri string) string {
+	switch {
+	case strings.HasPrefix(uri, objectstore.SchemeS3+"://"):
+		return objectstore.SchemeS3
+	case strings.HasPrefix(uri, objectstore.SchemeGCS+"://"):
+		return objectstore.SchemeGCS
+	case strings.HasPrefix(uri, objectstore.SchemeAzure+"://"):
+		return objectstore.SchemeAzure
+	default:
+		return "unknown"
+	}
+}
+
+// uploadDurationSeconds returns the wall-clock seconds between
+// status.startTime and now for the duration histogram.
+func uploadDurationSeconds(s *podtracev1alpha1.PodTraceSession) float64 {
+	if s.Status.StartTime == nil {
+		return 0
+	}
+	return time.Since(s.Status.StartTime.Time).Seconds()
+}

--- a/internal/operator/podtracesession_metrics_test.go
+++ b/internal/operator/podtracesession_metrics_test.go
@@ -1,0 +1,128 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestObserveReportUploadMetrics_DedupesAcrossReconciles(t *testing.T) {
+	reset := func() {
+		forgetReportObservations("ns", "s")
+		reportUploadAttempts.Reset()
+		reportUploadDuration.Reset()
+	}
+	reset()
+	defer reset()
+
+	s := &podtracev1alpha1.PodTraceSession{}
+	s.Name, s.Namespace = "s", "ns"
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k/"},
+	}
+	obs := reportUploadObservation{
+		ResolvedURI: "s3://b/k/r.txt",
+		Terminated:  true,
+		Succeeded:   true,
+		Attempts:    1,
+	}
+
+	for i := 0; i < 5; i++ {
+		observeReportUploadMetrics(s, obs)
+	}
+
+	if got := counterTotal(t, "s3", "success", ""); got != 1 {
+		t.Errorf("dedup failed: counter = %v, want 1 after 5 identical observations", got)
+	}
+}
+
+func TestObserveReportUploadMetrics_NewAttemptCountsAgain(t *testing.T) {
+	reset := func() {
+		forgetReportObservations("ns", "s")
+		reportUploadAttempts.Reset()
+	}
+	reset()
+	defer reset()
+
+	s := &podtracev1alpha1.PodTraceSession{}
+	s.Name, s.Namespace = "s", "ns"
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k/"},
+	}
+
+	observeReportUploadMetrics(s, reportUploadObservation{
+		ResolvedURI: "404 NoSuchBucket",
+		Terminated:  true, Succeeded: false, Attempts: 1,
+	})
+	observeReportUploadMetrics(s, reportUploadObservation{
+		ResolvedURI: "s3://b/k/r.txt",
+		Terminated:  true, Succeeded: true, Attempts: 2,
+	})
+
+	if got := counterTotal(t, "s3", "failure", "BucketNotFound"); got != 1 {
+		t.Errorf("first attempt failure counter = %v, want 1", got)
+	}
+	if got := counterTotal(t, "s3", "success", ""); got != 1 {
+		t.Errorf("second attempt success counter = %v, want 1", got)
+	}
+}
+
+func TestObserveReportUploadMetrics_DropsPendingAndNonObjectStore(t *testing.T) {
+	reset := func() {
+		forgetReportObservations("ns", "s")
+		reportUploadAttempts.Reset()
+	}
+	reset()
+	defer reset()
+
+	pending := &podtracev1alpha1.PodTraceSession{}
+	pending.Name, pending.Namespace = "s", "ns"
+	pending.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k/"},
+	}
+	observeReportUploadMetrics(pending, reportUploadObservation{Terminated: false})
+
+	cmSink := &podtracev1alpha1.PodTraceSession{}
+	cmSink.Name, cmSink.Namespace = "cm", "ns"
+	observeReportUploadMetrics(cmSink, reportUploadObservation{Terminated: true, Succeeded: true})
+
+	if got := counterTotal(t, "s3", "success", ""); got != 0 {
+		t.Errorf("pending observation must not contribute, got %v", got)
+	}
+	if got := counterTotal(t, "s3", "failure", "BucketNotFound"); got != 0 {
+		t.Errorf("non-objectstore must not contribute, got %v", got)
+	}
+}
+
+func TestBackendFromURI(t *testing.T) {
+	cases := map[string]string{
+		"s3://b/k":             "s3",
+		"gs://b/k":             "gs",
+		"azblob://acct/cont/k": "azblob",
+		"":                     "unknown",
+		"http://b/k":           "unknown",
+	}
+	for uri, want := range cases {
+		t.Run(strings.ReplaceAll(uri, "/", "_"), func(t *testing.T) {
+			if got := backendFromURI(uri); got != want {
+				t.Errorf("backendFromURI(%q) = %q, want %q", uri, got, want)
+			}
+		})
+	}
+}
+
+func counterTotal(t *testing.T, backend, result, reason string) float64 {
+	t.Helper()
+	m, err := reportUploadAttempts.GetMetricWithLabelValues(backend, result, reason)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}

--- a/internal/operator/podtracesession_objectstore.go
+++ b/internal/operator/podtracesession_objectstore.go
@@ -10,13 +10,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/internal/reportsink/objectstore"
 )
 
 const reportUploaderContainerName = "report-uploader"
 
-func harvestReportLocation(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) (resolvedURI string, terminated bool, ok bool, err error) {
+// reportUploadObservation is the operator's view of one session's
+// objectStore uploader sidecar across all of its node Jobs.
+type reportUploadObservation struct {
+	ResolvedURI string
+
+	Terminated bool
+
+	Succeeded bool
+
+	Attempts int32
+}
+
+func harvestReportLocation(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) (reportUploadObservation, error) {
 	if s == nil || s.Spec.ReportRef == nil || s.Spec.ReportRef.ObjectStore == nil {
-		return "", false, false, nil
+		return reportUploadObservation{}, nil
 	}
 
 	var pods corev1.PodList
@@ -27,36 +40,46 @@ func harvestReportLocation(ctx context.Context, c client.Client, s *podtracev1al
 			LabelSessionNS:   s.Namespace,
 		},
 	); err != nil {
-		return "", false, false, fmt.Errorf("list session pods: %w", err)
+		return reportUploadObservation{}, fmt.Errorf("list session pods: %w", err)
 	}
 
+	var obs reportUploadObservation
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		for _, cs := range pod.Status.InitContainerStatuses {
 			if cs.Name != reportUploaderContainerName {
 				continue
 			}
+			if cs.RestartCount > obs.Attempts {
+				obs.Attempts = cs.RestartCount
+			}
 			if cs.State.Terminated == nil {
 				continue
 			}
-			msg := strings.TrimSpace(cs.State.Terminated.Message)
+			msg := bestTerminationMessage(cs)
+			obs.Terminated = true
 			if cs.State.Terminated.ExitCode == 0 && msg != "" {
-				return msg, true, true, nil
+				obs.ResolvedURI = msg
+				obs.Succeeded = true
+				return obs, nil
 			}
-			return msg, true, false, nil
+			obs.ResolvedURI = msg
+			return obs, nil
 		}
 	}
-	return "", false, false, nil
+	return obs, nil
 }
 
-func applyReportUploadStatus(s *podtracev1alpha1.PodTraceSession, uri string, terminated, ok bool) {
+func applyReportUploadStatus(s *podtracev1alpha1.PodTraceSession, obs reportUploadObservation) {
 	if s == nil || s.Spec.ReportRef == nil || s.Spec.ReportRef.ObjectStore == nil {
 		return
 	}
 	now := metav1.Now()
+	s.Status.ReportAttempts = obs.Attempts
 
 	switch {
-	case !terminated:
+	case !obs.Terminated:
+		s.Status.ReportFailureReason = ""
 		s.Status.Conditions = upsertCondition(s.Status.Conditions, metav1.Condition{
 			Type:               ConditionReportUploaded,
 			Status:             metav1.ConditionUnknown,
@@ -65,24 +88,114 @@ func applyReportUploadStatus(s *podtracev1alpha1.PodTraceSession, uri string, te
 			LastTransitionTime: now,
 			ObservedGeneration: s.Generation,
 		})
-	case ok:
-		s.Status.ReportLocation = uri
+	case obs.Succeeded:
+		s.Status.ReportLocation = obs.ResolvedURI
+		s.Status.ReportFailureReason = ""
 		s.Status.Conditions = upsertCondition(s.Status.Conditions, metav1.Condition{
 			Type:               ConditionReportUploaded,
 			Status:             metav1.ConditionTrue,
 			Reason:             "ObjectStoreUploadSucceeded",
-			Message:            uri,
+			Message:            obs.ResolvedURI,
 			LastTransitionTime: now,
 			ObservedGeneration: s.Generation,
 		})
 	default:
+		s.Status.ReportFailureReason = classifyUploadFailure(obs.ResolvedURI)
 		s.Status.Conditions = upsertCondition(s.Status.Conditions, metav1.Condition{
 			Type:               ConditionReportUploaded,
 			Status:             metav1.ConditionFalse,
 			Reason:             "ObjectStoreUploadFailed",
-			Message:            uri,
+			Message:            obs.ResolvedURI,
 			LastTransitionTime: now,
 			ObservedGeneration: s.Generation,
 		})
 	}
+}
+
+// classifyUploadFailure maps a sidecar's stderr / termination message
+// into a stable reason enum. The mapping is intentionally pattern-based
+// rather than typed-error-based because the message arrives as a string
+// from another process (the sidecar) — there is no in-process error
+// chain to .Is() / .As() against.
+func classifyUploadFailure(message string) podtracev1alpha1.ReportFailureReason {
+	if message == "" {
+		return podtracev1alpha1.ReportFailureReasonUnknown
+	}
+	m := strings.ToLower(message)
+
+	switch {
+	case strings.Contains(m, "no such bucket"),
+		strings.Contains(m, "nosuchbucket"),
+		strings.Contains(m, "404"),
+		strings.Contains(m, "storage: bucket doesn't exist"),
+		strings.Contains(m, "containernotfound"):
+		return podtracev1alpha1.ReportFailureReasonBucketNotFound
+	case strings.Contains(m, "access denied"),
+		strings.Contains(m, "accessdenied"),
+		strings.Contains(m, "forbidden"),
+		strings.Contains(m, "403"),
+		strings.Contains(m, "authorizationfailed"),
+		strings.Contains(m, "signaturedoesnotmatch"):
+		return podtracev1alpha1.ReportFailureReasonAccessDenied
+	case strings.Contains(m, "credential"),
+		strings.Contains(m, "unauthorized"),
+		strings.Contains(m, "401"),
+		strings.Contains(m, "no credentials"),
+		strings.Contains(m, "missing"+"credentials"),
+		strings.Contains(m, "default credentials"):
+		return podtracev1alpha1.ReportFailureReasonCredentialMissing
+	case strings.Contains(m, "timeout"),
+		strings.Contains(m, "deadline exceeded"),
+		strings.Contains(m, "i/o timeout"),
+		strings.Contains(m, "connection refused"),
+		strings.Contains(m, "no such host"),
+		strings.Contains(m, "tls handshake"):
+		return podtracev1alpha1.ReportFailureReasonNetworkTimeout
+	case isInvalidURIMessage(m):
+		return podtracev1alpha1.ReportFailureReasonInvalidURI
+	default:
+		return podtracev1alpha1.ReportFailureReasonUnknown
+	}
+}
+
+func isInvalidURIMessage(lowered string) bool {
+	return strings.Contains(lowered, "unsupported uri scheme") ||
+		strings.Contains(lowered, "must include scheme and host") ||
+		strings.Contains(lowered, "must include a container") ||
+		strings.Contains(lowered, "parse uri") ||
+		strings.Contains(lowered, "object key is empty")
+}
+
+var _ = objectstore.SchemeS3
+
+// bestTerminationMessage picks the most informative termination
+// message between the container's current and previous terminated
+// states.
+func bestTerminationMessage(cs corev1.ContainerStatus) string {
+	current := ""
+	if cs.State.Terminated != nil {
+		current = strings.TrimSpace(cs.State.Terminated.Message)
+	}
+	previous := ""
+	if cs.LastTerminationState.Terminated != nil {
+		previous = strings.TrimSpace(cs.LastTerminationState.Terminated.Message)
+	}
+
+	if current != "" && !isKubeletShutdownMessage(current) {
+		return current
+	}
+	if previous != "" {
+		return previous
+	}
+	return current
+}
+
+// isKubeletShutdownMessage reports whether a message looks like the
+// generic placeholder kubelet writes when it SIGKILLs a sidecar
+// during pod shutdown rather than wording produced by our uploader.
+func isKubeletShutdownMessage(msg string) bool {
+	lc := strings.ToLower(msg)
+	return strings.Contains(lc, "container could not be located when the pod was terminated") ||
+		strings.Contains(lc, "the node was lost") ||
+		strings.Contains(lc, "containerstatusunknown")
 }

--- a/internal/operator/podtracesession_objectstore_classify_test.go
+++ b/internal/operator/podtracesession_objectstore_classify_test.go
@@ -1,0 +1,189 @@
+package operator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TestBestTerminationMessage_PrefersInformativeOverKubeletShutdown is
+// the regression test for a real bug found during manual e2e: when a
+// native sidecar's parent pod terminates while the sidecar is still
+// running, the kubelet overwrites the sidecar's /dev/termination-log
+// with a generic "container could not be located when the pod was
+// terminated" message.
+func TestBestTerminationMessage_PrefersInformativeOverKubeletShutdown(t *testing.T) {
+	cases := []struct {
+		name     string
+		current  string
+		previous string
+		want     string
+	}{
+		{
+			name:     "current_informative_preferred",
+			current:  "s3://b/k/r.txt",
+			previous: "stale earlier message",
+			want:     "s3://b/k/r.txt",
+		},
+		{
+			name:     "kubelet_shutdown_falls_back",
+			current:  "The container could not be located when the pod was terminated",
+			previous: "Error: 403 InvalidAccessKeyId",
+			want:     "Error: 403 InvalidAccessKeyId",
+		},
+		{
+			name:     "empty_current_falls_back",
+			current:  "",
+			previous: "Error: bucket not found",
+			want:     "Error: bucket not found",
+		},
+		{
+			name:     "both_empty",
+			current:  "",
+			previous: "",
+			want:     "",
+		},
+		{
+			name:     "kubelet_shutdown_with_no_previous",
+			current:  "The container could not be located when the pod was terminated",
+			previous: "",
+			want:     "The container could not be located when the pod was terminated",
+		},
+		{
+			name:     "node_was_lost_falls_back",
+			current:  "The node was lost",
+			previous: "Error: connection refused",
+			want:     "Error: connection refused",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{Message: tc.current},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{Message: tc.previous},
+				},
+			}
+			if got := bestTerminationMessage(cs); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBestTerminationMessage_NilStatesAreSafe documents the
+// nil-tolerance contract of the helper: a ContainerStatus where the
+// kubelet has not populated either terminated state must not panic.
+func TestBestTerminationMessage_NilStatesAreSafe(t *testing.T) {
+	if got := bestTerminationMessage(corev1.ContainerStatus{}); got != "" {
+		t.Errorf("empty ContainerStatus: got %q, want empty", got)
+	}
+}
+
+func TestClassifyUploadFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want podtracev1alpha1.ReportFailureReason
+	}{
+		{name: "s3_no_such_bucket", msg: "operation error S3: PutObject, https response error StatusCode: 404, NoSuchBucket: The specified bucket does not exist", want: podtracev1alpha1.ReportFailureReasonBucketNotFound},
+		{name: "gcs_bucket_doesnt_exist", msg: "googleapi: Error 404: storage: bucket doesn't exist", want: podtracev1alpha1.ReportFailureReasonBucketNotFound},
+		{name: "azure_container_not_found", msg: "RESPONSE 404 ContainerNotFound", want: podtracev1alpha1.ReportFailureReasonBucketNotFound},
+
+		{name: "s3_access_denied", msg: "operation error S3: PutObject, https response error StatusCode: 403, AccessDenied: Access Denied", want: podtracev1alpha1.ReportFailureReasonAccessDenied},
+		{name: "s3_signature", msg: "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided", want: podtracev1alpha1.ReportFailureReasonAccessDenied},
+		{name: "azure_authorization_failed", msg: "RESPONSE 403 AuthorizationFailed", want: podtracev1alpha1.ReportFailureReasonAccessDenied},
+
+		{name: "aws_no_credentials", msg: "failed to retrieve credentials, no credentials found", want: podtracev1alpha1.ReportFailureReasonCredentialMissing},
+		{name: "gcs_default_credentials", msg: "google: could not find default credentials", want: podtracev1alpha1.ReportFailureReasonCredentialMissing},
+
+		{name: "ctx_deadline", msg: "context deadline exceeded", want: podtracev1alpha1.ReportFailureReasonNetworkTimeout},
+		{name: "tls_handshake", msg: "net/http: TLS handshake timeout", want: podtracev1alpha1.ReportFailureReasonNetworkTimeout},
+		{name: "dns_no_such_host", msg: "dial tcp: lookup s3.bogus.example: no such host", want: podtracev1alpha1.ReportFailureReasonNetworkTimeout},
+		{name: "connection_refused", msg: "dial tcp 127.0.0.1:9000: connect: connection refused", want: podtracev1alpha1.ReportFailureReasonNetworkTimeout},
+
+		{name: "unsupported_scheme", msg: `unsupported URI scheme "ftp" (want s3, gs, or azblob)`, want: podtracev1alpha1.ReportFailureReasonInvalidURI},
+		{name: "no_host", msg: `URI "s3://" must include scheme and host`, want: podtracev1alpha1.ReportFailureReasonInvalidURI},
+		{name: "empty_key", msg: "s3: resolved object key is empty (URI must include a key or prefix)", want: podtracev1alpha1.ReportFailureReasonInvalidURI},
+
+		{name: "empty", msg: "", want: podtracev1alpha1.ReportFailureReasonUnknown},
+		{name: "novel_sdk_wording", msg: "ECONNRESET: kernel said no", want: podtracev1alpha1.ReportFailureReasonUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyUploadFailure(tc.msg)
+			if got != tc.want {
+				t.Errorf("classifyUploadFailure(%q) = %q, want %q", tc.msg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyReportUploadStatus_AttemptsAndReason(t *testing.T) {
+	session := func(prev podtracev1alpha1.ReportFailureReason) *podtracev1alpha1.PodTraceSession {
+		s := &podtracev1alpha1.PodTraceSession{
+			Spec: podtracev1alpha1.PodTraceSessionSpec{
+				ReportRef: &podtracev1alpha1.ReportReference{
+					ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k"},
+				},
+			},
+		}
+		s.Status.ReportFailureReason = prev
+		return s
+	}
+
+	t.Run("pending clears prior reason", func(t *testing.T) {
+		s := session(podtracev1alpha1.ReportFailureReasonNetworkTimeout)
+		applyReportUploadStatus(s, reportUploadObservation{Attempts: 2})
+		if s.Status.ReportFailureReason != "" {
+			t.Errorf("pending must clear reason, got %q", s.Status.ReportFailureReason)
+		}
+		if s.Status.ReportAttempts != 2 {
+			t.Errorf("attempts = %d, want 2", s.Status.ReportAttempts)
+		}
+	})
+
+	t.Run("success clears reason and stamps location", func(t *testing.T) {
+		s := session(podtracev1alpha1.ReportFailureReasonAccessDenied)
+		applyReportUploadStatus(s, reportUploadObservation{
+			ResolvedURI: "s3://b/k/r.txt",
+			Terminated:  true,
+			Succeeded:   true,
+			Attempts:    1,
+		})
+		if s.Status.ReportFailureReason != "" {
+			t.Errorf("success must clear reason, got %q", s.Status.ReportFailureReason)
+		}
+		if s.Status.ReportLocation != "s3://b/k/r.txt" {
+			t.Errorf("location not stamped, got %q", s.Status.ReportLocation)
+		}
+	})
+
+	t.Run("failure sets reason from classifier", func(t *testing.T) {
+		s := session("")
+		applyReportUploadStatus(s, reportUploadObservation{
+			ResolvedURI: "operation error S3: PutObject, 403 AccessDenied",
+			Terminated:  true,
+			Succeeded:   false,
+			Attempts:    4,
+		})
+		if s.Status.ReportFailureReason != podtracev1alpha1.ReportFailureReasonAccessDenied {
+			t.Errorf("reason = %q, want AccessDenied", s.Status.ReportFailureReason)
+		}
+		if s.Status.ReportAttempts != 4 {
+			t.Errorf("attempts = %d, want 4", s.Status.ReportAttempts)
+		}
+	})
+
+	t.Run("non-objectstore session is no-op", func(t *testing.T) {
+		s := &podtracev1alpha1.PodTraceSession{} // no ReportRef.ObjectStore
+		applyReportUploadStatus(s, reportUploadObservation{Terminated: true, Succeeded: false, Attempts: 7})
+		if s.Status.ReportAttempts != 0 {
+			t.Errorf("non-objectstore session must not touch status, attempts=%d", s.Status.ReportAttempts)
+		}
+	})
+}

--- a/internal/operator/podtracesession_objectstore_test.go
+++ b/internal/operator/podtracesession_objectstore_test.go
@@ -217,15 +217,15 @@ func TestHarvestReportLocation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := sessionWithObjectStore("")
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.pod).Build()
-			uri, term, ok, err := harvestReportLocation(context.Background(), c, s, "podtrace-system")
+			obs, err := harvestReportLocation(context.Background(), c, s, "podtrace-system")
 			if err != nil {
 				t.Fatalf("harvest: %v", err)
 			}
-			if term != tc.wantTerm || ok != tc.wantOK || uri != tc.wantURI {
+			if obs.Terminated != tc.wantTerm || obs.Succeeded != tc.wantOK || obs.ResolvedURI != tc.wantURI {
 				t.Errorf("got (uri=%q, term=%v, ok=%v); want (uri=%q, term=%v, ok=%v)",
-					uri, term, ok, tc.wantURI, tc.wantTerm, tc.wantOK)
+					obs.ResolvedURI, obs.Terminated, obs.Succeeded, tc.wantURI, tc.wantTerm, tc.wantOK)
 			}
-			applyReportUploadStatus(s, uri, term, ok)
+			applyReportUploadStatus(s, obs)
 			var got *metav1.Condition
 			for i := range s.Status.Conditions {
 				if s.Status.Conditions[i].Type == ConditionReportUploaded {
@@ -263,11 +263,11 @@ func TestHarvestReportLocation_NonObjectStoreIsNoop(t *testing.T) {
 			},
 		},
 	}
-	uri, term, ok, err := harvestReportLocation(context.Background(), c, s, "podtrace-system")
-	if err != nil || uri != "" || term || ok {
-		t.Errorf("expected silent no-op, got uri=%q term=%v ok=%v err=%v", uri, term, ok, err)
+	obs, err := harvestReportLocation(context.Background(), c, s, "podtrace-system")
+	if err != nil || obs.ResolvedURI != "" || obs.Terminated || obs.Succeeded {
+		t.Errorf("expected silent no-op, got %+v err=%v", obs, err)
 	}
-	applyReportUploadStatus(s, uri, term, ok)
+	applyReportUploadStatus(s, obs)
 	for _, c := range s.Status.Conditions {
 		if c.Type == ConditionReportUploaded {
 			t.Errorf("non-ObjectStore session must not get a ReportUploaded condition: %+v", c)

--- a/internal/reportsink/objectstore/azblob.go
+++ b/internal/reportsink/objectstore/azblob.go
@@ -4,10 +4,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -42,6 +48,12 @@ func newAzureSink(_ context.Context, cfg Config, d destination) (Sink, error) {
 	}
 	endpoint = strings.TrimRight(endpoint, "/")
 
+	azClientOpts := &azblob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			PerRetryPolicies: []policy.Policy{newAzureRetryLogPolicy()},
+		},
+	}
+
 	var client *azblob.Client
 	switch {
 	case stringFromCreds(creds, azureSecretKeyAccountKey) != "":
@@ -49,7 +61,7 @@ func newAzureSink(_ context.Context, cfg Config, d destination) (Sink, error) {
 		if err != nil {
 			return nil, fmt.Errorf("azblob: shared key credential: %w", err)
 		}
-		client, err = azblob.NewClientWithSharedKeyCredential(endpoint, key, nil)
+		client, err = azblob.NewClientWithSharedKeyCredential(endpoint, key, azClientOpts)
 		if err != nil {
 			return nil, fmt.Errorf("azblob: new shared-key client: %w", err)
 		}
@@ -65,7 +77,7 @@ func newAzureSink(_ context.Context, cfg Config, d destination) (Sink, error) {
 		if err != nil {
 			return nil, fmt.Errorf("azblob: SPN credential: %w", err)
 		}
-		client, err = azblob.NewClient(endpoint, spn, nil)
+		client, err = azblob.NewClient(endpoint, spn, azClientOpts)
 		if err != nil {
 			return nil, fmt.Errorf("azblob: new SPN client: %w", err)
 		}
@@ -74,7 +86,7 @@ func newAzureSink(_ context.Context, cfg Config, d destination) (Sink, error) {
 		if err != nil {
 			return nil, fmt.Errorf("azblob: default credential: %w", err)
 		}
-		client, err = azblob.NewClient(endpoint, def, nil)
+		client, err = azblob.NewClient(endpoint, def, azClientOpts)
 		if err != nil {
 			return nil, fmt.Errorf("azblob: new default-cred client: %w", err)
 		}
@@ -111,3 +123,45 @@ func (a *azureSink) Close() error {
 func toPtr[T any](v T) *T { return &v }
 
 var _ = azcore.NullValue[int]
+
+type azureRetryLogPolicy struct {
+	attempts sync.Map
+}
+
+func newAzureRetryLogPolicy() *azureRetryLogPolicy {
+	return &azureRetryLogPolicy{}
+}
+
+func (p *azureRetryLogPolicy) Do(req *policy.Request) (*http.Response, error) {
+	raw := req.Raw()
+	key := raw.Method + " " + raw.URL.Host + raw.URL.Path
+	counter := p.counterFor(key)
+	attempt := int(counter.Add(1))
+
+	started := time.Now()
+	resp, err := req.Next()
+	took := time.Since(started)
+
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	_, _ = fmt.Fprintf(os.Stderr,
+		`{"component":"objectstore.retry","backend":%q,"method":%q,"url":%q,"status":%d,"attempt":%d,"took_ms":%d,"error":%q}`+"\n",
+		SchemeAzure, raw.Method, raw.URL.String(), status, attempt, took.Milliseconds(), errStr,
+	)
+	return resp, err
+}
+
+func (p *azureRetryLogPolicy) counterFor(key string) *atomic.Int32 {
+	if v, ok := p.attempts.Load(key); ok {
+		return v.(*atomic.Int32)
+	}
+	fresh := new(atomic.Int32)
+	actual, _ := p.attempts.LoadOrStore(key, fresh)
+	return actual.(*atomic.Int32)
+}

--- a/internal/reportsink/objectstore/gcs.go
+++ b/internal/reportsink/objectstore/gcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/storage"
@@ -16,10 +17,7 @@ const (
 )
 
 // gcsScopes lists the OAuth2 scopes the storage client needs. Hardcoding
-// them keeps the credentials-construction path explicit; the older
-// option.WithCredentialsJSON helper looked up scopes implicitly but is
-// deprecated as of the auth-library v0.20 because it surfaces JSON
-// material through chains where it can be logged or cached unintendedly.
+// them keeps the credentials-construction path explicit.
 var gcsScopes = []string{
 	"https://www.googleapis.com/auth/devstorage.read_write",
 	"https://www.googleapis.com/auth/cloud-platform",
@@ -37,11 +35,6 @@ func newGCSSink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 	var opts []option.ClientOption
 	saJSON := stringFromCreds(creds, gcsSecretKeyServiceAccountJSON)
 	if saJSON != "" {
-		// Use the modern cloud.google.com/go/auth/credentials path
-		// instead of the deprecated option.WithCredentialsJSON: the
-		// new helper validates the payload, derives an explicit token
-		// source, and avoids the security-review concerns documented
-		// in the v0.20 deprecation notice.
 		ac, err := credentials.DetectDefault(&credentials.DetectOptions{
 			CredentialsJSON: []byte(saJSON),
 			Scopes:          gcsScopes,
@@ -53,9 +46,6 @@ func newGCSSink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 	}
 	if endpoint := stringFromCreds(creds, gcsSecretKeyEndpoint); endpoint != "" {
 		opts = append(opts, option.WithEndpoint(endpoint))
-		// Test endpoints (fake-gcs-server) speak plaintext HTTP with
-		// no auth handshake. Skip auth when the user provided no
-		// explicit service account.
 		if saJSON == "" {
 			opts = append(opts, option.WithoutAuthentication())
 		}
@@ -66,11 +56,27 @@ func newGCSSink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 		return nil, fmt.Errorf("gcs: new client: %w", err)
 	}
 
+	client.SetRetry(storage.WithErrorFunc(loggingGCSShouldRetry))
+
 	return &gcsSink{
 		client:    client,
 		dest:      d,
 		uriPrefix: SchemeGCS + "://" + d.bucket,
 	}, nil
+}
+
+// loggingGCSShouldRetry mirrors storage.ShouldRetry's decision while
+// emitting one structured log line per evaluation.
+func loggingGCSShouldRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+	shouldRetry := storage.ShouldRetry(err)
+	_, _ = fmt.Fprintf(os.Stderr,
+		`{"component":"objectstore.retry","backend":"gs","retry":%v,"error":%q}`+"\n",
+		shouldRetry, err.Error(),
+	)
+	return shouldRetry
 }
 
 func (g *gcsSink) Upload(ctx context.Context, keyHint, contentType string, body io.Reader) (string, error) {

--- a/internal/reportsink/objectstore/retry_log.go
+++ b/internal/reportsink/objectstore/retry_log.go
@@ -1,0 +1,82 @@
+package objectstore
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// RetryLogger receives one event per HTTP boundary the SDK crosses for
+// a single Upload.
+type RetryLogger interface {
+	OnAttempt(backend, method, url string, status int, attempt int, took time.Duration, err error)
+}
+
+// defaultRetryLogger emits JSON-ish lines to stderr. Kept format-stable
+// so log shippers can field-extract (the agent log pipeline already
+// expects zap-style fields).
+type defaultRetryLogger struct{}
+
+func (defaultRetryLogger) OnAttempt(backend, method, url string, status, attempt int, took time.Duration, err error) {
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	_, _ = fmt.Fprintf(os.Stderr,
+		`{"component":"objectstore.retry","backend":%q,"method":%q,"url":%q,"status":%d,"attempt":%d,"took_ms":%d,"error":%q}`+"\n",
+		backend, method, url, status, attempt, took.Milliseconds(), errStr,
+	)
+}
+
+// loggingTransport is an http.RoundTripper that wraps an inner
+// transport with a RetryLogger callback. Used by the S3 and GCS
+// backends (both speak HTTP under the SDK).
+type loggingTransport struct {
+	inner   http.RoundTripper
+	backend string
+	logger  RetryLogger
+
+	attempts map[string]*atomic.Int32
+	mu       sync.Mutex
+}
+
+func newLoggingTransport(inner http.RoundTripper, backend string, logger RetryLogger) *loggingTransport {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	if logger == nil {
+		logger = defaultRetryLogger{}
+	}
+	return &loggingTransport{
+		inner:    inner,
+		backend:  backend,
+		logger:   logger,
+		attempts: map[string]*atomic.Int32{},
+	}
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Method + " " + req.URL.Host + req.URL.Path
+	t.mu.Lock()
+	counter, ok := t.attempts[key]
+	if !ok {
+		counter = new(atomic.Int32)
+		t.attempts[key] = counter
+	}
+	t.mu.Unlock()
+	attempt := int(counter.Add(1))
+
+	started := time.Now()
+	resp, err := t.inner.RoundTrip(req)
+	took := time.Since(started)
+
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	t.logger.OnAttempt(t.backend, req.Method, req.URL.String(), status, attempt, took, err)
+	return resp, err
+}

--- a/internal/reportsink/objectstore/retry_log_test.go
+++ b/internal/reportsink/objectstore/retry_log_test.go
@@ -1,0 +1,107 @@
+package objectstore
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordingLogger struct {
+	mu     sync.Mutex
+	events []retryLogEntry
+}
+
+type retryLogEntry struct {
+	Backend string
+	Method  string
+	URL     string
+	Status  int
+	Attempt int
+	Err     error
+}
+
+func (r *recordingLogger) OnAttempt(backend, method, url string, status, attempt int, _ time.Duration, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, retryLogEntry{
+		Backend: backend,
+		Method:  method,
+		URL:     url,
+		Status:  status,
+		Attempt: attempt,
+		Err:     err,
+	})
+}
+
+func TestLoggingTransport_AttemptsIncrementPerSameURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	rl := &recordingLogger{}
+	transport := newLoggingTransport(http.DefaultTransport, "test", rl)
+	client := &http.Client{Transport: transport}
+
+	for i := 0; i < 3; i++ {
+		resp, err := client.Get(srv.URL + "/put-object")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		_ = resp.Body.Close()
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if len(rl.events) != 3 {
+		t.Fatalf("expected 3 logged attempts, got %d", len(rl.events))
+	}
+	for i, e := range rl.events {
+		if e.Attempt != i+1 {
+			t.Errorf("event[%d].Attempt = %d, want %d", i, e.Attempt, i+1)
+		}
+		if e.Status != http.StatusServiceUnavailable {
+			t.Errorf("event[%d].Status = %d, want 503", i, e.Status)
+		}
+		if e.Backend != "test" {
+			t.Errorf("event[%d].Backend = %q, want test", i, e.Backend)
+		}
+	}
+}
+
+func TestLoggingTransport_DifferentURLsResetCounter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rl := &recordingLogger{}
+	client := &http.Client{Transport: newLoggingTransport(http.DefaultTransport, "test", rl)}
+
+	if _, err := client.Get(srv.URL + "/object-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get(srv.URL + "/object-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if len(rl.events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(rl.events))
+	}
+	for _, e := range rl.events {
+		if e.Attempt != 1 {
+			t.Errorf("event for %s logged Attempt=%d, want 1 (distinct URLs must reset)", e.URL, e.Attempt)
+		}
+	}
+}
+
+func TestLoggingTransport_NilInnerUsesDefault(t *testing.T) {
+	transport := newLoggingTransport(nil, "test", &recordingLogger{})
+	if transport.inner != http.DefaultTransport {
+		t.Error("nil inner must fall back to http.DefaultTransport")
+	}
+}

--- a/internal/reportsink/objectstore/s3.go
+++ b/internal/reportsink/objectstore/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -16,8 +17,6 @@ import (
 // S3 credential keys read from the user-supplied Secret. All optional —
 // missing keys mean "fall back to the SDK default credential chain"
 // (which discovers IRSA, env vars, EC2 instance profile, etc.).
-//
-// Documented as a public API surface in docs/object-store-reports.md.
 const (
 	s3SecretKeyAccessKeyID     = "access_key_id"
 	s3SecretKeySecretAccessKey = "secret_access_key"
@@ -29,13 +28,6 @@ const (
 
 // s3Sink uploads to AWS S3 or any S3-compatible bucket via the
 // low-level s3.Client.PutObject API.
-//
-// We deliberately do not use feature/s3/manager.Uploader (now
-// deprecated) or its successor feature/s3/transfermanager: session
-// reports are text artifacts a few hundred KB at most, well below the
-// 5 MiB single-part PutObject limit. Multipart adds round-trips and
-// complexity (CompleteMultipartUpload, error recovery on partial
-// uploads) that buy nothing for our payload size.
 type s3Sink struct {
 	client    *s3.Client
 	dest      destination
@@ -46,6 +38,10 @@ func newS3Sink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 	creds := cfg.Credentials
 
 	loadOpts := []func(*awsconfig.LoadOptions) error{}
+
+	loadOpts = append(loadOpts, awsconfig.WithHTTPClient(&http.Client{
+		Transport: newLoggingTransport(http.DefaultTransport, SchemeS3, nil),
+	}))
 
 	region := stringFromCreds(creds, s3SecretKeyRegion)
 	if region == "" {


### PR DESCRIPTION
Four hardening cuts on the existing session objectStore sink, aimed at operator-grade observability rather than new feature surface:

- **Doc alignment** — `docs/operator.md` and `docs/crd-podtracesession.md` no longer claim `reportRef.objectStore`
  is "reserved" or that the webhook rejects it. Both have been false since the feature actually landed; new copy points at
  [docs/object-store-reports.md](docs/object-store-reports.md) for semantics.
- **Failure observability** — new typed enum `ReportFailureReason` (`InvalidURI` | `CredentialMissing` |
  `BucketNotFound` | `AccessDenied` | `NetworkTimeout` | `Unknown`) on `status.reportFailureReason`, plus `status.reportAttempts` mirroring the sidecar's `RestartCount`. Two new operator-side
  Prometheus series (`session_report_upload_attempts_total` with result+reason labels, `session_report_upload_duration_seconds` histogram) for SLO and trend tracking.
- **Idempotent timestamp** — the sidecar persists its chosen object-key suffix to an emptyDir state file on first run and rereads it on every subsequent restart, so a kubelet-induced restart no longer produces a duplicate object under a fresh timestamp.
- **Retry transparency** — each S3/GCS/Azure SDK retry boundary now produces a structured JSON log line on the sidecar's stderr with `backend`, `method`, `url`, `status`, `attempt`, `took_ms`, and `error`. Wiring is per-SDK (S3 via `awsconfig.WithHTTPClient`, GCS via `storage.Client.SetRetry(storage.WithErrorFunc)`, Azure via a  `policy.PerRetryPolicies` entry).
