### PR TITLE
fix: default namespace to current kubeconfig context

### DIFF
--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -125,7 +125,7 @@ func main() {
 	rootCmd.AddCommand(newScheduleCmd())
 	rootCmd.AddCommand(newWatchCmd())
 
-	rootCmd.Flags().StringVarP(&namespace, "namespace", "n", config.DefaultNamespace, "Kubernetes namespace")
+	rootCmd.Flags().StringVarP(&namespace, "namespace", "n", config.DefaultNamespace, "Kubernetes namespace (defaults to the current kubeconfig context's namespace)")
 	rootCmd.Flags().StringVar(&namespacesCSV, "namespaces", "", "Comma-separated namespaces for multi-pod tracing (e.g., default,prod)")
 	rootCmd.Flags().StringVar(&podsCSV, "pods", "", "Comma-separated pod references to trace (pod or namespace/pod)")
 	rootCmd.Flags().StringVar(&podSelector, "pod-selector", "", "Kubernetes label selector for target pods (e.g., app=api,team=payments)")
@@ -179,6 +179,12 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	if showVersion {
 		fmt.Println(config.GetVersion())
 		return nil
+	}
+
+	if !cmd.Flags().Changed("namespace") {
+		if ctxNamespace, ok := kubernetes.NamespaceFromContext(); ok {
+			namespace = ctxNamespace
+		}
 	}
 
 	if watchAppName != "" && watchLabel != "" {

--- a/cmd/podtrace/watch.go
+++ b/cmd/podtrace/watch.go
@@ -20,6 +20,7 @@ import (
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/kubernetes"
 	"github.com/podtrace/podtrace/internal/operator"
 	"github.com/podtrace/podtrace/internal/validation"
 )
@@ -84,12 +85,17 @@ exits. Events flow to the referenced ExporterConfig, not to this terminal.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
+			if !cmd.Flags().Changed("namespace") {
+				if ctxNamespace, ok := kubernetes.NamespaceFromContext(); ok {
+					namespace = ctxNamespace
+				}
+			}
 			return runWatch(ctx, watchOptionsFromFlags())
 		},
 	}
 	registerTargetFlags(cmd.Flags())
 	registerWatchOnlyFlags(cmd.Flags())
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", config.DefaultNamespace, "Namespace to create the PodTrace in (its ExporterConfig must live here too)")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", config.DefaultNamespace, "Namespace to create the PodTrace in (its ExporterConfig must live here too; defaults to the current kubeconfig context's namespace)")
 	cmd.Flags().StringVar(&eventFilter, "filter", "", "Event categories to capture (dns,net,fs,cpu,proc); empty = all")
 	return cmd
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -61,7 +61,7 @@ This will:
 Usage: ./bin/podtrace -n <namespace> <pod-name> [flags]
 
 Flags:
-  -n, --namespace string        Kubernetes namespace (default: "default")
+  -n, --namespace string        Kubernetes namespace (defaults to the current kubeconfig context's namespace, then "default")
       --namespaces string       Comma-separated namespaces for multi-pod tracing
       --pods string             Comma-separated pod references (pod or namespace/pod)
       --pod-selector string     Label selector for target pods

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -48,36 +48,51 @@ func (r *PodResolver) GetRestConfig() *rest.Config {
 	return r.restConfig
 }
 
+func kubeconfigLoadingRules() *clientcmd.ClientConfigLoadingRules {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+		return loadingRules
+	}
+
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser != "" {
+		homePath := filepath.Join("/home", sudoUser, ".kube", "config")
+		if _, err := hostfs.Stat(homePath); err == nil {
+			loadingRules.ExplicitPath = homePath
+		}
+	}
+	if loadingRules.ExplicitPath == "" {
+		if home := os.Getenv("HOME"); home != "" && home != "/root" {
+			homePath := filepath.Join(home, ".kube", "config")
+			if _, err := hostfs.Stat(homePath); err == nil {
+				loadingRules.ExplicitPath = homePath
+			}
+		}
+	}
+
+	return loadingRules
+}
+
+func NamespaceFromContext() (string, bool) {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		kubeconfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	ns, _, err := clientConfig.Namespace()
+	if err != nil || ns == "" {
+		return "", false
+	}
+	return ns, true
+}
+
 func NewPodResolver() (*PodResolver, error) {
 	var config *rest.Config
 	var err error
 
 	config, err = rest.InClusterConfig()
 	if err != nil {
-		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-
-		if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
-			loadingRules.ExplicitPath = kubeconfig
-		} else {
-			sudoUser := os.Getenv("SUDO_USER")
-			if sudoUser != "" {
-				homePath := filepath.Join("/home", sudoUser, ".kube", "config")
-				if _, err := hostfs.Stat(homePath); err == nil {
-					loadingRules.ExplicitPath = homePath
-				}
-			}
-			if loadingRules.ExplicitPath == "" {
-				if home := os.Getenv("HOME"); home != "" && home != "/root" {
-					homePath := filepath.Join(home, ".kube", "config")
-					if _, err := hostfs.Stat(homePath); err == nil {
-						loadingRules.ExplicitPath = homePath
-					}
-				}
-			}
-		}
-
-		configOverrides := &clientcmd.ConfigOverrides{}
-		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			kubeconfigLoadingRules(), &clientcmd.ConfigOverrides{})
 
 		config, err = kubeConfig.ClientConfig()
 		if err != nil {

--- a/internal/kubernetes/pod_test.go
+++ b/internal/kubernetes/pod_test.go
@@ -1670,3 +1670,59 @@ func TestDirExists_File(t *testing.T) {
 		t.Error("expected dirExists to return false for a regular file")
 	}
 }
+
+func writeKubeconfigWithNamespace(t *testing.T, namespace string) {
+	t.Helper()
+	nsLine := ""
+	if namespace != "" {
+		nsLine = "    namespace: " + namespace + "\n"
+	}
+	content := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+` + nsLine + `  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	t.Setenv("KUBECONFIG", path)
+	t.Setenv("SUDO_USER", "")
+	t.Setenv("HOME", "")
+}
+
+func TestNamespaceFromContext_ContextNamespace(t *testing.T) {
+	writeKubeconfigWithNamespace(t, "o11y")
+
+	ns, ok := NamespaceFromContext()
+	if !ok {
+		t.Fatal("expected a namespace to be resolved from the context")
+	}
+	if ns != "o11y" {
+		t.Errorf("expected namespace %q, got %q", "o11y", ns)
+	}
+}
+
+func TestNamespaceFromContext_NoNamespaceFallsBackToDefault(t *testing.T) {
+	writeKubeconfigWithNamespace(t, "")
+
+	ns, ok := NamespaceFromContext()
+	if !ok {
+		t.Fatal("expected a namespace to be resolved when the context omits one")
+	}
+	if ns != config.DefaultNamespace {
+		t.Errorf("expected namespace %q, got %q", config.DefaultNamespace, ns)
+	}
+}


### PR DESCRIPTION
The CLI hardcoded the `-n/--namespace` default to `"default"` and never consulted the namespace bound to the user's current kubeconfig context, so `kubectl podtrace <pod>` failed for anyone relying on a context-set namespace.

It now falls back to the current context's namespace (matching kubectl and most plugins) when `-n` is not explicitly passed, keeping `"default"` only as the final fallback; an explicit `-n` still wins. The same fallback is applied to the `watch` subcommand.

Relates to #181
