### PR TITLE
fix(cli): reap spawn pod orphans by owner-pid liveness

### DIFF
--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -76,7 +76,7 @@ func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.
 	}
 
 	host := nodespawn.HostnameFromEnv()
-	if _, err := nodespawn.ReapStale(ctx, clientset, ns, host, nodespawn.DefaultReaperMaxAge); err != nil {
+	if _, err := nodespawn.ReapStale(ctx, clientset, ns, host); err != nil {
 		logger.Debug("Reaper failed (non-fatal)", zap.Error(err))
 	}
 

--- a/internal/kubernetes/nodespawn/cleanup.go
+++ b/internal/kubernetes/nodespawn/cleanup.go
@@ -2,16 +2,18 @@ package nodespawn
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"time"
+	"os"
+	"strconv"
+	"syscall"
 
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-)
 
-// DefaultReaperMaxAge is how old a stray spawn pod has to be before the reaper
-// deletes it. Tuned so a slow CLI run isn't reaped mid-execution.
-const DefaultReaperMaxAge = 2 * time.Hour
+	"github.com/podtrace/podtrace/internal/logger"
+)
 
 // DeletePod best-effort deletes the spawn pod; NotFound is swallowed so retries
 // and parallel reapers don't error out.
@@ -26,12 +28,19 @@ func DeletePod(ctx context.Context, clientset kubernetes.Interface, namespace, n
 	return fmt.Errorf("nodespawn: delete %s/%s: %w", namespace, name, err)
 }
 
-// ReapStale scans the namespace for pods labelled managed-by=podtrace-cli that
-// belong to ownerHost and are older than maxAge, deleting them.
-func ReapStale(ctx context.Context, clientset kubernetes.Interface, namespace, ownerHost string, maxAge time.Duration) (int, error) {
-	if maxAge <= 0 {
-		maxAge = DefaultReaperMaxAge
-	}
+// ReapStale deletes spawn pods whose owning CLI process is gone.
+func ReapStale(ctx context.Context, clientset kubernetes.Interface, namespace, ownerHost string) (int, error) {
+	return reapStaleWithLiveness(ctx, clientset, namespace, ownerHost, processAlive)
+}
+
+// reapStaleWithLiveness is the test-injectable form. Production callers use
+// ReapStale, which wires in the OS-backed processAlive check.
+func reapStaleWithLiveness(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, ownerHost string,
+	alive func(int) bool,
+) (int, error) {
 	labelSel := fmt.Sprintf("%s=%s", LabelManagedBy, ManagedByValue)
 	if ownerHost != "" {
 		labelSel += fmt.Sprintf(",%s=%s", LabelOwnerHost, sanitizeLabelValue(ownerHost))
@@ -40,16 +49,54 @@ func ReapStale(ctx context.Context, clientset kubernetes.Interface, namespace, o
 	if err != nil {
 		return 0, fmt.Errorf("nodespawn: list stale pods: %w", err)
 	}
-	cutoff := time.Now().Add(-maxAge)
+
 	reaped := 0
 	for i := range list.Items {
 		p := &list.Items[i]
-		if p.CreationTimestamp.After(cutoff) {
+
+		pidStr := p.Labels[LabelOwnerPID]
+		if pidStr == "" {
+			logger.Debug("Spawn pod has no owner-pid label; not reaping (anomaly — surface but don't touch)",
+				zap.String("namespace", p.Namespace),
+				zap.String("name", p.Name))
 			continue
 		}
-		if err := DeletePod(ctx, clientset, p.Namespace, p.Name); err == nil {
+		pid, perr := strconv.Atoi(pidStr)
+		if perr != nil || pid <= 0 {
+			logger.Debug("Spawn pod has malformed owner-pid label; not reaping",
+				zap.String("namespace", p.Namespace),
+				zap.String("name", p.Name),
+				zap.String("owner-pid", pidStr))
+			continue
+		}
+		if alive(pid) {
+			// owning CLI is still running — leave its pod alone.
+			continue
+		}
+
+		// dead owner → orphan → reap
+		if derr := DeletePod(ctx, clientset, p.Namespace, p.Name); derr == nil {
 			reaped++
+			logger.Debug("Reaped orphan spawn pod",
+				zap.String("namespace", p.Namespace),
+				zap.String("name", p.Name),
+				zap.Int("owner_pid", pid))
 		}
 	}
 	return reaped, nil
+}
+
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return true
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
+		return false
+	}
+	return true
 }

--- a/internal/kubernetes/nodespawn/cleanup_test.go
+++ b/internal/kubernetes/nodespawn/cleanup_test.go
@@ -2,23 +2,44 @@ package nodespawn
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func reapPod(name, host string, age time.Duration) *corev1.Pod {
+func reapPod(name, host string, pid int) *corev1.Pod {
+	labels := map[string]string{
+		LabelManagedBy: ManagedByValue,
+	}
+	if host != "" {
+		labels[LabelOwnerHost] = host
+	}
+	if pid >= 0 {
+		labels[LabelOwnerPID] = strconv.Itoa(pid)
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              name,
-			Namespace:         "ns1",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			Name:      name,
+			Namespace: "ns1",
+			Labels:    labels,
+		},
+	}
+}
+
+// reapPodWithBadPID is the malformed-label case ("abc" instead of an int).
+func reapPodWithBadPID(name, host string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns1",
 			Labels: map[string]string{
 				LabelManagedBy: ManagedByValue,
 				LabelOwnerHost: host,
+				LabelOwnerPID:  "abc",
 			},
 		},
 	}
@@ -32,7 +53,7 @@ func TestDeletePod_SwallowsNotFound(t *testing.T) {
 }
 
 func TestDeletePod_RemovesExisting(t *testing.T) {
-	cs := fake.NewClientset(reapPod("alive", "laptop", time.Minute))
+	cs := fake.NewClientset(reapPod("alive", "laptop", 1234))
 	if err := DeletePod(context.Background(), cs, "ns1", "alive"); err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -41,40 +62,131 @@ func TestDeletePod_RemovesExisting(t *testing.T) {
 	}
 }
 
-func TestReapStale_DeletesOnlyOldOnesMatchingHost(t *testing.T) {
+func TestReapStale_DeadPidIsReapedAlivePidIsKept(t *testing.T) {
 	cs := fake.NewClientset(
-		reapPod("fresh", "laptop", time.Minute),
-		reapPod("stale-mine", "laptop", 3*time.Hour),
-		reapPod("stale-other", "other-host", 3*time.Hour),
+		reapPod("orphan", "laptop", 100),
+		reapPod("running", "laptop", 200),
 	)
-	n, err := ReapStale(context.Background(), cs, "ns1", "laptop", 2*time.Hour)
+	alive := func(pid int) bool { return pid == 200 }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "laptop", alive)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
 	if n != 1 {
 		t.Errorf("reaped = %d, want 1", n)
 	}
-	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "stale-mine", metav1.GetOptions{}); err == nil {
-		t.Errorf("stale-mine should have been deleted")
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "orphan", metav1.GetOptions{}); err == nil {
+		t.Errorf("orphan (dead owner-pid) should have been reaped")
 	}
-	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "fresh", metav1.GetOptions{}); err != nil {
-		t.Errorf("fresh should still exist: %v", err)
-	}
-	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "stale-other", metav1.GetOptions{}); err != nil {
-		t.Errorf("stale-other belongs to another host and should be untouched: %v", err)
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "running", metav1.GetOptions{}); err != nil {
+		t.Errorf("running pod (alive owner-pid) must be left alone: %v", err)
 	}
 }
 
-func TestReapStale_EmptyHostReapsAnyOwner(t *testing.T) {
+// TestReapStale_OwnerHostFilter pins the multi-workstation safety invariant:
+// a pod created by a different host must never be touched, even if its owning
+// pid is dead from THIS host's perspective.
+func TestReapStale_OwnerHostFilter(t *testing.T) {
 	cs := fake.NewClientset(
-		reapPod("stale-a", "host-a", 3*time.Hour),
-		reapPod("stale-b", "host-b", 3*time.Hour),
+		reapPod("mine", "laptop", 100),
+		reapPod("theirs", "other-host", 100),
 	)
-	n, err := ReapStale(context.Background(), cs, "ns1", "", time.Hour)
+	allDead := func(int) bool { return false }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "laptop", allDead)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reaped = %d, want 1 (only the local-host pod)", n)
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "theirs", metav1.GetOptions{}); err != nil {
+		t.Errorf("other-host pod must be left alone: %v", err)
+	}
+}
+
+// TestReapStale_MissingOwnerPidLabelIsSkipped surfaces an anomaly without
+// touching the pod.
+func TestReapStale_MissingOwnerPidLabelIsSkipped(t *testing.T) {
+	cs := fake.NewClientset(reapPod("no-pid-label", "laptop", -1)) // pid=-1 means "don't set label"
+	allDead := func(int) bool { return false }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "laptop", allDead)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reaped = %d, want 0 (anomaly must be surfaced, not reaped)", n)
+	}
+	if _, err := cs.CoreV1().Pods("ns1").Get(context.Background(), "no-pid-label", metav1.GetOptions{}); err != nil {
+		t.Errorf("pod without owner-pid label must be left for activeDeadlineSeconds to handle: %v", err)
+	}
+}
+
+// TestReapStale_MalformedOwnerPidLabelIsSkipped covers the "owner-pid is
+// not parseable as an int" anomaly. Same disposition as missing label: skip
+// + log, don't guess.
+func TestReapStale_MalformedOwnerPidLabelIsSkipped(t *testing.T) {
+	cs := fake.NewClientset(reapPodWithBadPID("garbled", "laptop"))
+	allDead := func(int) bool { return false }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "laptop", allDead)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reaped = %d, want 0 (malformed pid label must not be reaped)", n)
+	}
+}
+
+// TestReapStale_ZeroPidIsSkipped — defensive: the owner-pid label is a
+// well-formed integer, but its value is 0. kill(0, ...) signals the calling
+// process's session, not a specific PID, so we must not treat 0 as a real
+// owner.
+func TestReapStale_ZeroPidIsSkipped(t *testing.T) {
+	cs := fake.NewClientset(reapPod("zero", "laptop", 0))
+	allDead := func(int) bool { return false }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "laptop", allDead)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reaped = %d, want 0 (pid=0 must not be reaped)", n)
+	}
+}
+
+// TestReapStale_EmptyHostListsAcrossOwners — when ownerHost is unset, the
+// reaper does not narrow by owner-host.
+func TestReapStale_EmptyHostListsAcrossOwners(t *testing.T) {
+	cs := fake.NewClientset(
+		reapPod("a", "host-a", 100),
+		reapPod("b", "host-b", 200),
+	)
+	allDead := func(int) bool { return false }
+
+	n, err := reapStaleWithLiveness(context.Background(), cs, "ns1", "", allDead)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
 	if n != 2 {
 		t.Errorf("reaped = %d, want 2", n)
+	}
+}
+
+// TestProcessAlive_OwnPidIsAlive sanity-checks the OS-backed helper used in
+// production. The current test process is definitively alive.
+func TestProcessAlive_OwnPidIsAlive(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("processAlive(os.Getpid()) must return true for the running test process")
+	}
+}
+
+// TestProcessAlive_ImpossiblePidIsDead picks a PID well above any plausible
+// pid_max so syscall.Kill returns ESRCH on every POSIX system.
+func TestProcessAlive_ImpossiblePidIsDead(t *testing.T) {
+	if processAlive(999999999) {
+		t.Error("processAlive(999999999) must return false — pid above any pid_max")
 	}
 }


### PR DESCRIPTION
Relates to #160 — Fixes the orphan pile-up reported. `ReapStale` filtered by pod age (`< 2h = skip`), so pods kept by `--keep-spawn-pod` survived every subsequent invocation until they hit 2h. Two `--keep-spawn-pod` runs in a row left two orphans.

Replaces the age filter with a POSIX `kill(pid, 0)` liveness check against the `podtrace.io/owner-pid` label that's already stamped on every spawn pod. If the owning CLI is dead, the pod is an orphan and gets reaped. If it's alive, the pod belongs to an in-flight run and is left alone. Missing/malformed label to skip with a debug log; the pod's own `activeDeadlineSeconds=1h` is the kubelet-level backstop.

This unifies every orphan cause, Ctrl-C, SIGKILL, network blip, `--keep-spawn-pod`, BPF-load failures, under the same rule.