### PR TITLE
fix: timeline bucket overlap (#186) and OLM workflow-scope push

### DIFF
--- a/internal/diagnose/profiling/timeline.go
+++ b/internal/diagnose/profiling/timeline.go
@@ -46,9 +46,9 @@ func AnalyzeTimeline(events []*events.Event, startTime time.Time, duration time.
 	var timeline []TimelineBucket
 	totalEvents := len(events)
 	for i, count := range buckets {
-		startTime := startTime.Add(time.Duration(i) * bucketDuration)
-		endTime := startTime.Add(time.Duration(i+1) * bucketDuration)
-		period := fmt.Sprintf("%s-%s", startTime.Format("15:04:05"), endTime.Format("15:04:05"))
+		bucketStart := startTime.Add(time.Duration(i) * bucketDuration)
+		bucketEnd := startTime.Add(time.Duration(i+1) * bucketDuration)
+		period := fmt.Sprintf("%s-%s", bucketStart.Format("15:04:05"), bucketEnd.Format("15:04:05"))
 		percentage := float64(count) / float64(totalEvents) * 100
 		timeline = append(timeline, TimelineBucket{
 			Period:     period,

--- a/internal/diagnose/profiling/timeline_test.go
+++ b/internal/diagnose/profiling/timeline_test.go
@@ -27,6 +27,44 @@ func TestAnalyzeTimeline_Basic(t *testing.T) {
 	}
 }
 
+func TestAnalyzeTimeline_ContiguousNonOverlappingBuckets(t *testing.T) {
+	start := time.Date(2026, 1, 1, 13, 45, 20, 0, time.UTC)
+	duration := 90 * time.Second // 5 buckets of 18s each
+
+	evs := []*events.Event{
+		{Timestamp: uint64(start.UnixNano())},
+	}
+
+	buckets := AnalyzeTimeline(evs, start, duration)
+	if len(buckets) != config.TimelineBuckets {
+		t.Fatalf("expected %d buckets, got %d", config.TimelineBuckets, len(buckets))
+	}
+
+	bucketDuration := duration / time.Duration(config.TimelineBuckets)
+	layout := "15:04:05"
+	for i, b := range buckets {
+		var got struct{ start, end string }
+		if _, err := fmt.Sscanf(b.Period, "%8s-%8s", &got.start, &got.end); err != nil {
+			t.Fatalf("bucket %d: could not parse period %q: %v", i, b.Period, err)
+		}
+
+		wantStart := start.Add(time.Duration(i) * bucketDuration).Format(layout)
+		wantEnd := start.Add(time.Duration(i+1) * bucketDuration).Format(layout)
+		if got.start != wantStart || got.end != wantEnd {
+			t.Errorf("bucket %d: got %s-%s, want %s-%s", i, got.start, got.end, wantStart, wantEnd)
+		}
+
+		if i > 0 {
+			var prev struct{ end string }
+			_, _ = fmt.Sscanf(buckets[i-1].Period, "%8s-%8s", new(string), &prev.end)
+			if got.start != prev.end {
+				t.Errorf("bucket %d starts at %s but previous bucket ended at %s (overlap/gap)",
+					i, got.start, prev.end)
+			}
+		}
+	}
+}
+
 func TestDetectBursts(t *testing.T) {
 	start := time.Now()
 	duration := 2 * time.Second

--- a/scripts/submit-olm-bundle.sh
+++ b/scripts/submit-olm-bundle.sh
@@ -89,6 +89,12 @@ if [[ ! -d "${BUNDLE_DIR}/manifests" ]] || [[ ! -d "${BUNDLE_DIR}/metadata" ]]; 
 	exit 1
 fi
 
+log_info "syncing fork ${FORK_OWNER}/${FORK_REPO}:main with ${UPSTREAM}:main"
+if ! gh api --method POST "repos/${FORK_OWNER}/${FORK_REPO}/merge-upstream" \
+	-f branch=main >/dev/null 2>&1; then
+	log_info "fork sync skipped (already up to date or not fast-forwardable)"
+fi
+
 log_info "cloning fork ${FORK_OWNER}/${FORK_REPO}"
 gh repo clone "${FORK_OWNER}/${FORK_REPO}" "${WORK_DIR}/fork" -- --depth=1
 cd "${WORK_DIR}/fork"
@@ -99,16 +105,9 @@ else
 	gh auth setup-git
 fi
 
-if git remote get-url upstream >/dev/null 2>&1; then
-	git remote set-url upstream "https://github.com/${UPSTREAM}.git"
-else
-	git remote add upstream "https://github.com/${UPSTREAM}.git"
-fi
-git fetch upstream main --depth=1
-
 local_branch="add-podtrace-${VERSION}"
-log_info "creating branch ${local_branch} from upstream/main"
-git checkout -b "${local_branch}" upstream/main
+log_info "creating branch ${local_branch} from fork main"
+git checkout -b "${local_branch}"
 
 target="operators/podtrace/${VERSION}"
 mkdir -p "${target}"


### PR DESCRIPTION
Two fixes:

- **#186**,  `AnalyzeTimeline` shadowed `startTime`, so bucket end times grew twice as fast as starts and overlapped. Fixed; added a regression test.
- **OLM**,  `submit-olm-bundle.sh` now syncs the fork and branches off fork `main`, so the push no longer needs `workflow` token scope.
