### PR TITLE
fix: full BPF verifier log on failure + spawn pod argv strip

### DIFF
--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -29,6 +29,7 @@ var spawnControlFlags = map[string]struct{}{
 	"spawn-namespace":  {},
 	"service-account":  {},
 	"dynamic-spawn":    {},
+	"keep-spawn-pod":   {},
 	"namespace":        {},
 	"namespaces":       {},
 	"pods":             {},

--- a/cmd/podtrace/nodespawn_hook_test.go
+++ b/cmd/podtrace/nodespawn_hook_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestSpawnControlFlags_PinsTheStrippedSet(t *testing.T) {
+	wantStripped := []string{
+		"local",
+		"image",
+		"spawn-namespace",
+		"service-account",
+		"dynamic-spawn",
+		"keep-spawn-pod",
+		"namespace",
+		"namespaces",
+		"pods",
+		"pod-selector",
+		"all-in-namespace",
+	}
+	for _, name := range wantStripped {
+		if _, ok := spawnControlFlags[name]; !ok {
+			t.Errorf("flag %q must be in spawnControlFlags so it is stripped from the spawn pod's argv reconstruction; "+
+				"workstation-only flags forwarded to the spawn pod break against any image that doesn't recognise them", name)
+		}
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -186,9 +186,11 @@ func NewTracer() (*Tracer, error) {
 			}
 		}
 	}
+	applyVerifierLogOptions(&opts)
 
 	coll, err := ebpf.NewCollectionWithOptions(spec, opts)
 	if err != nil {
+		logVerifierFailure(err)
 		return nil, NewCollectionError(err)
 	}
 

--- a/internal/ebpf/tracer/verifier_log.go
+++ b/internal/ebpf/tracer/verifier_log.go
@@ -1,0 +1,92 @@
+package tracer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+const (
+	envBPFLogLevel = "PODTRACE_BPF_LOG_LEVEL"
+	envBPFLogSize  = "PODTRACE_BPF_LOG_SIZE"
+
+	defaultVerboseLogSize uint32 = 64 * 1024
+)
+
+// applyVerifierLogOptions reads PODTRACE_BPF_LOG_LEVEL / PODTRACE_BPF_LOG_SIZE
+// and applies them to opts.Programs.LogLevel / opts.Programs.LogSizeStart.
+func applyVerifierLogOptions(opts *ebpf.CollectionOptions) {
+	level := parseBPFLogLevel(os.Getenv(envBPFLogLevel))
+	if level == 0 {
+		return
+	}
+	opts.Programs.LogLevel = level
+	opts.Programs.LogSizeStart = parseBPFLogSize(os.Getenv(envBPFLogSize))
+	logger.Debug("Verifier log capture enabled",
+		zap.String(envBPFLogLevel, os.Getenv(envBPFLogLevel)),
+		zap.Uint32("log_size_start", opts.Programs.LogSizeStart),
+	)
+}
+
+// parseBPFLogLevel turns the value of PODTRACE_BPF_LOG_LEVEL into a bitmask of
+// cilium/ebpf LogLevel constants. Unknown / empty values return 0, which
+// signals "use the library default (no upfront log, fallback retry on error)".
+//
+// Accepted forms (case-insensitive, whitespace-trimmed):
+//
+//	"" / "disabled" / "none" / "0" / "false"  → 0
+//	"branch" / "1"                            → LogLevelBranch
+//	"stats" / "2"                             → LogLevelStats
+//	"instructions" / "instruction" / "verbose" / "all" / "3"
+//	                                          → LogLevelBranch | LogLevelInstruction | LogLevelStats
+func parseBPFLogLevel(s string) ebpf.LogLevel {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "disabled", "none", "0", "false":
+		return 0
+	case "branch", "1":
+		return ebpf.LogLevelBranch
+	case "stats", "2":
+		return ebpf.LogLevelStats
+	case "instructions", "instruction", "verbose", "all", "3":
+		return ebpf.LogLevelBranch | ebpf.LogLevelInstruction | ebpf.LogLevelStats
+	}
+	return 0
+}
+
+// parseBPFLogSize parses PODTRACE_BPF_LOG_SIZE. Empty / unparseable / zero
+// returns the default (defaultVerboseLogSize). uint32 ceiling is the cilium/ebpf
+// API limit (LogSizeStart is uint32).
+func parseBPFLogSize(s string) uint32 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return defaultVerboseLogSize
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil || n == 0 {
+		return defaultVerboseLogSize
+	}
+	return uint32(n)
+}
+
+// logVerifierFailure surfaces the full kernel verifier output when an eBPF
+// load fails.
+func logVerifierFailure(err error) {
+	if err == nil {
+		return
+	}
+	var ve *ebpf.VerifierError
+	if !errors.As(err, &ve) {
+		return
+	}
+	logger.Error(
+		"eBPF program load rejected by the kernel verifier — full log follows",
+		zap.String("verifier_output", fmt.Sprintf("%+v", ve)),
+	)
+}

--- a/internal/ebpf/tracer/verifier_log_test.go
+++ b/internal/ebpf/tracer/verifier_log_test.go
@@ -1,0 +1,191 @@
+package tracer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestParseBPFLogLevel(t *testing.T) {
+	verbose := ebpf.LogLevelBranch | ebpf.LogLevelInstruction | ebpf.LogLevelStats
+
+	tests := []struct {
+		name string
+		in   string
+		want ebpf.LogLevel
+	}{
+		{"empty is disabled (library default applies)", "", 0},
+		{"disabled keyword", "disabled", 0},
+		{"none keyword", "none", 0},
+		{"zero numeric", "0", 0},
+		{"false keyword", "false", 0},
+		{"branch keyword", "branch", ebpf.LogLevelBranch},
+		{"branch numeric", "1", ebpf.LogLevelBranch},
+		{"stats keyword", "stats", ebpf.LogLevelStats},
+		{"stats numeric", "2", ebpf.LogLevelStats},
+		{"instructions keyword", "instructions", verbose},
+		{"instruction singular keyword", "instruction", verbose},
+		{"verbose keyword", "verbose", verbose},
+		{"all keyword", "all", verbose},
+		{"instructions numeric", "3", verbose},
+		{"whitespace trimmed", "  verbose  ", verbose},
+		{"case-insensitive", "VERBOSE", verbose},
+		{"unknown value falls back to disabled (no surprise behaviour on typo)", "moarlogs", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseBPFLogLevel(tc.in); got != tc.want {
+				t.Errorf("parseBPFLogLevel(%q) = %#x, want %#x", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseBPFLogSize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want uint32
+	}{
+		{"empty returns default 64 KiB", "", defaultVerboseLogSize},
+		{"unparseable returns default", "huge", defaultVerboseLogSize},
+		{"zero returns default (no point allocating 0)", "0", defaultVerboseLogSize},
+		{"explicit value honoured", "131072", 131072},
+		{"whitespace trimmed", "  131072  ", 131072},
+		{"negative returns default (unparseable as uint)", "-1", defaultVerboseLogSize},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseBPFLogSize(tc.in); got != tc.want {
+				t.Errorf("parseBPFLogSize(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyVerifierLogOptions_DisabledByDefault(t *testing.T) {
+	t.Setenv(envBPFLogLevel, "")
+	var opts ebpf.CollectionOptions
+	applyVerifierLogOptions(&opts)
+
+	if opts.Programs.LogLevel != 0 {
+		t.Errorf("default LogLevel should be 0, got %#x", opts.Programs.LogLevel)
+	}
+	if opts.Programs.LogSizeStart != 0 {
+		t.Errorf("default LogSizeStart should be 0 (cilium/ebpf default kicks in), got %d", opts.Programs.LogSizeStart)
+	}
+}
+
+func TestApplyVerifierLogOptions_VerboseSetsBothFields(t *testing.T) {
+	t.Setenv(envBPFLogLevel, "verbose")
+	t.Setenv(envBPFLogSize, "")
+	var opts ebpf.CollectionOptions
+	applyVerifierLogOptions(&opts)
+
+	wantLevel := ebpf.LogLevelBranch | ebpf.LogLevelInstruction | ebpf.LogLevelStats
+	if opts.Programs.LogLevel != wantLevel {
+		t.Errorf("LogLevel = %#x, want %#x", opts.Programs.LogLevel, wantLevel)
+	}
+	if opts.Programs.LogSizeStart != defaultVerboseLogSize {
+		t.Errorf("LogSizeStart = %d, want %d", opts.Programs.LogSizeStart, defaultVerboseLogSize)
+	}
+}
+
+func TestApplyVerifierLogOptions_CustomBufferSize(t *testing.T) {
+	t.Setenv(envBPFLogLevel, "instructions")
+	t.Setenv(envBPFLogSize, "262144")
+	var opts ebpf.CollectionOptions
+	applyVerifierLogOptions(&opts)
+
+	if opts.Programs.LogSizeStart != 262144 {
+		t.Errorf("LogSizeStart = %d, want 262144", opts.Programs.LogSizeStart)
+	}
+}
+
+func TestApplyVerifierLogOptions_KernelTypesUntouched(t *testing.T) {
+	t.Setenv(envBPFLogLevel, "verbose")
+	var opts ebpf.CollectionOptions
+	applyVerifierLogOptions(&opts)
+
+	if opts.Programs.KernelTypes != nil {
+		t.Errorf("KernelTypes should remain nil — applyVerifierLogOptions must not alter unrelated fields")
+	}
+}
+
+func TestLogVerifierFailure_NilDoesNotPanic(t *testing.T) {
+	logVerifierFailure(nil) // must not panic
+}
+
+func TestLogVerifierFailure_NonVerifierErrorIsNoop(t *testing.T) {
+	logVerifierFailure(errPlain)
+}
+
+// TestVerifierErrorFormatting_PlusVPrintsFullLog proves the formatting choice
+// in logVerifierFailure is correct: cilium/ebpf's default Error() truncates
+// to the last 1-2 lines + "(N line(s) omitted)", while %+v renders the
+// entire log.
+func TestVerifierErrorFormatting_PlusVPrintsFullLog(t *testing.T) {
+	logLines := []string{
+		"0: (b7) r1 = 1                  ; R1_w=1",
+		"1: (61) r2 = *(u32 *)(r1 +0)",
+		"R1 pointer arithmetic on PTR_TO_FUNC prohibited",
+		"verifier rejected program",
+		"Lockdown: podtrace: use of bpf to read kernel RAM is restricted",
+		"see man kernel_lockdown.7 for details",
+		"program 'uretprobe_rd_kafka_consumer_poll' cannot use this helper in this context",
+	}
+	ve := &ebpf.VerifierError{
+		Cause: errPlain,
+		Log:   logLines,
+	}
+
+	truncated := ve.Error()
+	full := fmt.Sprintf("%+v", ve)
+
+	if strings.Contains(truncated, logLines[0]) {
+		t.Errorf("default Error() unexpectedly includes early log line — cilium/ebpf changed behaviour?\n got: %s", truncated)
+	}
+	if !strings.Contains(truncated, "line(s) omitted") {
+		t.Errorf("default Error() must indicate truncation; got: %s", truncated)
+	}
+
+	for _, line := range logLines {
+		if !strings.Contains(full, line) {
+			t.Errorf("%%+v formatting must include every log line; missing %q\n  full: %s", line, full)
+		}
+	}
+	if strings.Contains(full, "line(s) omitted") {
+		t.Errorf("%%+v must not truncate; got: %s", full)
+	}
+}
+
+// TestVerifierErrorFormatting_WrappedErrorStillReachable proves
+// logVerifierFailure works even when the caller has wrapped the VerifierError
+// further (e.g. tracer/errors.go's NewCollectionError), because we use
+// errors.As which walks the wrapping chain.
+func TestVerifierErrorFormatting_WrappedErrorStillReachable(t *testing.T) {
+	ve := &ebpf.VerifierError{
+		Cause: errPlain,
+		Log:   []string{"single line"},
+	}
+	wrapped := fmt.Errorf("failed to create eBPF collection: %w", ve)
+
+	var got *ebpf.VerifierError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As must unwrap to *ebpf.VerifierError through fmt.Errorf chains")
+	}
+	if got != ve {
+		t.Errorf("unwrapped error must be the original instance")
+	}
+}
+
+var errPlain = &plainErr{msg: "not a verifier error"}
+
+type plainErr struct{ msg string }
+
+func (e *plainErr) Error() string { return e.msg }

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -102,6 +102,11 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 			},
 		},
 	}
+	for _, name := range []string{"PODTRACE_BPF_LOG_LEVEL", "PODTRACE_BPF_LOG_SIZE"} {
+		if v := os.Getenv(name); v != "" {
+			env = append(env, corev1.EnvVar{Name: name, Value: v})
+		}
+	}
 
 	container := corev1.Container{
 		Name:            "podtrace",

--- a/internal/kubernetes/nodespawn/pod_spec_test.go
+++ b/internal/kubernetes/nodespawn/pod_spec_test.go
@@ -215,6 +215,48 @@ func TestBuildPodSpec_OwnerHostSanitized(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_ForwardsBPFLogEnvWhenSet(t *testing.T) {
+	t.Setenv("PODTRACE_BPF_LOG_LEVEL", "verbose")
+	t.Setenv("PODTRACE_BPF_LOG_SIZE", "131072")
+
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	want := map[string]string{
+		"PODTRACE_BPF_LOG_LEVEL": "verbose",
+		"PODTRACE_BPF_LOG_SIZE":  "131072",
+	}
+	for _, ev := range got.Spec.Containers[0].Env {
+		if v, ok := want[ev.Name]; ok {
+			if ev.Value != v {
+				t.Errorf("env %s: got %q, want %q", ev.Name, ev.Value, v)
+			}
+			delete(want, ev.Name)
+		}
+	}
+	if len(want) > 0 {
+		t.Errorf("spawn pod env missing forwarded vars: %v", want)
+	}
+}
+
+func TestBuildPodSpec_DoesNotForwardBPFLogEnvWhenUnset(t *testing.T) {
+	t.Setenv("PODTRACE_BPF_LOG_LEVEL", "")
+	t.Setenv("PODTRACE_BPF_LOG_SIZE", "")
+
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	for _, ev := range got.Spec.Containers[0].Env {
+		if ev.Name == "PODTRACE_BPF_LOG_LEVEL" || ev.Name == "PODTRACE_BPF_LOG_SIZE" {
+			t.Errorf("spawn pod must not carry empty BPF log env (%s=%q) — keeps the pod spec clean for normal runs", ev.Name, ev.Value)
+		}
+	}
+}
+
 func TestSanitizeName(t *testing.T) {
 	tests := map[string]string{
 		"WORKER.example.com": "worker-example-com",


### PR DESCRIPTION
Closes #165 — the requested `PODTRACE_BPF_LOG_LEVEL` plumbing plus a regression discovered during end-to-end testing of it.

## Full BPF verifier log on load failure (the primary fix for #165)

When `ebpf.NewCollectionWithOptions` fails, cilium/ebpf's default `Error()` truncates the verifier output to the last 1-2 lines plus `(N line(s) omitted)`. The omitted lines are exactly where the *actual* rejection reason lives (lockdown LSM denial, helper not allowed, missing kernel symbol, etc.) — which is what made #160 take hours of `dmesg` archaeology to diagnose.

- **Always-on**: when the load fails with a `*ebpf.VerifierError`, `logVerifierFailure` (`internal/ebpf/tracer/verifier_log.go`) emits the full log via cilium/ebpf's `%+v` formatter. Users see every line, every time. No env var required.
- **Opt-in detail level**: two env vars — `PODTRACE_BPF_LOG_LEVEL` (`disabled` / `branch` / `stats` / `instructions` / `verbose`) and `PODTRACE_BPF_LOG_SIZE` — translate into `opts.Programs.LogLevel` and `opts.Programs.LogSizeStart`. Default (unset) keeps cilium/ebpf's behaviour unchanged.
- **Auto-forwarded to spawn pods**: when set on the workstation, both env vars are appended to the spawn container's env so users can debug in-pod load failures without rebuilding the image.

## `--keep-spawn-pod` was forwarded to the spawn pod's argv

Found while live-testing against the published `0.12.1` image: the `--keep-spawn-pod` flag introduced in the spawn-pod-debug PR was forwarded to the spawn pod, where the binary doesn't recognise it. The spawn pod crashed with `unknown flag: --keep-spawn-pod`, breaking the feature against any older image.

### Fix
- Add `"keep-spawn-pod"` to the `spawnControlFlags` map in `cmd/podtrace/nodespawn_hook.go`. One-line change.
- Pin the full stripped-flag set via a regression test (`cmd/podtrace/nodespawn_hook_test.go`) so any future workstation-only flag has to either be added to the map or explicitly opt out — prevents the same class of bug from recurring.