### PR TITLE
fix: quieter startup warnings and workstation-side event correlation

### DIFF
--- a/cmd/podtrace/events_section.go
+++ b/cmd/podtrace/events_section.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+	"github.com/podtrace/podtrace/internal/logger"
+	"go.uber.org/zap"
+)
+
+// podEvents groups the Kubernetes events collected for one target pod.
+type podEvents struct {
+	pod    string
+	events []*pkgkube.K8sEvent
+}
+
+// startWorkstationEventCorrelation watches Kubernetes Events for the
+// pre-resolved target pods using the workstation's clientset (the user's
+// kubeconfig).
+func startWorkstationEventCorrelation(ctx context.Context, clientset kubernetes.Interface, pods []nodespawn.PodRef, out io.Writer) func() {
+	if clientset == nil || len(pods) == 0 {
+		return func() {}
+	}
+
+	type key struct{ ns, name string }
+	seen := map[key]bool{}
+	uniq := make([]nodespawn.PodRef, 0, len(pods))
+	for _, p := range pods {
+		k := key{p.Namespace, p.Name}
+		if p.Name == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		uniq = append(uniq, p)
+	}
+	sort.Slice(uniq, func(i, j int) bool { return uniq[i].String() < uniq[j].String() })
+
+	correlators := make([]*pkgkube.EventsCorrelator, 0, len(uniq))
+	refs := make([]nodespawn.PodRef, 0, len(uniq))
+	for _, p := range uniq {
+		ec := pkgkube.NewEventsCorrelator(clientset, p.Name, p.Namespace)
+		if err := ec.Start(ctx); err != nil {
+			if pkgkube.IsPermissionError(err) {
+				logger.Info("Kubernetes event correlation skipped: your kubeconfig cannot watch events in namespace " + p.Namespace + ". Tracing is unaffected.")
+				for _, c := range correlators {
+					c.Stop()
+				}
+				return func() {}
+			}
+			logger.Debug("event correlator failed to start (non-fatal)", zap.Error(err))
+			continue
+		}
+		correlators = append(correlators, ec)
+		refs = append(refs, p)
+	}
+	if len(correlators) == 0 {
+		return func() {}
+	}
+
+	return func() {
+		var groups []podEvents
+		for i, ec := range correlators {
+			ec.Stop()
+			evs := ec.GetEvents()
+			if len(evs) == 0 {
+				continue
+			}
+			groups = append(groups, podEvents{pod: refs[i].String(), events: evs})
+		}
+		if section := formatK8sEventsSection(groups); section != "" {
+			_, _ = fmt.Fprint(out, section)
+		}
+	}
+}
+
+// formatK8sEventsSection renders collected pod events into a human-readable
+// section.
+func formatK8sEventsSection(groups []podEvents) string {
+	if len(groups) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n=== Kubernetes Events (observed during trace) ===\n\n")
+	for _, g := range groups {
+		evs := make([]*pkgkube.K8sEvent, len(g.events))
+		copy(evs, g.events)
+		sort.SliceStable(evs, func(i, j int) bool { return evs[i].Timestamp.Before(evs[j].Timestamp) })
+
+		fmt.Fprintf(&b, "  %s:\n", g.pod)
+		for _, e := range evs {
+			count := ""
+			if e.Count > 1 {
+				count = fmt.Sprintf(" (x%d)", e.Count)
+			}
+			fmt.Fprintf(&b, "    %s  %-7s %-22s %s%s\n",
+				e.Timestamp.Format("15:04:05"), e.Type, e.Reason, e.Message, count)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/cmd/podtrace/events_section_test.go
+++ b/cmd/podtrace/events_section_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+)
+
+func TestFormatK8sEventsSection_Empty(t *testing.T) {
+	if got := formatK8sEventsSection(nil); got != "" {
+		t.Errorf("expected empty string for no groups, got %q", got)
+	}
+}
+
+func TestFormatK8sEventsSection(t *testing.T) {
+	base := time.Date(2026, 6, 5, 15, 11, 45, 0, time.UTC)
+	groups := []podEvents{{
+		pod: "o11y/web",
+		events: []*pkgkube.K8sEvent{
+			{Type: "Warning", Reason: "BackOff", Message: "back-off restarting", Timestamp: base.Add(10 * time.Second), Count: 3},
+			{Type: "Normal", Reason: "Pulled", Message: "pulled image", Timestamp: base, Count: 1},
+		},
+	}}
+
+	out := formatK8sEventsSection(groups)
+
+	if !strings.Contains(out, "Kubernetes Events (observed during trace)") {
+		t.Errorf("missing section header:\n%s", out)
+	}
+	if !strings.Contains(out, "o11y/web:") {
+		t.Errorf("missing pod heading:\n%s", out)
+	}
+	if !strings.Contains(out, "(x3)") {
+		t.Errorf("expected repeat count for BackOff:\n%s", out)
+	}
+	if strings.Index(out, "Pulled") > strings.Index(out, "BackOff") {
+		t.Errorf("events not sorted chronologically:\n%s", out)
+	}
+}
+
+func TestStartWorkstationEventCorrelation_NoopInputs(t *testing.T) {
+	var buf bytes.Buffer
+
+	startWorkstationEventCorrelation(context.Background(), nil, nil, &buf)()
+	startWorkstationEventCorrelation(context.Background(), fake.NewSimpleClientset(), nil, &buf)()
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for no-op inputs, got %q", buf.String())
+	}
+}
+
+func TestStartWorkstationEventCorrelation_Forbidden(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependWatchReactor("events", func(k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "", Resource: "events"}, "", nil)
+	})
+
+	var buf bytes.Buffer
+	finish := startWorkstationEventCorrelation(
+		context.Background(),
+		clientset,
+		[]nodespawn.PodRef{{Namespace: "o11y", Name: "web"}},
+		&buf,
+	)
+	finish()
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when events watch is forbidden, got %q", buf.String())
+	}
+}

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -496,7 +496,6 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 
 	var enricher *kubernetes.ContextEnricher
-	var eventsCorrelator *kubernetes.EventsCorrelator
 	enrichmentEnabled := os.Getenv("PODTRACE_K8S_ENRICHMENT_ENABLED") != "false"
 	if enrichmentEnabled {
 		if clientsetProvider, ok := resolver.(kubernetes.ClientsetProvider); ok {
@@ -505,12 +504,6 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 				enricher = kubernetes.NewContextEnricher(clientset, podInfo)
 				enricher.Start(ctx)
 				defer enricher.Stop()
-				eventsCorrelator = kubernetes.NewEventsCorrelator(clientset, podInfo.PodName, podInfo.Namespace)
-				if err := eventsCorrelator.Start(ctx); err != nil {
-					logger.Warn("Failed to start Kubernetes events correlator", zap.Error(err))
-				} else {
-					defer eventsCorrelator.Stop()
-				}
 			}
 		}
 	}
@@ -625,10 +618,10 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 
 	if diagnoseDuration != "" {
-		return runDiagnoseModeWithSource(ctx, filteredChan, diagnoseDuration, podInfo, enricher, eventsCorrelator, tracingManager, enableTracing, sourceIndex.Resolve, profilingHandler)
+		return runDiagnoseModeWithSource(ctx, filteredChan, diagnoseDuration, podInfo, enricher, nil, tracingManager, enableTracing, sourceIndex.Resolve, profilingHandler)
 	}
 
-	return runNormalModeWithSource(ctx, filteredChan, podInfo, enricher, eventsCorrelator, tracingManager, enableTracing, sourceIndex.Resolve, profilingHandler)
+	return runNormalModeWithSource(ctx, filteredChan, podInfo, enricher, nil, tracingManager, enableTracing, sourceIndex.Resolve, profilingHandler)
 }
 
 func runNormalMode(ctx context.Context, eventChan <-chan *events.Event, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, eventsCorrelator *kubernetes.EventsCorrelator, tracingManager *tracing.Manager, enableTracing bool) error {

--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -126,6 +126,13 @@ func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.
 		sa = os.Getenv("PODTRACE_SPAWN_SA")
 	}
 
+	var allTargetPods []nodespawn.PodRef
+	for _, refs := range preResolved.ByNode {
+		allTargetPods = append(allTargetPods, refs...)
+	}
+	finishEventCorrelation := startWorkstationEventCorrelation(ctx, clientset, allTargetPods, streams.Out)
+	defer finishEventCorrelation()
+
 	err = nodespawn.Run(ctx, nodespawn.RunOptions{
 		Clientset:             clientset,
 		RestConfig:            restCfg,

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -296,6 +296,36 @@ enforcing `restricted` PodSecurity block by default. Three options:
 3. Use the operator path (CR-driven sessions in `podtrace-system`) — already
    pre-allowed by the helm chart.
 
+### DNS tracking needs a libc in the traced container
+
+DNS name resolution is traced by attaching a uprobe to `getaddrinfo` in the
+**workload container's** libc. If the target is a statically-linked binary
+(common for Go images) or runs on a distroless/scratch base, there is no libc
+to probe and podtrace emits a one-shot message at startup:
+
+> DNS tracking disabled: no libc found in the target container (e.g. a
+> statically-linked binary or distroless/scratch image). DNS name resolution
+> will not be traced; other tracing is unaffected.
+
+This is expected and harmless — every other tracer (network, filesystem, CPU,
+memory, syscalls) works regardless. There is nothing to fix on the node; it is
+a property of the image being traced. To get DNS names, trace a workload whose
+image ships a dynamic glibc or musl libc.
+
+### Kubernetes event correlation runs on the workstation (no spawn-pod RBAC)
+
+As an enhancement, the CLI correlates your app's activity with Kubernetes
+`Events` on the target pod and prints a **"Kubernetes Events" section** after the
+trace. This watch runs on your **workstation**, using your kubeconfig, which can
+already watch events (you can run `kubectl get events`). The spawn pod keeps its
+**zero-RBAC** design and is never involved in this lookup.
+
+If your own kubeconfig is restricted and cannot watch events, the section is
+simply skipped with a one-shot, non-fatal message; tracing is unaffected:
+
+> Kubernetes event correlation skipped: your kubeconfig cannot watch events in
+> namespace <ns>. Tracing is unaffected.
+
 ### What works without any extra config
 
 - cgroupfs path discovery (auto-detects Talos's `kubelet.slice/...` layout)

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -302,10 +302,10 @@ func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 				}
 			}
 		} else {
-			logger.Info("DNS tracking unavailable (libc not found)")
+			logger.Info("DNS tracking disabled: libc was located but could not be opened for uprobe attachment. DNS name resolution will not be traced; other tracing is unaffected.")
 		}
 	} else {
-		logger.Info("DNS tracking unavailable (libc path not found)")
+		logger.Info("DNS tracking disabled: no libc found in the target container (e.g. a statically-linked binary or distroless/scratch image). DNS name resolution will not be traced; other tracing is unaffected.")
 	}
 	return links
 }

--- a/internal/kubernetes/events_correlator.go
+++ b/internal/kubernetes/events_correlator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -37,6 +38,10 @@ func NewEventsCorrelator(clientset kubernetes.Interface, podName, namespace stri
 		events:    make([]*K8sEvent, 0),
 		stopCh:    make(chan struct{}),
 	}
+}
+
+func IsPermissionError(err error) bool {
+	return apierrors.IsForbidden(err)
 }
 
 func (ec *EventsCorrelator) Start(ctx context.Context) error {
@@ -138,4 +143,3 @@ func (ec *EventsCorrelator) CorrelateWithAppEvents(appEventTime time.Time, windo
 
 	return correlated
 }
-

--- a/internal/kubernetes/events_correlator_test.go
+++ b/internal/kubernetes/events_correlator_test.go
@@ -6,9 +6,46 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+func TestEventsCorrelator_Start_Forbidden(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependWatchReactor("events", func(k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "", Resource: "events"},
+			"",
+			nil,
+		)
+	})
+
+	correlator := NewEventsCorrelator(clientset, "test-pod", "o11y")
+	err := correlator.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected a forbidden error from Start(), got nil")
+	}
+	if !IsPermissionError(err) {
+		t.Errorf("IsPermissionError(%v) = false, want true", err)
+	}
+}
+
+func TestIsPermissionError(t *testing.T) {
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Resource: "events"}, "", nil)
+	if !IsPermissionError(forbidden) {
+		t.Error("expected forbidden error to be classified as a permission error")
+	}
+	if IsPermissionError(apierrors.NewNotFound(schema.GroupResource{Resource: "events"}, "x")) {
+		t.Error("not-found error must not be classified as a permission error")
+	}
+	if IsPermissionError(nil) {
+		t.Error("nil must not be classified as a permission error")
+	}
+}
 
 func TestNewEventsCorrelator(t *testing.T) {
 	clientset := fake.NewSimpleClientset()

--- a/internal/resource/monitor.go
+++ b/internal/resource/monitor.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -336,6 +337,10 @@ func (rm *ResourceMonitor) syncToBPF() error {
 	return nil
 }
 
+func isBenignMapDeleteError(err error) bool {
+	return errors.Is(err, ebpf.ErrKeyNotExist)
+}
+
 func (rm *ResourceMonitor) checkAlerts() {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
@@ -378,7 +383,7 @@ func (rm *ResourceMonitor) checkAlerts() {
 				logger.Warn("Failed to update alert map", zap.Error(err))
 			}
 		} else {
-			if err := rm.alertsMap.Delete(key); err != nil {
+			if err := rm.alertsMap.Delete(key); err != nil && !isBenignMapDeleteError(err) {
 				logger.Warn("Failed to delete alert from map", zap.Error(err))
 			}
 		}
@@ -414,15 +419,15 @@ func (rm *ResourceMonitor) checkAlerts() {
 					recommendations = append(recommendations, "Immediate action required - resource exhaustion imminent")
 				}
 				alert := &alerting.Alert{
-					Severity:        severity,
-					Title:           title,
-					Message:         message,
-					Timestamp:       time.Now(),
-					Source:          "resource_monitor",
-					PodName:         "",
-					Namespace:       rm.namespace,
+					Severity:  severity,
+					Title:     title,
+					Message:   message,
+					Timestamp: time.Now(),
+					Source:    "resource_monitor",
+					PodName:   "",
+					Namespace: rm.namespace,
 					Context: map[string]interface{}{
-						"resource_type":      resourceTypeLabel,
+						"resource_type":       resourceTypeLabel,
 						"utilization_percent": float64(utilizationUint32),
 						"usage_bytes":         limit.UsageBytes,
 						"limit_bytes":         limit.LimitBytes,
@@ -475,7 +480,6 @@ func (rm *ResourceMonitor) GetLimits() map[uint32]*ResourceLimit {
 	}
 	return result
 }
-
 
 func getCgroupInode(cgroupPath string) (uint64, error) {
 	info, err := os.Stat(cgroupPath)

--- a/internal/resource/monitor_test.go
+++ b/internal/resource/monitor_test.go
@@ -2,15 +2,40 @@ package resource
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/cilium/ebpf"
+
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/sysfs"
 )
+
+func TestIsBenignMapDeleteError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"key does not exist", ebpf.ErrKeyNotExist, true},
+		{"wrapped key does not exist", fmt.Errorf("delete: %w", ebpf.ErrKeyNotExist), true},
+		{"unrelated error", errors.New("some other failure"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBenignMapDeleteError(tt.err); got != tt.want {
+				t.Errorf("isBenignMapDeleteError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 // useCgroupBase points the cgroup root at base for the duration of
 // the test. Required because readCgroupFile and the V1/V2 readers go


### PR DESCRIPTION
Addresses the startup warnings reported in #187:

- **events** — the Kubernetes events correlator no longer runs inside the zero-RBAC spawn pod (it was dead code there and logged a misleading `events is forbidden`). Correlation now runs on the workstation with the user's kubeconfig and renders a "Kubernetes Events" section after the trace.
- **alert map** — suppress the benign `delete: key does not exist` race between the kernel and userspace cleanup paths.