### PR TITLE
fix: spawn image tag v-prefix mismatch and OLM bundle push auth

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,9 +32,10 @@ indent_size              = 8
 indent_style             = tab
 
 # ─── Shell ───────────────────────────────────────────────────────────
+# Tabs to match the existing scripts and the project's wider "system
+# files use tabs" convention (Go, C/H, Makefile).
 [*.{sh,bash}]
-indent_style             = space
-indent_size              = 2
+indent_style             = tab
 
 # ─── YAML (Helm, K8s manifests, GitHub Actions, chainsaw fixtures) ──
 [*.{yml,yaml}]

--- a/internal/kubernetes/nodespawn/image.go
+++ b/internal/kubernetes/nodespawn/image.go
@@ -40,7 +40,7 @@ func ResolveImage(opts ResolveImageOptions) (image string, warn bool) {
 	if looksLikeDevBuild(version) {
 		return repo + ":latest", true
 	}
-	return repo + ":" + version, false
+	return repo + ":" + strings.TrimPrefix(version, "v"), false
 }
 
 // looksLikeDevBuild reports whether the linker-baked version string is one

--- a/internal/kubernetes/nodespawn/image_test.go
+++ b/internal/kubernetes/nodespawn/image_test.go
@@ -33,10 +33,16 @@ func TestResolveImage(t *testing.T) {
 			want:      "env.example/podtrace:env",
 		},
 		{
-			name:      "linker default + released version",
+			name:      "linker default + released version strips leading v",
 			linkerVal: "ghcr.io/gma1k/podtrace",
 			opts:      ResolveImageOptions{Version: "v1.2.3"},
-			want:      "ghcr.io/gma1k/podtrace:v1.2.3",
+			want:      "ghcr.io/gma1k/podtrace:1.2.3",
+		},
+		{
+			name:      "version without leading v is used verbatim",
+			linkerVal: "ghcr.io/gma1k/podtrace",
+			opts:      ResolveImageOptions{Version: "1.2.3"},
+			want:      "ghcr.io/gma1k/podtrace:1.2.3",
 		},
 		{
 			name:      "dev version falls back to latest with warn",
@@ -53,9 +59,9 @@ func TestResolveImage(t *testing.T) {
 			wantWarn:  true,
 		},
 		{
-			name: "empty linker falls back to project default",
+			name: "empty linker falls back to project default, leading v stripped",
 			opts: ResolveImageOptions{Version: "v1.0.0"},
-			want: "ghcr.io/gma1k/podtrace:v1.0.0",
+			want: "ghcr.io/gma1k/podtrace:1.0.0",
 		},
 		{
 			name:      "empty version yields latest tag without warn (non-dev)",
@@ -109,10 +115,10 @@ func TestResolveImage(t *testing.T) {
 			wantWarn:  true,
 		},
 		{
-			name:      "clean release tag used verbatim",
+			name:      "clean release tag strips leading v for image tag",
 			linkerVal: "ghcr.io/gma1k/podtrace",
-			opts:      ResolveImageOptions{Version: "v0.11.12"},
-			want:      "ghcr.io/gma1k/podtrace:v0.11.12",
+			opts:      ResolveImageOptions{Version: "v0.12.0"},
+			want:      "ghcr.io/gma1k/podtrace:0.12.0",
 		},
 	}
 

--- a/scripts/submit-olm-bundle.sh
+++ b/scripts/submit-olm-bundle.sh
@@ -93,7 +93,8 @@ log_info "cloning fork ${FORK_OWNER}/${FORK_REPO}"
 gh repo clone "${FORK_OWNER}/${FORK_REPO}" "${WORK_DIR}/fork" -- --depth=1
 cd "${WORK_DIR}/fork"
 
-gh auth setup-git
+: "${GH_TOKEN:?GH_TOKEN must be set with write access to ${FORK_OWNER}/${FORK_REPO}}"
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${FORK_OWNER}/${FORK_REPO}.git"
 
 if git remote get-url upstream >/dev/null 2>&1; then
 	git remote set-url upstream "https://github.com/${UPSTREAM}.git"


### PR DESCRIPTION
Two related fixes needed before v0.12.1 can ship cleanly.

### Closes #157 — spawn pod cannot pull image
Binary version is git-describe output (`v0.12.0`) but published image tags drop the conventional `v` (docker/metadata-action). The CLI used the binary's version verbatim as the image tag, so the spawn pod tried to pull `ghcr.io/gma1k/podtrace:v0.12.0` which doesn't exist. Strip the prefix only at the registry boundary so `podtrace --version` still shows the git-tag form.

### OLM bundle push auth
`olm-bundle` job has been failing with `Permission to gma1k/community-operators.git denied to gma1k` (403). `gh auth setup-git` falls through other credential helpers in CI. Pin the PAT directly on the `origin` remote URL via `x-access-token:` so the push uses the exact token, no helper indirection.