### PR TITLE
fix: bucket timeline by event clock and clarify DNS fallback log

### DIFF
--- a/internal/diagnose/profiling/timeline.go
+++ b/internal/diagnose/profiling/timeline.go
@@ -21,6 +21,22 @@ type BurstInfo struct {
 	Multiplier float64
 }
 
+// minEventTimestamp returns the smallest BPF timestamp among the events.
+func minEventTimestamp(evs []*events.Event) uint64 {
+	origin := evs[0].Timestamp
+	for _, e := range evs {
+		if e.Timestamp < origin {
+			origin = e.Timestamp
+		}
+	}
+	return origin
+}
+
+// eventOffsetNS returns an event's nanosecond offset from the origin timestamp.
+func eventOffsetNS(e *events.Event, origin uint64) int64 {
+	return safeconv.Uint64ToInt64(e.Timestamp) - safeconv.Uint64ToInt64(origin)
+}
+
 func AnalyzeTimeline(events []*events.Event, startTime time.Time, duration time.Duration) []TimelineBucket {
 	if len(events) == 0 {
 		return nil
@@ -28,12 +44,15 @@ func AnalyzeTimeline(events []*events.Event, startTime time.Time, duration time.
 
 	numBuckets := config.TimelineBuckets
 	bucketDuration := duration / time.Duration(numBuckets)
+	if bucketDuration <= 0 {
+		bucketDuration = time.Nanosecond
+	}
+	bucketNS := int64(bucketDuration)
 	buckets := make([]int, numBuckets)
 
+	origin := minEventTimestamp(events)
 	for _, e := range events {
-		eventTime := time.Unix(0, safeconv.Uint64ToInt64(e.Timestamp))
-		elapsed := eventTime.Sub(startTime)
-		bucketIndex := int(elapsed / bucketDuration)
+		bucketIndex := int(eventOffsetNS(e, origin) / bucketNS)
 		if bucketIndex >= numBuckets {
 			bucketIndex = numBuckets - 1
 		}
@@ -75,15 +94,21 @@ func DetectBursts(events []*events.Event, startTime time.Time, duration time.Dur
 		return nil
 	}
 
-	var bursts []BurstInfo
-	windowStart := startTime
+	if avgRate <= 0 {
+		return nil
+	}
 
+	origin := minEventTimestamp(events)
+	windowNS := int64(windowDuration)
+
+	var bursts []BurstInfo
 	for i := 0; i < numWindows; i++ {
-		windowEnd := windowStart.Add(windowDuration)
+		lo := int64(i) * windowNS
+		hi := lo + windowNS
 		count := 0
 		for _, e := range events {
-			eventTime := time.Unix(0, safeconv.Uint64ToInt64(e.Timestamp))
-			if eventTime.After(windowStart) && eventTime.Before(windowEnd) {
+			off := eventOffsetNS(e, origin)
+			if off >= lo && off < hi {
 				count++
 			}
 		}
@@ -91,12 +116,11 @@ func DetectBursts(events []*events.Event, startTime time.Time, duration time.Dur
 		if rate > avgRate*2.0 {
 			multiplier := rate / avgRate
 			bursts = append(bursts, BurstInfo{
-				Time:       windowStart,
+				Time:       startTime.Add(time.Duration(lo)),
 				Rate:       rate,
 				Multiplier: multiplier,
 			})
 		}
-		windowStart = windowEnd
 	}
 
 	return bursts
@@ -123,19 +147,31 @@ func AnalyzeConnectionPattern(connectEvents []*events.Event, startTime, endTime 
 		windowDuration = config.MinBurstWindowDuration
 	}
 
-	var windowCounts []int
-	windowStart := startTime
-	for windowStart.Before(endTime) {
-		windowEnd := windowStart.Add(windowDuration)
+	// Span the trace by offset from the earliest event (CLOCK_MONOTONIC domain)
+	// rather than comparing event times to the wall-clock startTime/endTime.
+	span := endTime.Sub(startTime)
+	if span <= 0 {
+		span = duration
+	}
+	numWindows := int(span / windowDuration)
+	if numWindows < 1 {
+		numWindows = 1
+	}
+	origin := minEventTimestamp(connectEvents)
+	windowNS := int64(windowDuration)
+
+	windowCounts := make([]int, 0, numWindows)
+	for i := 0; i < numWindows; i++ {
+		lo := int64(i) * windowNS
+		hi := lo + windowNS
 		count := 0
 		for _, e := range connectEvents {
-			eventTime := time.Unix(0, safeconv.Uint64ToInt64(e.Timestamp))
-			if eventTime.After(windowStart) && eventTime.Before(windowEnd) {
+			off := eventOffsetNS(e, origin)
+			if off >= lo && off < hi {
 				count++
 			}
 		}
 		windowCounts = append(windowCounts, count)
-		windowStart = windowEnd
 	}
 
 	if len(windowCounts) == 0 {
@@ -219,21 +255,24 @@ func AnalyzeIOPattern(tcpEvents []*events.Event, startTime time.Time, duration t
 	}
 
 	peakThroughput := 0.0
-	windowStart := startTime
-	for i := 0; i < numWindows; i++ {
-		windowEnd := windowStart.Add(windowDuration)
-		count := 0
-		for _, e := range tcpEvents {
-			eventTime := time.Unix(0, safeconv.Uint64ToInt64(e.Timestamp))
-			if eventTime.After(windowStart) && eventTime.Before(windowEnd) {
-				count++
+	if len(tcpEvents) > 0 {
+		origin := minEventTimestamp(tcpEvents)
+		windowNS := int64(windowDuration)
+		for i := 0; i < numWindows; i++ {
+			lo := int64(i) * windowNS
+			hi := lo + windowNS
+			count := 0
+			for _, e := range tcpEvents {
+				off := eventOffsetNS(e, origin)
+				if off >= lo && off < hi {
+					count++
+				}
+			}
+			rate := float64(count) / windowDuration.Seconds()
+			if rate > peakThroughput {
+				peakThroughput = rate
 			}
 		}
-		rate := float64(count) / windowDuration.Seconds()
-		if rate > peakThroughput {
-			peakThroughput = rate
-		}
-		windowStart = windowEnd
 	}
 
 	return IOPattern{

--- a/internal/diagnose/profiling/timeline_test.go
+++ b/internal/diagnose/profiling/timeline_test.go
@@ -65,6 +65,35 @@ func TestAnalyzeTimeline_ContiguousNonOverlappingBuckets(t *testing.T) {
 	}
 }
 
+func TestAnalyzeTimeline_MonotonicTimestamps_Issue186(t *testing.T) {
+	startTime := time.Now()
+	duration := 320 * time.Second
+	bucketDur := duration / time.Duration(config.TimelineBuckets)
+
+	const bootNS = uint64(5 * 24 * 60 * 60 * 1_000_000_000)
+
+	var evs []*events.Event
+	for b := 0; b < config.TimelineBuckets; b++ {
+		base := bootNS + uint64(int64(b)*int64(bucketDur))
+		for k := 0; k < 3; k++ {
+			evs = append(evs, &events.Event{Timestamp: base + uint64(k)*uint64(time.Second)})
+		}
+	}
+
+	buckets := AnalyzeTimeline(evs, startTime, duration)
+	if len(buckets) != config.TimelineBuckets {
+		t.Fatalf("expected %d buckets, got %d", config.TimelineBuckets, len(buckets))
+	}
+	if buckets[0].Count == len(evs) {
+		t.Fatalf("all %d events fell into the first bucket — issue #186 regression", len(evs))
+	}
+	for i, b := range buckets {
+		if b.Count != 3 {
+			t.Errorf("bucket %d: got %d events, want 3 (events must distribute by monotonic time)", i, b.Count)
+		}
+	}
+}
+
 func TestDetectBursts(t *testing.T) {
 	start := time.Now()
 	duration := 2 * time.Second

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -279,10 +279,16 @@ func AttachDNSProbes(coll *ebpf.Collection, containerID string) []link.Link {
 	return AttachDNSProbesWithPID(coll, containerID, 0)
 }
 
+// packetDNSCaptureEnabled reports whether the libc-independent, packet-based
+// DNS capture path is active.
+func packetDNSCaptureEnabled() bool {
+	return os.Getenv("PODTRACE_DNS_PACKET_CAPTURE") != "false"
+}
+
 // AttachDNSPacketProbes attaches the cgroup_skb DNS program to each target pod
 // cgroup, capturing DNS by parsing packets rather than via libc uprobes.
 func AttachDNSPacketProbes(coll *ebpf.Collection, cgroupPaths []string) []link.Link {
-	if os.Getenv("PODTRACE_DNS_PACKET_CAPTURE") == "false" {
+	if !packetDNSCaptureEnabled() {
 		logger.Debug("Packet-based DNS capture disabled via PODTRACE_DNS_PACKET_CAPTURE=false")
 		return nil
 	}
@@ -359,11 +365,15 @@ func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 					logger.Info("DNS tracking (uretprobe) unavailable", zap.Error(err))
 				}
 			}
+		} else if packetDNSCaptureEnabled() {
+			logger.Debug("libc uprobe DNS unavailable; DNS is captured via the packet-based path instead")
 		} else {
 			logger.Info("DNS tracking disabled: libc was located but could not be opened for uprobe attachment. DNS name resolution will not be traced; other tracing is unaffected.")
 		}
+	} else if packetDNSCaptureEnabled() {
+		logger.Debug("libc uprobe DNS unavailable; DNS is captured via the packet-based path instead")
 	} else {
-		logger.Info("DNS tracking disabled: no libc found in the target container (e.g. a statically-linked binary or distroless/scratch image). DNS name resolution will not be traced; other tracing is unaffected.")
+		logger.Info("DNS tracking disabled: no libc found in the target container and packet-based DNS capture is disabled. DNS name resolution will not be traced; other tracing is unaffected.")
 	}
 	return links
 }


### PR DESCRIPTION
Timeline analyzers compared CLOCK_MONOTONIC event timestamps against a wall-clock start time, so every event landed in the oldest bucket (#186).
Bucket relative to the earliest event instead. Also stop logging "DNS tracking disabled" when packet-based capture is active, since DNS is still traced off the wire (#187).

Relates to #186 & #187