### PR TITLE
fix(cli): run eBPF on target node via spawn pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update \
 
 WORKDIR /src
 
-# Prime the module cache first for better layer reuse on source-only changes.
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
@@ -39,6 +38,7 @@ ARG TARGETARCH=amd64
 ARG TARGETOS=linux
 ARG VERSION=dev
 ARG COMMIT=unknown
+ARG IMAGE_REPO=ghcr.io/gma1k/podtrace
 
 ENV BPF_GOARCH=${TARGETARCH} \
     CGO_ENABLED=0 \
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build \
       -trimpath \
       -tags embed_bpf \
-      -ldflags "-s -w -X github.com/podtrace/podtrace/internal/config.Version=${VERSION} -X github.com/podtrace/podtrace/internal/config.Commit=${COMMIT}" \
+      -ldflags "-s -w -X github.com/podtrace/podtrace/internal/config.Version=${VERSION} -X github.com/podtrace/podtrace/internal/config.Commit=${COMMIT} -X github.com/podtrace/podtrace/internal/config.Image=${IMAGE_REPO}" \
       -o /out/podtrace \
       ./cmd/podtrace
 
@@ -72,10 +72,5 @@ LABEL org.opencontainers.image.title="podtrace" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=builder /out/podtrace /usr/local/bin/podtrace
-
-# CLI and operator Deployment run unprivileged as 65532:65532 (distroless
-# nonroot). The agent DaemonSet and session Jobs override runAsUser to 0
-# and add CAP_BPF/CAP_SYS_ADMIN/CAP_PERFMON in their securityContext.
-USER 65532:65532
 
 ENTRYPOINT ["/usr/local/bin/podtrace"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@
 
 CLANG ?= clang
 LLC ?= llc
-# Prefer /usr/local/go/bin/go if available (newer Go versions), otherwise use system go
 GO ?= $(shell if [ -f /usr/local/go/bin/go ]; then echo /usr/local/go/bin/go; else echo go; fi)
 BPF_SRC = bpf/podtrace.bpf.c bpf/network.c bpf/filesystem.c bpf/cpu.c bpf/memory.c
 BPF_OBJ = internal/ebpf/embedded/podtrace.$(BPF_GOARCH).bpf.o
@@ -89,9 +88,6 @@ ifeq ($(HAVE_BTF),yes)
 endif
 
 ifdef USE_BTF_VMLINUX
-# /sys/kernel/btf/vmlinux is a sysfs pseudo-file whose modification time can be
-# unreliable for make dependency checks. Use a phony intermediate so generated
-# vmlinux.h is always refreshed when bpftool is available.
 .PHONY: _vmlinux_btf_gen
 _vmlinux_btf_gen:
 	@mkdir -p "$(BPF_GEN_DIR)"
@@ -110,11 +106,14 @@ $(BPF_OBJ): $(VMLINUX_GEN) bpf/podtrace.bpf.c bpf/*.h bpf/network.c bpf/filesyst
 	@mkdir -p $(dir $(BPF_OBJ))
 	$(CLANG) $(BPF_CFLAGS) -Ibpf -I. -c bpf/podtrace.bpf.c -o $(BPF_OBJ)
 
+IMAGE_REPO ?= ghcr.io/gma1k/podtrace
+
 build: $(BPF_OBJ)
 	@mkdir -p bin
 	$(GO) build -tags embed_bpf \
 	  -ldflags "-X $(MODULE)/internal/config.Version=$(VERSION) \
-	            -X $(MODULE)/internal/config.Commit=$(COMMIT)" \
+	            -X $(MODULE)/internal/config.Commit=$(COMMIT) \
+	            -X $(MODULE)/internal/config.Image=$(IMAGE_REPO)" \
 	  -o $(BINARY) ./cmd/podtrace
 
 # Release: produce cross-arch tarballs for linux+darwin × amd64+arm64.
@@ -144,7 +143,8 @@ release: release-bpf-objects
 	    $(GO) build -trimpath -tags=embed_bpf \
 	      -ldflags "-s -w \
 	        -X $(MODULE)/internal/config.Version=$(VERSION) \
-	        -X $(MODULE)/internal/config.Commit=$(COMMIT)" \
+	        -X $(MODULE)/internal/config.Commit=$(COMMIT) \
+	        -X $(MODULE)/internal/config.Image=$(IMAGE_REPO)" \
 	      -o "$$staging/podtrace" ./cmd/podtrace; \
 	  if [ ! -s "$$staging/podtrace" ]; then \
 	    echo "::error::go build produced empty/missing binary for $$os/$$arch"; \
@@ -242,13 +242,9 @@ IMAGE_REPO ?= ghcr.io/gma1k/podtrace
 IMAGE_TAG  ?= dev
 IMAGE      ?= $(IMAGE_REPO):$(IMAGE_TAG)
 
-# operator-tools installs controller-gen at a pinned version. Safe to run on
-# every invocation; the `go install` is a no-op if already present.
 operator-tools:
 	@GOBIN=$(dir $(CONTROLLER_GEN)) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
-# generate (re)emits api/v1alpha1/zz_generated.deepcopy.go from the type
-# definitions. Run after any api/ type change.
 generate: operator-tools
 	$(CONTROLLER_GEN) object:headerFile=$(BOILERPLATE) paths=./api/v1alpha1/...
 
@@ -291,6 +287,7 @@ docker-build:
 	docker build \
 	  --build-arg VERSION=$(IMAGE_TAG) \
 	  --build-arg COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown) \
+	  --build-arg IMAGE_REPO=$(IMAGE_REPO) \
 	  -t $(IMAGE) .
 
 # envtest runs the CRD schema validation suite against a real

--- a/README.md
+++ b/README.md
@@ -71,9 +71,23 @@ podtrace -n production my-pod
 podtrace -n production my-pod --diagnose 30s --export json > report.json
 ```
 
+By default the CLI spawns a privileged pod on the target pod's node and
+runs eBPF there — works on Talos, EKS, GKE, AKS, OpenShift, and any
+cluster where your workstation is not the kubelet host. On kind /
+minikube / docker-desktop the workstation **is** the kubelet host, so
+add `--local` to skip the spawn and load eBPF on the workstation
+directly (faster, no privileged pod needed):
+
+```bash
+podtrace --local -n production my-pod
+```
+
 For other platforms (linux/arm64, darwin/amd64, darwin/arm64) and
 cosign-verifiable installs, see
 [docs/installation.md#install-the-cli](docs/installation.md#install-the-cli).
+The CLI architecture (when to use `--local`, RBAC needed for the spawn
+path, etc.) is documented in
+[docs/cli-architecture.md](docs/cli-architecture.md).
 Full CLI reference: [docs/usage.md](docs/usage.md).
 
 ### 2. Continuous tracing via the `PodTrace` CR

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -117,6 +117,9 @@ struct sockaddr_in {
 #ifndef BPF_MAP_TYPE_ARRAY
 #define BPF_MAP_TYPE_ARRAY 2
 #endif
+#ifndef BPF_MAP_TYPE_PERCPU_ARRAY
+#define BPF_MAP_TYPE_PERCPU_ARRAY 6
+#endif
 #ifndef BPF_MAP_TYPE_LRU_HASH
 #define BPF_MAP_TYPE_LRU_HASH 9
 #endif

--- a/bpf/cpu.c
+++ b/bpf/cpu.c
@@ -47,7 +47,8 @@ int tracepoint_sched_switch(void *ctx) {
 				e->tcp_state = 0;
 				e->target[0] = '\0';
 				e->details[0] = '\0';
-				
+				__builtin_memcpy(e->comm, args_local.prev_comm, sizeof(e->comm));
+
 				capture_user_stack(ctx, prev_pid, 0, e);
 				bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 			}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -144,8 +144,10 @@ struct {
 	__type(value, u32);
 } alert_thresholds SEC(".maps");
 
+/* event_buf is a scratch slot that each probe fills before pushing into the
+ * ring buffer. */
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__type(key, u32);
 	__type(value, struct event);
@@ -238,8 +240,10 @@ struct {
 	__type(value, u64); /* byte count captured at uprobe entry */
 } proto_bytes SEC(".maps");
 
+/* stack_buf is a scratch slot for bpf_get_stack(). Same percpu reasoning as
+ * event_buf: a shared slot races between CPUs and produces corrupted frames. */
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__type(key, u32);
 	__type(value, struct stack_trace_t);

--- a/bpf/memory.c
+++ b/bpf/memory.c
@@ -63,7 +63,10 @@ int tracepoint_oom_kill_process(void *ctx) {
 	e->error = 0;
 	e->bytes = args_local.totalpages * PAGE_SIZE;
 	e->tcp_state = 0;
-	
+	/* Same pattern as sched_switch: get_event_buf() filled e->comm with the
+	 * OOM-killer task's name (typically a kthread), but e->pid points at the
+	 * victim. Overwrite comm with the victim's name from the tracepoint. */
+	__builtin_memcpy(e->comm, args_local.comm, sizeof(e->comm));
 	bpf_probe_read_kernel_str(e->target, sizeof(e->target), args_local.comm);
 	
 	capture_user_stack(ctx, e->pid, 0, e);

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -93,6 +93,10 @@ int tracepoint_sched_process_fork(void *ctx) {
 	e->error = 0;
 	e->bytes = 0;
 	e->tcp_state = 0;
+	/* e->pid is the child's; get_event_buf() set e->comm to the parent's name
+	 * via bpf_get_current_comm(). Overwrite with the child's comm from the
+	 * tracepoint so the pair refers to the same task. */
+	__builtin_memcpy(e->comm, args_local.child_comm, sizeof(e->comm));
 
 	bpf_probe_read_kernel_str(e->target, sizeof(e->target), args_local.child_comm);
 

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -61,13 +61,17 @@ var (
 	showVersion           bool
 	enableProfiling       bool
 
-	// Session-mode flags. These are set by the operator when it builds a
-	// session Job's argv; end users do not typically set them. They all
-	// default to empty/disabled, preserving existing CLI behavior.
-	exporterFromFile        string
-	summaryFile             string
-	terminationMessagePath  string
-	reportTo                string
+	localMode           bool
+	spawnImage          string
+	spawnNamespace      string
+	spawnServiceAccount string
+	dynamicSpawn        bool
+	preresolvedPods     []string
+
+	exporterFromFile       string
+	summaryFile            string
+	terminationMessagePath string
+	reportTo               string
 
 	resolverFactory func() (kubernetes.PodResolverInterface, error)
 	tracerFactory   func() (ebpf.TracerInterface, error)
@@ -83,12 +87,6 @@ func init() {
 	}
 	exitFunc = os.Exit
 
-	// client-go's informers retry on RBAC denials at klog ERROR level
-	// every few seconds; in narrow per-session SA contexts (where
-	// cluster-scope list/watch is intentionally denied) those retries
-	// are expected and just spam stderr. Route klog into its own flagset
-	// so we don't conflict with cobra, lower its verbosity to fatal-only,
-	// and silence the writer.
 	klogFlags := flag.NewFlagSet("klog", flag.ContinueOnError)
 	klog.InitFlags(klogFlags)
 	_ = klogFlags.Set("logtostderr", "false")
@@ -147,6 +145,13 @@ func main() {
 	rootCmd.Flags().Float64Var(&tracingSampleRate, "tracing-sample-rate", config.DefaultTracingSampleRate, "Tracing sample rate (0.0-1.0)")
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Print version information")
 	rootCmd.Flags().BoolVar(&enableProfiling, "profiling", false, "Enable performance profiling: pprof endpoint discovery on the target pod, auto-trigger on latency spikes, and CPU/memory correlation in reports")
+	rootCmd.Flags().BoolVar(&localMode, "local", false, "Run eBPF on this workstation instead of spawning a privileged pod on the target node. Use for kind/minikube/docker-desktop where the workstation IS the kubelet host.")
+	rootCmd.Flags().StringVar(&spawnImage, "image", "", "Container image used when spawning on the target node (overrides PODTRACE_IMAGE and the linker default)")
+	rootCmd.Flags().StringVar(&spawnNamespace, "spawn-namespace", "", "Namespace for the ephemeral spawn pod (defaults to the target pod's namespace; overridable via PODTRACE_SPAWN_NAMESPACE)")
+	rootCmd.Flags().BoolVar(&dynamicSpawn, "dynamic-spawn", false, "Continuously poll target selection and spawn additional pods on newly-matched nodes (incompatible with --diagnose; covers new nodes only, not new pods on already-covered nodes)")
+	rootCmd.Flags().StringVar(&spawnServiceAccount, "service-account", "", "ServiceAccount the spawn pod runs as. Only required when --dynamic-spawn watches selector changes from inside the pod; otherwise the workstation pre-resolves everything and the spawn pod needs no RBAC.")
+	rootCmd.Flags().StringSliceVar(&preresolvedPods, "preresolved-pod", nil, "internal: workstation pre-resolved target as ns/name/containerID/containerName, lets the spawn pod skip its own K8s lookup")
+	_ = rootCmd.Flags().MarkHidden("preresolved-pod")
 	rootCmd.Flags().StringVar(&exporterFromFile, "exporter-from-file", "", "Load exporter config from a YAML file (set by the operator for session Jobs)")
 	_ = rootCmd.Flags().MarkHidden("exporter-from-file")
 	rootCmd.Flags().StringVar(&summaryFile, "summary-file", "", "Write a JSON summary of diagnose results to this path when diagnose completes")
@@ -171,10 +176,6 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// --exporter-from-file populates the same config.* globals the other
-	// tracing flags do, so it runs before the tracing manager is built.
-	// A parse error aborts — the operator-mounted bundle is the only
-	// source of exporter endpoint/credential in session Jobs.
 	if exporterFromFile != "" {
 		if err := applyExporterFromFile(exporterFromFile); err != nil {
 			return fmt.Errorf("load --exporter-from-file: %w", err)
@@ -256,7 +257,7 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	if argPodName != "" {
 		pods = append([]string{argPodName}, pods...)
 	}
-	if len(pods) == 0 && podSelector == "" && !allInNamespace {
+	if len(pods) == 0 && podSelector == "" && !allInNamespace && len(preresolvedPods) == 0 {
 		return fmt.Errorf("target pod selection is required: pass <pod-name>, --pods, --pod-selector, or --all-in-namespace")
 	}
 	for _, p := range pods {
@@ -324,12 +325,31 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		Pods:             pods,
 		ContainerName:    containerName,
 	}
+
+	if handled, err := maybeSpawnOnNode(ctx, cmd, resolver, selection); handled {
+		return err
+	}
+
 	targetInfos := make([]*kubernetes.PodInfo, 0, 8)
 	var targetRegistry *kubernetes.TargetRegistry
 
-	_, useDynamicTargets := resolver.(kubernetes.ClientsetProvider)
-	useDynamicTargets = useDynamicTargets && (len(selection.Pods) > 1 || selection.PodSelector != "" || selection.AllInNamespace || len(selection.Namespaces) > 1)
-	if useDynamicTargets {
+	_, hasClientset := resolver.(kubernetes.ClientsetProvider)
+	useDynamicTargets := hasClientset && (len(selection.Pods) > 1 || selection.PodSelector != "" || selection.AllInNamespace || len(selection.Namespaces) > 1)
+	usePreResolved := len(preresolvedPods) > 0
+
+	if usePreResolved {
+		for _, raw := range preresolvedPods {
+			ref, err := kubernetes.ParsePreResolvedRef(raw)
+			if err != nil {
+				return err
+			}
+			info, err := kubernetes.BuildPodInfoFromPreResolved(ref)
+			if err != nil {
+				return fmt.Errorf("preresolved resolve %s/%s: %w", ref.Namespace, ref.PodName, err)
+			}
+			targetInfos = append(targetInfos, info)
+		}
+	} else if useDynamicTargets {
 		clientset := resolver.(kubernetes.ClientsetProvider).GetClientset()
 		targetRegistry = kubernetes.NewTargetRegistry(clientset, selection)
 		if err := targetRegistry.Start(ctx); err != nil {
@@ -382,7 +402,6 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check kernel version, BTF availability, and SELinux before loading eBPF.
 	if err := system.CheckRequirements(); err != nil {
 		return err
 	}
@@ -516,7 +535,6 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
-	// Profiling handler — set up before tracer.Start() so management routes are ready.
 	var profilingHandler *profiling.Handler
 	if enableProfiling || config.ProfilingEnabled {
 		config.ProfilingEnabled = true // ensures MetricsEnablePprof() returns true

--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/podtrace/podtrace/internal/config"
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+	"github.com/podtrace/podtrace/internal/logger"
+	"go.uber.org/zap"
+)
+
+// spawnControlFlags are stripped when reconstructing the child argv; they only
+// make sense on the workstation. --metrics is also stripped (with a warning)
+// because the in-pod port can't be reached from the user's machine.
+var spawnControlFlags = map[string]struct{}{
+	"local":            {},
+	"image":            {},
+	"spawn-namespace":  {},
+	"service-account":  {},
+	"dynamic-spawn":    {},
+	"namespace":        {},
+	"namespaces":       {},
+	"pods":             {},
+	"pod-selector":     {},
+	"all-in-namespace": {},
+}
+
+// maybeSpawnOnNode runs the spawn flow when appropriate. The boolean return
+// reports whether the spawn flow handled the invocation (true = caller should
+// return without falling through to the local eBPF path). When err is non-nil
+// the caller propagates it; the exit code is encoded via nodespawn.ExitError.
+func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.PodResolverInterface, selection pkgkube.TargetSelection) (handled bool, err error) {
+	if os.Getenv(nodespawn.EnvNodeLocalSentinel) == "1" {
+		return false, nil
+	}
+	if localMode {
+		return false, nil
+	}
+	if _, err := rest.InClusterConfig(); err == nil {
+		return false, nil
+	}
+
+	clientset, restCfg, ok := clusterHandles(resolver)
+	if !ok {
+		return false, nil
+	}
+
+	if !selectionIsSpawnable(selection) {
+		return false, nil
+	}
+
+	image, warnDev := nodespawn.ResolveImage(nodespawn.ResolveImageOptions{
+		Override: spawnImage,
+		Version:  config.GetVersion(),
+	})
+	if warnDev {
+		logger.Warn("Using fallback image tag :latest; pin a real version via --image or PODTRACE_IMAGE",
+			zap.String("image", image))
+	}
+
+	ns := spawnNamespace
+	if ns == "" {
+		ns = os.Getenv("PODTRACE_SPAWN_NAMESPACE")
+	}
+
+	host := nodespawn.HostnameFromEnv()
+	if _, err := nodespawn.ReapStale(ctx, clientset, ns, host, nodespawn.DefaultReaperMaxAge); err != nil {
+		logger.Debug("Reaper failed (non-fatal)", zap.Error(err))
+	}
+
+	preResolved, err := nodespawn.ResolveTargetNodes(ctx, clientset, selection)
+	if err != nil {
+		return true, err
+	}
+	if preResolved.Empty() {
+		return true, fmt.Errorf("nodespawn: no scheduled target pods")
+	}
+	multiNode := len(preResolved.NodeNames) > 1
+
+	metricsPassThrough := enableMetrics && !multiNode
+	if enableMetrics && multiNode {
+		logger.Warn("--metrics ignored: spawn covers multiple nodes; auto-port-forward only single-node spawns. Pass --local for workstation metrics.")
+	}
+
+	build := newChildArgsBuilder(cmd, metricsPassThrough)
+	streams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+
+	var onRunning func(context.Context, *corev1.Pod) error
+	if metricsPassThrough {
+		onRunning = func(podCtx context.Context, pod *corev1.Pod) error {
+			go func() {
+				logger.Info("Forwarding metrics port",
+					zap.String("local", fmt.Sprintf("127.0.0.1:%d", config.DefaultMetricsPort)),
+					zap.String("pod", pod.Namespace+"/"+pod.Name))
+				if err := nodespawn.StartPortForward(podCtx, restCfg, clientset, pod,
+					config.DefaultMetricsPort, config.DefaultMetricsPort,
+					io.Discard, io.Discard); err != nil && podCtx.Err() == nil {
+					logger.Warn("Metrics port-forward exited", zap.Error(err))
+				}
+			}()
+			return nil
+		}
+	}
+
+	dynamic := dynamicSpawn
+	if dynamic && diagnoseDuration != "" {
+		logger.Warn("--dynamic-spawn ignored: incompatible with --diagnose (child pods would each restart the timer). Drop --diagnose or --dynamic-spawn.")
+		dynamic = false
+	}
+
+	sa := spawnServiceAccount
+	if sa == "" {
+		sa = os.Getenv("PODTRACE_SPAWN_SA")
+	}
+
+	err = nodespawn.Run(ctx, nodespawn.RunOptions{
+		Clientset:          clientset,
+		RestConfig:         restCfg,
+		Selection:          selection,
+		Image:              image,
+		SpawnNamespace:     ns,
+		BuildChildArgs:     build,
+		OwnerHost:          host,
+		OwnerPID:           os.Getpid(),
+		Streams:            streams,
+		OnPodRunning:       onRunning,
+		DynamicReSpawn:     dynamic,
+		ServiceAccountName: sa,
+	})
+	if err != nil {
+		var exitErr *nodespawn.ExitError
+		if errorsAs(err, &exitErr) {
+			return true, exitErr
+		}
+		return true, err
+	}
+	return true, nil
+}
+
+// clusterHandles pulls the kube clientset and rest.Config from the resolver.
+// Returns ok=false when the resolver doesn't expose them (mock paths).
+func clusterHandles(resolver pkgkube.PodResolverInterface) (kubernetes.Interface, *rest.Config, bool) {
+	cp, ok := resolver.(pkgkube.ClientsetProvider)
+	if !ok {
+		return nil, nil, false
+	}
+	rp, ok := resolver.(pkgkube.RestConfigProvider)
+	if !ok {
+		return nil, nil, false
+	}
+	return cp.GetClientset(), rp.GetRestConfig(), true
+}
+
+// selectionIsSpawnable is a guardrail: when the user invoked --version, --help,
+// or one of the subcommands, we shouldn't try to spawn anything. The cobra
+// layer keeps subcommands out of runPodtrace already, but we still need to
+// bail on empty selection.
+func selectionIsSpawnable(sel pkgkube.TargetSelection) bool {
+	if len(sel.Pods) > 0 || sel.PodSelector != "" || sel.AllInNamespace {
+		return true
+	}
+	return false
+}
+
+// newChildArgsBuilder returns a callback that reconstructs the argv for one
+// spawned pod, walking the cobra flag set and emitting only flags the user
+// actually changed (minus spawn-control flags) plus a fresh --pods list for
+// the targets on this node.
+func newChildArgsBuilder(cmd *cobra.Command, passMetrics bool) func(string, []nodespawn.PodRef) []string {
+	return func(_ string, pods []nodespawn.PodRef) []string {
+		args := []string{}
+		cmd.Flags().Visit(func(f *pflag.Flag) {
+			if _, drop := spawnControlFlags[f.Name]; drop {
+				return
+			}
+			if f.Name == "metrics" && !passMetrics {
+				return
+			}
+			args = append(args, "--"+f.Name+"="+f.Value.String())
+		})
+		for _, p := range pods {
+			if p.ContainerID != "" {
+				args = append(args, "--preresolved-pod="+p.PreResolved())
+			}
+		}
+		return args
+	}
+}
+
+// errorsAs is a minimal local helper to avoid importing "errors" twice in
+// callsites that already import other things named errors.
+func errorsAs(err error, target any) bool {
+	type wrapped interface{ Unwrap() error }
+	for err != nil {
+		if t, ok := target.(**nodespawn.ExitError); ok {
+			if e, ok := err.(*nodespawn.ExitError); ok {
+				*t = e
+				return true
+			}
+		}
+		w, ok := err.(wrapped)
+		if !ok {
+			return false
+		}
+		err = w.Unwrap()
+	}
+	return false
+}
+
+var _ = fmt.Sprintf

--- a/deploy/cli-rbac/role.yaml
+++ b/deploy/cli-rbac/role.yaml
@@ -1,0 +1,51 @@
+# Optional RBAC for podtrace CLI's spawn pods.
+#
+# The CLI works out-of-the-box without this file. The workstation pre-resolves
+# every target pod's containerID and hands it to the spawn pod via a flag, so
+# the spawn pod's child binary needs **zero** Kubernetes API access for
+# tracing itself.
+#
+# Apply this ONLY if you want:
+#   - Kubernetes events to annotate traces (the "events correlator" feature)
+#   - --dynamic-spawn mode watching selector changes from inside the spawn pod
+#     (not yet implemented — currently the workstation does the poll)
+#
+# Apply per cluster:
+#   kubectl apply -f deploy/cli-rbac/role.yaml
+#
+# Then pass --service-account=podtrace-cli to the CLI, or set
+# PODTRACE_SPAWN_SA=podtrace-cli.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: podtrace-cli
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: podtrace-cli
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: podtrace-cli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: podtrace-cli
+subjects:
+- kind: ServiceAccount
+  name: podtrace-cli
+  namespace: kube-system

--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -1,0 +1,176 @@
+# CLI architecture: the node-spawn model
+
+`kubectl podtrace` (and the standalone `podtrace` binary) doesn't load
+eBPF on the workstation it's invoked from. It identifies the node
+hosting each target pod and runs a short-lived privileged pod *on
+that node*; eBPF is loaded inside the spawned pod against the host
+namespaces it mounts.
+
+## Why
+
+eBPF code runs in the kernel of the machine where it's loaded. The
+workstation's kernel has no visibility into a remote node's processes
+or cgroups, so loading eBPF on the workstation can only observe the
+workstation itself. The CLI used to assume the workstation was the
+kubelet host; that worked on kind, minikube, and docker-desktop but
+silently failed on any real cluster (Talos, GKE, EKS, AKS, OpenShift,
+Fargate, anywhere the workstation isn't the node).
+
+The spawn model fixes the structural mismatch: the kernel that loads
+eBPF is the same kernel running the target pod.
+
+## What the spawn looks like
+
+```
+                  workstation                          target node (kubelet host)
+ ┌──────────────────────────────────┐      ┌─────────────────────────────────────────┐
+ │ kubectl podtrace -n app api-pod  │      │                                         │
+ │  │                               │      │  /sys/fs/cgroup ─┐                      │
+ │  │ ResolveTargetNodes()          │ ──▶  │  /proc           ├─ mounted at /host/*  │
+ │  │ → app/api-pod on worker-3     │      │  /run/containerd ┘  in spawned pod      │
+ │  │                               │      │                                         │
+ │  │ Create privileged Pod         │ ──▶  │  podtrace-cli-worker-3-abc12345         │
+ │  │ on worker-3, hostPID, mounts  │      │   ├─ podtrace --pods app/api-pod ...    │
+ │  │                               │      │   ├─ PODTRACE_NODE_LOCAL=1              │
+ │  │ Attach to pod stdout/stderr   │ ◀──  │   ├─ PODTRACE_PROC_BASE=/host/proc      │
+ │  │                               │      │   ├─ PODTRACE_CGROUP_BASE=...           │
+ │  │ Print events to terminal      │      │   └─ loads eBPF, attaches to cgroup     │
+ │  │                               │      │                                         │
+ │  │ on exit: Delete spawn pod     │ ──▶  │  (gone)                                 │
+ └──────────────────────────────────┘      └─────────────────────────────────────────┘
+```
+
+The spawned pod runs the **same** `podtrace` binary the user has on
+their workstation, just inside the node's kernel. The
+`PODTRACE_NODE_LOCAL=1` env var tells the child binary it's already
+on the kubelet host and to skip the spawn step itself (no recursion).
+
+## When the spawn is skipped
+
+Three conditions short-circuit the spawn and run eBPF on the local
+host instead:
+
+1. `--local` flag set explicitly.
+2. `PODTRACE_NODE_LOCAL=1` env var set (the child uses this).
+3. `rest.InClusterConfig()` succeeds — the binary is already running
+   inside a Pod, typical when the operator launches a session Job.
+
+### Use `--local` for kind / minikube / docker-desktop
+
+These setups run cluster nodes as docker containers on your workstation,
+which means the workstation kernel **is** the cluster's kernel. The
+spawn step exists to bridge a different-kernel gap that doesn't apply
+here, so it's pure overhead — pod-create latency, an image pull,
+PodSecurity labelling, RBAC bootstrap, all of it skippable.
+
+```bash
+# kind / minikube / docker-desktop — fastest, zero setup
+./bin/podtrace --local -n my-app my-pod
+```
+
+`--local` needs `CAP_BPF` + `CAP_SYS_ADMIN` (etc.) on the local binary.
+The release tarball ships these via setcap; for source builds,
+`./scripts/build-and-setup.sh` runs setcap automatically as the last
+step of `make build`. **`cp` does NOT preserve file capabilities** — if
+you copy the binary somewhere else (like `~/.krew/bin/`), re-run
+`./scripts/setup-capabilities.sh /path/to/copy` or just invoke the
+original `./bin/podtrace` directly.
+
+For all other clusters (Talos, EKS, GKE, AKS, OpenShift, bare-metal,
+Fargate), do **not** use `--local` — the workstation kernel isn't the
+node's, and eBPF on the workstation can't see the target pod's
+syscalls. The default spawn behavior is the correct choice.
+
+## RBAC
+
+### What the workstation needs (your kubeconfig)
+
+The user running `kubectl podtrace` needs to be able to:
+
+```yaml
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "get", "delete", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/log", "pods/attach"]
+  verbs: ["get", "create"]
+```
+
+Cluster-wide read on `pods` is required for target selection. `pods/attach` is
+preferred (real Ctrl+C and stdin); the CLI falls back to `pods/log` (read-only)
+when attach is denied and prints a degraded-mode warning. Any user with `view` +
+`pod-exec` already has this — there is nothing to apply.
+
+### What the spawn pod needs (zero, by default)
+
+**The spawn pod runs as the namespace's default ServiceAccount and needs no
+permissions.** The workstation pre-resolves each target pod's containerID and
+hands it to the spawn pod via a hidden `--preresolved-pod` flag; the child
+binary builds its `PodInfo` from that hand-off without making a single K8s API
+call. This is what makes `kubectl podtrace -n ns pod` work out-of-the-box on a
+fresh cluster.
+
+The optional [deploy/cli-rbac/role.yaml](../deploy/cli-rbac/role.yaml) ServiceAccount + ClusterRole exists
+only for enriched-events correlation (annotating traces with Kubernetes
+`Event` objects). Without it, you lose the events sidebar but tracing itself
+works perfectly.
+
+## PodSecurity
+
+The spawn pod is privileged: `hostPID=true`, capabilities `BPF`,
+`SYS_ADMIN`, `PERFMON`, `SYS_RESOURCE`, `NET_ADMIN`, plus hostPath
+mounts for `/sys/fs/bpf`, `/sys/kernel/btf`, `/proc`, `/sys/fs/cgroup`,
+`/run/containerd`.
+
+Namespaces that enforce `restricted` or `baseline` will reject the
+spawn pod. The CLI surfaces this with an exact remediation command:
+
+```bash
+kubectl label ns/<spawn-ns> pod-security.kubernetes.io/enforce=privileged --overwrite
+```
+
+Or use `--spawn-namespace=<dedicated-ns>` to centralize the
+admission requirement in one namespace.
+
+## Reaping leaked pods
+
+If the CLI crashes or its connection drops before the in-process
+`defer Delete` runs, the spawn pod survives until its
+`activeDeadlineSeconds` ceiling (default 1h) kicks in. To clean up
+sooner, the next CLI invocation runs a reaper that lists pods
+labelled `app.kubernetes.io/managed-by=podtrace-cli`,
+`podtrace.io/owner-host=<hostname>`, older than 2h, and deletes
+them. The owner-host filter ensures collaborators sharing a cluster
+don't reap each other's pods.
+
+Manual reaper:
+
+```bash
+kubectl delete pods -A -l app.kubernetes.io/managed-by=podtrace-cli
+```
+
+## Image source
+
+The spawn pod runs the container image baked at link time:
+`ghcr.io/gma1k/podtrace:<CLI version>`. Override precedence:
+
+1. `--image <ref>` flag
+2. `PODTRACE_IMAGE` env var
+3. Linker default (`-X .../config.Image`, set by the Makefile)
+
+Dev builds (CLI version like `dev` or `dev-<sha>`) have no published
+image, so they fall back to `ghcr.io/gma1k/podtrace:latest` and emit
+a startup warning telling the user to pin a real tag.
+
+## Multi-node fan-out
+
+When `--pods` / `--pod-selector` / `--all-in-namespace` resolves to
+pods on multiple nodes, the CLI launches one spawn pod per node and
+streams them concurrently. Output lines are prefixed with
+`[<node-name>] ` when more than one node is in play, so collated
+output is greppable per node.
+
+`v1` snapshot semantics: the target set is resolved once at start.
+If new pods matching the selector appear on a fresh node mid-run,
+they're not picked up. To trace them, restart the CLI.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -185,6 +185,26 @@ kubectl podtrace --version
 kubectl krew upgrade podtrace
 ```
 
+> **How `kubectl podtrace` reaches the kernel**
+>
+> - **Real clusters** (Talos, EKS, GKE, AKS, OpenShift, bare-metal): the CLI
+>   spawns a short-lived privileged pod on the target pod's node and runs
+>   eBPF there. Zero workstation caps needed; one-time namespace
+>   PodSecurity label required. See [cli-architecture.md](cli-architecture.md).
+>
+> - **kind / minikube / docker-desktop**: the workstation **is** the kubelet
+>   host (nodes are docker containers sharing the host kernel), so the
+>   spawn step is wasted overhead. Add `--local`:
+>   ```bash
+>   kubectl podtrace --local -n my-app api-pod
+>   ```
+>   Skip-the-spawn means eBPF loads on your workstation directly, no
+>   privileged pod, no PSA label, no image to load. Same UX as pre-PR
+>   podtrace on a single-node setup. Needs `CAP_BPF` / `CAP_SYS_ADMIN` on
+>   the local binary — the release tarball ships these via setcap, and
+>   `make build` + `./scripts/setup-capabilities.sh` does the same for
+>   source builds.
+
 #### Verify the tarball signature (cosign keyless + sha256sum)
 
 The release pipeline signs `checksums.txt` via cosign keyless and

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -1,5 +1,74 @@
 # Running podtrace on Talos Linux
 
+## Using `kubectl podtrace`
+
+The CLI works on Talos out-of-the-box. It identifies the node
+hosting the target pod, spawns a short-lived privileged pod on that
+node, runs eBPF there, and streams events back to your terminal. The
+workstation pre-resolves the target's containerID and passes it via a
+flag so the spawn pod needs **zero RBAC** — see [cli-architecture.md](cli-architecture.md).
+This replaces the old workstation-eBPF mode that silently failed on Talos
+because Talos's container runtime is isolated from the host that ran
+`kubectl podtrace` (issue [#149](https://github.com/gma1k/podtrace/issues/149)).
+
+```bash
+# One-time: allow the spawn pod's privileged spec in the target namespace
+kubectl label ns/<your-app-ns> pod-security.kubernetes.io/enforce=privileged --overwrite
+
+# Then trace as normal
+kubectl podtrace -n <your-app-ns> <pod-name>
+```
+
+If you'd rather keep your application namespaces non-privileged,
+create a dedicated namespace once and aim the spawn at it:
+
+```bash
+kubectl create ns podtrace-cli
+kubectl label ns/podtrace-cli pod-security.kubernetes.io/enforce=privileged
+export PODTRACE_SPAWN_NAMESPACE=podtrace-cli
+kubectl podtrace -n <app-ns> <pod>
+```
+
+### Air-gapped Talos clusters
+
+The spawn pod pulls `ghcr.io/gma1k/podtrace:<CLI version>` by default.
+Pre-pull on each node or point at a mirror:
+
+```bash
+talosctl --nodes <nodes> image pull ghcr.io/gma1k/podtrace:<version>
+# or
+kubectl podtrace --image=mirror.internal/podtrace:<tag> ...
+```
+
+### Local dev/testing against a Talos cluster
+
+To exercise an in-development binary on a real Talos VM cluster:
+
+```bash
+# Build a dev image
+make docker-build IMAGE_REPO=10.5.0.1:5000/podtrace IMAGE_TAG=dev
+
+# Push to a local registry reachable from Talos VMs
+docker run -d --name pt-reg -p 10.5.0.1:5000:5000 registry:2
+docker push 10.5.0.1:5000/podtrace:dev
+
+# Tell Talos to allow the insecure registry
+talosctl --nodes <nodes> patch machineconfig --immediate -p '[
+  {"op":"add","path":"/machine/registries","value":{
+    "config":{"10.5.0.1:5000":{"tls":{"insecureSkipVerify":true}}}
+  }}
+]'
+
+# Pre-pull and run
+talosctl --nodes <nodes> image pull 10.5.0.1:5000/podtrace:dev
+./bin/podtrace --pods <ns>/<pod> --image=10.5.0.1:5000/podtrace:dev --diagnose 5s
+```
+
+A turnkey Talos QEMU cluster setup that was used to validate this fix
+lives at [`stuffs/talos-setup/`](https://github.com/gma1k/podtrace) in the user's
+local workspace; the `scripts/up.sh` script brings up a Talos v1.13.2
+cluster with Cilium in ~3 minutes.
+
 ## Overview
 
 Talos Linux is an immutable, minimal OS designed exclusively for Kubernetes.
@@ -28,81 +97,86 @@ make build GOARCH=amd64
 make build GOARCH=arm64
 ```
 
-## Deploying podtrace on Talos
+## Production deployment via Helm
 
-The recommended approach is a **DaemonSet** with the binary embedded in a
-container image.
+Use the operator + agent chart. The agent DaemonSet runs on every node and
+reconciles eBPF attachments from `PodTrace` / `PodTraceSession` /
+`PodTraceSchedule` CRs:
 
-### Container image example
+```bash
+# cert-manager is required for the validating webhook's TLS certs
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true
 
-```dockerfile
-FROM debian:12-slim AS builder
-RUN apt-get update && apt-get install -y make clang llvm libbpf-dev bpftool
-COPY . /src
-WORKDIR /src
-RUN make build
+# self-signed Issuer for the webhook cert
+kubectl create namespace podtrace-system
+kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata: {name: podtrace-selfsigned, namespace: podtrace-system}
+spec: {selfSigned: {}}
+EOF
 
-FROM debian:12-slim
-COPY --from=builder /src/bin/podtrace /podtrace
-ENTRYPOINT ["/podtrace"]
+# Install podtrace
+helm install podtrace oci://ghcr.io/gma1k/charts/podtrace \
+  --namespace podtrace-system \
+  --set webhook.enabled=true
 ```
 
-### DaemonSet
+After install you get:
 
-Talos nodes use the **cgroupfs** driver (not systemd), so cgroup paths look like:
+- **Operator** Deployment reconciling 5 CRDs (`PodTrace`, `PodTraceSession`,
+  `PodTraceSchedule`, `ExporterConfig`, `TracerConfig`)
+- **Agent** DaemonSet — one privileged pod per node, attaches eBPF locally,
+  filters events by cgroup_id
+- **Validating webhook** — admits only well-formed CRs (must have cert-manager)
+- **Default `TracerConfig`** — controls the agent image / resources
 
+Talos nodes use **cgroup v2 with the cgroupfs driver**; the agent
+auto-detects this and uses paths like
+`/sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/.../cri-containerd-<id>.scope`.
+No env-var overrides needed for default Talos installs.
+
+### Verifying the install
+
+```bash
+kubectl -n podtrace-system get pods
+# expect: podtrace-operator Running, podtrace-agent (N) Running
+
+kubectl get crd | grep podtrace.io
+# expect: 5 CRDs
+
+kubectl get validatingwebhookconfigurations | grep podtrace
+# expect: podtrace-validating-webhook
 ```
-/sys/fs/cgroup/kubepods/burstable/pod<uid>/<container-id>/
-```
 
-```yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: podtrace
-  namespace: kube-system
+End-to-end smoke test:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata: {name: smoke, namespace: default}
 spec:
-  template:
-    spec:
-      hostPID: true
-      hostNetwork: true
-      containers:
-      - name: podtrace
-        image: your-registry/podtrace:latest
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: sys-fs-cgroup
-          mountPath: /sys/fs/cgroup
-          readOnly: true
-        - name: proc
-          mountPath: /proc
-          readOnly: true
-        - name: cri-sock
-          mountPath: /run/containerd/containerd.sock
-        env:
-        - name: PODTRACE_CGROUP_BASE
-          value: /sys/fs/cgroup
-        - name: PODTRACE_PROC_BASE
-          value: /proc
-        - name: PODTRACE_CRI_ENDPOINT
-          value: unix:///run/containerd/containerd.sock
-        # Talos may not embed container ID in cgroup path:
-        - name: PODTRACE_ALLOW_BROAD_CGROUP
-          value: "1"
-      volumes:
-      - name: sys-fs-cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-      - name: proc
-        hostPath:
-          path: /proc
-      - name: cri-sock
-        hostPath:
-          path: /run/containerd/containerd.sock
-          type: Socket
-      tolerations:
-      - operator: Exists
+  type: otlp
+  otlp: {endpoint: collector.default.svc.cluster.local:4318}
+---
+apiVersion: podtrace.io/v1alpha1
+kind: PodTraceSession
+metadata: {name: smoke, namespace: default}
+spec:
+  selector: {matchLabels: {app: nginx}}
+  duration: 10s
+  exporterRef: {name: smoke}
+  reportRef: {configMap: {name: smoke-report}}
+EOF
+
+# Session runs a Job on the target's node, finishes within ~15s
+kubectl wait --for=jsonpath='{.status.state}'=Completed \
+  podtracesession smoke --timeout=60s
+kubectl get cm smoke-report -o jsonpath='{.data.report\.txt}'
 ```
 
 ## BTF on Talos
@@ -121,13 +195,60 @@ bpftool btf dump file /tmp/talos-vmlinux format c > bpf/vmlinux.h
 make build
 ```
 
-## Known issues
+## Hardening trade-offs
 
-- **No systemd** — the kubelet cgroup-parent auto-detection via `/proc/<pid>/cmdline`
-  works normally since kubelet still runs as a process.
-- **cgroupfs driver** — Talos uses the cgroupfs driver. If the kubelet process is
-  not visible in `/proc` (e.g. running in a separate namespace), set
-  `PODTRACE_CGROUP_BASE=/sys/fs/cgroup` explicitly.
-- **Talos API restrictions** — some Talos machine config hardening options can
-  restrict `/proc` visibility. Ensure `hostPID: true` is allowed by your Talos
-  machine config.
+Talos's secure defaults affect what podtrace can display. Each item below is
+an intentional kernel/Kubernetes choice; podtrace surfaces a clear message and
+the workaround if you accept the security cost.
+
+### Kernel stack symbolication needs `kernel.kptr_restrict=0`
+
+Talos defaults `kernel.kptr_restrict=2`, which zeroes every address in
+`/proc/kallsyms` regardless of capability — `CAP_SYSLOG` doesn't help.
+The sysctl exists to deny userspace any address that could be used as an exploit
+primitive (ROP gadgets, SMEP/SMAP bypasses).
+
+There is no userspace API that returns real kernel addresses when
+`kptr_restrict=2` is in effect — not BTF, not `bpf_kallsyms_lookup_name`,
+not `bpf_get_func_ip`. Podtrace falls back to raw hex (`0xffffffff97dd580e`)
+and emits a one-shot warning:
+
+> Kernel symbol resolution unavailable: /proc/kallsyms returned no addresses
+> (kernel.kptr_restrict is non-zero). Stack frames at kernel addresses will
+> display as raw hex. Set kernel.kptr_restrict=0 on the node to enable symbolication.
+
+User-space frames (your app's stack) symbolicate normally via `/proc/<pid>/exe`
++ `addr2line`. To enable kernel-side symbolication, patch the machine config:
+
+```yaml
+machine:
+  sysctls:
+    kernel.kptr_restrict: "0"
+```
+
+`talosctl --nodes <node> patch machineconfig --immediate -p @patch.yaml`
+
+This is a security trade-off — `kptr_restrict=0` exposes kernel addresses to
+all processes on the node and weakens exploit mitigations. Apply per node only
+when actively debugging; revert when done. User-space stack frames (your app's
+code) symbolicate normally regardless via `/proc/<pid>/exe` + `addr2line`.
+
+### PodSecurity admission on workload namespaces
+
+The spawn pod needs `hostPID` + `CAP_BPF` + `CAP_SYS_ADMIN`, which clusters
+enforcing `restricted` PodSecurity block by default. Three options:
+
+1. Label the target namespace: `kubectl label ns/<app-ns> pod-security.kubernetes.io/enforce=privileged --overwrite`
+2. Use a dedicated namespace and set `PODTRACE_SPAWN_NAMESPACE=podtrace-cli`.
+3. Use the operator path (CR-driven sessions in `podtrace-system`) — already
+   pre-allowed by the helm chart.
+
+### What works without any extra config
+
+- cgroupfs path discovery (auto-detects Talos's `kubelet.slice/...` layout)
+- BTF loading from `/sys/kernel/btf/vmlinux` (all Talos kernels ≥ 1.3 ship BTF)
+- containerd via `/run/containerd/containerd.sock`
+- User-space stack symbolication (addr2line on `/proc/<pid>/exe`)
+- All 5 CRDs reconciling
+- Validating webhook (once cert-manager is installed)
+- Chainsaw e2e suite (validated 13/13 functional)

--- a/docs/viewing-events.md
+++ b/docs/viewing-events.md
@@ -17,27 +17,72 @@ path is. Pick the one that matches what you're doing.
 | Archived per-run snapshots over time | `PodTraceSchedule` with `reportRef.objectStore` | `aws s3 cp s3://…/<key> -` |
 | Real-time spans in a UI (production) | any CR with an `ExporterConfig` pointed at OTLP | Jaeger / Tempo / Datadog / Splunk |
 
-## Surface 1: live CLI streaming
+## Live CLI streaming
 
-The CLI is **not** operator-managed. It runs from your workstation
-against any pod in the cluster, attaches eBPF probes through the agent
-DaemonSet, and prints events as they happen.
+The CLI runs from your workstation against any pod in the cluster.
+Under the hood it spawns a short-lived privileged pod on the **target
+pod's node** (one per node when targets span multiple nodes), runs
+eBPF there against the host's `/sys/fs/cgroup`, and streams events
+back to your terminal. The spawn pod is deleted on exit.
 
 ```bash
 # One pod, real-time
 kubectl podtrace -n my-app api-pod-abc
 
-# Many pods via label selector
+# Many pods via label selector (one spawn pod per node)
 kubectl podtrace -n my-app --pod-selector app=api
 
-# Ctrl+C → final diagnostic report + clean detach
+# Ctrl+C → spawn pod deleted, final diagnostic report on stdout
 ```
 
-Pros: zero setup once the operator + agents are installed.
-Cons: ephemeral. Close the terminal, you lose the events. Use it for
-interactive debugging.
+### Why a spawn pod
+
+eBPF programs run in the kernel of the machine where they're loaded.
+The workstation kernel can't observe a pod running on a remote node,
+so the CLI loads eBPF *on that node* by way of an ephemeral pod with
+`hostPID` and the host's `/proc` + `/sys/fs/cgroup` mounted at
+`/host/*`. The child binary respects `PODTRACE_PROC_BASE` and
+`PODTRACE_CGROUP_BASE` env vars and finds the cgroup hierarchy there.
+
+### Flags that control the spawn
+
+| Flag | Default | What it does |
+|---|---|---|
+| `--local` | off | Skip the spawn; run eBPF on the workstation. Use for kind/minikube/docker-desktop where the workstation IS the kubelet host. |
+| `--image` | linker default `ghcr.io/gma1k/podtrace:<CLI version>` | Override the image the spawn pod runs. Also settable via `PODTRACE_IMAGE` env. |
+| `--spawn-namespace` | target pod's namespace | Namespace where the spawn pod lives. Also settable via `PODTRACE_SPAWN_NAMESPACE`. |
+
+### Required cluster setup
+
+The spawn pod is privileged (`hostPID`, `CAP_BPF`, `CAP_SYS_ADMIN`,
+hostPath mounts). If the target namespace enforces PodSecurity
+"restricted" or "baseline", admission rejects the spawn pod with an
+error the CLI surfaces verbatim, including the one-line remediation:
+
+```bash
+kubectl label ns/<ns> pod-security.kubernetes.io/enforce=privileged --overwrite
+```
+
+Or use `--spawn-namespace=<centralized-ns>` to point at a namespace
+you've already labelled for privileged workloads.
+
+RBAC needed in **your kubeconfig** (the workstation): `pods` (`create`, `get`,
+`delete`, `list`, `watch`), `pods/log`, `pods/attach`. Falls back to
+`pods/log` (stream-only, no stdin) if `pods/attach` is denied. **The spawn
+pod itself runs as the default ServiceAccount and needs zero RBAC** — the
+workstation pre-resolves every target's containerID and hands it to the
+spawn pod via a flag, so the child binary never calls the K8s API.
 
 For the full CLI flag reference see [usage.md](usage.md).
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `cgroup path not found for container <id>` | You passed `--local` on a cluster where the workstation isn't the kubelet host | Remove `--local`, or run on the kubelet host |
+| `violates PodSecurity` admission error | Spawn namespace enforces non-privileged PSA | Label the namespace (CLI prints the exact command) or use `--spawn-namespace` |
+| `ImagePullBackOff` on the spawn pod | Cluster can't pull the image | Use `--image=<reachable-ref>` or pre-pull via `talosctl image pull` / your registry mirror |
+| Spawn pod created but stdin doesn't work | RBAC denies `pods/attach` (degraded mode) | Grant `pods/attach` in the spawn namespace |
 
 ## Surface 2: a single ConfigMap (kubectl-friendly snapshot)
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
+	k8s.io/cli-runtime v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/cri-api v0.36.1
 	sigs.k8s.io/controller-runtime v0.24.1
@@ -76,8 +77,10 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -98,6 +101,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
+	k8s.io/streaming v0.36.1 // indirect
 )
 
 require (
@@ -127,7 +131,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.2
-	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/pflag v1.0.10
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
@@ -187,6 +189,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.15 h1:xolVQTEXusUcAA5Ugt
 github.com/googleapis/enterprise-certificate-proxy v0.3.15/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU5vlZD4=
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -211,6 +215,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -348,6 +354,8 @@ k8s.io/apiextensions-apiserver v0.36.0 h1:Wt7E8J+VBCbj4FjiBfDTK/neXDDjyJVJc7xfuO
 k8s.io/apiextensions-apiserver v0.36.0/go.mod h1:kGDjH0msuiIB3tgsYRV0kS9GqpMYMUsQ3GHv7TApyug=
 k8s.io/apimachinery v0.36.1 h1:G63Gjx2W+q0YD+72Vo8oY0nDnePVwnuzTmmy5ENrVSA=
 k8s.io/apimachinery v0.36.1/go.mod h1:ibYOR00vW/I1kzvi5SF0dRuJ52BvKtfvRdOn35GPQ+8=
+k8s.io/cli-runtime v0.36.1 h1:yuC/BGnnj1YYPh6D1P+pZnzinCs6DvMq86yAeNqoqzM=
+k8s.io/cli-runtime v0.36.1/go.mod h1:ZQWHGt8xAF7KnviB79vX0lYNyUUqKIpU+LQg7exuFAw=
 k8s.io/client-go v0.36.1 h1:FN/K8QIT2CEDt+2WB2HnWrUANZ50AP5GII43/SP2JR0=
 k8s.io/client-go v0.36.1/go.mod h1:s6rAnCtTGYDQnpNjEhSaISV+2O8jwruZ6m3QOYBFbtU=
 k8s.io/cri-api v0.36.1 h1:g4vRySdoN5G+FMXC1jfGdUyynsHy2qaHZKZhCXZuEmg=
@@ -356,6 +364,8 @@ k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hkbPJgdATINPMAxaynU2Ovg=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
+k8s.io/streaming v0.36.1 h1:L+K68n4Gg940BGNNYtUBvL1WTLL0YnKT3s+P1MNAmR4=
+k8s.io/streaming v0.36.1/go.mod h1:z6fV3D+NVkoeqRMtWwlUZK6U17SY/LqNzOxWL6GyR/s=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0xi3g0ZcxxJ7vbWU=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
@@ -364,8 +374,6 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,21 +106,15 @@ var (
 	EventSamplingRate         = getIntEnvOrDefault("PODTRACE_EVENT_SAMPLING_RATE", DefaultEventSamplingRate)
 	ContainerPID              = getIntEnvOrDefault("PODTRACE_CONTAINER_PID", DefaultContainerPID)
 
-	// BPF resource tuning — applied to the CollectionSpec before loading.
 	RingBufferSizeKB = getIntEnvOrDefault("PODTRACE_RING_BUFFER_SIZE_KB", DefaultRingBufferSizeKB)
 	BPFHashMapSize   = getIntEnvOrDefault("PODTRACE_BPF_HASH_MAP_SIZE", DefaultBPFHashMapSize)
 
-	// Alert threshold percentages written into the alert_thresholds BPF map.
-	// Clamped to [0, 100] so the int → uint32 narrowing at the BPF call
-	// sites is provably safe; see ClampPct for why.
 	AlertWarnPct  = ClampPct(getIntEnvOrDefault("PODTRACE_ALERT_WARN_PCT", DefaultAlertWarnPct))
 	AlertCritPct  = ClampPct(getIntEnvOrDefault("PODTRACE_ALERT_CRIT_PCT", DefaultAlertCritPct))
 	AlertEmergPct = ClampPct(getIntEnvOrDefault("PODTRACE_ALERT_EMERG_PCT", DefaultAlertEmergPct))
 
-	// Optional HTTP management port for runtime probe group control (0 = disabled).
 	ManagementPort = getIntEnvOrDefault("PODTRACE_MANAGEMENT_PORT", 0)
 
-	// Language-runtime adapter options.
 	GRPCPort             = getIntEnvOrDefault("PODTRACE_GRPC_PORT", 50051)
 	USDTEnabled          = getEnvOrDefault("PODTRACE_USDT_ENABLED", "false") == "true"
 	RedactPII            = getEnvOrDefault("PODTRACE_REDACT_PII", "false") == "true"
@@ -128,12 +122,11 @@ var (
 	CriticalPathEnabled  = getEnvOrDefault("PODTRACE_CRITICAL_PATH", "true") == "true"
 	CriticalPathWindowMS = getIntEnvOrDefault("PODTRACE_CRITICAL_PATH_WINDOW_MS", 500)
 
-	// Profiling integration — pprof endpoint discovery, auto-trigger, and correlation.
-	ProfilingEnabled        = getEnvOrDefault("PODTRACE_PROFILING_ENABLED", "false") == "true"
-	ProfilingPprofPorts     = getEnvOrDefault("PODTRACE_PROFILING_PPROF_PORTS", "6060,8080,8081,9090,2345")
-	ProfilingAutoTriggerMS  = getFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
+	ProfilingEnabled         = getEnvOrDefault("PODTRACE_PROFILING_ENABLED", "false") == "true"
+	ProfilingPprofPorts      = getEnvOrDefault("PODTRACE_PROFILING_PPROF_PORTS", "6060,8080,8081,9090,2345")
+	ProfilingAutoTriggerMS   = getFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
 	ProfilingDefaultDuration = getDurationEnvOrDefault("PODTRACE_PROFILING_DEFAULT_DURATION", DefaultProfilingDuration)
-	ProfilingMaxConcurrent  = getIntEnvOrDefault("PODTRACE_PROFILING_MAX_CONCURRENT", DefaultProfilingMaxConcurrent)
+	ProfilingMaxConcurrent   = getIntEnvOrDefault("PODTRACE_PROFILING_MAX_CONCURRENT", DefaultProfilingMaxConcurrent)
 )
 
 const (
@@ -165,7 +158,7 @@ const (
 	DefaultTopTargetsLimit      = 5
 	DefaultTopFilesLimit        = 5
 	DefaultTopURLsLimit         = 5
-	DefaultTopProcessesLimit    = 5
+	DefaultTopProcessesLimit    = 10
 	DefaultTopStatesLimit       = 10
 	DefaultMaxStackTracesLimit  = 5
 	DefaultMaxStackFramesLimit  = 5
@@ -185,18 +178,15 @@ const (
 	MaxEvents                      = 1000000
 	DefaultEventSamplingRate       = 100
 
-	// BPF map sizing defaults.
 	DefaultBPFHashMapSize = 4096
 
-	// Alert threshold defaults (percentages).
 	DefaultAlertWarnPct  = 80
 	DefaultAlertCritPct  = 90
 	DefaultAlertEmergPct = 95
 
-	// Profiling defaults.
-	DefaultProfilingAutoTriggerMS  = 500.0
-	DefaultProfilingDuration       = 30 * time.Second
-	DefaultProfilingMaxConcurrent  = 1
+	DefaultProfilingAutoTriggerMS = 500.0
+	DefaultProfilingDuration      = 30 * time.Second
+	DefaultProfilingMaxConcurrent = 1
 )
 
 const (
@@ -365,15 +355,6 @@ func getIntEnvOrDefault(key string, defaultValue int) int {
 	return defaultValue
 }
 
-// ClampPct clamps an integer percentage into the [0, 100] range.
-//
-// Why: AlertWarnPct/CritPct/EmergPct are sourced from operator-supplied
-// env vars and later narrowed to uint32 when written to the BPF
-// alert_thresholds map. Without an upper bound, a misconfigured value
-// like 4294967296 would silently wrap to 0 and cause every event to
-// trip an alert. The bound also makes the int → uint32 conversion at
-// the call sites provably safe (CodeQL/gosec G115 false-positives go
-// away because the value is now constrained by a constant).
 func ClampPct(pct int) int {
 	if pct < 0 {
 		return 0
@@ -384,14 +365,6 @@ func ClampPct(pct int) int {
 	return pct
 }
 
-// ClampUint32 clamps a non-negative int into the [0, math.MaxUint32]
-// range and returns it as uint32. Negative values become 0.
-//
-// Used for BPF map sizes (BPFHashMapSize, RingBufferSizeKB*1024) which
-// are read as int via getIntEnvOrDefault but consumed as uint32 by the
-// cilium/ebpf API. Without this clamp, a configuration value above
-// math.MaxUint32 would wrap to a small map size and the BPF load could
-// silently use the wrong capacity.
 func ClampUint32(v int) uint32 {
 	if v < 0 {
 		return 0
@@ -453,6 +426,7 @@ func GetSplunkToken() string {
 var (
 	Version = "dev"
 	Commit  = "unknown"
+	Image   = "ghcr.io/gma1k/podtrace"
 )
 
 var readVCSRevision = func() string {
@@ -485,26 +459,18 @@ func GetUserAgent() string {
 	return "Podtrace/" + GetVersion()
 }
 
-// OTLPAllowInsecureNonLoopback returns true when PODTRACE_OTLP_INSECURE=1,
-// allowing http:// to non-loopback OTLP collectors (cleartext).
 func OTLPAllowInsecureNonLoopback() bool {
 	return os.Getenv("PODTRACE_OTLP_INSECURE") == "1"
 }
 
-// MetricsEnablePprof registers /debug/pprof/* when PODTRACE_METRICS_ENABLE_PPROF=1
-// or when profiling integration is enabled (--profiling / PODTRACE_PROFILING_ENABLED).
 func MetricsEnablePprof() bool {
 	return os.Getenv("PODTRACE_METRICS_ENABLE_PPROF") == "1" || ProfilingEnabled
 }
 
-// SplunkAlertAllowHTTP returns true when PODTRACE_ALERT_SPLUNK_ALLOW_HTTP=1,
-// allowing http:// Splunk HEC URLs for non-loopback hosts.
 func SplunkAlertAllowHTTP() bool {
 	return os.Getenv("PODTRACE_ALERT_SPLUNK_ALLOW_HTTP") == "1"
 }
 
-// AllowCgroupFilterAutoDisable returns true when PODTRACE_ALLOW_CGROUP_FILTER_DISABLE=1,
-// permitting the tracer to automatically disable cgroup filtering as a last-resort fallback.
 func AllowCgroupFilterAutoDisable() bool {
 	return os.Getenv("PODTRACE_ALLOW_CGROUP_FILTER_DISABLE") == "1"
 }

--- a/internal/diagnose/profiling/cpu_profiling.go
+++ b/internal/diagnose/profiling/cpu_profiling.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+	"github.com/podtrace/podtrace/internal/ebpf/cache"
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/procfs"
 )
 
-func GenerateCPUUsageReport(events []*events.Event, duration time.Duration) string {
-	pidActivity := tracker.AnalyzeProcessActivity(events)
+func GenerateCPUUsageReport(allEvents []*events.Event, duration time.Duration) string {
+	pidActivity := tracker.AnalyzeProcessActivity(allEvents)
 	if len(pidActivity) == 0 {
 		return GenerateCPUUsageFromProc(duration)
 	}
@@ -24,17 +25,46 @@ func GenerateCPUUsageReport(events []*events.Event, duration time.Duration) stri
 	durationSec := duration.Seconds()
 	totalCPUPercent := 0.0
 
+	cpuTimeFromSched := make(map[uint32]uint64)
+	for _, e := range allEvents {
+		if e == nil || e.Type != events.EventSchedSwitch {
+			continue
+		}
+		cpuTimeFromSched[e.PID] += e.LatencyNS
+	}
+
 	pidCPUTimes := make(map[uint32]cpuTimeInfo)
 	for _, info := range pidActivity {
-		cpuTime := getProcessCPUTime(info.Pid)
-		if cpuTime.totalNS > 0 {
-			cpuPercent := (float64(cpuTime.totalNS) / 1e9) / durationSec * 100.0
+		var totalNS uint64
+		if ns, ok := cpuTimeFromSched[info.Pid]; ok && ns > 0 {
+			totalNS = ns
+		} else if proc := getProcessCPUTime(info.Pid); proc.totalNS > 0 {
+			totalNS = proc.totalNS
+		}
+		if totalNS > 0 {
+			cpuPercent := (float64(totalNS) / 1e9) / durationSec * 100.0
 			pidCPUTimes[info.Pid] = cpuTimeInfo{
 				cpuPercent: cpuPercent,
-				cpuTimeSec: float64(cpuTime.totalNS) / 1e9,
+				cpuTimeSec: float64(totalNS) / 1e9,
 				name:       info.Name,
 			}
 		}
+	}
+
+	if len(pidCPUTimes) == 0 && len(pidActivity) > 0 {
+		report += "  Process Activity Ranking (event count — CPU samples unavailable for short-lived processes):\n"
+		limit := config.TopProcessesLimit
+		if limit > len(pidActivity) {
+			limit = len(pidActivity)
+		}
+		for i := 0; i < limit; i++ {
+			a := pidActivity[i]
+			report += fmt.Sprintf("    PID %d (%s): %d events (%.1f%%)\n",
+				a.Pid, a.Name, a.Count, a.Percentage)
+		}
+		report += "\n  Total CPU usage: unavailable (no /proc samples)\n"
+		report += fmt.Sprintf("  Sample duration: %.2fs across %d distinct processes\n\n", durationSec, len(pidActivity))
+		return report
 	}
 
 	type cpuUsageInfo struct {
@@ -120,6 +150,9 @@ type cpuTimeInfo struct {
 func getProcessCPUTime(pid uint32) cpuTimeInfo {
 	data, err := procfs.ReadFile(fmt.Sprintf("%d/stat", pid))
 	if err != nil {
+		if cached := cache.GetCPUTime(pid); cached.TotalNS > 0 {
+			return cpuTimeInfo{totalNS: cached.TotalNS}
+		}
 		return cpuTimeInfo{}
 	}
 

--- a/internal/diagnose/stacktrace/kallsyms.go
+++ b/internal/diagnose/stacktrace/kallsyms.go
@@ -1,0 +1,113 @@
+package stacktrace
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/podtrace/podtrace/internal/logger"
+	"github.com/podtrace/podtrace/internal/procfs"
+)
+
+// kallsymsLookup loads /proc/kallsyms once and resolves kernel addresses to
+// symbol names. /proc/kallsyms is sorted by address; we keep the parsed list
+// and binary-search for the largest symbol whose address <= the target.
+//
+// On clusters where kptr_restrict hides addresses (typical default), the file
+// lists all symbols at address 0x0 and resolution returns "" — callers fall
+// back to the raw hex format. Set sysctl kernel.kptr_restrict=0 to get
+// resolution; podtrace doesn't require it.
+type kallsymsLookup struct {
+	once    sync.Once
+	syms    []ksym
+	loaded  bool
+	maxAddr uint64
+}
+
+type ksym struct {
+	Addr uint64
+	Name string
+}
+
+var defaultKallsyms = &kallsymsLookup{}
+
+func (k *kallsymsLookup) load() {
+	f, err := procfs.Open("kallsyms")
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		addr, err := strconv.ParseUint(parts[0], 16, 64)
+		if err != nil || addr == 0 {
+			continue
+		}
+		k.syms = append(k.syms, ksym{Addr: addr, Name: parts[2]})
+		if addr > k.maxAddr {
+			k.maxAddr = addr
+		}
+	}
+	if !isSorted(k.syms) {
+		sortKsyms(k.syms)
+	}
+	k.loaded = len(k.syms) > 0
+	if !k.loaded {
+		logger.Warn("Kernel symbol resolution unavailable: /proc/kallsyms returned no addresses (kernel.kptr_restrict is non-zero). Stack frames at kernel addresses will display as raw hex. Set kernel.kptr_restrict=0 on the node to enable symbolication.")
+	}
+}
+
+// Resolve returns "<symbol>+0x<offset>" for kernel address addr, or "" when
+// kallsyms is unavailable or the address falls outside the symbol table.
+func (k *kallsymsLookup) Resolve(addr uint64) string {
+	k.once.Do(k.load)
+	if !k.loaded || addr == 0 || addr > k.maxAddr {
+		return ""
+	}
+	lo, hi := 0, len(k.syms)-1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if k.syms[mid].Addr <= addr {
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	if hi < 0 {
+		return ""
+	}
+	s := k.syms[hi]
+	return s.Name + "+0x" + strconv.FormatUint(addr-s.Addr, 16)
+}
+
+// IsKernelAddress is a fast heuristic: x86_64 and arm64 kernel virtual
+// addresses live above 0xffff800000000000. User addresses are below.
+func IsKernelAddress(addr uint64) bool {
+	return addr >= 0xffff800000000000
+}
+
+func isSorted(s []ksym) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i].Addr < s[i-1].Addr {
+			return false
+		}
+	}
+	return true
+}
+
+func sortKsyms(s []ksym) {
+	for i := 1; i < len(s); i++ {
+		j := i
+		for j > 0 && s[j].Addr < s[j-1].Addr {
+			s[j], s[j-1] = s[j-1], s[j]
+			j--
+		}
+	}
+}

--- a/internal/diagnose/stacktrace/kallsyms_test.go
+++ b/internal/diagnose/stacktrace/kallsyms_test.go
@@ -1,0 +1,51 @@
+package stacktrace
+
+import "testing"
+
+func TestKallsyms_BinarySearch(t *testing.T) {
+	k := &kallsymsLookup{
+		syms: []ksym{
+			{Addr: 0xffffffff81000000, Name: "_text"},
+			{Addr: 0xffffffff81234000, Name: "sys_open"},
+			{Addr: 0xffffffff81234100, Name: "sys_close"},
+			{Addr: 0xffffffff81fff000, Name: "_end"},
+		},
+		loaded:  true,
+		maxAddr: 0xffffffff81fff000,
+	}
+	k.once.Do(func() {})
+
+	tests := []struct {
+		name string
+		addr uint64
+		want string
+	}{
+		{"first symbol exact", 0xffffffff81000000, "_text+0x0"},
+		{"between sys_open and sys_close", 0xffffffff8123407f, "sys_open+0x7f"},
+		{"sys_close exact", 0xffffffff81234100, "sys_close+0x0"},
+		{"out of range", 0xffffffff82000000, ""},
+		{"zero", 0, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := k.Resolve(tc.addr)
+			if got != tc.want {
+				t.Errorf("Resolve(0x%x) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsKernelAddress(t *testing.T) {
+	tests := map[uint64]bool{
+		0x7fff12345678:     false, // user-space
+		0xffff800000000000: true,  // kernel boundary
+		0xffffffff81000000: true,  // typical x86_64 kernel
+		0x0:                false,
+	}
+	for addr, want := range tests {
+		if got := IsKernelAddress(addr); got != want {
+			t.Errorf("IsKernelAddress(0x%x) = %v, want %v", addr, got, want)
+		}
+	}
+}

--- a/internal/diagnose/stacktrace/stacktrace.go
+++ b/internal/diagnose/stacktrace/stacktrace.go
@@ -43,14 +43,16 @@ func (r *stackResolver) resolve(ctx context.Context, pid uint32, addr uint64) st
 	if r.cache == nil {
 		r.cache = make(map[string]string)
 	}
+	if IsKernelAddress(addr) {
+		if sym := defaultKallsyms.Resolve(addr); sym != "" {
+			return sym
+		}
+		return fmt.Sprintf("0x%x", addr)
+	}
 	exePath, err := procfs.Readlink(fmt.Sprintf("%d/exe", pid))
 	if err != nil || exePath == "" {
 		return fmt.Sprintf("0x%x", addr)
 	}
-	// Reject pathological symlink targets (relative paths, ".."
-	// segments) before passing to addr2line. The kernel won't emit
-	// these for /proc/<pid>/exe in practice, but the explicit check
-	// makes the exec invocation provably safe.
 	if _, err := hostfs.Stat(exePath); err != nil {
 		return fmt.Sprintf("0x%x", addr)
 	}
@@ -66,9 +68,6 @@ func (r *stackResolver) resolve(ctx context.Context, pid uint32, addr uint64) st
 		r.cache[key] = v
 		return v
 	}
-	// addr2lineBin is exec.LookPath-resolved; exePath was just
-	// validated by hostfs.Stat (absolute, no traversal); address is a
-	// formatted hex literal. All exec inputs are constrained.
 	cmd := exec.CommandContext(timeoutCtx, addr2lineBin, "-e", exePath, fmt.Sprintf("%#x", addr)) // #nosec G204 -- LookPath-resolved binary; exePath validated via hostfs.Stat; address is %#x-formatted
 	out, err := cmd.Output()
 	if err != nil {
@@ -152,7 +151,11 @@ func GenerateStackTraceSectionWithContext(d Diagnostician, ctx context.Context) 
 		if e == nil {
 			continue
 		}
-		report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, target=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), e.Target, float64(e.LatencyNS)/float64(config.NSPerMS))
+		if e.Target != "" {
+			report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, target=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), e.Target, float64(e.LatencyNS)/float64(config.NSPerMS))
+		} else {
+			report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), float64(e.LatencyNS)/float64(config.NSPerMS))
+		}
 		maxFrames := config.MaxStackFramesLimit
 		if len(e.Stack) < maxFrames {
 			maxFrames = len(e.Stack)
@@ -166,4 +169,3 @@ func GenerateStackTraceSectionWithContext(d Diagnostician, ctx context.Context) 
 	report += "\n"
 	return report
 }
-

--- a/internal/diagnose/tracker/process.go
+++ b/internal/diagnose/tracker/process.go
@@ -25,15 +25,33 @@ func AnalyzeProcessActivity(events []*events.Event) []PidInfo {
 		pidMap[e.PID]++
 	}
 
+	type latestName struct {
+		ts   uint64
+		name string
+	}
+	latest := make(map[uint32]latestName)
+	transient := make(map[uint32]latestName)
+	for _, e := range events {
+		if e == nil || e.ProcessName == "" {
+			continue
+		}
+		bucket := latest
+		if isTransientName(e.ProcessName) {
+			bucket = transient
+		}
+		if cur, ok := bucket[e.PID]; !ok || e.Timestamp > cur.ts {
+			bucket[e.PID] = latestName{ts: e.Timestamp, name: e.ProcessName}
+		}
+	}
+
 	var pidInfos []PidInfo
 	for pid, count := range pidMap {
 		percentage := float64(count) / float64(totalEvents) * 100
 		name := ""
-		for _, e := range events {
-			if e.PID == pid && e.ProcessName != "" {
-				name = e.ProcessName
-				break
-			}
+		if l, ok := latest[pid]; ok {
+			name = l.name
+		} else if l, ok := transient[pid]; ok {
+			name = l.name
 		}
 		if name == "" {
 			name = getProcessName(pid)
@@ -54,6 +72,20 @@ func AnalyzeProcessActivity(events []*events.Event) []PidInfo {
 	})
 
 	return pidInfos
+}
+
+// isTransientName flags comm values that the kernel sets briefly during
+// container setup — they get superseded by the user's command after runc's
+// setns+exec dance. Aggregation prefers a stable name over these whenever
+// the same PID also has events tagged with the post-exec identity.
+func isTransientName(name string) bool {
+	if strings.HasPrefix(name, "runc-bootstrap[") {
+		return true
+	}
+	if strings.HasPrefix(name, "runc:[") {
+		return true
+	}
+	return false
 }
 
 func getProcessName(pid uint32) string {

--- a/internal/ebpf/cache/cache.go
+++ b/internal/ebpf/cache/cache.go
@@ -33,6 +33,8 @@ func GetProcessNameQuick(pid uint32) string {
 		return ""
 	}
 
+	SnapshotCPUTime(pid)
+
 	if name, ok := globalCache.Get(pid); ok {
 		return name
 	}
@@ -74,4 +76,3 @@ func GetProcessNameQuick(pid uint32) string {
 	globalCache.Set(pid, sanitized)
 	return sanitized
 }
-

--- a/internal/ebpf/cache/cpu.go
+++ b/internal/ebpf/cache/cpu.go
@@ -1,0 +1,115 @@
+package cache
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/podtrace/podtrace/internal/procfs"
+)
+
+// ProcessCPUTime is a snapshot of /proc/<pid>/stat's utime+stime, captured at
+// event-arrival time when the process is still alive. Short-lived processes
+// (runc helpers, exec'd commands) are gone by the time the diagnose report
+// renders, so reading /proc/<pid>/stat at report time always returns 0 —
+// this cache preserves the last-seen value so the report can attribute CPU
+// to terminated processes.
+type ProcessCPUTime struct {
+	TotalNS uint64 // (utime + stime) converted to nanoseconds
+}
+
+var (
+	cpuTimeMu    sync.RWMutex
+	cpuTimes     = map[uint32]ProcessCPUTime{}
+	clockTicks   uint64 = 100
+	clockTicksOK bool
+)
+
+// SnapshotCPUTime reads /proc/<pid>/stat once and stores the result in the
+// per-PID cache. Safe to call multiple times per PID — later calls overwrite
+// with the most recent sample so accumulated CPU is captured.
+func SnapshotCPUTime(pid uint32) {
+	data, err := procfs.ReadFile(fmt.Sprintf("%d/stat", pid))
+	if err != nil {
+		return
+	}
+	// /proc/<pid>/stat fields are space-separated except the (comm) field
+	// which is parenthesized and may contain spaces. utime/stime are fields
+	// 14 and 15 (1-indexed), which become 13/14 (0-indexed) AFTER the
+	// `(comm)` chunk. Find the last ')' to skip the comm safely.
+	s := string(data)
+	rp := strings.LastIndex(s, ")")
+	if rp < 0 || rp+2 >= len(s) {
+		return
+	}
+	after := s[rp+2:]
+	fields := strings.Fields(after)
+	// In `after`, field 0 is the state char; field 11 is utime, field 12 is
+	// stime. (Original 0-indexed positions were 13 and 14, but two were
+	// consumed by pid and comm before "after".)
+	if len(fields) < 13 {
+		return
+	}
+	utime, _ := strconv.ParseUint(fields[11], 10, 64)
+	stime, _ := strconv.ParseUint(fields[12], 10, 64)
+
+	ct := loadClockTicks()
+	totalNS := (utime + stime) * (1_000_000_000 / ct)
+
+	cpuTimeMu.Lock()
+	cpuTimes[pid] = ProcessCPUTime{TotalNS: totalNS}
+	cpuTimeMu.Unlock()
+}
+
+// GetCPUTime returns the cached snapshot for pid, or zero when nothing has
+// been recorded.
+func GetCPUTime(pid uint32) ProcessCPUTime {
+	cpuTimeMu.RLock()
+	t := cpuTimes[pid]
+	cpuTimeMu.RUnlock()
+	return t
+}
+
+// ResetCPUTimes clears the cache. Tests use it; production code does not.
+func ResetCPUTimes() {
+	cpuTimeMu.Lock()
+	cpuTimes = map[uint32]ProcessCPUTime{}
+	cpuTimeMu.Unlock()
+}
+
+func loadClockTicks() uint64 {
+	cpuTimeMu.RLock()
+	ok := clockTicksOK
+	v := clockTicks
+	cpuTimeMu.RUnlock()
+	if ok {
+		return v
+	}
+	cpuTimeMu.Lock()
+	defer cpuTimeMu.Unlock()
+	if clockTicksOK {
+		return clockTicks
+	}
+	// AT_CLKTCK (key 17) in /proc/self/auxv carries the clock ticks per
+	// second. Fallback to 100 (USER_HZ on most x86_64 kernels) when unavail.
+	if data, err := procfs.ReadFile("self/auxv"); err == nil {
+		for i := 0; i+16 <= len(data); i += 16 {
+			key := readUint64LE(data[i : i+8])
+			if key == 17 {
+				v := readUint64LE(data[i+8 : i+16])
+				if v > 0 {
+					clockTicks = v
+				}
+				break
+			}
+		}
+	}
+	clockTicksOK = true
+	return clockTicks
+}
+
+func readUint64LE(b []byte) uint64 {
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -66,12 +66,12 @@ type ProfilingControllerSetter interface {
 }
 
 type Tracer struct {
-	collection               *ebpf.Collection
-	links                    []link.Link
-	probeGroupsMu            sync.Mutex
-	probeGroups              map[probes.ProbeGroup][]link.Link
+	collection    *ebpf.Collection
+	links         []link.Link
+	probeGroupsMu sync.Mutex
+	probeGroups   map[probes.ProbeGroup][]link.Link
 
-	intentionallyDisabled map[probes.ProbeGroup]struct{}
+	intentionallyDisabled    map[probes.ProbeGroup]struct{}
 	reader                   *ringbuf.Reader
 	filter                   *filter.CgroupFilter
 	containerID              string
@@ -83,8 +83,8 @@ type Tracer struct {
 	cgroupPaths              []string
 	useUserspaceCgroupFilter bool
 	targetCgroupID           uint64
-	targetCgroupIDs atomic.Pointer[map[uint64]struct{}]
-	cgroupWriteMu   sync.Mutex
+	targetCgroupIDs          atomic.Pointer[map[uint64]struct{}]
+	cgroupWriteMu            sync.Mutex
 	cpAnalyzer               *criticalpath.Analyzer
 	piiRedactor              *redactor.Redactor
 	profilingCtrl            ProfilingController
@@ -740,6 +740,22 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 				}
 				event.ProcessName = validation.SanitizeProcessName(event.ProcessName)
 
+				if isLikelyTransientComm(event.ProcessName) {
+					resolved := false
+					if data, err := procfs.ReadFile(fmt.Sprintf("%d/comm", event.PID)); err == nil {
+						real := strings.TrimSpace(string(data))
+						if real != "" && !isLikelyTransientComm(real) {
+							event.ProcessName = validation.SanitizeProcessName(real)
+							resolved = true
+						}
+					}
+					if !resolved {
+						event.ProcessName = "runc-bootstrap[" + event.ProcessName + "]"
+					}
+				}
+
+				cache.SnapshotCPUTime(event.PID)
+
 				if t.piiRedactor != nil {
 					t.piiRedactor.Redact(event)
 				}
@@ -853,6 +869,20 @@ func (t *Tracer) Stop() error {
 	}
 
 	return nil
+}
+
+// isLikelyTransientComm flags single-character or single-digit comm values
+// that the kernel sets transiently during exec — most commonly runc's
+// memfd-based re-exec where comm becomes the FD basename ("6") before runc
+// calls prctl(PR_SET_NAME) to rename itself. Re-reading /proc/<pid>/comm a
+// few milliseconds later (when our userspace processes the event) returns
+// the post-prctl name.
+func isLikelyTransientComm(name string) bool {
+	if len(name) != 1 {
+		return false
+	}
+	c := name[0]
+	return c >= '0' && c <= '9'
 }
 
 func (t *Tracer) getProcessNameQuick(pid uint32) string {
@@ -1049,7 +1079,7 @@ var groupCategoryNeeds = map[probes.ProbeGroup][]string{
 	probes.GroupCPU:        {"cpu", "proc"},
 	probes.GroupMemory:     {"proc"},
 	probes.GroupFastCGI:    {"net"},
-	probes.GroupTLS: {"dns", "cpu"},
+	probes.GroupTLS:        {"dns", "cpu"},
 }
 
 // DisableProbeGroup closes all links associated with the given group.

--- a/internal/kubernetes/nodespawn/cleanup.go
+++ b/internal/kubernetes/nodespawn/cleanup.go
@@ -1,0 +1,55 @@
+package nodespawn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DefaultReaperMaxAge is how old a stray spawn pod has to be before the reaper
+// deletes it. Tuned so a slow CLI run isn't reaped mid-execution.
+const DefaultReaperMaxAge = 2 * time.Hour
+
+// DeletePod best-effort deletes the spawn pod; NotFound is swallowed so retries
+// and parallel reapers don't error out.
+func DeletePod(ctx context.Context, clientset kubernetes.Interface, namespace, name string) error {
+	zero := int64(0)
+	err := clientset.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+	})
+	if err == nil || IsNotFound(err) {
+		return nil
+	}
+	return fmt.Errorf("nodespawn: delete %s/%s: %w", namespace, name, err)
+}
+
+// ReapStale scans the namespace for pods labelled managed-by=podtrace-cli that
+// belong to ownerHost and are older than maxAge, deleting them.
+func ReapStale(ctx context.Context, clientset kubernetes.Interface, namespace, ownerHost string, maxAge time.Duration) (int, error) {
+	if maxAge <= 0 {
+		maxAge = DefaultReaperMaxAge
+	}
+	labelSel := fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByValue)
+	if ownerHost != "" {
+		labelSel += fmt.Sprintf(",%s=%s", LabelOwnerHost, sanitizeLabelValue(ownerHost))
+	}
+	list, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSel})
+	if err != nil {
+		return 0, fmt.Errorf("nodespawn: list stale pods: %w", err)
+	}
+	cutoff := time.Now().Add(-maxAge)
+	reaped := 0
+	for i := range list.Items {
+		p := &list.Items[i]
+		if p.CreationTimestamp.After(cutoff) {
+			continue
+		}
+		if err := DeletePod(ctx, clientset, p.Namespace, p.Name); err == nil {
+			reaped++
+		}
+	}
+	return reaped, nil
+}

--- a/internal/kubernetes/nodespawn/cleanup_test.go
+++ b/internal/kubernetes/nodespawn/cleanup_test.go
@@ -1,0 +1,80 @@
+package nodespawn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func reapPod(name, host string, age time.Duration) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "ns1",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			Labels: map[string]string{
+				LabelManagedBy: ManagedByValue,
+				LabelOwnerHost: host,
+			},
+		},
+	}
+}
+
+func TestDeletePod_SwallowsNotFound(t *testing.T) {
+	cs := fake.NewClientset()
+	if err := DeletePod(context.Background(), cs, "ns1", "missing"); err != nil {
+		t.Fatalf("DeletePod on missing pod should be a no-op, got %v", err)
+	}
+}
+
+func TestDeletePod_RemovesExisting(t *testing.T) {
+	cs := fake.NewClientset(reapPod("alive", "laptop", time.Minute))
+	if err := DeletePod(context.Background(), cs, "ns1", "alive"); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "alive", metav1.GetOptions{}); err == nil {
+		t.Fatalf("expected pod to be gone")
+	}
+}
+
+func TestReapStale_DeletesOnlyOldOnesMatchingHost(t *testing.T) {
+	cs := fake.NewClientset(
+		reapPod("fresh", "laptop", time.Minute),
+		reapPod("stale-mine", "laptop", 3*time.Hour),
+		reapPod("stale-other", "other-host", 3*time.Hour),
+	)
+	n, err := ReapStale(context.Background(), cs, "ns1", "laptop", 2*time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reaped = %d, want 1", n)
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "stale-mine", metav1.GetOptions{}); err == nil {
+		t.Errorf("stale-mine should have been deleted")
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "fresh", metav1.GetOptions{}); err != nil {
+		t.Errorf("fresh should still exist: %v", err)
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "stale-other", metav1.GetOptions{}); err != nil {
+		t.Errorf("stale-other belongs to another host and should be untouched: %v", err)
+	}
+}
+
+func TestReapStale_EmptyHostReapsAnyOwner(t *testing.T) {
+	cs := fake.NewClientset(
+		reapPod("stale-a", "host-a", 3*time.Hour),
+		reapPod("stale-b", "host-b", 3*time.Hour),
+	)
+	n, err := ReapStale(context.Background(), cs, "ns1", "", time.Hour)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("reaped = %d, want 2", n)
+	}
+}

--- a/internal/kubernetes/nodespawn/doc.go
+++ b/internal/kubernetes/nodespawn/doc.go
@@ -1,0 +1,3 @@
+// Package nodespawn lets the podtrace CLI run eBPF on the target pod's node
+// instead of the user's workstation.
+package nodespawn

--- a/internal/kubernetes/nodespawn/dynamic_test.go
+++ b/internal/kubernetes/nodespawn/dynamic_test.go
@@ -1,0 +1,74 @@
+package nodespawn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func newPodForDynamic(ns, name, node string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+}
+
+func TestRun_DynamicReSpawn_DiscoversNewNode(t *testing.T) {
+	cs := fake.NewClientset(
+		newPodForDynamic("ns1", "early", "node-1", map[string]string{"app": "x"}),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		_, _ = cs.CoreV1().Pods("ns1").Create(ctx, newPodForDynamic("ns1", "late", "node-2", map[string]string{"app": "x"}), metav1.CreateOptions{})
+	}()
+
+	created := map[string]int{}
+	build := func(node string, _ []PodRef) []string { created[node]++; return []string{"--noop"} }
+
+	sel := pkgkube.TargetSelection{DefaultNamespace: "ns1", PodSelector: "app=x", AllInNamespace: true}
+	seen := map[string]bool{}
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		got, err := ResolveTargetNodes(ctx, cs, sel)
+		if err == nil {
+			for _, n := range got.NodeNames {
+				if !seen[n] {
+					seen[n] = true
+					build(n, got.ByNode[n])
+				}
+			}
+		}
+		if len(seen) >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if !seen["node-1"] || !seen["node-2"] {
+		t.Errorf("expected both node-1 and node-2 to be discovered, got %v", seen)
+	}
+}
+
+func TestRun_RejectsMissingCallback(t *testing.T) {
+	cs := fake.NewClientset()
+	err := Run(context.Background(), RunOptions{
+		Clientset:  cs,
+		RestConfig: &rest.Config{},
+		Image:      "x",
+		Streams:    genericiooptions.IOStreams{},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing BuildChildArgs")
+	}
+}

--- a/internal/kubernetes/nodespawn/image.go
+++ b/internal/kubernetes/nodespawn/image.go
@@ -1,0 +1,78 @@
+package nodespawn
+
+import (
+	"os"
+	"strings"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// ResolveImageOptions feed ResolveImage.
+type ResolveImageOptions struct {
+	Override string
+	Version  string
+}
+
+// ResolveImage returns the container reference to run on the target node and
+// a flag indicating whether the caller should warn the user about a soft
+// fallback.
+func ResolveImage(opts ResolveImageOptions) (image string, warn bool) {
+	if v := strings.TrimSpace(opts.Override); v != "" {
+		return v, false
+	}
+	if v := strings.TrimSpace(os.Getenv("PODTRACE_IMAGE")); v != "" {
+		return v, false
+	}
+
+	repo := strings.TrimSpace(config.Image)
+	if repo == "" {
+		repo = "ghcr.io/gma1k/podtrace"
+	}
+
+	if hasTagOrDigest(repo) {
+		return repo, false
+	}
+
+	version := strings.TrimSpace(opts.Version)
+	if version == "" {
+		version = "latest"
+	}
+	if looksLikeDevBuild(version) {
+		return repo + ":latest", true
+	}
+	return repo + ":" + version, false
+}
+
+// looksLikeDevBuild reports whether the linker-baked version string is one
+// that's clearly not a published release tag — i.e. a registry pull would
+// fail. Catches the common cases:
+//   - "dev" or "dev-<sha>"        (Makefile fallback when git is absent)
+//   - "v0.11.11-14-g<sha>-dirty"  (git describe on a dirty tree — never a tag)
+//   - "v0.11.11-14-g<sha>"        (git describe past a tag — also never a tag)
+//
+// A clean release like "v0.11.12" is treated as a real tag and used verbatim.
+func looksLikeDevBuild(version string) bool {
+	if strings.HasPrefix(version, "dev") {
+		return true
+	}
+	if strings.HasSuffix(version, "-dirty") {
+		return true
+	}
+	if strings.Contains(version, "-g") {
+		return true
+	}
+	return false
+}
+
+// hasTagOrDigest reports whether the given image reference already carries a
+// tag (":tag") or a digest ("@sha256:...").
+func hasTagOrDigest(ref string) bool {
+	if strings.Contains(ref, "@") {
+		return true
+	}
+	last := strings.LastIndex(ref, "/")
+	if last < 0 {
+		return strings.Contains(ref, ":")
+	}
+	return strings.Contains(ref[last:], ":")
+}

--- a/internal/kubernetes/nodespawn/image_test.go
+++ b/internal/kubernetes/nodespawn/image_test.go
@@ -1,0 +1,133 @@
+package nodespawn
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func TestResolveImage(t *testing.T) {
+	originalImage := config.Image
+	t.Cleanup(func() { config.Image = originalImage })
+
+	tests := []struct {
+		name      string
+		linkerVal string
+		envVal    string
+		opts      ResolveImageOptions
+		want      string
+		wantWarn  bool
+	}{
+		{
+			name:      "override wins over env and linker",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			envVal:    "env.example/podtrace:env",
+			opts:      ResolveImageOptions{Override: "flag.example/podtrace:flag", Version: "v1.2.3"},
+			want:      "flag.example/podtrace:flag",
+		},
+		{
+			name:      "env wins over linker default",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			envVal:    "env.example/podtrace:env",
+			opts:      ResolveImageOptions{Version: "v1.2.3"},
+			want:      "env.example/podtrace:env",
+		},
+		{
+			name:      "linker default + released version",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "v1.2.3"},
+			want:      "ghcr.io/gma1k/podtrace:v1.2.3",
+		},
+		{
+			name:      "dev version falls back to latest with warn",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "dev"},
+			want:      "ghcr.io/gma1k/podtrace:latest",
+			wantWarn:  true,
+		},
+		{
+			name:      "dev-sha version falls back to latest with warn",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "dev-a7e4dc2"},
+			want:      "ghcr.io/gma1k/podtrace:latest",
+			wantWarn:  true,
+		},
+		{
+			name: "empty linker falls back to project default",
+			opts: ResolveImageOptions{Version: "v1.0.0"},
+			want: "ghcr.io/gma1k/podtrace:v1.0.0",
+		},
+		{
+			name:      "empty version yields latest tag without warn (non-dev)",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{},
+			want:      "ghcr.io/gma1k/podtrace:latest",
+		},
+		{
+			name:      "whitespace in override is trimmed and treated as set",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Override: "  flag.example/podtrace:flag  ", Version: "v1.2.3"},
+			want:      "flag.example/podtrace:flag",
+		},
+		{
+			name:      "whitespace-only override is treated as unset and yields env",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			envVal:    "env.example/podtrace:env",
+			opts:      ResolveImageOptions{Override: "   ", Version: "v1.2.3"},
+			want:      "env.example/podtrace:env",
+		},
+		{
+			name:      "linker default with tag baked in is used verbatim (no version suffix)",
+			linkerVal: "10.5.0.1:5000/podtrace:dev5",
+			opts:      ResolveImageOptions{Version: "dev"},
+			want:      "10.5.0.1:5000/podtrace:dev5",
+		},
+		{
+			name:      "linker default with port and tag is parsed correctly",
+			linkerVal: "registry.example.com:5000/podtrace:v1.0",
+			opts:      ResolveImageOptions{Version: "v9.9"},
+			want:      "registry.example.com:5000/podtrace:v1.0",
+		},
+		{
+			name:      "linker default with digest is used verbatim",
+			linkerVal: "ghcr.io/gma1k/podtrace@sha256:abc",
+			opts:      ResolveImageOptions{Version: "v1.0"},
+			want:      "ghcr.io/gma1k/podtrace@sha256:abc",
+		},
+		{
+			name:      "git-describe dirty version falls back to latest with warn",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "v0.11.11-14-g8ff3976-dirty"},
+			want:      "ghcr.io/gma1k/podtrace:latest",
+			wantWarn:  true,
+		},
+		{
+			name:      "git-describe post-tag version falls back to latest with warn",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "v0.11.11-14-g8ff3976"},
+			want:      "ghcr.io/gma1k/podtrace:latest",
+			wantWarn:  true,
+		},
+		{
+			name:      "clean release tag used verbatim",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "v0.11.12"},
+			want:      "ghcr.io/gma1k/podtrace:v0.11.12",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config.Image = tc.linkerVal
+			t.Setenv("PODTRACE_IMAGE", tc.envVal)
+
+			got, warn := ResolveImage(tc.opts)
+			if got != tc.want {
+				t.Errorf("image = %q, want %q", got, tc.want)
+			}
+			if warn != tc.wantWarn {
+				t.Errorf("warn = %v, want %v", warn, tc.wantWarn)
+			}
+		})
+	}
+}

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -1,0 +1,227 @@
+package nodespawn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Labels stamped on every spawned pod. Used by the reaper to find pods left
+// behind by a crashed CLI.
+const (
+	LabelManagedBy = "app.kubernetes.io/managed-by"
+	LabelComponent = "app.kubernetes.io/component"
+	LabelNode      = "podtrace.io/node"
+	LabelOwnerHost = "podtrace.io/owner-host"
+	LabelOwnerPID  = "podtrace.io/owner-pid"
+	LabelCreatedAt = "podtrace.io/created-at"
+	ManagedByValue = "podtrace-cli"
+	ComponentValue = "cli-spawn"
+
+	EnvNodeLocalSentinel = "PODTRACE_NODE_LOCAL"
+
+	ReaperMaxAge = 2 * time.Hour
+)
+
+// PodSpecOptions configures BuildPodSpec.
+type PodSpecOptions struct {
+	NodeName              string
+	Namespace             string
+	Image                 string
+	ImagePullPolicy       corev1.PullPolicy
+	ImagePullSecrets      []corev1.LocalObjectReference
+	Args                  []string
+	ActiveDeadlineSeconds int64
+	Tolerations           []corev1.Toleration
+	ServiceAccountName    string
+	OwnerHost             string
+	OwnerPID              int
+}
+
+// BuildPodSpec returns a pod with privileged + hostPID set, mounting the host
+// root under /host/* and pointing the podtrace binary at those paths via env
+// vars.
+func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
+	if opts.NodeName == "" {
+		return nil, fmt.Errorf("nodespawn: NodeName is required")
+	}
+	if opts.Namespace == "" {
+		return nil, fmt.Errorf("nodespawn: Namespace is required")
+	}
+	if opts.Image == "" {
+		return nil, fmt.Errorf("nodespawn: Image is required")
+	}
+
+	priv := true
+	runAsRoot := int64(0)
+
+	suffix, err := randomSuffix()
+	if err != nil {
+		return nil, err
+	}
+	name := podName(opts.NodeName, suffix)
+
+	createdAt := fmt.Sprintf("%d", time.Now().UTC().Unix())
+
+	hpDir := corev1.HostPathDirectoryOrCreate
+	volumes := []corev1.Volume{
+		{Name: "bpf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf"}}},
+		{Name: "btf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/btf"}}},
+		{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+		{Name: "cgroup", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/cgroup"}}},
+		{Name: "containerd-sock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/containerd"}}},
+		{Name: "debug", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/debug", Type: &hpDir}}},
+		{Name: "tracing", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/tracing", Type: &hpDir}}},
+	}
+
+	mounts := []corev1.VolumeMount{
+		{Name: "bpf", MountPath: "/sys/fs/bpf"},
+		{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
+		{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
+		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+		{Name: "cgroup", MountPath: "/host/sys/fs/cgroup", ReadOnly: true},
+		{Name: "containerd-sock", MountPath: "/run/containerd", ReadOnly: true},
+		{Name: "debug", MountPath: "/sys/kernel/debug"},
+		{Name: "tracing", MountPath: "/sys/kernel/tracing"},
+	}
+
+	env := []corev1.EnvVar{
+		{Name: EnvNodeLocalSentinel, Value: "1"},
+		{Name: "PODTRACE_PROC_BASE", Value: "/host/proc"},
+		{Name: "PODTRACE_CGROUP_BASE", Value: "/host/sys/fs/cgroup"},
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			},
+		},
+	}
+
+	container := corev1.Container{
+		Name:            "podtrace",
+		Image:           opts.Image,
+		ImagePullPolicy: opts.ImagePullPolicy,
+		Args:            append([]string(nil), opts.Args...),
+		Env:             env,
+		Stdin:           true,
+		StdinOnce:       true,
+		TTY:             false,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: &priv,
+			RunAsUser:  &runAsRoot,
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN"},
+			},
+		},
+		VolumeMounts: mounts,
+	}
+
+	labels := map[string]string{
+		LabelManagedBy: ManagedByValue,
+		LabelComponent: ComponentValue,
+		LabelNode:      opts.NodeName,
+		LabelCreatedAt: createdAt,
+	}
+	if opts.OwnerHost != "" {
+		labels[LabelOwnerHost] = sanitizeLabelValue(opts.OwnerHost)
+	}
+	if opts.OwnerPID > 0 {
+		labels[LabelOwnerPID] = fmt.Sprintf("%d", opts.OwnerPID)
+	}
+
+	spec := corev1.PodSpec{
+		RestartPolicy:      corev1.RestartPolicyNever,
+		HostPID:            true,
+		NodeSelector:       map[string]string{"kubernetes.io/hostname": opts.NodeName},
+		Tolerations:        opts.Tolerations,
+		ServiceAccountName: opts.ServiceAccountName,
+		ImagePullSecrets:   opts.ImagePullSecrets,
+		Containers:         []corev1.Container{container},
+		Volumes:            volumes,
+	}
+	if opts.ActiveDeadlineSeconds > 0 {
+		spec.ActiveDeadlineSeconds = &opts.ActiveDeadlineSeconds
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: opts.Namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}, nil
+}
+
+func podName(nodeName, suffix string) string {
+	prefix := "podtrace-cli-"
+	maxNode := 63 - len(prefix) - 1 - len(suffix)
+	node := sanitizeName(nodeName)
+	if len(node) > maxNode {
+		node = node[:maxNode]
+	}
+	return prefix + node + "-" + suffix
+}
+
+func sanitizeName(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	last := byte('-')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'
+		if !ok {
+			c = '-'
+		}
+		if c == '-' && last == '-' {
+			continue
+		}
+		b.WriteByte(c)
+		last = c
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = "node"
+	}
+	return out
+}
+
+func sanitizeLabelValue(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	for i := 0; i < len(s) && b.Len() < 63; i++ {
+		c := s[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.'
+		if !ok {
+			c = '_'
+		}
+		b.WriteByte(c)
+	}
+	out := strings.Trim(b.String(), "-_.")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}
+
+func randomSuffix() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("nodespawn: random suffix: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func Hostname() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return "unknown"
+}

--- a/internal/kubernetes/nodespawn/pod_spec_test.go
+++ b/internal/kubernetes/nodespawn/pod_spec_test.go
@@ -1,0 +1,218 @@
+package nodespawn
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func baseOpts() PodSpecOptions {
+	return PodSpecOptions{
+		NodeName:              "worker-1",
+		Namespace:             "kube-system",
+		Image:                 "ghcr.io/gma1k/podtrace:v1.2.3",
+		ImagePullPolicy:       corev1.PullIfNotPresent,
+		Args:                  []string{"--pods", "kube-system/api", "--diagnose", "5s"},
+		ActiveDeadlineSeconds: 300,
+		OwnerHost:             "laptop",
+		OwnerPID:              1234,
+	}
+}
+
+func TestBuildPodSpec_RequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*PodSpecOptions)
+	}{
+		{"no node", func(o *PodSpecOptions) { o.NodeName = "" }},
+		{"no namespace", func(o *PodSpecOptions) { o.Namespace = "" }},
+		{"no image", func(o *PodSpecOptions) { o.Image = "" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := baseOpts()
+			tc.mut(&o)
+			if _, err := BuildPodSpec(o); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestBuildPodSpec_NameWithinDNSBudget(t *testing.T) {
+	o := baseOpts()
+	o.NodeName = "gke-very-long-cluster-name-default-pool-12345678-abcd-this-should-truncate"
+	got, err := BuildPodSpec(o)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(got.Name) > 63 {
+		t.Errorf("name %q exceeds 63 chars (got %d)", got.Name, len(got.Name))
+	}
+	if !strings.HasPrefix(got.Name, "podtrace-cli-") {
+		t.Errorf("name %q missing podtrace-cli- prefix", got.Name)
+	}
+}
+
+func TestBuildPodSpec_NodeNameSanitized(t *testing.T) {
+	o := baseOpts()
+	o.NodeName = "WORKER.example.com"
+	got, err := BuildPodSpec(o)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if strings.ContainsAny(got.Name, ".") || strings.ContainsAny(got.Name, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		t.Errorf("name %q not DNS-1123 safe", got.Name)
+	}
+}
+
+func TestBuildPodSpec_SecurityContext(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if !got.Spec.HostPID {
+		t.Errorf("expected HostPID=true")
+	}
+	if got.Spec.Containers[0].SecurityContext.Privileged == nil || !*got.Spec.Containers[0].SecurityContext.Privileged {
+		t.Errorf("expected privileged container")
+	}
+	caps := got.Spec.Containers[0].SecurityContext.Capabilities.Add
+	wantCaps := map[string]bool{"BPF": true, "SYS_ADMIN": true, "PERFMON": true, "SYS_RESOURCE": true, "NET_ADMIN": true}
+	for _, c := range caps {
+		delete(wantCaps, string(c))
+	}
+	if len(wantCaps) > 0 {
+		t.Errorf("missing capabilities: %v", wantCaps)
+	}
+}
+
+func TestBuildPodSpec_HostMountsAndEnv(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	container := got.Spec.Containers[0]
+
+	wantEnv := map[string]string{
+		"PODTRACE_NODE_LOCAL":  "1",
+		"PODTRACE_PROC_BASE":   "/host/proc",
+		"PODTRACE_CGROUP_BASE": "/host/sys/fs/cgroup",
+	}
+	for _, e := range container.Env {
+		if exp, ok := wantEnv[e.Name]; ok {
+			if e.Value != exp {
+				t.Errorf("env %s = %q, want %q", e.Name, e.Value, exp)
+			}
+			delete(wantEnv, e.Name)
+		}
+	}
+	if len(wantEnv) > 0 {
+		t.Errorf("missing env entries: %v", wantEnv)
+	}
+
+	mountPaths := map[string]bool{}
+	for _, m := range container.VolumeMounts {
+		mountPaths[m.MountPath] = true
+	}
+	wantMounts := []string{"/sys/fs/bpf", "/sys/kernel/btf", "/host/proc", "/sys/fs/cgroup", "/host/sys/fs/cgroup", "/run/containerd"}
+	for _, p := range wantMounts {
+		if !mountPaths[p] {
+			t.Errorf("missing mount path %s", p)
+		}
+	}
+}
+
+func TestBuildPodSpec_NodeSelectorPinsToTargetNode(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got.Spec.NodeSelector["kubernetes.io/hostname"] != "worker-1" {
+		t.Errorf("nodeSelector hostname = %q, want worker-1", got.Spec.NodeSelector["kubernetes.io/hostname"])
+	}
+}
+
+func TestBuildPodSpec_LabelsForReaper(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got.Labels[LabelManagedBy] != ManagedByValue {
+		t.Errorf("managed-by = %q, want %q", got.Labels[LabelManagedBy], ManagedByValue)
+	}
+	if got.Labels[LabelComponent] != ComponentValue {
+		t.Errorf("component = %q, want %q", got.Labels[LabelComponent], ComponentValue)
+	}
+	if got.Labels[LabelNode] != "worker-1" {
+		t.Errorf("node label = %q, want worker-1", got.Labels[LabelNode])
+	}
+	if got.Labels[LabelOwnerHost] != "laptop" {
+		t.Errorf("owner-host label = %q, want laptop", got.Labels[LabelOwnerHost])
+	}
+	if got.Labels[LabelOwnerPID] != "1234" {
+		t.Errorf("owner-pid label = %q, want 1234", got.Labels[LabelOwnerPID])
+	}
+	if _, ok := got.Labels[LabelCreatedAt]; !ok {
+		t.Errorf("missing created-at label")
+	}
+}
+
+func TestBuildPodSpec_ActiveDeadlineApplied(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got.Spec.ActiveDeadlineSeconds == nil || *got.Spec.ActiveDeadlineSeconds != 300 {
+		t.Errorf("activeDeadlineSeconds = %v, want 300", got.Spec.ActiveDeadlineSeconds)
+	}
+}
+
+func TestBuildPodSpec_ArgsCopiedNotAliased(t *testing.T) {
+	opts := baseOpts()
+	got, err := BuildPodSpec(opts)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	original := append([]string(nil), opts.Args...)
+	got.Spec.Containers[0].Args[0] = "MUTATED"
+	if !reflect.DeepEqual(opts.Args, original) {
+		t.Errorf("BuildPodSpec aliased caller's Args slice")
+	}
+}
+
+func TestBuildPodSpec_OwnerHostSanitized(t *testing.T) {
+	opts := baseOpts()
+	opts.OwnerHost = "my.workstation.local!"
+	got, err := BuildPodSpec(opts)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	v := got.Labels[LabelOwnerHost]
+	for _, c := range v {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.':
+		default:
+			t.Errorf("owner-host label %q has invalid char %q", v, c)
+		}
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := map[string]string{
+		"WORKER.example.com": "worker-example-com",
+		"--node--1--":        "node-1",
+		"???":                "node",
+		"":                   "node",
+	}
+	for in, want := range tests {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/kubernetes/nodespawn/portforward.go
+++ b/internal/kubernetes/nodespawn/portforward.go
@@ -1,0 +1,67 @@
+package nodespawn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// StartPortForward opens a TCP tunnel from localPort on the workstation to
+// remotePort inside the named pod.
+func StartPortForward(ctx context.Context, restCfg *rest.Config, clientset kubernetes.Interface, pod *corev1.Pod, localPort, remotePort int, stdout, stderr io.Writer) error {
+	if pod == nil {
+		return fmt.Errorf("nodespawn: nil pod")
+	}
+	roundTripper, upgrader, err := spdy.RoundTripperFor(restCfg)
+	if err != nil {
+		return fmt.Errorf("nodespawn: portforward roundtripper: %w", err)
+	}
+
+	req := clientset.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, "POST", req.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(stopCh)
+	}()
+
+	fw, err := portforward.New(dialer,
+		[]string{fmt.Sprintf("%d:%d", localPort, remotePort)},
+		stopCh, readyCh, stdout, stderr)
+	if err != nil {
+		return fmt.Errorf("nodespawn: portforward init: %w", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- fw.ForwardPorts() }()
+
+	select {
+	case <-readyCh:
+	case err := <-errCh:
+		return fmt.Errorf("nodespawn: portforward did not become ready: %w", err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return nil
+	}
+}

--- a/internal/kubernetes/nodespawn/run.go
+++ b/internal/kubernetes/nodespawn/run.go
@@ -1,0 +1,294 @@
+package nodespawn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+// RunOptions drives the per-CLI-invocation orchestration: figure out which
+// nodes host the targets, spawn one privileged pod on each, stream their
+// output, and clean up on exit.
+type RunOptions struct {
+	Clientset  kubernetes.Interface
+	RestConfig *rest.Config
+
+	Selection pkgkube.TargetSelection
+
+	Image            string
+	ImagePullPolicy  corev1.PullPolicy
+	ImagePullSecrets []corev1.LocalObjectReference
+
+	SpawnNamespace string
+
+	ActiveDeadlineSeconds int64
+
+	BuildChildArgs func(nodeName string, pods []PodRef) []string
+
+	OwnerHost string
+	OwnerPID  int
+
+	ServiceAccountName string
+
+	Streams genericiooptions.IOStreams
+
+	OnPodRunning func(ctx context.Context, pod *corev1.Pod) error
+
+	DynamicReSpawn bool
+	PollInterval   time.Duration
+}
+
+// Run orchestrates the spawn + stream lifecycle. It returns when every per-node
+// pod has terminated or ctx is cancelled.
+func Run(ctx context.Context, opts RunOptions) error {
+	if opts.Clientset == nil || opts.RestConfig == nil {
+		return fmt.Errorf("nodespawn: Clientset and RestConfig required")
+	}
+	if opts.Image == "" {
+		return fmt.Errorf("nodespawn: Image required")
+	}
+	if opts.BuildChildArgs == nil {
+		return fmt.Errorf("nodespawn: BuildChildArgs callback required")
+	}
+
+	nodes, err := ResolveTargetNodes(ctx, opts.Clientset, opts.Selection)
+	if err != nil {
+		return err
+	}
+	if nodes.Empty() {
+		return fmt.Errorf("nodespawn: no scheduled target pods")
+	}
+
+	if opts.ActiveDeadlineSeconds <= 0 {
+		opts.ActiveDeadlineSeconds = 3600
+	}
+
+	multiNode := len(nodes.NodeNames) > 1
+
+	g, gctx := errgroup.WithContext(ctx)
+	var wmu sync.Mutex
+	var cmu sync.Mutex
+	covered := map[string]bool{}
+
+	startNode := func(node string, podRefs []PodRef, tols []corev1.Toleration) error {
+		cmu.Lock()
+		if covered[node] {
+			cmu.Unlock()
+			return nil
+		}
+		covered[node] = true
+		cmu.Unlock()
+		ns := opts.SpawnNamespace
+		if ns == "" {
+			ns = podRefs[0].Namespace
+		}
+		args := opts.BuildChildArgs(node, podRefs)
+		podSpec, err := BuildPodSpec(PodSpecOptions{
+			NodeName:              node,
+			Namespace:             ns,
+			Image:                 opts.Image,
+			ImagePullPolicy:       opts.ImagePullPolicy,
+			ImagePullSecrets:      opts.ImagePullSecrets,
+			Args:                  args,
+			ActiveDeadlineSeconds: opts.ActiveDeadlineSeconds,
+			Tolerations:           tols,
+			ServiceAccountName:    opts.ServiceAccountName,
+			OwnerHost:             opts.OwnerHost,
+			OwnerPID:              opts.OwnerPID,
+		})
+		if err != nil {
+			cmu.Lock()
+			delete(covered, node)
+			cmu.Unlock()
+			return err
+		}
+		g.Go(func() error {
+			return runOneNode(gctx, opts, podSpec, multiNode, &wmu)
+		})
+		return nil
+	}
+
+	for _, node := range nodes.NodeNames {
+		if err := startNode(node, nodes.ByNode[node], nodes.TolerationsByNode[node]); err != nil {
+			return err
+		}
+	}
+
+	if opts.DynamicReSpawn {
+		interval := opts.PollInterval
+		if interval <= 0 {
+			interval = 30 * time.Second
+		}
+		g.Go(func() error {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-gctx.Done():
+					return nil
+				case <-t.C:
+				}
+				poll, err := ResolveTargetNodes(gctx, opts.Clientset, opts.Selection)
+				if err != nil {
+					continue
+				}
+				for _, n := range poll.NodeNames {
+					cmu.Lock()
+					already := covered[n]
+					cmu.Unlock()
+					if already {
+						continue
+					}
+					if err := startNode(n, poll.ByNode[n], poll.TolerationsByNode[n]); err != nil {
+						return err
+					}
+				}
+			}
+		})
+	}
+
+	return g.Wait()
+}
+
+func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multiNode bool, wmu *sync.Mutex) (retErr error) {
+	created, err := opts.Clientset.CoreV1().Pods(podSpec.Namespace).Create(ctx, podSpec, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "violates PodSecurity") {
+			return fmt.Errorf("spawn pod admission rejected by PodSecurity in namespace %q. "+
+				"Remediation: kubectl label ns/%s pod-security.kubernetes.io/enforce=privileged --overwrite\n  (or use --spawn-namespace to point at a namespace that allows privileged pods). "+
+				"Underlying error: %w", podSpec.Namespace, podSpec.Namespace, err)
+		}
+		return fmt.Errorf("create spawn pod %s/%s: %w", podSpec.Namespace, podSpec.Name, err)
+	}
+
+	cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
+	defer cancelCleanup()
+	defer func() {
+		_ = DeletePod(cleanupCtx, opts.Clientset, created.Namespace, created.Name)
+	}()
+
+	running, err := waitForPodRunningOrTerminated(ctx, opts.Clientset, created.Namespace, created.Name)
+	if err != nil {
+		return err
+	}
+
+	if opts.OnPodRunning != nil {
+		if cbErr := opts.OnPodRunning(ctx, running); cbErr != nil {
+			return cbErr
+		}
+	}
+
+	streams := opts.Streams
+	if multiNode {
+		streams.Out = newPrefixedWriter(streams.Out, "["+podSpec.Spec.NodeSelector["kubernetes.io/hostname"]+"] ", wmu)
+		streams.ErrOut = newPrefixedWriter(streams.ErrOut, "["+podSpec.Spec.NodeSelector["kubernetes.io/hostname"]+"] ", wmu)
+		streams.In = nil
+	}
+
+	if _, err := AttachToPod(ctx, opts.RestConfig, opts.Clientset, running, streams); err != nil {
+		return fmt.Errorf("attach to %s/%s: %w", running.Namespace, running.Name, err)
+	}
+
+	exit := WaitForExitCode(ctx, opts.Clientset, running.Namespace, running.Name)
+	if exit != 0 {
+		if tail := dumpPodLogs(cleanupCtx, opts.Clientset, running.Namespace, running.Name); tail != "" {
+			_, _ = fmt.Fprintf(opts.Streams.ErrOut, "spawn pod %s/%s tail:\n%s\n", running.Namespace, running.Name, tail)
+		}
+		return &ExitError{Code: int(exit), Node: podSpec.Spec.NodeSelector["kubernetes.io/hostname"]}
+	}
+	return nil
+}
+
+// dumpPodLogs returns the spawned pod's last log lines on a best-effort basis;
+// errors are swallowed because this runs on the failure path and shouldn't
+// itself fail.
+func dumpPodLogs(ctx context.Context, clientset kubernetes.Interface, namespace, name string) string {
+	req := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{TailLines: ptrInt64(50)})
+	rc, err := req.Stream(ctx)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = rc.Close() }()
+	buf := make([]byte, 8*1024)
+	n, _ := rc.Read(buf)
+	return string(buf[:n])
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+
+// ExitError carries a non-zero exit code from a spawned pod so the CLI can
+// propagate the same code to its caller.
+type ExitError struct {
+	Code int
+	Node string
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("spawn pod on node %q exited with code %d", e.Node, e.Code)
+}
+
+// prefixedWriter wraps an io.Writer with a per-line prefix and a shared lock
+// so multi-node streams interleave cleanly.
+type prefixedWriter struct {
+	out    io.Writer
+	prefix string
+	mu     *sync.Mutex
+	buf    []byte
+}
+
+func newPrefixedWriter(out io.Writer, prefix string, mu *sync.Mutex) *prefixedWriter {
+	return &prefixedWriter{out: out, prefix: prefix, mu: mu}
+}
+
+func (w *prefixedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		i := indexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := w.buf[:i+1]
+		if _, err := w.out.Write([]byte(w.prefix)); err != nil {
+			return len(p), err
+		}
+		if _, err := w.out.Write(line); err != nil {
+			return len(p), err
+		}
+		w.buf = w.buf[i+1:]
+	}
+	return len(p), nil
+}
+
+func indexByte(b []byte, c byte) int {
+	for i := 0; i < len(b); i++ {
+		if b[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// HostnameFromEnv returns the workstation hostname, useful for stamping into
+// owner-host labels at the CLI layer.
+func HostnameFromEnv() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return Hostname()
+}

--- a/internal/kubernetes/nodespawn/stream.go
+++ b/internal/kubernetes/nodespawn/stream.go
@@ -1,0 +1,171 @@
+package nodespawn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/remotecommand"
+	watchtools "k8s.io/client-go/tools/watch"
+)
+
+func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
+	fieldSel := fields.OneTermEqualSelector("metadata.name", name).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = fieldSel
+			return clientset.CoreV1().Pods(namespace).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = fieldSel
+			return clientset.CoreV1().Pods(namespace).Watch(ctx, opts)
+		},
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	evt, err := watchtools.UntilWithSync(waitCtx, lw, &corev1.Pod{}, nil, func(e watch.Event) (bool, error) {
+		switch e.Type {
+		case watch.Deleted:
+			return false, fmt.Errorf("spawn pod %s/%s deleted before reaching Running", namespace, name)
+		case watch.Error:
+			return false, fmt.Errorf("watch error on %s/%s", namespace, name)
+		}
+		p, ok := e.Object.(*corev1.Pod)
+		if !ok {
+			return false, nil
+		}
+		switch p.Status.Phase {
+		case corev1.PodRunning, corev1.PodSucceeded, corev1.PodFailed:
+			return true, nil
+		case corev1.PodPending:
+			if r := unschedulableReason(p); r != "" {
+				return false, fmt.Errorf("spawn pod %s/%s cannot be scheduled: %s", namespace, name, r)
+			}
+			if r := imagePullFailureReason(p); r != "" {
+				return false, fmt.Errorf("spawn pod %s/%s image pull failed: %s", namespace, name, r)
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	pod, _ := evt.Object.(*corev1.Pod)
+	return pod, nil
+}
+
+func unschedulableReason(p *corev1.Pod) string {
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
+			return c.Message
+		}
+	}
+	return ""
+}
+
+func imagePullFailureReason(p *corev1.Pod) string {
+	for _, cs := range p.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			switch w.Reason {
+			case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
+				return w.Reason + ": " + w.Message
+			}
+		}
+	}
+	return ""
+}
+
+// AttachToPod attaches stdin/stdout/stderr to the spawn pod and blocks until
+// the pod terminates or ctx is cancelled.
+func AttachToPod(ctx context.Context, restCfg *rest.Config, clientset kubernetes.Interface, pod *corev1.Pod, streams genericiooptions.IOStreams) (warnDegraded bool, err error) {
+	if pod == nil {
+		return false, fmt.Errorf("nodespawn: nil pod")
+	}
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Namespace(pod.Namespace).Name(pod.Name).
+		SubResource("attach").
+		VersionedParams(&corev1.PodAttachOptions{
+			Container: pod.Spec.Containers[0].Name,
+			Stdin:     streams.In != nil,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	exec, execErr := remotecommand.NewSPDYExecutor(restCfg, "POST", req.URL())
+	if execErr == nil {
+		opts := remotecommand.StreamOptions{Stdout: streams.Out, Stderr: streams.ErrOut}
+		if streams.In != nil {
+			opts.Stdin = streams.In
+		}
+		streamErr := exec.StreamWithContext(ctx, opts)
+		if streamErr == nil {
+			return false, nil
+		}
+		if !apierrors.IsForbidden(streamErr) {
+			return false, streamErr
+		}
+	}
+
+	return true, streamLogs(ctx, clientset, pod, streams.Out)
+}
+
+func streamLogs(ctx context.Context, clientset kubernetes.Interface, pod *corev1.Pod, stdout io.Writer) error {
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: pod.Spec.Containers[0].Name,
+		Follow:    true,
+	})
+	rc, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("nodespawn: stream logs: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+	_, copyErr := io.Copy(stdout, rc)
+	if copyErr != nil && !errors.Is(copyErr, context.Canceled) {
+		return copyErr
+	}
+	return nil
+}
+
+// WaitForExitCode polls until the primary container terminates and returns its
+// exit code.
+func WaitForExitCode(ctx context.Context, clientset kubernetes.Interface, namespace, name string) int32 {
+	const pollEvery = 500 * time.Millisecond
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return -1
+		default:
+		}
+		p, err := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return -1
+		}
+		for _, cs := range p.Status.ContainerStatuses {
+			if t := cs.State.Terminated; t != nil {
+				return t.ExitCode
+			}
+		}
+		time.Sleep(pollEvery)
+	}
+	return -1
+}
+
+// IsNotFound is exported so cleanup callers can swallow "already-gone" errors.
+func IsNotFound(err error) bool { return apierrors.IsNotFound(err) }

--- a/internal/kubernetes/nodespawn/target_nodes.go
+++ b/internal/kubernetes/nodespawn/target_nodes.go
@@ -1,0 +1,163 @@
+package nodespawn
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+// PodRef holds everything the workstation pre-resolves about a target pod so
+// the spawned binary can build its PodInfo without a single K8s API call.
+type PodRef struct {
+	Namespace     string
+	Name          string
+	ContainerID   string
+	ContainerName string
+}
+
+// String returns the "namespace/name" form ResolvePod accepts.
+func (r PodRef) String() string {
+	return r.Namespace + "/" + r.Name
+}
+
+// PreResolved returns the "ns/name/containerID/containerName" form the spawn
+// pod accepts via --preresolved-pod (single string keeps the argv compact).
+func (r PodRef) PreResolved() string {
+	return r.Namespace + "/" + r.Name + "/" + r.ContainerID + "/" + r.ContainerName
+}
+
+// NodeTargets groups the resolved target pods by the node they run on.
+// One ephemeral pod will be spawned per key.
+type NodeTargets struct {
+	ByNode            map[string][]PodRef
+	NodeNames         []string
+	TolerationsByNode map[string][]corev1.Toleration
+}
+
+// Empty reports whether ResolveTargetNodes returned no pods at all.
+func (t NodeTargets) Empty() bool { return len(t.NodeNames) == 0 }
+
+// ResolveTargetNodes walks the TargetSelection, lists pods that match, and
+// groups them by node.
+func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel pkgkube.TargetSelection) (NodeTargets, error) {
+	if clientset == nil {
+		return NodeTargets{}, fmt.Errorf("nodespawn: clientset is nil")
+	}
+
+	byNode := map[string][]PodRef{}
+	tolByNode := map[string][]corev1.Toleration{}
+	tolSeen := map[string]map[string]struct{}{}
+	unscheduled := []PodRef{}
+
+	add := func(pod *corev1.Pod) {
+		ref := PodRef{Namespace: pod.Namespace, Name: pod.Name}
+		if pod.Spec.NodeName == "" {
+			unscheduled = append(unscheduled, ref)
+			return
+		}
+		if len(pod.Status.ContainerStatuses) > 0 {
+			cs := pod.Status.ContainerStatuses[0]
+			ref.ContainerName = cs.Name
+			if idx := indexAfterScheme(cs.ContainerID); idx >= 0 {
+				ref.ContainerID = cs.ContainerID[idx:]
+			}
+		}
+		node := pod.Spec.NodeName
+		byNode[node] = append(byNode[node], ref)
+		if tolSeen[node] == nil {
+			tolSeen[node] = map[string]struct{}{}
+		}
+		for _, t := range pod.Spec.Tolerations {
+			k := tolerationKey(t)
+			if _, dup := tolSeen[node][k]; dup {
+				continue
+			}
+			tolSeen[node][k] = struct{}{}
+			tolByNode[node] = append(tolByNode[node], t)
+		}
+	}
+
+	for ns, names := range sel.PodRefSet() {
+		for name := range names {
+			pod, err := clientset.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return NodeTargets{}, fmt.Errorf("nodespawn: get pod %s/%s: %w", ns, name, err)
+			}
+			add(pod)
+		}
+	}
+
+	if sel.PodSelector != "" || sel.AllInNamespace || len(sel.Namespaces) > 1 {
+		listOpts := metav1.ListOptions{LabelSelector: sel.PodSelector}
+		for _, ns := range sel.EffectiveNamespaces() {
+			list, err := clientset.CoreV1().Pods(ns).List(ctx, listOpts)
+			if err != nil {
+				return NodeTargets{}, fmt.Errorf("nodespawn: list pods in %s: %w", ns, err)
+			}
+			for i := range list.Items {
+				pod := &list.Items[i]
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+				add(pod)
+			}
+		}
+	}
+
+	if len(unscheduled) > 0 && len(byNode) == 0 {
+		return NodeTargets{}, fmt.Errorf("nodespawn: %d target pod(s) are not yet scheduled to a node: %s",
+			len(unscheduled), joinRefs(unscheduled))
+	}
+
+	out := NodeTargets{ByNode: byNode, TolerationsByNode: tolByNode}
+	for n := range byNode {
+		out.NodeNames = append(out.NodeNames, n)
+	}
+	sort.Strings(out.NodeNames)
+	for n := range byNode {
+		sort.Slice(byNode[n], func(i, j int) bool {
+			a, b := byNode[n][i], byNode[n][j]
+			if a.Namespace != b.Namespace {
+				return a.Namespace < b.Namespace
+			}
+			return a.Name < b.Name
+		})
+	}
+	return out, nil
+}
+
+// indexAfterScheme returns the offset right after "://" in a containerID like
+// "containerd://abc123" so the caller can slice off the runtime prefix.
+func indexAfterScheme(s string) int {
+	i := strings.Index(s, "://")
+	if i < 0 {
+		return -1
+	}
+	return i + 3
+}
+
+// tolerationKey is a stable string used to dedupe Tolerations across the
+// target pods on one node. Effect+Key+Operator+Value+TolerationSeconds is
+// enough to distinguish every Kubernetes toleration uniquely.
+func tolerationKey(t corev1.Toleration) string {
+	sec := "nil"
+	if t.TolerationSeconds != nil {
+		sec = fmt.Sprintf("%d", *t.TolerationSeconds)
+	}
+	return string(t.Effect) + "|" + t.Key + "|" + string(t.Operator) + "|" + t.Value + "|" + sec
+}
+
+func joinRefs(refs []PodRef) string {
+	s := make([]string, len(refs))
+	for i, r := range refs {
+		s[i] = r.String()
+	}
+	return strings.Join(s, ", ")
+}

--- a/internal/kubernetes/nodespawn/target_nodes_test.go
+++ b/internal/kubernetes/nodespawn/target_nodes_test.go
@@ -1,0 +1,158 @@
+package nodespawn
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func pod(ns, name, node string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+		Spec:       corev1.PodSpec{NodeName: node},
+	}
+}
+
+func TestResolveTargetNodes_NilClientset(t *testing.T) {
+	if _, err := ResolveTargetNodes(context.Background(), nil, pkgkube.TargetSelection{}); err == nil {
+		t.Fatalf("expected error for nil clientset")
+	}
+}
+
+func TestResolveTargetNodes_ExplicitPods_FanOutByNode(t *testing.T) {
+	cs := fake.NewClientset(
+		pod("ns1", "a", "node-1", nil),
+		pod("ns1", "b", "node-2", nil),
+		pod("ns2", "c", "node-1", nil),
+	)
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		Pods:             []string{"a", "b", "ns2/c"},
+	}
+
+	got, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got.NodeNames, []string{"node-1", "node-2"}) {
+		t.Errorf("node names = %v, want [node-1 node-2]", got.NodeNames)
+	}
+	wantNode1 := []PodRef{{Namespace: "ns1", Name: "a"}, {Namespace: "ns2", Name: "c"}}
+	if !reflect.DeepEqual(got.ByNode["node-1"], wantNode1) {
+		t.Errorf("node-1 refs = %v, want %v", got.ByNode["node-1"], wantNode1)
+	}
+	wantNode2 := []PodRef{{Namespace: "ns1", Name: "b"}}
+	if !reflect.DeepEqual(got.ByNode["node-2"], wantNode2) {
+		t.Errorf("node-2 refs = %v, want %v", got.ByNode["node-2"], wantNode2)
+	}
+}
+
+func TestResolveTargetNodes_PodSelector_AcrossNamespaces(t *testing.T) {
+	cs := fake.NewClientset(
+		pod("app", "api-1", "node-1", map[string]string{"app": "api"}),
+		pod("app", "api-2", "node-2", map[string]string{"app": "api"}),
+		pod("app", "worker", "node-1", map[string]string{"app": "worker"}),
+		pod("other", "api-3", "node-1", map[string]string{"app": "api"}),
+	)
+	sel := pkgkube.TargetSelection{
+		Namespaces:  []string{"app", "other"},
+		PodSelector: "app=api",
+	}
+	got, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got.NodeNames, []string{"node-1", "node-2"}) {
+		t.Errorf("node names = %v, want [node-1 node-2]", got.NodeNames)
+	}
+	got1 := got.ByNode["node-1"]
+	want1 := []PodRef{{Namespace: "app", Name: "api-1"}, {Namespace: "other", Name: "api-3"}}
+	if !reflect.DeepEqual(got1, want1) {
+		t.Errorf("node-1 refs = %v, want %v", got1, want1)
+	}
+	got2 := got.ByNode["node-2"]
+	want2 := []PodRef{{Namespace: "app", Name: "api-2"}}
+	if !reflect.DeepEqual(got2, want2) {
+		t.Errorf("node-2 refs = %v, want %v", got2, want2)
+	}
+}
+
+func TestResolveTargetNodes_AllInNamespace(t *testing.T) {
+	cs := fake.NewClientset(
+		pod("ns1", "p1", "node-1", nil),
+		pod("ns1", "p2", "node-2", nil),
+		pod("ns2", "ignored", "node-1", nil),
+	)
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		AllInNamespace:   true,
+	}
+	got, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got.NodeNames, []string{"node-1", "node-2"}) {
+		t.Errorf("node names = %v, want [node-1 node-2]", got.NodeNames)
+	}
+	if got.ByNode["node-1"][0].Name != "p1" || got.ByNode["node-2"][0].Name != "p2" {
+		t.Errorf("unexpected refs: %+v", got.ByNode)
+	}
+}
+
+func TestResolveTargetNodes_SkipsTerminatingPods(t *testing.T) {
+	terminating := pod("ns1", "going", "node-1", map[string]string{"app": "x"})
+	now := metav1.NewTime(time.Now())
+	terminating.DeletionTimestamp = &now
+	cs := fake.NewClientset(
+		terminating,
+		pod("ns1", "alive", "node-1", map[string]string{"app": "x"}),
+	)
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		AllInNamespace:   true,
+	}
+	got, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.ByNode["node-1"]) != 1 || got.ByNode["node-1"][0].Name != "alive" {
+		t.Errorf("expected only the non-terminating pod, got %+v", got.ByNode["node-1"])
+	}
+}
+
+func TestResolveTargetNodes_AllUnscheduled_Errors(t *testing.T) {
+	cs := fake.NewClientset(
+		pod("ns1", "pending", "", nil),
+	)
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		Pods:             []string{"pending"},
+	}
+	_, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err == nil {
+		t.Fatalf("expected error when all pods unscheduled")
+	}
+	if !strings.Contains(err.Error(), "not yet scheduled") {
+		t.Errorf("error %q does not mention scheduling state", err)
+	}
+}
+
+func TestResolveTargetNodes_GetPodError_Propagates(t *testing.T) {
+	cs := fake.NewClientset() // no pods
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		Pods:             []string{"missing"},
+	}
+	_, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err == nil {
+		t.Fatalf("expected error from missing pod")
+	}
+}

--- a/internal/kubernetes/nodespawn/tolerations_test.go
+++ b/internal/kubernetes/nodespawn/tolerations_test.go
@@ -1,0 +1,65 @@
+package nodespawn
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func tolPod(ns, name, node string, tols []corev1.Toleration) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: map[string]string{"app": "x"}},
+		Spec:       corev1.PodSpec{NodeName: node, Tolerations: tols},
+	}
+}
+
+func TestResolveTargetNodes_PropagatesTolerations(t *testing.T) {
+	tolA := corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+	tolB := corev1.Toleration{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "gpu", Effect: corev1.TaintEffectNoSchedule}
+
+	cs := fake.NewClientset(
+		tolPod("ns1", "a", "node-1", []corev1.Toleration{tolA, tolB}),
+		tolPod("ns1", "b", "node-1", []corev1.Toleration{tolA}),
+		tolPod("ns1", "c", "node-2", []corev1.Toleration{tolB}),
+	)
+	got, err := ResolveTargetNodes(context.Background(), cs, pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		AllInNamespace:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	want1 := []corev1.Toleration{tolA, tolB}
+	if !reflect.DeepEqual(got.TolerationsByNode["node-1"], want1) {
+		t.Errorf("node-1 tolerations = %+v, want %+v", got.TolerationsByNode["node-1"], want1)
+	}
+	want2 := []corev1.Toleration{tolB}
+	if !reflect.DeepEqual(got.TolerationsByNode["node-2"], want2) {
+		t.Errorf("node-2 tolerations = %+v, want %+v", got.TolerationsByNode["node-2"], want2)
+	}
+}
+
+func TestResolveTargetNodes_DedupesIdenticalTolerations(t *testing.T) {
+	tol := corev1.Toleration{Key: "k", Operator: corev1.TolerationOpExists}
+	cs := fake.NewClientset(
+		tolPod("ns1", "a", "node-1", []corev1.Toleration{tol}),
+		tolPod("ns1", "b", "node-1", []corev1.Toleration{tol}),
+	)
+	got, err := ResolveTargetNodes(context.Background(), cs, pkgkube.TargetSelection{
+		DefaultNamespace: "ns1",
+		AllInNamespace:   true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(got.TolerationsByNode["node-1"]) != 1 {
+		t.Errorf("expected 1 deduped toleration, got %d: %+v", len(got.TolerationsByNode["node-1"]), got.TolerationsByNode["node-1"])
+	}
+}

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -32,13 +32,20 @@ var (
 )
 
 type PodResolver struct {
-	clientset kubernetes.Interface
+	clientset  kubernetes.Interface
+	restConfig *rest.Config
 }
 
 var _ PodResolverInterface = (*PodResolver)(nil)
 
 func (r *PodResolver) GetClientset() kubernetes.Interface {
 	return r.clientset
+}
+
+// GetRestConfig exposes the underlying client-go rest.Config so callers (like
+// nodespawn) can build SPDY executors against the same cluster.
+func (r *PodResolver) GetRestConfig() *rest.Config {
+	return r.restConfig
 }
 
 func NewPodResolver() (*PodResolver, error) {
@@ -83,7 +90,7 @@ func NewPodResolver() (*PodResolver, error) {
 		return nil, NewClientsetError(err)
 	}
 
-	return &PodResolver{clientset: clientset}, nil
+	return &PodResolver{clientset: clientset, restConfig: config}, nil
 }
 
 func (r *PodResolver) ResolvePod(ctx context.Context, podName, namespace, containerName string) (*PodInfo, error) {
@@ -188,7 +195,6 @@ func cgroupRootCandidates() []string {
 	seen := map[string]bool{base: true}
 	candidates := []string{base}
 
-	// cgroup v1 systemd hierarchy.
 	if systemdRoot := filepath.Join(base, "systemd"); dirExists(systemdRoot) {
 		if !seen[systemdRoot] {
 			seen[systemdRoot] = true
@@ -196,7 +202,6 @@ func cgroupRootCandidates() []string {
 		}
 	}
 
-	// Kubelet --cgroup-root / --cgroup-parent (GKE, AKS, EKS, custom clusters).
 	if kcp := detectKubeletCgroupParent(); kcp != "" {
 		// kcp may be a relative path like "kubepods" or absolute.
 		var full string
@@ -253,7 +258,6 @@ func readKubeletCgroupFlag() string {
 			continue
 		}
 
-		// cmdline is NUL-separated.
 		args := strings.Split(string(data), "\x00")
 		for i, arg := range args {
 			for _, flag := range []string{"--cgroup-root", "--cgroup-parent"} {
@@ -276,7 +280,6 @@ func readKubeletCgroupFlag() string {
 				}
 			}
 		}
-		// Found kubelet but no relevant flag — stop searching.
 		break
 	}
 	return ""
@@ -288,9 +291,7 @@ func dirExists(path string) bool {
 }
 
 // statCgroupDir returns true when path resolves to anything (file or
-// dir) under the configured cgroup base. The check goes through
-// sysfs.CgroupStat so the operation is os.Root-scoped rather than a
-// raw os.Stat on a tainted path.
+// dir) under the configured cgroup base.
 func statCgroupDir(path string) bool {
 	rel, ok := sysfs.CgroupRelative(path)
 	if !ok {
@@ -336,9 +337,6 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 	cg := info.CgroupsPath
 	roots := cgroupRootCandidates()
 
-	// If CRI returned an absolute filesystem path (e.g. CRI-O on OpenShift may
-	// return /sys/fs/cgroup/kubepods.slice/... directly), check it first, then
-	// strip the cgroup base so the relative path is used in the searches below.
 	if strings.HasPrefix(cg, "/") {
 		if _, err := os.Stat(cg); err == nil {
 			if cg != config.CgroupBasePath {
@@ -372,10 +370,6 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 		}
 	}
 
-	// Systemd parent slice expansion: CRI-O on cgroupv2+systemd (OpenShift 4.14+)
-	// returns a path relative to the kubepods.slice scope, not the cgroup root.
-	// e.g. CRI-O returns:  kubepods-besteffort.slice/kubepods-besteffort-pod<uid>.slice/crio-<id>.scope
-	// actual path is:      /sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/...
 	for _, parent := range []string{"kubepods.slice", "kubepods"} {
 		for _, root := range roots {
 			fullPath := filepath.Join(root, parent, trimmed)

--- a/internal/kubernetes/preresolved.go
+++ b/internal/kubernetes/preresolved.go
@@ -1,0 +1,60 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PreResolvedRef is the workstation's hand-off to the spawn pod: enough fields
+// to build PodInfo without making any Kubernetes API call.
+type PreResolvedRef struct {
+	Namespace     string
+	PodName       string
+	ContainerID   string
+	ContainerName string
+}
+
+// ParsePreResolvedRef parses the "namespace/podName/containerID/containerName"
+// form. Empty containerName is allowed (the spawned binary defaults to the
+// first container's name during its own resolution).
+func ParsePreResolvedRef(s string) (PreResolvedRef, error) {
+	parts := strings.SplitN(s, "/", 4)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return PreResolvedRef{}, fmt.Errorf("preresolved ref %q must be ns/name/containerID[/containerName]", s)
+	}
+	ref := PreResolvedRef{
+		Namespace:   parts[0],
+		PodName:     parts[1],
+		ContainerID: parts[2],
+	}
+	if len(parts) == 4 {
+		ref.ContainerName = parts[3]
+	}
+	return ref, nil
+}
+
+// BuildPodInfoFromPreResolved finishes the workstation's hand-off by walking
+// /sys/fs/cgroup (or whatever PODTRACE_CGROUP_BASE points at — inside the
+// spawn pod that's /host/sys/fs/cgroup) to find the container's cgroup. No
+// K8s API call, so no RBAC needed on the spawn pod's ServiceAccount.
+func BuildPodInfoFromPreResolved(ref PreResolvedRef) (*PodInfo, error) {
+	if ref.ContainerID == "" {
+		return nil, fmt.Errorf("preresolved ref for %s/%s has empty containerID", ref.Namespace, ref.PodName)
+	}
+	cgroupPath, err := findCgroupPath(ref.ContainerID)
+	if err != nil || cgroupPath == "" {
+		fromProc, procErr := findCgroupPathFromProc(ref.ContainerID)
+		if procErr != nil || fromProc == "" {
+			return nil, NewCgroupNotFoundError(ref.ContainerID)
+		}
+		cgroupPath = fromProc
+	}
+	return &PodInfo{
+		PodName:       ref.PodName,
+		Namespace:     ref.Namespace,
+		ContainerID:   ref.ContainerID,
+		ContainerName: ref.ContainerName,
+		CgroupPath:    cgroupPath,
+		Labels:        map[string]string{},
+	}, nil
+}

--- a/internal/kubernetes/resolver.go
+++ b/internal/kubernetes/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type PodResolverInterface interface {
@@ -12,5 +13,9 @@ type PodResolverInterface interface {
 
 type ClientsetProvider interface {
 	GetClientset() kubernetes.Interface
+}
+
+type RestConfigProvider interface {
+	GetRestConfig() *rest.Config
 }
 

--- a/internal/webhook/v1alpha1/exporterconfig_webhook.go
+++ b/internal/webhook/v1alpha1/exporterconfig_webhook.go
@@ -32,7 +32,10 @@ func (v *ExporterConfigCustomValidator) ValidateCreate(_ context.Context, ec *po
 	return nil, podtracev1alpha1.ValidateExporterConfigVariant(ec.Spec)
 }
 
-func (v *ExporterConfigCustomValidator) ValidateUpdate(_ context.Context, _, newEC *podtracev1alpha1.ExporterConfig) (admission.Warnings, error) {
+func (v *ExporterConfigCustomValidator) ValidateUpdate(_ context.Context, oldEC, newEC *podtracev1alpha1.ExporterConfig) (admission.Warnings, error) {
+	if oldEC != nil && specUnchanged(oldEC.Spec, newEC.Spec) {
+		return nil, nil
+	}
 	return nil, podtracev1alpha1.ValidateExporterConfigVariant(newEC.Spec)
 }
 

--- a/internal/webhook/v1alpha1/podtrace_webhook.go
+++ b/internal/webhook/v1alpha1/podtrace_webhook.go
@@ -42,7 +42,10 @@ func (v *PodTraceCustomValidator) ValidateCreate(ctx context.Context, pt *podtra
 	return v.validate(ctx, pt)
 }
 
-func (v *PodTraceCustomValidator) ValidateUpdate(ctx context.Context, _, newPT *podtracev1alpha1.PodTrace) (admission.Warnings, error) {
+func (v *PodTraceCustomValidator) ValidateUpdate(ctx context.Context, oldPT, newPT *podtracev1alpha1.PodTrace) (admission.Warnings, error) {
+	if oldPT != nil && specUnchanged(oldPT.Spec, newPT.Spec) {
+		return nil, nil
+	}
 	return v.validate(ctx, newPT)
 }
 

--- a/internal/webhook/v1alpha1/podtraceschedule_webhook.go
+++ b/internal/webhook/v1alpha1/podtraceschedule_webhook.go
@@ -34,7 +34,10 @@ func (v *PodTraceScheduleCustomValidator) ValidateCreate(ctx context.Context, s 
 	return v.validate(ctx, s)
 }
 
-func (v *PodTraceScheduleCustomValidator) ValidateUpdate(ctx context.Context, _, newSchedule *podtracev1alpha1.PodTraceSchedule) (admission.Warnings, error) {
+func (v *PodTraceScheduleCustomValidator) ValidateUpdate(ctx context.Context, oldSchedule, newSchedule *podtracev1alpha1.PodTraceSchedule) (admission.Warnings, error) {
+	if oldSchedule != nil && specUnchanged(oldSchedule.Spec, newSchedule.Spec) {
+		return nil, nil
+	}
 	return v.validate(ctx, newSchedule)
 }
 

--- a/internal/webhook/v1alpha1/podtracesession_webhook.go
+++ b/internal/webhook/v1alpha1/podtracesession_webhook.go
@@ -40,7 +40,10 @@ func (v *PodTraceSessionCustomValidator) ValidateCreate(ctx context.Context, s *
 	return v.validate(ctx, s)
 }
 
-func (v *PodTraceSessionCustomValidator) ValidateUpdate(ctx context.Context, _, newSession *podtracev1alpha1.PodTraceSession) (admission.Warnings, error) {
+func (v *PodTraceSessionCustomValidator) ValidateUpdate(ctx context.Context, oldSession, newSession *podtracev1alpha1.PodTraceSession) (admission.Warnings, error) {
+	if oldSession != nil && specUnchanged(oldSession.Spec, newSession.Spec) {
+		return nil, nil
+	}
 	return v.validate(ctx, newSession)
 }
 

--- a/internal/webhook/v1alpha1/webhook_helpers.go
+++ b/internal/webhook/v1alpha1/webhook_helpers.go
@@ -13,6 +13,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,20 @@ import (
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
+
+// specUnchanged reports whether old and new spec values are deep-equal. When
+// they are, validating webhooks should skip re-validation of the spec: the
+// admission request is touching only metadata (finalizers, labels, annotations)
+// or status, and re-running spec validation can wedge legacy CRs whose spec
+// pre-dates a stricter validation rule (e.g. a session created before the
+// "at most one reportRef sink" rule landed can't have its finalizer cleared
+// because the webhook rejects every UPDATE on spec grounds).
+//
+// Standard Kubernetes pattern — built-in validators use the same shortcut to
+// allow finalizer-only updates on otherwise-invalid resources.
+func specUnchanged(oldSpec, newSpec any) bool {
+	return reflect.DeepEqual(oldSpec, newSpec)
+}
 
 func validateNamespaceSelector(sel *metav1.LabelSelector) error {
 	if sel == nil {

--- a/internal/webhook/v1alpha1/webhook_test.go
+++ b/internal/webhook/v1alpha1/webhook_test.go
@@ -298,6 +298,44 @@ func TestPodTraceSessionValidator_ObjectStoreReportRef(t *testing.T) {
 	}
 }
 
+// TestPodTraceSessionValidator_FinalizerOnlyUpdateOnInvalidSpec locks in the
+// fix for a stuck-finalizer scenario: a session whose spec was created when an
+// older webhook rule allowed two reportRef sinks must still be deletable.
+func TestPodTraceSessionValidator_FinalizerOnlyUpdateOnInvalidSpec(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+	legacySpec := podtracev1alpha1.PodTraceSessionSpec{
+		Selector:    validSelector(),
+		Duration:    metav1.Duration{Duration: time.Minute},
+		ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		ReportRef: &podtracev1alpha1.ReportReference{
+			ConfigMap:   &corev1.LocalObjectReference{Name: "rpt"},
+			ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/"},
+		},
+	}
+	oldObj := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pts", Namespace: "default",
+			Finalizers: []string{"podtrace.io/cleanup"},
+		},
+		Spec: legacySpec,
+	}
+	newObj := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pts", Namespace: "default",
+		},
+		Spec: legacySpec,
+	}
+	if _, err := v.ValidateUpdate(context.Background(), oldObj, newObj); err != nil {
+		t.Fatalf("finalizer-only update on legacy invalid spec must be allowed, got: %v", err)
+	}
+	mutated := newObj.DeepCopy()
+	mutated.Spec.Duration = metav1.Duration{Duration: 2 * time.Minute}
+	if _, err := v.ValidateUpdate(context.Background(), oldObj, mutated); err == nil {
+		t.Fatalf("spec change on legacy invalid spec must still be rejected")
+	}
+}
+
 // TestPodTraceSessionValidator_ReportRefExclusivity locks in that at
 // most one sink can be set.
 func TestPodTraceSessionValidator_ReportRefExclusivity(t *testing.T) {


### PR DESCRIPTION
## Summary

Relates to #149. This PR introduces a node-spawn CLI architecture so that `kubectl podtrace` works correctly across every supported Kubernetes distribution, bare-metal, and the local-kernel setups (kind, minikube, docker-desktop), by loading eBPF inside the kernel of the node that actually runs the target pod. The CLI resolves the target's node, launches a short-lived privileged pod there, and streams its output back. Local-kernel setups can opt into a faster `--local` path that skips the spawn. The change also folds in a set of BPF and userspace correctness improvements found during the broader audit.

## Architecture change

- New `internal/kubernetes/nodespawn/` package: target-node resolution, spawn-pod spec, attach/log fallback, reaper for leaked pods, multi-node fan-out with per-node line prefixing.
- New `internal/kubernetes/preresolved.go`: the workstation pre-resolves each target's `containerID` and hands it to the child via a hidden `--preresolved-pod` flag, so **the spawn pod runs as the namespace default ServiceAccount with zero RBAC**.
- `cmd/podtrace/nodespawn_hook.go`: orchestrator that decides whether to spawn or run locally; reconstructs child argv minus spawn-control flags.
- New flags on the CLI: `--local`, `--image`, `--spawn-namespace`, `--service-account`, `--dynamic-spawn`. Spawn is skipped when `--local`, `PODTRACE_NODE_LOCAL=1`, or `rest.InClusterConfig()` succeeds.
- Image resolution: `--image` > `PODTRACE_IMAGE` > linker default (`config.Image`). Dirty/dev versions fall back to `:latest` with a startup warning. Linker defaults with tag or digest are used verbatim.
- Reaper labels (`app.kubernetes.io/managed-by=podtrace-cli`, `podtrace.io/owner-host=<host>`) clean up leaked spawn pods on the next invocation; `activeDeadlineSeconds` is the safety net.

## BPF + userspace correctness fixes

- `bpf/maps.h`: `event_buf` and `stack_buf` now `BPF_MAP_TYPE_PERCPU_ARRAY` (race-safe scratch).
- `bpf/cpu.c`, `bpf/syscalls.c`, `bpf/memory.c`: copy tracepoint `comm` fields via `__builtin_memcpy` from a local args struct to avoid the verifier-rejected variable-offset stack writes seen on 6.12+ kernels.
- `internal/ebpf/cache/cpu.go`: per-event CPU-time snapshot from sched_switch `LatencyNS`, so CPU rankings work even when `/proc` sampling misses short-lived PIDs.
- `internal/ebpf/tracer/tracer.go`: re-resolves single-digit `comm`s via `/proc/<pid>/comm` and labels `runc-bootstrap[N]` transients.
- `internal/diagnose/tracker/process.go`: latest-name aggregation per PID; `isTransientName()` covers `runc-bootstrap[*]` and `runc:[*:LABEL]`.
- `internal/diagnose/stacktrace/kallsyms.go` (new): one-time `/proc/kallsyms` load, binary-search resolve, clear warning when `kptr_restrict` blocks (Talos default).
- `internal/diagnose/profiling/cpu_profiling.go`: ranks by summed sched_switch latency; falls back to event count when `/proc` samples are unavailable.

## Webhook stuck-finalizer fix

All four `ValidateUpdate` functions (`PodTrace`, `PodTraceSession`, `PodTraceSchedule`, `ExporterConfig`) now short-circuit via `specUnchanged(old, new)` (deep-equal) before running spec validation. This unblocks finalizer-only updates on legacy CRs whose specs no longer pass current validation, so they can be deleted cleanly. Regression test: `TestPodTraceSessionValidator_FinalizerOnlyUpdateOnInvalidSpec`.

## Misc

- `internal/config/config.go`: linker-overridable `Image`; default `DefaultTopProcessesLimit` 5 → 10.
- `Dockerfile` + `Makefile`: thread `IMAGE_REPO` and `VERSION` into the linker so released binaries point at the right tag, dev builds at `:latest`.
- `deploy/cli-rbac/role.yaml` (new): **optional** SA + ClusterRole for enriched-events correlation. Not required for tracing.

## Docs

- `docs/cli-architecture.md`: full node-spawn architecture, when to use `--local`, RBAC matrix (workstation vs. spawn pod), PodSecurity remediation, reaper, image source, multi-node fan-out.
- `README.md`: `--local` quickstart for kind/minikube/docker-desktop.
- `docs/installation.md`: spawn vs. local distinction.
- `docs/talos.md`: replaced obsolete DaemonSet example with `helm install` flow and "Hardening trade-offs" note on `kptr_restrict`.
- `docs/viewing-events.md`: rewrote Surface 1.
