### PR TITLE
feat(cli): improve spawn pod debug UX and detect kernel Lockdown

### DIFF
--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -61,12 +61,13 @@ var (
 	showVersion           bool
 	enableProfiling       bool
 
-	localMode           bool
-	spawnImage          string
-	spawnNamespace      string
-	spawnServiceAccount string
-	dynamicSpawn        bool
-	preresolvedPods     []string
+	localMode             bool
+	spawnImage            string
+	spawnNamespace        string
+	spawnServiceAccount   string
+	dynamicSpawn          bool
+	keepSpawnPodOnFailure bool
+	preresolvedPods       []string
 
 	exporterFromFile       string
 	summaryFile            string
@@ -149,6 +150,7 @@ func main() {
 	rootCmd.Flags().StringVar(&spawnImage, "image", "", "Container image used when spawning on the target node (overrides PODTRACE_IMAGE and the linker default)")
 	rootCmd.Flags().StringVar(&spawnNamespace, "spawn-namespace", "", "Namespace for the ephemeral spawn pod (defaults to the target pod's namespace; overridable via PODTRACE_SPAWN_NAMESPACE)")
 	rootCmd.Flags().BoolVar(&dynamicSpawn, "dynamic-spawn", false, "Continuously poll target selection and spawn additional pods on newly-matched nodes (incompatible with --diagnose; covers new nodes only, not new pods on already-covered nodes)")
+	rootCmd.Flags().BoolVar(&keepSpawnPodOnFailure, "keep-spawn-pod", false, "On failure, leave the spawn pod in place so its logs and state can be inspected (the reaper still cleans it up on the next podtrace invocation)")
 	rootCmd.Flags().StringVar(&spawnServiceAccount, "service-account", "", "ServiceAccount the spawn pod runs as. Only required when --dynamic-spawn watches selector changes from inside the pod; otherwise the workstation pre-resolves everything and the spawn pod needs no RBAC.")
 	rootCmd.Flags().StringSliceVar(&preresolvedPods, "preresolved-pod", nil, "internal: workstation pre-resolved target as ns/name/containerID/containerName, lets the spawn pod skip its own K8s lookup")
 	_ = rootCmd.Flags().MarkHidden("preresolved-pod")
@@ -403,6 +405,9 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := system.CheckRequirements(); err != nil {
+		return err
+	}
+	if err := system.CheckKernelLockdown(); err != nil {
 		return err
 	}
 	system.CheckSELinux()

--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -125,18 +125,19 @@ func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.
 	}
 
 	err = nodespawn.Run(ctx, nodespawn.RunOptions{
-		Clientset:          clientset,
-		RestConfig:         restCfg,
-		Selection:          selection,
-		Image:              image,
-		SpawnNamespace:     ns,
-		BuildChildArgs:     build,
-		OwnerHost:          host,
-		OwnerPID:           os.Getpid(),
-		Streams:            streams,
-		OnPodRunning:       onRunning,
-		DynamicReSpawn:     dynamic,
-		ServiceAccountName: sa,
+		Clientset:             clientset,
+		RestConfig:            restCfg,
+		Selection:             selection,
+		Image:                 image,
+		SpawnNamespace:        ns,
+		BuildChildArgs:        build,
+		OwnerHost:             host,
+		OwnerPID:              os.Getpid(),
+		Streams:               streams,
+		OnPodRunning:          onRunning,
+		DynamicReSpawn:        dynamic,
+		ServiceAccountName:    sa,
+		KeepSpawnPodOnFailure: keepSpawnPodOnFailure,
 	})
 	if err != nil {
 		var exitErr *nodespawn.ExitError

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -201,6 +201,59 @@ Talos's secure defaults affect what podtrace can display. Each item below is
 an intentional kernel/Kubernetes choice; podtrace surfaces a clear message and
 the workaround if you accept the security cost.
 
+### Kernel Lockdown LSM `confidentiality` mode blocks BPF entirely
+
+Talos boots with `lockdown=confidentiality` on the kernel command line, the
+strictest setting of the Lockdown LSM. In this mode the kernel denies *all*
+BPF reads of kernel RAM — including the modern `bpf_probe_read_kernel`,
+`bpf_probe_read_kernel_str` helpers, and the CO-RE `BPF_CORE_READ` macro that
+podtrace relies on for almost every program. The verifier rejects the load
+with a misleading helper-id message (the helper number printed isn't stable
+across runs), but the real cause is visible in `dmesg`:
+
+```
+Lockdown: podtrace: use of bpf to read kernel RAM is restricted; see man kernel_lockdown.7
+```
+
+Podtrace v0.12.2+ detects this at startup and fails fast:
+
+> Error: kernel Lockdown LSM is in 'confidentiality' mode
+> (/sys/kernel/security/lockdown). BPF programs cannot read kernel RAM in this
+> mode … On Talos: drop `lockdown=confidentiality` from
+> `.machine.install.extraKernelArgs` …
+
+To fix, patch the machine config to drop `lockdown=confidentiality` (or set it
+to `lockdown=none` / `lockdown=integrity`):
+
+```yaml
+machine:
+  install:
+    extraKernelArgs:
+      - lockdown=none
+```
+
+Apply and reboot the node:
+
+```bash
+talosctl --nodes <node> patch machineconfig --immediate -p @patch.yaml
+talosctl --nodes <node> reboot
+```
+
+Confirm:
+
+```bash
+talosctl --nodes <node> read /sys/kernel/security/lockdown
+# expected: [none] integrity confidentiality
+```
+
+This is the largest security trade-off in this document — confidentiality mode
+specifically exists to prevent any read of kernel RAM by any unprivileged path,
+including BPF. `integrity` (a middle ground) prevents kernel-RAM *writes* but
+permits the reads podtrace needs; it's the recommended setting for nodes you
+trace regularly. Power users on test kernels can set
+`PODTRACE_SKIP_LOCKDOWN_CHECK=1` to bypass the check (the BPF load will then
+fail with the misleading verifier error).
+
 ### Kernel stack symbolication needs `kernel.kptr_restrict=0`
 
 Talos defaults `kernel.kptr_restrict=2`, which zeroes every address in

--- a/internal/kubernetes/nodespawn/diagnose.go
+++ b/internal/kubernetes/nodespawn/diagnose.go
@@ -1,0 +1,123 @@
+package nodespawn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// AttachFailedError wraps an attach-time failure with the spawn pod's
+// post-mortem state so the CLI can show users the actual exit reason
+// (verifier rejection, missing capability, etc.) instead of the raw
+// kubelet "container not found" / "CONTAINER_EXITED" race error.
+type AttachFailedError struct {
+	Namespace string
+	PodName   string
+
+	ExitCode *int32
+	Reason   string
+	Message  string
+	LastLogs string
+
+	Cause error
+}
+
+func (e *AttachFailedError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.ExitCode == nil {
+		return fmt.Sprintf("attach to %s/%s: %v", e.Namespace, e.PodName, e.Cause)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "spawn pod %s/%s exited with code %d before tracer was ready",
+		e.Namespace, e.PodName, *e.ExitCode)
+	if e.Reason != "" {
+		fmt.Fprintf(&b, "\n  reason:  %s", e.Reason)
+	}
+	if e.Message != "" {
+		fmt.Fprintf(&b, "\n  message: %s", strings.TrimRight(e.Message, "\n"))
+	}
+	if e.LastLogs != "" {
+		fmt.Fprintf(&b, "\n  last logs:\n%s", indent(e.LastLogs, "    "))
+	}
+	fmt.Fprintf(&b, "\n  to reproduce: kubectl -n %s logs %s", e.Namespace, e.PodName)
+	return b.String()
+}
+
+func (e *AttachFailedError) Unwrap() error { return e.Cause }
+
+// diagnoseAttachFailure refreshes the spawn pod's status after an attach error
+// and, if the primary container has already terminated, returns a structured
+// AttachFailedError carrying its exit code, reason, termination message, and
+// last log lines.
+func diagnoseAttachFailure(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, podName string,
+	origErr error,
+) error {
+	if origErr == nil {
+		return nil
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return origErr
+	}
+
+	pod, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if getErr != nil || pod == nil {
+		return origErr
+	}
+
+	cs := primaryContainerStatus(pod)
+	if cs == nil || cs.State.Terminated == nil {
+		return origErr
+	}
+
+	term := cs.State.Terminated
+	logs := dumpPodLogs(ctx, clientset, namespace, podName)
+
+	exit := term.ExitCode
+	return &AttachFailedError{
+		Namespace: namespace,
+		PodName:   podName,
+		ExitCode:  &exit,
+		Reason:    term.Reason,
+		Message:   term.Message,
+		LastLogs:  logs,
+		Cause:     origErr,
+	}
+}
+
+// primaryContainerStatus returns the status entry for the spawn pod's only
+// container ("podtrace" — see pod_spec.go).
+func primaryContainerStatus(pod *corev1.Pod) *corev1.ContainerStatus {
+	if pod == nil {
+		return nil
+	}
+	for i, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "podtrace" {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	if len(pod.Status.ContainerStatuses) > 0 {
+		return &pod.Status.ContainerStatuses[0]
+	}
+	return nil
+}
+
+func indent(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/kubernetes/nodespawn/diagnose_test.go
+++ b/internal/kubernetes/nodespawn/diagnose_test.go
@@ -1,0 +1,186 @@
+package nodespawn
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDiagnoseAttachFailure_TerminatedPodWrapsWithExitCode(t *testing.T) {
+	pod := terminatedSpawnPod("ns", "spawn", 1, "Error",
+		"verifier rejected uretprobe_rd_kafka_consumer_poll: helper not supported")
+	clientset := fake.NewSimpleClientset(pod)
+	orig := errors.New("unable to upgrade connection: container podtrace not found in pod spawn_ns")
+
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if !errors.As(err, &afe) {
+		t.Fatalf("expected *AttachFailedError, got %T: %v", err, err)
+	}
+	if afe.ExitCode == nil || *afe.ExitCode != 1 {
+		t.Errorf("ExitCode: got %v, want 1", afe.ExitCode)
+	}
+	if afe.Reason != "Error" {
+		t.Errorf("Reason: got %q, want %q", afe.Reason, "Error")
+	}
+	if !strings.Contains(afe.Message, "uretprobe_rd_kafka_consumer_poll") {
+		t.Errorf("Message did not propagate termination message: %q", afe.Message)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("Unwrap should expose the original attach error")
+	}
+
+	msg := afe.Error()
+	for _, want := range []string{
+		"exited with code 1",
+		"uretprobe_rd_kafka_consumer_poll",
+		"kubectl -n ns logs spawn",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("formatted error missing %q\n got: %s", want, msg)
+		}
+	}
+}
+
+func TestDiagnoseAttachFailure_RunningPodReturnsUnwrapped(t *testing.T) {
+	pod := runningSpawnPod("ns", "spawn")
+	clientset := fake.NewSimpleClientset(pod)
+	orig := errors.New("transient attach error")
+
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("running pod must not be wrapped in AttachFailedError, got: %v", err)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+}
+
+func TestDiagnoseAttachFailure_NilErrorReturnsNil(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	if got := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", nil); got != nil {
+		t.Errorf("nil orig error must produce nil result, got %v", got)
+	}
+}
+
+func TestDiagnoseAttachFailure_MissingPodReturnsUnwrapped(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	orig := errors.New("attach failed")
+
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("missing pod must not be wrapped in AttachFailedError, got: %v", err)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+}
+
+func TestDiagnoseAttachFailure_CancelledContextReturnsUnwrapped(t *testing.T) {
+	pod := terminatedSpawnPod("ns", "spawn", 1, "Error", "anything")
+	clientset := fake.NewSimpleClientset(pod)
+	orig := errors.New("attach failed")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := diagnoseAttachFailure(ctx, clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("cancelled context must not be wrapped in AttachFailedError, got: %v", err)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+}
+
+func TestAttachFailedError_FormatWithoutExitCode(t *testing.T) {
+	afe := &AttachFailedError{
+		Namespace: "ns",
+		PodName:   "spawn",
+		Cause:     errors.New("transport hung up"),
+	}
+	want := "attach to ns/spawn: transport hung up"
+	if got := afe.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrimaryContainerStatus_PrefersNamedContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar"},
+				{Name: "podtrace", Image: "ghcr.io/gma1k/podtrace:0.12.1"},
+			},
+		},
+	}
+	cs := primaryContainerStatus(pod)
+	if cs == nil || cs.Name != "podtrace" {
+		t.Fatalf("expected podtrace container, got %v", cs)
+	}
+}
+
+func TestPrimaryContainerStatus_FallsBackToFirstWhenNamedAbsent(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "other"}},
+		},
+	}
+	cs := primaryContainerStatus(pod)
+	if cs == nil || cs.Name != "other" {
+		t.Fatalf("expected fallback to first container, got %v", cs)
+	}
+}
+
+func TestPrimaryContainerStatus_EmptyReturnsNil(t *testing.T) {
+	if primaryContainerStatus(&corev1.Pod{}) != nil {
+		t.Errorf("expected nil for empty status list")
+	}
+	if primaryContainerStatus(nil) != nil {
+		t.Errorf("expected nil for nil pod")
+	}
+}
+
+func terminatedSpawnPod(namespace, name string, exitCode int32, reason, message string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "podtrace",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: exitCode,
+						Reason:   reason,
+						Message:  message,
+					},
+				},
+			}},
+		},
+	}
+}
+
+func runningSpawnPod(namespace, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "podtrace",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+}

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -112,6 +112,7 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 		Stdin:           true,
 		StdinOnce:       true,
 		TTY:             false,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &priv,
 			RunAsUser:  &runAsRoot,

--- a/internal/kubernetes/nodespawn/pod_spec_test.go
+++ b/internal/kubernetes/nodespawn/pod_spec_test.go
@@ -89,6 +89,18 @@ func TestBuildPodSpec_SecurityContext(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_TerminationMessagePolicyFallsBackToLogs(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	want := corev1.TerminationMessageFallbackToLogsOnError
+	if got.Spec.Containers[0].TerminationMessagePolicy != want {
+		t.Errorf("TerminationMessagePolicy: got %q, want %q (needed so the CLI can surface verifier output instead of an attach-race error)",
+			got.Spec.Containers[0].TerminationMessagePolicy, want)
+	}
+}
+
 func TestBuildPodSpec_HostMountsAndEnv(t *testing.T) {
 	got, err := BuildPodSpec(baseOpts())
 	if err != nil {

--- a/internal/kubernetes/nodespawn/run.go
+++ b/internal/kubernetes/nodespawn/run.go
@@ -2,6 +2,7 @@ package nodespawn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/logger"
 )
 
 // RunOptions drives the per-CLI-invocation orchestration: figure out which
@@ -50,6 +53,8 @@ type RunOptions struct {
 
 	DynamicReSpawn bool
 	PollInterval   time.Duration
+
+	KeepSpawnPodOnFailure bool
 }
 
 // Run orchestrates the spawn + stream lifecycle. It returns when every per-node
@@ -174,10 +179,23 @@ func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multi
 		}
 		return fmt.Errorf("create spawn pod %s/%s: %w", podSpec.Namespace, podSpec.Name, err)
 	}
+	logger.Debug("Spawn pod created",
+		zap.String("namespace", created.Namespace),
+		zap.String("name", created.Name),
+		zap.String("node", podSpec.Spec.NodeSelector["kubernetes.io/hostname"]))
 
 	cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
 	defer cancelCleanup()
 	defer func() {
+		if retErr != nil && opts.KeepSpawnPodOnFailure {
+			_, _ = fmt.Fprintf(opts.Streams.ErrOut,
+				"spawn pod preserved for debugging: kubectl -n %s logs %s (reaper will clean it up on the next podtrace invocation)\n",
+				created.Namespace, created.Name)
+			logger.Debug("Spawn pod kept on failure",
+				zap.String("namespace", created.Namespace),
+				zap.String("name", created.Name))
+			return
+		}
 		_ = DeletePod(cleanupCtx, opts.Clientset, created.Namespace, created.Name)
 	}()
 
@@ -185,6 +203,10 @@ func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multi
 	if err != nil {
 		return err
 	}
+	logger.Debug("Spawn pod reached terminal-or-running phase",
+		zap.String("namespace", running.Namespace),
+		zap.String("name", running.Name),
+		zap.String("phase", string(running.Status.Phase)))
 
 	if opts.OnPodRunning != nil {
 		if cbErr := opts.OnPodRunning(ctx, running); cbErr != nil {
@@ -200,7 +222,17 @@ func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multi
 	}
 
 	if _, err := AttachToPod(ctx, opts.RestConfig, opts.Clientset, running, streams); err != nil {
-		return fmt.Errorf("attach to %s/%s: %w", running.Namespace, running.Name, err)
+		diag := diagnoseAttachFailure(cleanupCtx, opts.Clientset, running.Namespace, running.Name, err)
+		var afe *AttachFailedError
+		if errors.As(diag, &afe) && afe.ExitCode != nil {
+			logger.Debug("Spawn container exited before attach completed",
+				zap.String("namespace", afe.Namespace),
+				zap.String("name", afe.PodName),
+				zap.Int32("exit_code", *afe.ExitCode),
+				zap.String("reason", afe.Reason),
+				zap.String("termination_message", afe.Message))
+		}
+		return diag
 	}
 
 	exit := WaitForExitCode(ctx, opts.Clientset, running.Namespace, running.Name)

--- a/internal/system/checks.go
+++ b/internal/system/checks.go
@@ -92,6 +92,93 @@ func CheckSELinux() {
 			"  Set PODTRACE_SKIP_SELINUX_CHECK=1 to suppress this warning.")
 }
 
+// LockdownMode is the active level of the kernel Lockdown LSM.
+type LockdownMode string
+
+const (
+	LockdownNone            LockdownMode = "none"
+	LockdownIntegrity       LockdownMode = "integrity"
+	LockdownConfidentiality LockdownMode = "confidentiality"
+	LockdownUnknown LockdownMode = ""
+)
+
+// CheckKernelLockdown reads /sys/kernel/security/lockdown and returns an error
+// when the LSM is in 'confidentiality' mode, which denies all BPF reads of
+// kernel RAM (helpers like bpf_probe_read_kernel{,_str} and BPF_CORE_READ).
+//
+// The kernel emits these denials via the Lockdown LSM path rather than the
+// normal verifier helper-allowlist check, so the verifier error users see at
+// load time is the helper-id slot from a different code path and is not a
+// reliable indicator of the actual cause. Surfacing the LSM state at startup
+// gets the real reason in front of the user before any BPF load is attempted.
+//
+// Integrity mode is warned about but does not block — some integrity-mode
+// kernels still permit the helpers podtrace uses, so failing closed would be
+// over-aggressive. None / file-missing / unknown levels are silent.
+//
+// Set PODTRACE_SKIP_LOCKDOWN_CHECK=1 to bypass; intended for power users on
+// test kernels or anyone who has verified the check is over-triggering on
+// their environment.
+func CheckKernelLockdown() error {
+	if os.Getenv("PODTRACE_SKIP_LOCKDOWN_CHECK") == "1" {
+		return nil
+	}
+
+	data, err := os.ReadFile("/sys/kernel/security/lockdown")
+	if err != nil {
+		return nil
+	}
+
+	return evaluateLockdown(parseLockdownMode(string(data)))
+}
+
+// evaluateLockdown is the pure-function half of CheckKernelLockdown: it makes
+// the block/warn/silent decision for a known LockdownMode without touching
+// the filesystem so it can be unit-tested across all branches.
+func evaluateLockdown(mode LockdownMode) error {
+	switch mode {
+	case LockdownConfidentiality:
+		return fmt.Errorf(
+			"kernel Lockdown LSM is in 'confidentiality' mode (/sys/kernel/security/lockdown). " +
+				"BPF programs cannot read kernel RAM in this mode (helpers bpf_probe_read_kernel, " +
+				"bpf_probe_read_kernel_str, and the BPF_CORE_READ pointer-chase macro are all denied), " +
+				"which podtrace requires.\n" +
+				"  On Talos: drop `lockdown=confidentiality` from .machine.install.extraKernelArgs in your " +
+				"machine config (or set it to `lockdown=none` / `lockdown=integrity`), then `talosctl upgrade`\n" +
+				"  On other distros: boot without `lockdown=` on the kernel command line, or set it to " +
+				"`none` / `integrity` — active level is in /proc/cmdline\n" +
+				"  Set PODTRACE_SKIP_LOCKDOWN_CHECK=1 to bypass; BPF load will then fail with a misleading " +
+				"verifier error, intended only for test/CI scenarios")
+	case LockdownIntegrity:
+		logger.Warn(
+			"Kernel Lockdown LSM is in 'integrity' mode (/sys/kernel/security/lockdown). " +
+				"This may restrict some BPF reads of kernel RAM depending on the helper and program type. " +
+				"If tracing fails to load programs, retry with `lockdown=none` on the kernel command line.")
+		return nil
+	default:
+		return nil
+	}
+}
+
+// parseLockdownMode extracts the active bracketed value from the
+// /sys/kernel/security/lockdown file contents.
+func parseLockdownMode(s string) LockdownMode {
+	lb := strings.IndexByte(s, '[')
+	if lb < 0 {
+		return LockdownUnknown
+	}
+	rb := strings.IndexByte(s[lb+1:], ']')
+	if rb < 0 {
+		return LockdownUnknown
+	}
+	active := strings.TrimSpace(s[lb+1 : lb+1+rb])
+	switch LockdownMode(active) {
+	case LockdownNone, LockdownIntegrity, LockdownConfidentiality:
+		return LockdownMode(active)
+	}
+	return LockdownUnknown
+}
+
 // parseKernelVersion reads the running kernel version from /proc/version
 // and returns a KernelVersion. It handles forms like:
 //   - "Linux version 6.1.0-28-amd64 ..."

--- a/internal/system/checks_test.go
+++ b/internal/system/checks_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -141,6 +142,126 @@ func TestCheckSELinux_NoSELinux(t *testing.T) {
 	t.Setenv("PODTRACE_SKIP_SELINUX_CHECK", "1")
 	// Should not panic or return error.
 	CheckSELinux()
+}
+
+func TestParseLockdownMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  LockdownMode
+	}{
+		{
+			name:  "none active (typical Linux desktop / kind / minikube)",
+			input: "[none] integrity confidentiality\n",
+			want:  LockdownNone,
+		},
+		{
+			name:  "integrity active",
+			input: "none [integrity] confidentiality\n",
+			want:  LockdownIntegrity,
+		},
+		{
+			name:  "confidentiality active (Talos default)",
+			input: "none integrity [confidentiality]\n",
+			want:  LockdownConfidentiality,
+		},
+		{
+			name:  "no trailing newline",
+			input: "none integrity [confidentiality]",
+			want:  LockdownConfidentiality,
+		},
+		{
+			name:  "extra whitespace inside brackets",
+			input: "none integrity [ confidentiality ]\n",
+			want:  LockdownConfidentiality,
+		},
+		{
+			name:  "empty file → unknown",
+			input: "",
+			want:  LockdownUnknown,
+		},
+		{
+			name:  "no brackets → unknown",
+			input: "none integrity confidentiality\n",
+			want:  LockdownUnknown,
+		},
+		{
+			name:  "unbalanced open bracket → unknown",
+			input: "none integrity [confidentiality\n",
+			want:  LockdownUnknown,
+		},
+		{
+			name:  "unknown future level → LockdownUnknown (don't guess)",
+			input: "none integrity confidentiality [tpm]\n",
+			want:  LockdownUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseLockdownMode(tc.input)
+			if got != tc.want {
+				t.Errorf("parseLockdownMode(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckKernelLockdown_SkipEnvBypasses(t *testing.T) {
+	t.Setenv("PODTRACE_SKIP_LOCKDOWN_CHECK", "1")
+	if err := CheckKernelLockdown(); err != nil {
+		t.Errorf("PODTRACE_SKIP_LOCKDOWN_CHECK=1 must short-circuit even on a locked-down kernel, got %v", err)
+	}
+}
+
+func TestCheckKernelLockdown_AbsentFileIsSilent(t *testing.T) {
+	// We can't reliably remove /sys/kernel/security/lockdown from a unit test,
+	// but we can confirm the function tolerates whatever the host actually has
+	// (and exercises the os.ReadFile-returns-error branch on non-Linux CI).
+	t.Setenv("PODTRACE_SKIP_LOCKDOWN_CHECK", "")
+	if _, err := os.Stat("/sys/kernel/security/lockdown"); err != nil {
+		// On a host without the LSM, the check must be silent (no error).
+		if cerr := CheckKernelLockdown(); cerr != nil {
+			t.Errorf("expected nil on host without /sys/kernel/security/lockdown, got %v", cerr)
+		}
+	}
+}
+
+func TestEvaluateLockdown_ConfidentialityProducesActionableError(t *testing.T) {
+	err := evaluateLockdown(LockdownConfidentiality)
+	if err == nil {
+		t.Fatal("expected non-nil error for confidentiality mode")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"confidentiality",
+		"/sys/kernel/security/lockdown",
+		"Talos",
+		"extraKernelArgs",
+		"PODTRACE_SKIP_LOCKDOWN_CHECK",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("lockdown error missing %q\n got: %s", want, msg)
+		}
+	}
+}
+
+func TestEvaluateLockdown_IntegrityWarnsButDoesNotBlock(t *testing.T) {
+	if err := evaluateLockdown(LockdownIntegrity); err != nil {
+		t.Errorf("integrity mode should warn but not error, got: %v", err)
+	}
+}
+
+func TestEvaluateLockdown_NoneIsSilent(t *testing.T) {
+	if err := evaluateLockdown(LockdownNone); err != nil {
+		t.Errorf("none mode must not error, got: %v", err)
+	}
+}
+
+func TestEvaluateLockdown_UnknownIsSilent(t *testing.T) {
+	if err := evaluateLockdown(LockdownUnknown); err != nil {
+		t.Errorf("unknown mode must not error (don't guess on future kernels), got: %v", err)
+	}
 }
 
 // TestIsBTFAvailable returns a boolean; just make sure it doesn't panic.


### PR DESCRIPTION
Relates to #160:

Addresses the five debug-UX gaps raised by @fenio while diagnosing why podtrace failed on Talos cluster:

1. **Spawn pod was reaped on failure**, so `kubectl logs <pod>` raced against cleanup and almost always lost.
2. **`TerminationMessagePolicy` defaulted to `File`**, so the spawn container's stderr (which carried the real failure, an eBPF verifier rejection caused by the kernel Lockdown LSM in `confidentiality` mode) was thrown away by kubelet.
3. **CLI surfaced a downstream attach error** (`unable to upgrade connection: container podtrace not found in pod ...`) that pointed at the wrong layer of the system.
4. **`--log-level=debug` was silent about the spawn loop itself.** Users had to reverse-engineer the lifecycle from `kubectl get pods` polling.
5. **No early detection of Talos's `lockdown=confidentiality` kernel parameter**, which is the actual root cause of the failure and unfixable by any code podtrace ships.

This PR keeps the issue **open** so @fenio can validate the actual error wording on v0.12.2 against a confidentiality-mode Talos node before we close it.

### Changes

#### `--keep-spawn-pod` flag
- New flag on the CLI. When set, the spawn pod is preserved on any non-nil error path so its `kubectl logs` and `kubectl describe` stay reachable. The reaper still cleans it up on the next podtrace invocation, so no orphans.
- Pod is always deleted on success regardless of the flag.

#### `TerminationMessagePolicy: FallbackToLogsOnError`
- Set on the spawn container so kubelet puts the tail of stderr into `containerStatuses[].state.terminated.message` whenever the container exits non-zero.

#### `AttachFailedError` post-mortem
- New exported error type with `Unwrap()`, holding `ExitCode`, `Reason`, `Message`, `LastLogs`, and the original transport error.
- After any attach failure, `diagnoseAttachFailure` refreshes the pod and — if `State.Terminated != nil` — wraps with a structured error that prints exit code, reason, termination message, last 50 log lines, and a `kubectl -n ns logs pod` rerun command. When the pod is still running or unreachable, the original error is returned verbatim.

#### Debug-level lifecycle logging
- `nodespawn.runOneNode` now emits `logger.Debug` at: pod created, pod reached terminal-or-running phase, spawn container exit details (when attach fails), keep-on-failure decision.

#### Kernel Lockdown LSM startup check
- New `system.CheckKernelLockdown()` reads `/sys/kernel/security/lockdown` before any BPF load:
  - `[confidentiality]` → **hard error** at startup with a Talos-specific remediation (drop `lockdown=confidentiality` from `.machine.install.extraKernelArgs`).
  - `[integrity]` → **warning** (some integrity-mode kernels still permit the helpers podtrace uses; failing closed would over-trigger).
  - `none` / file missing / unknown future levels → silent.
- Pure-function split (`evaluateLockdown(LockdownMode)`) so all four branches are unit-testable without a real sysfs.
- `PODTRACE_SKIP_LOCKDOWN_CHECK=1` escape hatch for test/CI scenarios.

#### Docs
- New "Kernel Lockdown LSM `confidentiality` mode blocks BPF entirely" section at the top of `docs/talos.md`'s Hardening trade-offs. Quotes the new startup error verbatim, gives the exact `extraKernelArgs` patch, and frames the `none` / `integrity` / `confidentiality` trade-off.