### PR TITLE
chore(release): use standard semver bumps for pre-v1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
-  "bump-minor-pre-major": false,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "pull-request-title-pattern": "chore(release): release ${version}",
   "packages": {
     ".": {


### PR DESCRIPTION
Switches release-please to standard semver behaviour (feat: → minor, fix: → patch) while still on 0.x, so the v0.12.0 release PR is opened instead of v0.11.12.