### PR TITLE
fix(cli): always surface spawn-pod failure cause instead of bare kubelet error

### DIFF
--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -340,17 +340,27 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	usePreResolved := len(preresolvedPods) > 0
 
 	if usePreResolved {
-		for _, raw := range preresolvedPods {
-			ref, err := kubernetes.ParsePreResolvedRef(raw)
-			if err != nil {
-				return err
-			}
-			info, err := kubernetes.BuildPodInfoFromPreResolved(ref)
-			if err != nil {
-				return fmt.Errorf("preresolved resolve %s/%s: %w", ref.Namespace, ref.PodName, err)
-			}
-			targetInfos = append(targetInfos, info)
+		infos, skipped, parseErr := kubernetes.BuildPodInfosFromPreResolved(preresolvedPods)
+		if parseErr != nil {
+			return parseErr
 		}
+		for _, s := range skipped {
+			logger.Warn("Skipping pre-resolved target whose cgroup was not found on this node "+
+				"(pod likely rescheduled, restarted, or runs on a different node)",
+				zap.String("namespace", s.Ref.Namespace),
+				zap.String("pod", s.Ref.PodName),
+				zap.String("container_id", s.Ref.ContainerID),
+				zap.Error(s.Cause))
+		}
+		if len(infos) == 0 && len(skipped) > 0 {
+			parts := make([]string, len(skipped))
+			for i, s := range skipped {
+				parts[i] = fmt.Sprintf("%s/%s: %v", s.Ref.Namespace, s.Ref.PodName, s.Cause)
+			}
+			return fmt.Errorf("no pre-resolved targets resolvable on this node:\n  - %s",
+				strings.Join(parts, "\n  - "))
+		}
+		targetInfos = append(targetInfos, infos...)
 	} else if useDynamicTargets {
 		clientset := resolver.(kubernetes.ClientsetProvider).GetClientset()
 		targetRegistry = kubernetes.NewTargetRegistry(clientset, selection)

--- a/internal/kubernetes/nodespawn/diagnose.go
+++ b/internal/kubernetes/nodespawn/diagnose.go
@@ -5,10 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	diagnoseStatusTimeout      = 5 * time.Second
+	diagnoseStatusPollInterval = 250 * time.Millisecond
 )
 
 // AttachFailedError wraps an attach-time failure with the spawn pod's
@@ -31,17 +38,23 @@ func (e *AttachFailedError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	if e.ExitCode == nil {
+	if e.ExitCode == nil && e.LastLogs == "" {
 		return fmt.Sprintf("attach to %s/%s: %v", e.Namespace, e.PodName, e.Cause)
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "spawn pod %s/%s exited with code %d before tracer was ready",
-		e.Namespace, e.PodName, *e.ExitCode)
-	if e.Reason != "" {
-		fmt.Fprintf(&b, "\n  reason:  %s", e.Reason)
-	}
-	if e.Message != "" {
-		fmt.Fprintf(&b, "\n  message: %s", strings.TrimRight(e.Message, "\n"))
+	if e.ExitCode != nil {
+		fmt.Fprintf(&b, "spawn pod %s/%s exited with code %d before tracer was ready",
+			e.Namespace, e.PodName, *e.ExitCode)
+		if e.Reason != "" {
+			fmt.Fprintf(&b, "\n  reason:  %s", e.Reason)
+		}
+		if e.Message != "" {
+			fmt.Fprintf(&b, "\n  message: %s", strings.TrimRight(e.Message, "\n"))
+		}
+	} else {
+		fmt.Fprintf(&b, "attach to %s/%s failed before pod status was finalized",
+			e.Namespace, e.PodName)
+		fmt.Fprintf(&b, "\n  attach error: %v", e.Cause)
 	}
 	if e.LastLogs != "" {
 		fmt.Fprintf(&b, "\n  last logs:\n%s", indent(e.LastLogs, "    "))
@@ -68,29 +81,79 @@ func diagnoseAttachFailure(
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return origErr
 	}
-
-	pod, getErr := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-	if getErr != nil || pod == nil {
+	if errors.Is(origErr, context.Canceled) {
 		return origErr
 	}
 
-	cs := primaryContainerStatus(pod)
-	if cs == nil || cs.State.Terminated == nil {
+	term, logs, podGone := waitForTerminalSignals(ctx, clientset, namespace, podName)
+	if errors.Is(ctx.Err(), context.Canceled) {
 		return origErr
 	}
 
-	term := cs.State.Terminated
-	logs := dumpPodLogs(ctx, clientset, namespace, podName)
+	if podGone {
+		return fmt.Errorf("spawn pod %s/%s no longer exists (deleted or evicted during attach): %w",
+			namespace, podName, origErr)
+	}
 
-	exit := term.ExitCode
-	return &AttachFailedError{
+	if term == nil && logs == "" {
+		return origErr
+	}
+
+	afe := &AttachFailedError{
 		Namespace: namespace,
 		PodName:   podName,
-		ExitCode:  &exit,
-		Reason:    term.Reason,
-		Message:   term.Message,
 		LastLogs:  logs,
 		Cause:     origErr,
+	}
+	if term != nil {
+		exit := term.ExitCode
+		afe.ExitCode = &exit
+		afe.Reason = term.Reason
+		afe.Message = term.Message
+	}
+	return afe
+}
+
+// waitForTerminalSignals polls the apiserver until the primary container's
+// terminal state appears, AND accumulates the best-available pod logs along
+// the way. Returns:
+//   - term: the structured terminal state if observed, else nil
+//   - logs: the latest non-empty log dump seen across all poll iterations
+//   - podGone: true iff the apiserver definitively reports the pod is gone
+//     (NotFound), so callers can short-circuit instead of burning the budget
+func waitForTerminalSignals(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	namespace, podName string,
+) (term *corev1.ContainerStateTerminated, logs string, podGone bool) {
+	deadline := time.Now().Add(diagnoseStatusTimeout)
+	for {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, logs, false
+		}
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil, logs, true
+		case err == nil && pod != nil:
+			if cs := primaryContainerStatus(pod); cs != nil && cs.State.Terminated != nil {
+				if logs == "" {
+					logs = dumpPodLogs(ctx, clientset, namespace, podName)
+				}
+				return cs.State.Terminated, logs, false
+			}
+		}
+		if logs == "" {
+			logs = dumpPodLogs(ctx, clientset, namespace, podName)
+		}
+		if time.Now().After(deadline) {
+			return nil, logs, false
+		}
+		select {
+		case <-ctx.Done():
+			return nil, logs, false
+		case <-time.After(diagnoseStatusPollInterval):
+		}
 	}
 }
 

--- a/internal/kubernetes/nodespawn/diagnose_test.go
+++ b/internal/kubernetes/nodespawn/diagnose_test.go
@@ -3,13 +3,45 @@ package nodespawn
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+// shortDiagnoseTiming compresses the diagnose poll budget so tests stay fast.
+func shortDiagnoseTiming(t *testing.T, timeout, interval time.Duration) {
+	t.Helper()
+	prevT, prevI := diagnoseStatusTimeout, diagnoseStatusPollInterval
+	diagnoseStatusTimeout = timeout
+	diagnoseStatusPollInterval = interval
+	t.Cleanup(func() {
+		diagnoseStatusTimeout = prevT
+		diagnoseStatusPollInterval = prevI
+	})
+}
+
+// stubDumpPodLogs replaces the package-level log fetcher for the duration of
+// the test.
+func stubDumpPodLogs(t *testing.T, fn func(context.Context, kubernetes.Interface, string, string) string) {
+	t.Helper()
+	prev := dumpPodLogs
+	dumpPodLogs = fn
+	t.Cleanup(func() { dumpPodLogs = prev })
+}
+
+func emptyLogs(_ context.Context, _ kubernetes.Interface, _, _ string) string { return "" }
+func stubLogs(out string) func(context.Context, kubernetes.Interface, string, string) string {
+	return func(_ context.Context, _ kubernetes.Interface, _, _ string) string { return out }
+}
 
 func TestDiagnoseAttachFailure_TerminatedPodWrapsWithExitCode(t *testing.T) {
 	pod := terminatedSpawnPod("ns", "spawn", 1, "Error",
@@ -48,7 +80,13 @@ func TestDiagnoseAttachFailure_TerminatedPodWrapsWithExitCode(t *testing.T) {
 	}
 }
 
-func TestDiagnoseAttachFailure_RunningPodReturnsUnwrapped(t *testing.T) {
+// TestDiagnoseAttachFailure_RunningPodWithoutLogsReturnsUnwrapped — when the
+// container is still Running AND the kubelet has no logs to offer, there's
+// genuinely nothing for the user beyond the raw attach error.
+func TestDiagnoseAttachFailure_RunningPodWithoutLogsReturnsUnwrapped(t *testing.T) {
+	shortDiagnoseTiming(t, 50*time.Millisecond, 10*time.Millisecond)
+	stubDumpPodLogs(t, emptyLogs)
+
 	pod := runningSpawnPod("ns", "spawn")
 	clientset := fake.NewSimpleClientset(pod)
 	orig := errors.New("transient attach error")
@@ -57,7 +95,7 @@ func TestDiagnoseAttachFailure_RunningPodReturnsUnwrapped(t *testing.T) {
 
 	var afe *AttachFailedError
 	if errors.As(err, &afe) {
-		t.Fatalf("running pod must not be wrapped in AttachFailedError, got: %v", err)
+		t.Fatalf("non-terminal pod with no logs must not be wrapped, got: %v", err)
 	}
 	if !errors.Is(err, orig) {
 		t.Errorf("original error must remain reachable, got: %v", err)
@@ -71,18 +109,214 @@ func TestDiagnoseAttachFailure_NilErrorReturnsNil(t *testing.T) {
 	}
 }
 
+// TestDiagnoseAttachFailure_MissingPodReturnsUnwrapped — when the apiserver
+// definitively reports the pod as gone (NotFound), surface a clearer message
+// than the bare kubelet error.
 func TestDiagnoseAttachFailure_MissingPodReturnsUnwrapped(t *testing.T) {
+	shortDiagnoseTiming(t, 50*time.Millisecond, 10*time.Millisecond)
+	stubDumpPodLogs(t, emptyLogs)
+
 	clientset := fake.NewSimpleClientset()
 	orig := errors.New("attach failed")
+
+	start := time.Now()
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+	elapsed := time.Since(start)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("missing pod must not be wrapped as AttachFailedError, got: %v", err)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no longer exists") {
+		t.Errorf("expected NotFound wrapper to clarify pod is gone, got: %v", err)
+	}
+	if elapsed > 20*time.Millisecond {
+		t.Errorf("NotFound must short-circuit immediately, took %v", elapsed)
+	}
+}
+
+// TestDiagnoseAttachFailure_LogsArriveBeforeTerminalState — Gap 1: defense
+// in depth so the kubelet log endpoint flushing stderr before the status
+// manager publishes terminal state still surfaces the cause to the user.
+func TestDiagnoseAttachFailure_LogsArriveBeforeTerminalState(t *testing.T) {
+	shortDiagnoseTiming(t, 100*time.Millisecond, 10*time.Millisecond)
+	const podStderr = "Error: kernel Lockdown LSM is in 'confidentiality' mode"
+	var fetches atomic.Int32
+	stubDumpPodLogs(t, func(_ context.Context, _ kubernetes.Interface, _, _ string) string {
+		if fetches.Add(1) >= 2 {
+			return podStderr
+		}
+		return ""
+	})
+
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	orig := errors.New("Internal error occurred: error attaching to container: container is in CONTAINER_EXITED state")
 
 	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
 
 	var afe *AttachFailedError
+	if !errors.As(err, &afe) {
+		t.Fatalf("expected *AttachFailedError once logs arrive mid-poll, got %T: %v", err, err)
+	}
+	if !strings.Contains(afe.LastLogs, "Lockdown LSM") {
+		t.Errorf("LastLogs did not capture pod stderr from late iteration: %q", afe.LastLogs)
+	}
+	if afe.ExitCode != nil {
+		t.Errorf("ExitCode must be nil when only logs (not terminal state) were observed, got %v", *afe.ExitCode)
+	}
+}
+
+// TestDiagnoseAttachFailure_TerminalAfterRaceIsWrapped pins the kubelet
+// status-update race: the streaming endpoint reports CONTAINER_EXITED before
+// the status manager publishes the terminal state.
+func TestDiagnoseAttachFailure_TerminalAfterRaceIsWrapped(t *testing.T) {
+	shortDiagnoseTiming(t, 200*time.Millisecond, 10*time.Millisecond)
+
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	var calls atomic.Int32
+	terminal := terminatedSpawnPod("ns", "spawn", 1, "Error",
+		"kernel Lockdown LSM is in 'confidentiality' mode")
+	clientset.PrependReactor("get", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		if calls.Add(1) >= 3 {
+			return true, terminal, nil
+		}
+		return true, runningSpawnPod("ns", "spawn"), nil
+	})
+
+	orig := errors.New("Internal error occurred: error attaching to container: container is in CONTAINER_EXITED state")
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if !errors.As(err, &afe) {
+		t.Fatalf("expected *AttachFailedError once status lands, got %T: %v", err, err)
+	}
+	if afe.ExitCode == nil || *afe.ExitCode != 1 {
+		t.Errorf("ExitCode: got %v, want 1", afe.ExitCode)
+	}
+	if !strings.Contains(afe.Message, "Lockdown LSM") {
+		t.Errorf("Message did not propagate termination message: %q", afe.Message)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("Unwrap should expose the original attach error")
+	}
+}
+
+// TestDiagnoseAttachFailure_NeverTerminalNoLogsReturnsUnwrapped — when the
+// kubelet never publishes a terminal state AND has no logs (the kubelet is
+// truly unreachable), we surface origErr instead of hanging.
+func TestDiagnoseAttachFailure_NeverTerminalNoLogsReturnsUnwrapped(t *testing.T) {
+	shortDiagnoseTiming(t, 50*time.Millisecond, 10*time.Millisecond)
+	stubDumpPodLogs(t, emptyLogs)
+
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	orig := errors.New("Internal error occurred: error attaching to container: container is in CONTAINER_EXITED state")
+
+	start := time.Now()
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+	elapsed := time.Since(start)
+
+	var afe *AttachFailedError
 	if errors.As(err, &afe) {
-		t.Fatalf("missing pod must not be wrapped in AttachFailedError, got: %v", err)
+		t.Fatalf("non-terminal pod with no logs must not be wrapped, got: %v", err)
 	}
 	if !errors.Is(err, orig) {
 		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("diagnose blew past the configured 50ms timeout: %v", elapsed)
+	}
+}
+
+// TestDiagnoseAttachFailure_NoTerminalButLogsAreSurfaced — defense in depth:
+// even if the kubelet status manager doesn't publish the terminal state
+// within our budget, the kubelet's log endpoint usually already has stderr.
+func TestDiagnoseAttachFailure_NoTerminalButLogsAreSurfaced(t *testing.T) {
+	shortDiagnoseTiming(t, 50*time.Millisecond, 10*time.Millisecond)
+	const podStderr = "Error: kernel Lockdown LSM is in 'confidentiality' mode; BPF cannot read kernel RAM"
+	stubDumpPodLogs(t, stubLogs(podStderr))
+
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	orig := errors.New("Internal error occurred: error attaching to container: container is in CONTAINER_EXITED state")
+
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", orig)
+
+	var afe *AttachFailedError
+	if !errors.As(err, &afe) {
+		t.Fatalf("expected *AttachFailedError so the user sees pod logs, got %T: %v", err, err)
+	}
+	if afe.ExitCode != nil {
+		t.Errorf("ExitCode must be nil when terminal state was not observed, got %v", *afe.ExitCode)
+	}
+	if !strings.Contains(afe.LastLogs, "Lockdown LSM") {
+		t.Errorf("LastLogs did not propagate pod stderr: %q", afe.LastLogs)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("Unwrap must still expose the original attach error")
+	}
+	msg := afe.Error()
+	for _, want := range []string{
+		"attach to ns/spawn failed",
+		"Lockdown LSM",
+		"kubectl -n ns logs spawn",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("formatted error missing %q\n got: %s", want, msg)
+		}
+	}
+}
+
+// TestDiagnoseAttachFailure_PollAbortsOnContextCancel pins the cancellation
+// path inside the poll loop: if the caller cancels ctx mid-poll, we must
+// surface origErr immediately, not hang.
+func TestDiagnoseAttachFailure_PollAbortsOnContextCancel(t *testing.T) {
+	shortDiagnoseTiming(t, 5*time.Second, 50*time.Millisecond)
+
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	orig := errors.New("attach failed")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := diagnoseAttachFailure(ctx, clientset, "ns", "spawn", orig)
+	elapsed := time.Since(start)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("cancelled poll must surface origErr, got: %v", err)
+	}
+	if !errors.Is(err, orig) {
+		t.Errorf("original error must remain reachable, got: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("poll did not abort promptly on cancel: %v", elapsed)
+	}
+}
+
+// TestDiagnoseAttachFailure_UserCancelledOrigErrShortCircuits — when the
+// user hits Ctrl-C (or timeout/SIGTERM), the SPDY stream returns an error
+// that wraps context.Canceled.
+func TestDiagnoseAttachFailure_UserCancelledOrigErrShortCircuits(t *testing.T) {
+	clientset := fake.NewSimpleClientset(runningSpawnPod("ns", "spawn"))
+	wrapped := fmt.Errorf("stream interrupted: %w", context.Canceled)
+
+	err := diagnoseAttachFailure(context.Background(), clientset, "ns", "spawn", wrapped)
+
+	var afe *AttachFailedError
+	if errors.As(err, &afe) {
+		t.Fatalf("user-cancelled attach must not produce diagnostic dump, got: %v", err)
+	}
+	if !errors.Is(err, wrapped) {
+		t.Errorf("wrapped error must remain reachable, got: %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("context.Canceled must be unwrappable, got: %v", err)
 	}
 }
 

--- a/internal/kubernetes/nodespawn/run.go
+++ b/internal/kubernetes/nodespawn/run.go
@@ -245,19 +245,21 @@ func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multi
 	return nil
 }
 
+// dumpPodLogsCap bounds how much pod stderr we read into the error message.
+const dumpPodLogsCap = 64 * 1024
+
 // dumpPodLogs returns the spawned pod's last log lines on a best-effort basis;
 // errors are swallowed because this runs on the failure path and shouldn't
 // itself fail.
-func dumpPodLogs(ctx context.Context, clientset kubernetes.Interface, namespace, name string) string {
+var dumpPodLogs = func(ctx context.Context, clientset kubernetes.Interface, namespace, name string) string {
 	req := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{TailLines: ptrInt64(50)})
 	rc, err := req.Stream(ctx)
 	if err != nil {
 		return ""
 	}
 	defer func() { _ = rc.Close() }()
-	buf := make([]byte, 8*1024)
-	n, _ := rc.Read(buf)
-	return string(buf[:n])
+	out, _ := io.ReadAll(io.LimitReader(rc, dumpPodLogsCap))
+	return string(out)
 }
 
 func ptrInt64(v int64) *int64 { return &v }

--- a/internal/kubernetes/nodespawn/stream.go
+++ b/internal/kubernetes/nodespawn/stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,11 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 )
 
+// stuckPodEventThreshold is how long we wait in Pending without container
+// progress before consulting Events for fatal reasons (FailedMount,
+// FailedAttachVolume, etc.).
+var stuckPodEventThreshold = 5 * time.Second
+
 func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
 	fieldSel := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
@@ -38,6 +44,7 @@ func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Int
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	pendingSince := time.Time{} // zero until we first see Pending; reset on transition
 	evt, err := watchtools.UntilWithSync(waitCtx, lw, &corev1.Pod{}, nil, func(e watch.Event) (bool, error) {
 		switch e.Type {
 		case watch.Deleted:
@@ -59,6 +66,19 @@ func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Int
 			if r := imagePullFailureReason(p); r != "" {
 				return false, fmt.Errorf("spawn pod %s/%s image pull failed: %s", namespace, name, r)
 			}
+			if r := containerStartFailureReason(p); r != "" {
+				return false, fmt.Errorf("spawn pod %s/%s container failed to start: %s", namespace, name, r)
+			}
+			// Pod is in Pending without a structured container Waiting reason
+			// we recognize. After a short grace period, consult Events to
+			// catch FailedMount / FailedAttachVolume / FailedCreatePodSandBox.
+			if pendingSince.IsZero() {
+				pendingSince = time.Now()
+			} else if time.Since(pendingSince) >= stuckPodEventThreshold {
+				if r := stuckPodEventReason(ctx, clientset, p); r != "" {
+					return false, fmt.Errorf("spawn pod %s/%s stuck in Pending: %s", namespace, name, r)
+				}
+			}
 		}
 		return false, nil
 	})
@@ -67,6 +87,65 @@ func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Int
 	}
 	pod, _ := evt.Object.(*corev1.Pod)
 	return pod, nil
+}
+
+// containerStartFailureReason returns a non-empty reason when any container's
+// Waiting reason indicates a permanent failure to start (vs. transient
+// ContainerCreating). These reasons signal the kubelet has rejected the
+// container outright and waiting will not help.
+func containerStartFailureReason(p *corev1.Pod) string {
+	fatal := map[string]struct{}{
+		"CreateContainerError":       {},
+		"CreateContainerConfigError": {},
+		"RunContainerError":          {},
+		"PreCreateHookError":         {},
+		"PostStartHookError":         {},
+	}
+	for _, cs := range p.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			if _, isFatal := fatal[w.Reason]; isFatal {
+				return w.Reason + ": " + w.Message
+			}
+		}
+	}
+	return ""
+}
+
+// stuckPodEventReason fetches recent Events for the pod and returns a
+// non-empty reason when any event signals a fatal non-progressing state
+// (volume mount failure, sandbox creation failure, etc.). Best-effort:
+// Event API failures are swallowed so the watch loop keeps running.
+var stuckPodEventReason = func(ctx context.Context, clientset kubernetes.Interface, p *corev1.Pod) string {
+	fatal := map[string]struct{}{
+		"FailedMount":            {},
+		"FailedAttachVolume":    {},
+		"FailedCreatePodSandBox": {},
+		"FailedMapVolume":        {},
+	}
+	sel := fields.AndSelectors(
+		fields.OneTermEqualSelector("involvedObject.name", p.Name),
+		fields.OneTermEqualSelector("involvedObject.kind", "Pod"),
+		fields.OneTermEqualSelector("involvedObject.namespace", p.Namespace),
+	).String()
+	events, err := clientset.CoreV1().Events(p.Namespace).List(ctx, metav1.ListOptions{FieldSelector: sel})
+	if err != nil || events == nil {
+		return ""
+	}
+	// Walk newest-first by LastTimestamp to surface the most recent diagnosis.
+	var newest *corev1.Event
+	for i := range events.Items {
+		ev := &events.Items[i]
+		if _, isFatal := fatal[ev.Reason]; !isFatal {
+			continue
+		}
+		if newest == nil || ev.LastTimestamp.After(newest.LastTimestamp.Time) {
+			newest = ev
+		}
+	}
+	if newest == nil {
+		return ""
+	}
+	return newest.Reason + ": " + strings.TrimSpace(newest.Message)
 }
 
 func unschedulableReason(p *corev1.Pod) string {

--- a/internal/kubernetes/nodespawn/stream_test.go
+++ b/internal/kubernetes/nodespawn/stream_test.go
@@ -1,0 +1,113 @@
+package nodespawn
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func pendingPodWithContainerWaiting(namespace, name, reason, message string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "podtrace",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  reason,
+						Message: message,
+					},
+				},
+			}},
+		},
+	}
+}
+
+func TestContainerStartFailureReason_DetectsFatalWaitingReasons(t *testing.T) {
+	cases := []struct {
+		reason  string
+		message string
+		want    string
+	}{
+		{"CreateContainerError", "no such file or directory", "CreateContainerError: no such file or directory"},
+		{"CreateContainerConfigError", "invalid env", "CreateContainerConfigError: invalid env"},
+		{"RunContainerError", "OCI runtime create failed", "RunContainerError: OCI runtime create failed"},
+		{"PostStartHookError", "hook handler failed", "PostStartHookError: hook handler failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			p := pendingPodWithContainerWaiting("ns", "spawn", tc.reason, tc.message)
+			if got := containerStartFailureReason(p); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainerStartFailureReason_SilentOnTransientWaiting(t *testing.T) {
+	cases := []string{"ContainerCreating", "PodInitializing", "", "Pending"}
+	for _, reason := range cases {
+		t.Run(reason, func(t *testing.T) {
+			p := pendingPodWithContainerWaiting("ns", "spawn", reason, "still working on it")
+			if got := containerStartFailureReason(p); got != "" {
+				t.Errorf("transient %q should not be reported as fatal, got %q", reason, got)
+			}
+		})
+	}
+}
+
+func TestStuckPodEventReason_SurfacesFailedMount(t *testing.T) {
+	prev := stuckPodEventReason
+	stuckPodEventReason = func(_ context.Context, _ kubernetes.Interface, p *corev1.Pod) string {
+		ev := corev1.Event{
+			Reason:        "FailedMount",
+			Message:       "MountVolume.SetUp failed for volume \"securityfs\" : hostPath type check failed: /host/sys/kernel/security is not a directory",
+			LastTimestamp: metav1.NewTime(time.Now()),
+		}
+		return ev.Reason + ": " + strings.TrimSpace(ev.Message)
+	}
+	t.Cleanup(func() { stuckPodEventReason = prev })
+
+	got := stuckPodEventReason(context.Background(), fake.NewSimpleClientset(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"},
+	})
+	for _, want := range []string{"FailedMount", "securityfs", "hostPath type check failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("formatted event missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+func TestStuckPodEventReason_NoFatalEventsReturnsEmpty(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "evt-1"},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod", Namespace: "ns", Name: "spawn",
+			},
+			Reason:        "Scheduled",
+			Message:       "Successfully assigned ns/spawn to node1",
+			LastTimestamp: metav1.NewTime(time.Now()),
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "evt-2"},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod", Namespace: "ns", Name: "spawn",
+			},
+			Reason:        "Pulling",
+			Message:       "Pulling image \"ghcr.io/gma1k/podtrace:dev\"",
+			LastTimestamp: metav1.NewTime(time.Now()),
+		},
+	)
+	p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"}}
+	if got := stuckPodEventReason(context.Background(), clientset, p); got != "" {
+		t.Errorf("benign events must not fire fatal-reason path, got: %s", got)
+	}
+}

--- a/internal/kubernetes/nodespawn/target_nodes.go
+++ b/internal/kubernetes/nodespawn/target_nodes.go
@@ -62,8 +62,7 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 			unscheduled = append(unscheduled, ref)
 			return
 		}
-		if len(pod.Status.ContainerStatuses) > 0 {
-			cs := pod.Status.ContainerStatuses[0]
+		if cs := pickRunningContainer(pod); cs != nil {
 			ref.ContainerName = cs.Name
 			if idx := indexAfterScheme(cs.ContainerID); idx >= 0 {
 				ref.ContainerID = cs.ContainerID[idx:]
@@ -131,6 +130,21 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 		})
 	}
 	return out, nil
+}
+
+// pickRunningContainer returns the first container in the pod whose State is
+// Running.
+func pickRunningContainer(pod *corev1.Pod) *corev1.ContainerStatus {
+	if pod == nil {
+		return nil
+	}
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if cs.State.Running != nil && cs.ContainerID != "" {
+			return cs
+		}
+	}
+	return nil
 }
 
 // indexAfterScheme returns the offset right after "://" in a containerID like

--- a/internal/kubernetes/nodespawn/target_nodes_test.go
+++ b/internal/kubernetes/nodespawn/target_nodes_test.go
@@ -156,3 +156,112 @@ func TestResolveTargetNodes_GetPodError_Propagates(t *testing.T) {
 		t.Fatalf("expected error from missing pod")
 	}
 }
+
+// podWithContainer constructs a pod whose first container is in the given
+// state — used by the pickRunningContainer tests to pin the selection logic
+// for stale-restart / crash-loop / just-starting scenarios.
+func podWithContainer(ns, name, node, cName, cID string, state corev1.ContainerState) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:        cName,
+				ContainerID: cID,
+				State:       state,
+			}},
+		},
+	}
+}
+
+func TestPickRunningContainer_PrefersRunning(t *testing.T) {
+	p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+		{Name: "a", ContainerID: "containerd://aaa", State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+		}},
+		{Name: "b", ContainerID: "containerd://bbb", State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		}},
+		{Name: "c", ContainerID: "containerd://ccc", State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+		}},
+	}}}
+	cs := pickRunningContainer(p)
+	if cs == nil || cs.Name != "b" {
+		t.Fatalf("expected to pick the Running container, got %+v", cs)
+	}
+}
+
+func TestPickRunningContainer_RejectsAllNonRunning(t *testing.T) {
+	cases := map[string]corev1.ContainerState{
+		"Waiting":    {Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+		"Terminated": {Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}},
+	}
+	for name, st := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "x", ContainerID: "containerd://xxx", State: st},
+			}}}
+			if cs := pickRunningContainer(p); cs != nil {
+				t.Errorf("must not pick a %s container, got %+v", name, cs)
+			}
+		})
+	}
+}
+
+func TestPickRunningContainer_RejectsRunningWithEmptyID(t *testing.T) {
+	// A Pod can momentarily be in Status.Running with ContainerID="" right
+	// at startup. We must NOT hand the spawn pod an empty containerID.
+	p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+		{Name: "x", ContainerID: "", State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		}},
+	}}}
+	if cs := pickRunningContainer(p); cs != nil {
+		t.Errorf("Running container with empty ID must be rejected, got %+v", cs)
+	}
+}
+
+// TestResolveTargetNodes_SkipsNonRunningContainerIDs — the fix for the
+// cross-node "cgroup path not found" failure mode: when one matching pod's
+// container is Waiting/Terminated, the workstation must NOT hand its stale
+// containerID to the spawn pod. The pod is still routed to its node (with
+// an empty ContainerID), and main.go's preresolved loop skips it cleanly.
+func TestResolveTargetNodes_SkipsNonRunningContainerIDs(t *testing.T) {
+	running := podWithContainer("ns", "alive", "node-1", "app",
+		"containerd://aaaaaa", corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		})
+	restarting := podWithContainer("ns", "restarting", "node-1", "app",
+		"containerd://bbbbbb", corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+		})
+	cs := fake.NewClientset(running, restarting)
+
+	sel := pkgkube.TargetSelection{
+		DefaultNamespace: "ns",
+		Pods:             []string{"alive", "restarting"},
+	}
+	out, err := ResolveTargetNodes(context.Background(), cs, sel)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if got := len(out.ByNode["node-1"]); got != 2 {
+		t.Fatalf("expected both pods routed to node-1, got %d", got)
+	}
+	var aliveID, restartingID string
+	for _, r := range out.ByNode["node-1"] {
+		switch r.Name {
+		case "alive":
+			aliveID = r.ContainerID
+		case "restarting":
+			restartingID = r.ContainerID
+		}
+	}
+	if aliveID != "aaaaaa" {
+		t.Errorf("Running pod must propagate containerID, got %q", aliveID)
+	}
+	if restartingID != "" {
+		t.Errorf("CrashLoopBackOff pod must NOT propagate a stale containerID, got %q", restartingID)
+	}
+}

--- a/internal/kubernetes/preresolved.go
+++ b/internal/kubernetes/preresolved.go
@@ -58,3 +58,38 @@ func BuildPodInfoFromPreResolved(ref PreResolvedRef) (*PodInfo, error) {
 		Labels:        map[string]string{},
 	}, nil
 }
+
+// PreResolvedSkip records a single pre-resolved ref that couldn't be turned
+// into a PodInfo on this node. The most common reason is a stale containerID
+// (pod was rescheduled between workstation resolve time and spawn-pod start).
+type PreResolvedSkip struct {
+	Ref   PreResolvedRef
+	Cause error
+}
+
+// BuildPodInfosFromPreResolved processes a list of "ns/name/containerID[/cName]"
+// strings and returns:
+//   - infos:    the successfully-resolved targets
+//   - skipped:  per-ref failures with their reason (parse error, empty container,
+//               cgroup not found on THIS node) — caller decides whether to warn
+//               and continue, or hard-fail
+//   - parseErr: the first malformed-input error, if any (returned alongside the
+//               other slices so the caller can surface it deterministically)
+func BuildPodInfosFromPreResolved(refs []string) (infos []*PodInfo, skipped []PreResolvedSkip, parseErr error) {
+	for _, raw := range refs {
+		ref, err := ParsePreResolvedRef(raw)
+		if err != nil {
+			if parseErr == nil {
+				parseErr = err
+			}
+			continue
+		}
+		info, err := BuildPodInfoFromPreResolved(ref)
+		if err != nil {
+			skipped = append(skipped, PreResolvedSkip{Ref: ref, Cause: err})
+			continue
+		}
+		infos = append(infos, info)
+	}
+	return infos, skipped, parseErr
+}

--- a/internal/kubernetes/preresolved_test.go
+++ b/internal/kubernetes/preresolved_test.go
@@ -1,0 +1,115 @@
+package kubernetes
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParsePreResolvedRef_RejectsMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"ns",
+		"ns/name",
+		"/name/cid",
+		"ns//cid",
+		"ns/name/",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := ParsePreResolvedRef(in); err == nil {
+				t.Errorf("expected error for %q", in)
+			}
+		})
+	}
+}
+
+func TestParsePreResolvedRef_AcceptsThreeOrFourParts(t *testing.T) {
+	r3, err := ParsePreResolvedRef("ns/pod/cid")
+	if err != nil {
+		t.Fatalf("3-part form must parse: %v", err)
+	}
+	if r3.Namespace != "ns" || r3.PodName != "pod" || r3.ContainerID != "cid" || r3.ContainerName != "" {
+		t.Errorf("3-part parse mismatch: %+v", r3)
+	}
+	r4, err := ParsePreResolvedRef("ns/pod/cid/cname")
+	if err != nil {
+		t.Fatalf("4-part form must parse: %v", err)
+	}
+	if r4.ContainerName != "cname" {
+		t.Errorf("4-part container name lost: %+v", r4)
+	}
+}
+
+func TestBuildPodInfoFromPreResolved_EmptyContainerID(t *testing.T) {
+	_, err := BuildPodInfoFromPreResolved(PreResolvedRef{Namespace: "ns", PodName: "p"})
+	if err == nil || !strings.Contains(err.Error(), "empty containerID") {
+		t.Errorf("expected empty-containerID error, got: %v", err)
+	}
+}
+
+func TestBuildPodInfosFromPreResolved_NonexistentContainersBecomeSkips(t *testing.T) {
+	refs := []string{
+		"ns/pod-a/nonexistentcontainerid111/appA",
+		"ns/pod-b/nonexistentcontainerid222/appB",
+	}
+	infos, skipped, parseErr := BuildPodInfosFromPreResolved(refs)
+	if parseErr != nil {
+		t.Fatalf("parseErr must be nil for well-formed refs, got: %v", parseErr)
+	}
+	if len(infos) != 0 {
+		t.Errorf("no refs should resolve, got %d", len(infos))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("both refs should be skipped, got %d", len(skipped))
+	}
+	wantPods := map[string]bool{"pod-a": false, "pod-b": false}
+	for _, s := range skipped {
+		if _, ok := wantPods[s.Ref.PodName]; ok {
+			wantPods[s.Ref.PodName] = true
+		}
+		if s.Cause == nil {
+			t.Errorf("skip for %s must carry a cause", s.Ref.PodName)
+		}
+	}
+	for pod, seen := range wantPods {
+		if !seen {
+			t.Errorf("expected skip entry for %s", pod)
+		}
+	}
+}
+
+func TestBuildPodInfosFromPreResolved_MalformedRefSurfacesParseError(t *testing.T) {
+	refs := []string{
+		"not-a-valid-ref",
+		"ns/pod/nonexistentid/cname",
+	}
+	infos, skipped, parseErr := BuildPodInfosFromPreResolved(refs)
+	if parseErr == nil {
+		t.Fatalf("expected parse error for %q", refs[0])
+	}
+	if len(infos) != 0 {
+		t.Errorf("malformed batch should not produce infos, got %d", len(infos))
+	}
+	if len(skipped) != 1 {
+		t.Errorf("expected the well-formed ref to be skipped, got %d", len(skipped))
+	}
+}
+
+func TestBuildPodInfosFromPreResolved_EmptySliceIsAllNoOp(t *testing.T) {
+	infos, skipped, parseErr := BuildPodInfosFromPreResolved(nil)
+	if parseErr != nil || len(infos) != 0 || len(skipped) != 0 {
+		t.Errorf("empty input must yield all-empty result, got infos=%d skipped=%d err=%v",
+			len(infos), len(skipped), parseErr)
+	}
+}
+
+func TestPreResolvedSkip_CauseIsUnwrappable(t *testing.T) {
+	_, skipped, _ := BuildPodInfosFromPreResolved([]string{"ns/p/nonexistentid/cn"})
+	if len(skipped) != 1 {
+		t.Fatalf("expected one skip, got %d", len(skipped))
+	}
+	if !errors.Is(skipped[0].Cause, skipped[0].Cause) {
+		t.Error("cause must be a real error, not nil")
+	}
+}


### PR DESCRIPTION
## Summary

Relates to #160 — Closes the `CONTAINER_EXITED` race: spawn pods that exit before attach (lockdown=confidentiality, missing binary, fatal waiting state, image pull issue) used to surface only the bare kubelet error. The diagnose path now always shows the real cause, exit code, reason, last logs, reproduce hint.

## Changes

- Bounded poll + per-iteration log fetch in `diagnoseAttachFailure` to bridge the kubelet status-manager lag.
- Fast-fail on fatal container Waiting reasons (`CreateContainerError`, `RunContainerError`, …) and `FailedMount` / `FailedAttachVolume` / `FailedCreatePodSandBox` events instead of waiting the 2-minute scheduler timeout.
- 64 KB log drain cap (was a single 8 KB `Read` that truncated longer stderr).
- Pod-deleted-mid-diagnose now surfaces a clear "no longer exists (deleted or evicted during attach)" wrapper.
- Cross-node `--pod-selector` resilience: workstation picks only Running containers, and the spawn pod's pre-resolved loop skips per-ref failures with a warning instead of bailing the whole invocation.
- User-cancel UX: Ctrl-C / timeout produces a single clean `Error: context canceled`.
