### PR TITLE
test: improve coverage; fix nondeterministic mode-loop select

### DIFF
--- a/api/v1alpha1/validation_pure_test.go
+++ b/api/v1alpha1/validation_pure_test.go
@@ -1,0 +1,144 @@
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSchedule(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{"standard 5-field", "*/5 * * * *", false},
+		{"with seconds (6-field)", "0 */5 * * * *", false},
+		{"descriptor", "@hourly", false},
+		{"empty", "", true},
+		{"garbage", "not a cron", true},
+		{"too many fields", "* * * * * * * *", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, err := ParseSchedule(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseSchedule(%q) err = %v, wantErr %v", tt.expr, err, tt.wantErr)
+			}
+			if !tt.wantErr && sched == nil {
+				t.Errorf("expected non-nil schedule for %q", tt.expr)
+			}
+		})
+	}
+}
+
+func TestValidateObjectStoreReference(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     *ObjectStoreReference
+		wantErr string
+	}{
+		{"nil ref is ok", nil, ""},
+		{"empty URI", &ObjectStoreReference{URI: ""}, "is required"},
+		{"valid s3", &ObjectStoreReference{URI: "s3://bucket/key"}, ""},
+		{"valid gs", &ObjectStoreReference{URI: "gs://bucket/key"}, ""},
+		{"valid azblob", &ObjectStoreReference{URI: "azblob://account/container/key"}, ""},
+		{"bad scheme", &ObjectStoreReference{URI: "ftp://host/path"}, "unsupported URI scheme"},
+		{"missing host", &ObjectStoreReference{URI: "s3:///key"}, "must include scheme and host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateObjectStoreReference(tt.ref)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateObjectStoreURI_Variants(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{"s3 ok", "s3://bucket/prefix/", ""},
+		{"gs ok", "gs://bucket/object", ""},
+		{"azblob with container", "azblob://account/container/blob", ""},
+		{"azblob without container", "azblob://account", "must include a container"},
+		{"azblob empty path", "azblob://account/", "must include a container"},
+		{"empty scheme", "//host/path", "must include scheme and host"},
+		{"unsupported", "http://example.com/x", "unsupported URI scheme"},
+		{"unparseable", "://", "missing protocol scheme"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateObjectStoreURI(tt.uri)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error for %q, got %v", tt.uri, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateObjectStoreURI(%q) = %v, want substring %q", tt.uri, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateExporterConfigVariant(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    ExporterConfigSpec
+		wantErr string
+	}{
+		{
+			name:    "otlp populated and matching",
+			spec:    ExporterConfigSpec{Type: ExporterTypeOTLP, OTLP: &OTLPExporter{}},
+			wantErr: "",
+		},
+		{
+			name:    "jaeger populated and matching",
+			spec:    ExporterConfigSpec{Type: ExporterTypeJaeger, Jaeger: &JaegerExporter{}},
+			wantErr: "",
+		},
+		{
+			name:    "none populated",
+			spec:    ExporterConfigSpec{Type: ExporterTypeOTLP},
+			wantErr: "must be set",
+		},
+		{
+			name:    "two populated",
+			spec:    ExporterConfigSpec{Type: ExporterTypeOTLP, OTLP: &OTLPExporter{}, Zipkin: &ZipkinExporter{}},
+			wantErr: "only one of",
+		},
+		{
+			name:    "type mismatch",
+			spec:    ExporterConfigSpec{Type: ExporterTypeSplunk, DataDog: &DataDogExporter{}},
+			wantErr: "does not match populated field",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExporterConfigVariant(tt.spec)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateExporterConfigVariant = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/podtrace/agent_adapter_unit_test.go
+++ b/cmd/podtrace/agent_adapter_unit_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/ebpf"
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// fakeTracer is a hand-rolled ebpf.TracerInterface implementation that
+// records the arguments it receives and returns configurable errors.
+// It deliberately does NOT implement SetEnabledCategories so the
+// adapter's optional categoryGateable type-assertion takes its !ok path.
+type fakeTracer struct {
+	setCgroupsArg  []string
+	attachArg      string
+	containerIDArg string
+	startCalled    bool
+	stopCalled     bool
+	startCh        chan<- *events.Event
+
+	setCgroupsErr  error
+	attachErr      error
+	containerIDErr error
+	startErr       error
+	stopErr        error
+}
+
+func (f *fakeTracer) SetCgroups(paths []string) error {
+	f.setCgroupsArg = paths
+	return f.setCgroupsErr
+}
+
+func (f *fakeTracer) AttachToCgroup(path string) error {
+	f.attachArg = path
+	return f.attachErr
+}
+
+func (f *fakeTracer) SetContainerID(id string) error {
+	f.containerIDArg = id
+	return f.containerIDErr
+}
+
+func (f *fakeTracer) Start(_ context.Context, ch chan<- *events.Event) error {
+	f.startCalled = true
+	f.startCh = ch
+	return f.startErr
+}
+
+func (f *fakeTracer) Stop() error {
+	f.stopCalled = true
+	return f.stopErr
+}
+
+var _ ebpf.TracerInterface = (*fakeTracer)(nil)
+
+// gateableFakeTracer embeds fakeTracer and additionally satisfies the
+// optional categoryGateable interface so the adapter takes its ok path.
+type gateableFakeTracer struct {
+	fakeTracer
+	categoriesArg  []string
+	categoriesCall bool
+	categoriesErr  error
+}
+
+func (g *gateableFakeTracer) SetEnabledCategories(categories []string) error {
+	g.categoriesCall = true
+	g.categoriesArg = categories
+	return g.categoriesErr
+}
+
+var _ ebpf.TracerInterface = (*gateableFakeTracer)(nil)
+
+func TestEbpfBackendAdapter_SetCgroups_FiltersEmptyPaths(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	targets := []tracer.CgroupTarget{
+		{CgroupPath: "/sys/fs/cgroup/a", ContainerID: "c1"},
+		{CgroupPath: "", ContainerID: "c2"},
+		{CgroupPath: "/sys/fs/cgroup/b", ContainerID: "c3"},
+		{CgroupPath: "", ContainerID: "c4"},
+	}
+
+	if err := adapter.SetCgroups(targets); err != nil {
+		t.Fatalf("SetCgroups returned unexpected error: %v", err)
+	}
+
+	want := []string{"/sys/fs/cgroup/a", "/sys/fs/cgroup/b"}
+	if len(fake.setCgroupsArg) != len(want) {
+		t.Fatalf("fake received %v, want %v", fake.setCgroupsArg, want)
+	}
+	for i, p := range want {
+		if fake.setCgroupsArg[i] != p {
+			t.Errorf("path[%d] = %q, want %q", i, fake.setCgroupsArg[i], p)
+		}
+	}
+}
+
+func TestEbpfBackendAdapter_SetCgroups_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	fake := &fakeTracer{setCgroupsErr: wantErr}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	err := adapter.SetCgroups([]tracer.CgroupTarget{{CgroupPath: "/x"}})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestEbpfBackendAdapter_SetCgroups_AllEmpty(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	if err := adapter.SetCgroups([]tracer.CgroupTarget{{CgroupPath: ""}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.setCgroupsArg) != 0 {
+		t.Fatalf("expected no paths forwarded, got %v", fake.setCgroupsArg)
+	}
+}
+
+func TestEbpfBackendAdapter_AttachToCgroup(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	if err := adapter.AttachToCgroup("/sys/fs/cgroup/z"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.attachArg != "/sys/fs/cgroup/z" {
+		t.Errorf("attachArg = %q, want %q", fake.attachArg, "/sys/fs/cgroup/z")
+	}
+
+	wantErr := errors.New("attach failed")
+	failing := &ebpfBackendAdapter{tr: &fakeTracer{attachErr: wantErr}}
+	if err := failing.AttachToCgroup("/p"); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestEbpfBackendAdapter_SetContainerID(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	if err := adapter.SetContainerID("abc123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.containerIDArg != "abc123" {
+		t.Errorf("containerIDArg = %q, want %q", fake.containerIDArg, "abc123")
+	}
+
+	wantErr := errors.New("setid failed")
+	failing := &ebpfBackendAdapter{tr: &fakeTracer{containerIDErr: wantErr}}
+	if err := failing.SetContainerID("x"); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestEbpfBackendAdapter_Start(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	ch := make(chan *events.Event)
+	if err := adapter.Start(context.Background(), ch); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fake.startCalled {
+		t.Error("expected Start to be delegated to the fake tracer")
+	}
+
+	wantErr := errors.New("start failed")
+	failing := &ebpfBackendAdapter{tr: &fakeTracer{startErr: wantErr}}
+	if err := failing.Start(context.Background(), ch); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestEbpfBackendAdapter_Stop(t *testing.T) {
+	fake := &fakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: fake}
+
+	if err := adapter.Stop(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fake.stopCalled {
+		t.Error("expected Stop to be delegated to the fake tracer")
+	}
+
+	wantErr := errors.New("stop failed")
+	failing := &ebpfBackendAdapter{tr: &fakeTracer{stopErr: wantErr}}
+	if err := failing.Stop(); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestEbpfBackendAdapter_SetEnabledCategories_NotGateable(t *testing.T) {
+	adapter := &ebpfBackendAdapter{tr: &fakeTracer{}}
+	if err := adapter.SetEnabledCategories([]string{"net", "dns"}); err != nil {
+		t.Fatalf("expected nil for non-gateable tracer, got %v", err)
+	}
+}
+
+func TestEbpfBackendAdapter_SetEnabledCategories_Gateable(t *testing.T) {
+	g := &gateableFakeTracer{}
+	adapter := &ebpfBackendAdapter{tr: g}
+
+	cats := []string{"net", "fs"}
+	if err := adapter.SetEnabledCategories(cats); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !g.categoriesCall {
+		t.Fatal("expected SetEnabledCategories to be delegated")
+	}
+	if len(g.categoriesArg) != 2 || g.categoriesArg[0] != "net" || g.categoriesArg[1] != "fs" {
+		t.Errorf("categoriesArg = %v, want %v", g.categoriesArg, cats)
+	}
+
+	wantErr := errors.New("gate failed")
+	failing := &ebpfBackendAdapter{tr: &gateableFakeTracer{categoriesErr: wantErr}}
+	if err := failing.SetEnabledCategories(cats); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+// Compile-time confirmation that the adapter satisfies both the base
+// backend contract and the optional gating capability.
+var (
+	_ tracer.TracerBackend    = (*ebpfBackendAdapter)(nil)
+	_ tracer.CategoryGateable = (*ebpfBackendAdapter)(nil)
+)
+
+func TestAgentBackendFactory(t *testing.T) {
+	backend, err := agentBackendFactory()
+	if err == nil && backend == nil {
+		t.Fatal("agentBackendFactory returned (nil, nil); want a backend or an error")
+	}
+	if err != nil {
+		t.Logf("agentBackendFactory returned error (expected without BPF): %v", err)
+		if backend != nil {
+			t.Errorf("expected nil backend when error is returned, got %#v", backend)
+		}
+		return
+	}
+	t.Logf("agentBackendFactory returned a usable backend: %T", backend)
+}

--- a/cmd/podtrace/category_event_type_unit_test.go
+++ b/cmd/podtrace/category_event_type_unit_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestCategoryForEventType_AllBranches(t *testing.T) {
+	cases := map[string]string{
+		"dns":     "dns",
+		"DNS":     "dns",
+		"net":     "net",
+		"NET":     "net",
+		"fs":      "fs",
+		"cpu":     "cpu",
+		"proc":    "proc",
+		"unknown": "",
+		"":        "",
+	}
+	for in, want := range cases {
+		if got := categoryForEventType(in); got != want {
+			t.Errorf("categoryForEventType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cmd/podtrace/cmd_branches_unit_test.go
+++ b/cmd/podtrace/cmd_branches_unit_test.go
@@ -1,0 +1,446 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	"github.com/podtrace/podtrace/internal/events"
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+)
+
+func saveDiagnoseGlobals(t *testing.T) {
+	t.Helper()
+	origExport := exportFormat
+	origSummary := summaryFile
+	origTermination := terminationMessagePath
+	origReportTo := reportTo
+	origErrRate := errorRateThreshold
+	origRTT := rttSpikeThreshold
+	origFS := fsSlowThreshold
+	t.Cleanup(func() {
+		exportFormat = origExport
+		summaryFile = origSummary
+		terminationMessagePath = origTermination
+		reportTo = origReportTo
+		errorRateThreshold = origErrRate
+		rttSpikeThreshold = origRTT
+		fsSlowThreshold = origFS
+	})
+}
+
+func TestRunDiagnoseModeWithSource_InvalidDuration(t *testing.T) {
+	saveDiagnoseGlobals(t)
+	exportFormat = ""
+
+	ch := make(chan *events.Event)
+	err := runDiagnoseModeWithSource(context.Background(), ch, "not-a-duration",
+		nil, nil, nil, nil, false, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid duration") {
+		t.Fatalf("expected invalid duration error, got %v", err)
+	}
+}
+
+func TestRunDiagnoseModeWithSource_NonPositiveDuration(t *testing.T) {
+	saveDiagnoseGlobals(t)
+	exportFormat = ""
+
+	ch := make(chan *events.Event)
+	err := runDiagnoseModeWithSource(context.Background(), ch, "0s",
+		nil, nil, nil, nil, false, nil, nil)
+	if err == nil {
+		t.Fatalf("expected validation error for non-positive duration, got nil")
+	}
+}
+
+func TestRunDiagnoseModeWithSource_TimeoutFinishDrainsEvents(t *testing.T) {
+	saveDiagnoseGlobals(t)
+	exportFormat = ""
+	summaryFile = ""
+	terminationMessagePath = ""
+	reportTo = ""
+
+	ch := make(chan *events.Event, 4)
+	ch <- &events.Event{Type: events.EventDNS, ProcessName: "curl", Target: "example.com"}
+	ch <- &events.Event{Type: events.EventConnect, ProcessName: "curl", Target: "10.0.0.1:443"}
+
+	out := captureStdout(t, func() {
+		if err := runDiagnoseModeWithSource(context.Background(), ch, "120ms",
+			nil, nil, nil, nil, false, nil, nil); err != nil {
+			t.Fatalf("unexpected error from timeout finish: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Diagnostic") && out == "" {
+		t.Logf("diagnose timeout report output:\n%s", out)
+	}
+}
+
+func TestRunDiagnoseModeWithSource_ContextCancelFinish(t *testing.T) {
+	saveDiagnoseGlobals(t)
+	exportFormat = ""
+	summaryFile = ""
+	terminationMessagePath = ""
+	reportTo = ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan *events.Event)
+
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		cancel()
+	}()
+
+	out := captureStdout(t, func() {
+		if err := runDiagnoseModeWithSource(ctx, ch, "30s",
+			nil, nil, nil, nil, false, nil, nil); err != nil {
+			t.Fatalf("ctx-cancel finish should return nil, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "=== Final Diagnostic Report ===") {
+		t.Errorf("expected the final-report header on ctx cancel, got:\n%s", out)
+	}
+	if !strings.Contains(out, "No events collected") {
+		t.Errorf("expected the empty-collection report body on ctx cancel, got:\n%s", out)
+	}
+}
+
+func TestRunDiagnoseModeWithSource_ExportJSONOnTimeout(t *testing.T) {
+	saveDiagnoseGlobals(t)
+	exportFormat = "json"
+	summaryFile = ""
+	terminationMessagePath = ""
+	reportTo = ""
+
+	ch := make(chan *events.Event, 1)
+	ch <- &events.Event{Type: events.EventDNS, ProcessName: "curl", Target: "example.com"}
+
+	out := captureStdout(t, func() {
+		if err := runDiagnoseModeWithSource(context.Background(), ch, "100ms",
+			nil, nil, nil, nil, false, nil, nil); err != nil {
+			t.Fatalf("unexpected error exporting JSON: %v", err)
+		}
+	})
+	if !strings.Contains(out, "{") {
+		t.Errorf("expected JSON export output, got:\n%s", out)
+	}
+}
+
+func TestStartWorkstationEventCorrelation_NilClientset(t *testing.T) {
+	finish := startWorkstationEventCorrelation(context.Background(), nil,
+		[]nodespawn.PodRef{{Namespace: "default", Name: "web-0"}}, io.Discard)
+	if finish == nil {
+		t.Fatal("expected a non-nil no-op finish closure")
+	}
+	finish()
+}
+
+func TestStartWorkstationEventCorrelation_EmptyPods(t *testing.T) {
+	finish := startWorkstationEventCorrelation(context.Background(),
+		fake.NewSimpleClientset(), nil, io.Discard)
+	if finish == nil {
+		t.Fatal("expected a non-nil no-op finish closure")
+	}
+	finish()
+}
+
+func TestStartWorkstationEventCorrelation_DedupAndStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pods := []nodespawn.PodRef{
+		{Namespace: "default", Name: "web-0"},
+		{Namespace: "default", Name: "web-0"},
+		{Namespace: "default", Name: ""},
+		{Namespace: "other", Name: "api-0"},
+	}
+
+	var sb strings.Builder
+	finish := startWorkstationEventCorrelation(ctx, fake.NewSimpleClientset(), pods, &sb)
+	if finish == nil {
+		t.Fatal("expected non-nil finish closure")
+	}
+	finish()
+}
+
+type plainResolver struct{}
+
+func (plainResolver) ResolvePod(_ context.Context, podName, namespace, containerName string) (*pkgkube.PodInfo, error) {
+	return &pkgkube.PodInfo{PodName: podName, Namespace: namespace, ContainerName: containerName}, nil
+}
+
+var _ pkgkube.PodResolverInterface = plainResolver{}
+
+type clusterResolver struct{}
+
+func (clusterResolver) ResolvePod(_ context.Context, podName, namespace, containerName string) (*pkgkube.PodInfo, error) {
+	return &pkgkube.PodInfo{PodName: podName, Namespace: namespace, ContainerName: containerName}, nil
+}
+func (clusterResolver) GetClientset() k8s.Interface { return fake.NewSimpleClientset() }
+func (clusterResolver) GetRestConfig() *rest.Config { return &rest.Config{} }
+
+var _ pkgkube.PodResolverInterface = clusterResolver{}
+var _ pkgkube.ClientsetProvider = clusterResolver{}
+var _ pkgkube.RestConfigProvider = clusterResolver{}
+
+func saveSpawnGlobals(t *testing.T) {
+	t.Helper()
+	origLocal := localMode
+	t.Cleanup(func() { localMode = origLocal })
+}
+
+func saveNodespawnGlobals(t *testing.T) {
+	t.Helper()
+	origImage := spawnImage
+	origNamespace := spawnNamespace
+	t.Cleanup(func() {
+		spawnImage = origImage
+		spawnNamespace = origNamespace
+	})
+}
+
+func TestMaybeSpawnOnNode_SentinelSet(t *testing.T) {
+	saveSpawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "1")
+	localMode = false
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		plainResolver{}, pkgkube.TargetSelection{Pods: []string{"web-0"}})
+	if handled || err != nil {
+		t.Fatalf("sentinel set: want (false, nil), got (%v, %v)", handled, err)
+	}
+}
+
+func TestMaybeSpawnOnNode_LocalMode(t *testing.T) {
+	saveSpawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "")
+	localMode = true
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		plainResolver{}, pkgkube.TargetSelection{Pods: []string{"web-0"}})
+	if handled || err != nil {
+		t.Fatalf("local mode: want (false, nil), got (%v, %v)", handled, err)
+	}
+}
+
+func TestMaybeSpawnOnNode_ResolverWithoutClusterHandles(t *testing.T) {
+	saveSpawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "")
+	localMode = false
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		plainResolver{}, pkgkube.TargetSelection{Pods: []string{"web-0"}})
+	if handled || err != nil {
+		t.Fatalf("no cluster handles: want (false, nil), got (%v, %v)", handled, err)
+	}
+}
+
+func TestMaybeSpawnOnNode_NotSpawnableSelection(t *testing.T) {
+	saveSpawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "")
+	localMode = false
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		clusterResolver{}, pkgkube.TargetSelection{})
+	if handled || err != nil {
+		t.Fatalf("non-spawnable selection: want (false, nil), got (%v, %v)", handled, err)
+	}
+}
+
+func TestMaybeSpawnOnNode_PodNotFoundResolveError(t *testing.T) {
+	saveSpawnGlobals(t)
+	saveNodespawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "")
+	t.Setenv("PODTRACE_SPAWN_NAMESPACE", "")
+	localMode = false
+	spawnImage = "ghcr.io/gma1k/podtrace:test"
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		clusterResolver{}, pkgkube.TargetSelection{Pods: []string{"missing-pod"}, Namespaces: []string{"default"}})
+	if !handled {
+		t.Fatalf("expected handled=true once selection is spawnable, got false")
+	}
+	if err == nil || !strings.Contains(err.Error(), "get pod") {
+		t.Fatalf("expected a 'get pod' resolve error from the fake clientset, got %v", err)
+	}
+}
+
+func TestMaybeSpawnOnNode_NoScheduledTargets(t *testing.T) {
+	saveSpawnGlobals(t)
+	saveNodespawnGlobals(t)
+	t.Setenv(nodespawn.EnvNodeLocalSentinel, "")
+	t.Setenv("PODTRACE_SPAWN_NAMESPACE", "")
+	localMode = false
+	spawnImage = "ghcr.io/gma1k/podtrace:test"
+
+	handled, err := maybeSpawnOnNode(context.Background(), &cobra.Command{},
+		clusterResolver{}, pkgkube.TargetSelection{AllInNamespace: true, Namespaces: []string{"default"}})
+	if !handled {
+		t.Fatalf("expected handled=true once selection is spawnable, got false")
+	}
+	if err == nil || !strings.Contains(err.Error(), "no scheduled target pods") {
+		t.Fatalf("expected 'no scheduled target pods' error, got %v", err)
+	}
+}
+
+func saveWatchGlobals(t *testing.T) {
+	t.Helper()
+	orig := struct {
+		labels  []string
+		appName string
+		ns      string
+		printOn bool
+		exp     string
+		allNS   bool
+		nsSel   string
+		name    string
+		sample  int
+		kubecfg string
+		app     bool
+		filter  string
+	}{
+		labels: watchLabels, appName: watchAppName, ns: namespace,
+		printOn: watchPrintOnly, exp: watchExporter, allNS: watchAllNamespaces,
+		nsSel: watchNamespaceSelector, name: watchName, sample: watchSample,
+		kubecfg: watchKubeconfig, app: watchApplication, filter: eventFilter,
+	}
+	t.Cleanup(func() {
+		watchLabels = orig.labels
+		watchAppName = orig.appName
+		namespace = orig.ns
+		watchPrintOnly = orig.printOn
+		watchExporter = orig.exp
+		watchAllNamespaces = orig.allNS
+		watchNamespaceSelector = orig.nsSel
+		watchName = orig.name
+		watchSample = orig.sample
+		watchKubeconfig = orig.kubecfg
+		watchApplication = orig.app
+		eventFilter = orig.filter
+	})
+}
+
+func TestNewWatchCmd_PrintOnlyNoCluster(t *testing.T) {
+	saveWatchGlobals(t)
+
+	cmd := newWatchCmd()
+	cmd.SetArgs([]string{"--app", "checkout", "--all-namespaces", "--print-only"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	out := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("watch --print-only should succeed without a cluster, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "kind: PodTrace") {
+		t.Errorf("expected rendered PodTrace manifest, got:\n%s", out)
+	}
+}
+
+func TestNewWatchCmd_ConflictingFlags(t *testing.T) {
+	saveWatchGlobals(t)
+
+	cmd := newWatchCmd()
+	cmd.SetArgs([]string{"--app", "checkout", "--label", "tier=web", "--print-only"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutually-exclusive error, got %v", err)
+	}
+}
+
+func TestNewReportUploaderCmd_MissingRequiredFlags(t *testing.T) {
+	cmd := newReportUploaderCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "both required") {
+		t.Fatalf("expected 'both required' error, got %v", err)
+	}
+}
+
+func TestNewReportUploaderCmd_OnlyReportFile(t *testing.T) {
+	cmd := newReportUploaderCmd()
+	cmd.SetArgs([]string{"--report-file", "/tmp/report.txt"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "both required") {
+		t.Fatalf("expected 'both required' error with only --report-file, got %v", err)
+	}
+}
+
+func TestPersistKeyHint_WriteFailureIsSwallowed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory permissions are bypassed, write would succeed")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "ro")
+	if err := os.Mkdir(roDir, 0o500); err != nil {
+		t.Fatalf("mkdir ro: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) })
+
+	orig := keyHintStateFile
+	keyHintStateFile = filepath.Join(roDir, "upload-key-hint.txt")
+	t.Cleanup(func() { keyHintStateFile = orig })
+
+	persistKeyHint("pod-2026-06-08T00-00-00Z.txt")
+
+	if _, err := os.Stat(keyHintStateFile); err == nil {
+		t.Fatalf("expected write to fail into read-only dir, but file exists")
+	}
+}
+
+func TestLoadObjectStoreCredentials_UnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: file permissions are bypassed, read would succeed")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret-key")
+	if err := os.WriteFile(secret, []byte("s3cr3t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Fatalf("chmod 000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o600) })
+
+	t.Setenv(envObjectStoreCredentialsDir, dir)
+
+	_, err := loadObjectStoreCredentials()
+	if err == nil {
+		t.Fatal("expected a read error for the unreadable credential file, got nil")
+	}
+	if !strings.Contains(err.Error(), "read credential file") {
+		t.Fatalf("expected 'read credential file' error, got %v", err)
+	}
+}

--- a/cmd/podtrace/cmd_pure_partials_unit_test.go
+++ b/cmd/podtrace/cmd_pure_partials_unit_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildApplicationTrace_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*watchOptions)
+		wantSub string
+	}{
+		{
+			name:    "no target",
+			mutate:  func(o *watchOptions) {},
+			wantSub: "one of --app or --label",
+		},
+		{
+			name:    "empty exporter",
+			mutate:  func(o *watchOptions) { o.AppName = "shop"; o.Exporter = "" },
+			wantSub: "--exporter must not be empty",
+		},
+		{
+			name:    "label without name",
+			mutate:  func(o *watchOptions) { o.Labels = []string{"app=api"} },
+			wantSub: "--name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := baseWatchOpts()
+			tt.mutate(&opts)
+			_, err := buildApplicationTrace(opts)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCollectEnvReport_CRIEndpointEnv(t *testing.T) {
+	const want = "unix:///run/test-cri.sock"
+	t.Setenv("PODTRACE_CRI_ENDPOINT", want)
+
+	rep := collectEnvReport()
+	if rep.CRIEndpointEnv != want {
+		t.Fatalf("CRIEndpointEnv = %q, want %q", rep.CRIEndpointEnv, want)
+	}
+}
+
+func TestCollectEnvReport_CRIEndpointEnvUnset(t *testing.T) {
+	t.Setenv("PODTRACE_CRI_ENDPOINT", "")
+
+	rep := collectEnvReport()
+	if rep.CRIEndpointEnv != "" {
+		t.Fatalf("CRIEndpointEnv = %q, want empty", rep.CRIEndpointEnv)
+	}
+}

--- a/cmd/podtrace/cmd_tracer_multi_unit_test.go
+++ b/cmd/podtrace/cmd_tracer_multi_unit_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+type multiTracer struct {
+	gotCgroups   []string
+	gotIDs       []string
+	cgroupsErr   error
+	containerErr error
+}
+
+func (m *multiTracer) SetCgroups([]string) error   { return nil }
+func (m *multiTracer) AttachToCgroup(string) error { return nil }
+func (m *multiTracer) SetContainerID(string) error { return nil }
+func (m *multiTracer) Stop() error                 { return nil }
+func (m *multiTracer) Start(context.Context, chan<- *events.Event) error {
+	return nil
+}
+
+func (m *multiTracer) AttachToCgroups(paths []string) error {
+	m.gotCgroups = paths
+	return m.cgroupsErr
+}
+
+func (m *multiTracer) SetContainerIDs(ids []string) error {
+	m.gotIDs = ids
+	return m.containerErr
+}
+
+func TestAttachTracerToCgroups_MultiInterface(t *testing.T) {
+	tr := &multiTracer{}
+	paths := []string{"/sys/fs/cgroup/a", "/sys/fs/cgroup/b"}
+	if err := attachTracerToCgroups(tr, paths); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tr.gotCgroups) != 2 || tr.gotCgroups[0] != "/sys/fs/cgroup/a" {
+		t.Errorf("AttachToCgroups got %v, want all paths forwarded", tr.gotCgroups)
+	}
+}
+
+func TestAttachTracerToCgroups_MultiInterfacePropagatesError(t *testing.T) {
+	wantErr := errors.New("multi attach boom")
+	tr := &multiTracer{cgroupsErr: wantErr}
+	if err := attachTracerToCgroups(tr, []string{"/p"}); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestSetTracerContainerIDs_MultiInterface(t *testing.T) {
+	tr := &multiTracer{}
+	ids := []string{"cid-1", "cid-2"}
+	if err := setTracerContainerIDs(tr, ids); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tr.gotIDs) != 2 || tr.gotIDs[1] != "cid-2" {
+		t.Errorf("SetContainerIDs got %v, want all IDs forwarded", tr.gotIDs)
+	}
+}
+
+func TestSetTracerContainerIDs_MultiInterfacePropagatesError(t *testing.T) {
+	wantErr := errors.New("multi setid boom")
+	tr := &multiTracer{containerErr: wantErr}
+	if err := setTracerContainerIDs(tr, []string{"x"}); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}

--- a/cmd/podtrace/cmd_tracer_sink_unit_test.go
+++ b/cmd/podtrace/cmd_tracer_sink_unit_test.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+// ---------------------------------------------------------------------------
+// main.go: attachTracerToCgroups
+//
+// The mockTracer/fakeTracer fakes do NOT implement the optional
+// AttachToCgroups(plural) interface, so these tests exercise the
+// single-path fallback: the empty-slice error guard and the delegation
+// to AttachToCgroup(paths[0]) (success and propagated-error).
+// ---------------------------------------------------------------------------
+
+func TestAttachTracerToCgroups_NoPaths(t *testing.T) {
+	tr := &mockTracer{}
+	if err := attachTracerToCgroups(tr, nil); err == nil {
+		t.Fatal("expected error when no cgroup paths are provided")
+	}
+}
+
+func TestAttachTracerToCgroups_DelegatesFirstPath(t *testing.T) {
+	var got string
+	tr := &mockTracer{
+		attachToCgroupFunc: func(p string) error {
+			got = p
+			return nil
+		},
+	}
+	if err := attachTracerToCgroups(tr, []string{"/sys/fs/cgroup/a", "/sys/fs/cgroup/b"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/sys/fs/cgroup/a" {
+		t.Errorf("delegated path = %q, want first path %q", got, "/sys/fs/cgroup/a")
+	}
+}
+
+func TestAttachTracerToCgroups_PropagatesError(t *testing.T) {
+	wantErr := errors.New("attach boom")
+	tr := &mockTracer{
+		attachToCgroupFunc: func(string) error { return wantErr },
+	}
+	if err := attachTracerToCgroups(tr, []string{"/p"}); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// main.go: setTracerContainerIDs
+// ---------------------------------------------------------------------------
+
+func TestSetTracerContainerIDs_NoIDs(t *testing.T) {
+	tr := &mockTracer{}
+	if err := setTracerContainerIDs(tr, nil); err == nil {
+		t.Fatal("expected error when no container IDs are provided")
+	}
+}
+
+func TestSetTracerContainerIDs_DelegatesFirstID(t *testing.T) {
+	var got string
+	tr := &mockTracer{
+		setContainerIDFunc: func(id string) error {
+			got = id
+			return nil
+		},
+	}
+	if err := setTracerContainerIDs(tr, []string{"cid-1", "cid-2"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cid-1" {
+		t.Errorf("delegated id = %q, want first id %q", got, "cid-1")
+	}
+}
+
+func TestSetTracerContainerIDs_PropagatesError(t *testing.T) {
+	wantErr := errors.New("setid boom")
+	tr := &mockTracer{
+		setContainerIDFunc: func(string) error { return wantErr },
+	}
+	if err := setTracerContainerIDs(tr, []string{"x"}); !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// main.go: attachSourcePod
+// ---------------------------------------------------------------------------
+
+func TestAttachSourcePod_StampsResolvedIdentity(t *testing.T) {
+	e := &events.Event{}
+	resolve := func(*events.Event) *kubernetes.PodInfo {
+		return &kubernetes.PodInfo{
+			PodName:       "src-pod",
+			Namespace:     "src-ns",
+			ContainerName: "src-container",
+		}
+	}
+	attachSourcePod(e, resolve)
+	if e.K8s == nil {
+		t.Fatal("expected K8s metadata to be stamped onto the event")
+	}
+	if e.K8s.PodName != "src-pod" || e.K8s.Namespace != "src-ns" || e.K8s.ContainerName != "src-container" {
+		t.Errorf("stamped metadata = %+v, want src-pod/src-ns/src-container", e.K8s)
+	}
+}
+
+func TestAttachSourcePod_NilEventIsNoOp(t *testing.T) {
+	called := false
+	attachSourcePod(nil, func(*events.Event) *kubernetes.PodInfo {
+		called = true
+		return nil
+	})
+	if called {
+		t.Error("resolve must not be called for a nil event")
+	}
+}
+
+func TestAttachSourcePod_NilResolveIsNoOp(t *testing.T) {
+	e := &events.Event{}
+	attachSourcePod(e, nil)
+	if e.K8s != nil {
+		t.Errorf("expected K8s to stay nil with a nil resolver, got %+v", e.K8s)
+	}
+}
+
+func TestAttachSourcePod_AlreadyStampedIsNoOp(t *testing.T) {
+	e := &events.Event{K8s: &events.K8sMetadata{PodName: "existing"}}
+	called := false
+	attachSourcePod(e, func(*events.Event) *kubernetes.PodInfo {
+		called = true
+		return &kubernetes.PodInfo{PodName: "other"}
+	})
+	if called {
+		t.Error("resolve must not be called when K8s metadata is already present")
+	}
+	if e.K8s.PodName != "existing" {
+		t.Errorf("existing metadata overwritten: %+v", e.K8s)
+	}
+}
+
+func TestAttachSourcePod_EmptyResolvedPodNameIsNoOp(t *testing.T) {
+	e := &events.Event{}
+	attachSourcePod(e, func(*events.Event) *kubernetes.PodInfo {
+		return &kubernetes.PodInfo{PodName: ""} // empty PodName -> not stamped
+	})
+	if e.K8s != nil {
+		t.Errorf("expected no stamp for empty PodName, got %+v", e.K8s)
+	}
+}
+
+func TestAttachSourcePod_NilResolvedInfoIsNoOp(t *testing.T) {
+	e := &events.Event{}
+	attachSourcePod(e, func(*events.Event) *kubernetes.PodInfo { return nil })
+	if e.K8s != nil {
+		t.Errorf("expected no stamp for nil resolved info, got %+v", e.K8s)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_sink.go: writeSummaryFile error branch
+//
+// hostfs.WriteFile validates the path (must be absolute, no ".." segment),
+// so a relative path drives the error return without needing root or a
+// real privileged location.
+// ---------------------------------------------------------------------------
+
+func TestWriteSummaryFile_Success(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "summary.json")
+	if err := writeSummaryFile(path, SessionSummary{TotalEvents: 7, Node: "n1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("summary file not written: %v", err)
+	}
+	if len(raw) == 0 {
+		t.Error("summary file is empty")
+	}
+}
+
+func TestWriteSummaryFile_InvalidPathError(t *testing.T) {
+	if err := writeSummaryFile("relative/summary.json", SessionSummary{}); err == nil {
+		t.Fatal("expected error for a non-absolute summary path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_sink.go: uploadReport reachable error branch (parse failure)
+//
+// A spec without "://" and not in kind/namespace/name form fails in
+// parseReportToSpec, before any in-cluster client is constructed.
+// ---------------------------------------------------------------------------
+
+func TestUploadReport_ParseError(t *testing.T) {
+	err := uploadReport(context.Background(), "not-a-valid-spec", "report body")
+	if err == nil {
+		t.Fatal("expected parse error for malformed report-to spec")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// session_sink.go: upsertReportConfigMap / upsertReportSecret error branches
+//
+// Existing tests cover create + update. These force the create call to
+// fail with a non-AlreadyExists error (covering the wrapped-create-error
+// return) and the AlreadyExists-then-Get-fails path.
+// ---------------------------------------------------------------------------
+
+func TestUpsertReportConfigMap_CreateErrorPropagates(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	wantErr := errors.New("forbidden")
+	client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "body")
+	if err == nil {
+		t.Fatal("expected error when ConfigMap create fails")
+	}
+}
+
+func TestUpsertReportConfigMap_GetErrorAfterAlreadyExists(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	gvr := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+	client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(gvr.GroupResource(), "rpt")
+	})
+	client.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("get failed")
+	})
+	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "body")
+	if err == nil {
+		t.Fatal("expected error when Get after AlreadyExists fails")
+	}
+}
+
+func TestUpsertReportSecret_CreateErrorPropagates(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	wantErr := errors.New("forbidden")
+	client.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "body")
+	if err == nil {
+		t.Fatal("expected error when Secret create fails")
+	}
+}
+
+func TestUpsertReportSecret_UpdateErrorPropagates(t *testing.T) {
+	existing := &corev1.Secret{}
+	existing.Name = "rpt"
+	existing.Namespace = "ns"
+	client := fake.NewSimpleClientset(existing)
+	client.PrependReactor("update", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("update failed")
+	})
+	// Create will return AlreadyExists (object seeded), Get succeeds, Update fails.
+	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "body")
+	if err == nil {
+		t.Fatal("expected error when Secret update fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// report_uploader.go: writeResolvedLocation error branch
+//
+// reportLocationFile is the privileged /var/run/podtrace path. In a
+// non-root unit-test environment the underlying write fails, which is
+// exactly the error branch we want to cover. We assert an error is
+// returned without asserting on its specific cause (so the test stays
+// green if it ever happens to be runnable as root, where the success
+// branch is already exercised elsewhere is not the case here).
+// ---------------------------------------------------------------------------
+
+func TestWriteResolvedLocation_PrivilegedPathErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: privileged /var/run/podtrace path may be writable")
+	}
+	if err := writeResolvedLocation("s3://bucket/key"); err == nil {
+		t.Fatal("expected error writing to privileged report-location path as non-root")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// report_uploader.go: uploadIfPresent object-store branch
+//
+// A present report file plus an object-store-shaped spec routes through
+// uploadToObjectStore. An unsupported scheme makes objectstore.New fail
+// deterministically (no network), covering that branch.
+// ---------------------------------------------------------------------------
+
+func TestUploadIfPresent_ObjectStoreSchemeError(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.txt")
+	if err := os.WriteFile(reportPath, []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envObjectStoreCredentialsDir, "")
+
+	err := uploadIfPresent(context.Background(), reportUploaderOptions{
+		ReportFile:   reportPath,
+		ReportToSpec: "unsupported://bucket/key",
+	})
+	if err == nil {
+		t.Fatal("expected error from unsupported object-store scheme")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// schedule.go: newScheduleTriggerCmd RunE early validation branch
+//
+// trigger requires a positional schedule-name (ExactArgs(1)) and a
+// required --namespace flag. Omitting the namespace makes cobra's
+// required-flag validation fail before any client is built.
+// ---------------------------------------------------------------------------
+
+func TestNewScheduleTriggerCmd_MissingNamespaceErrors(t *testing.T) {
+	cmd := newScheduleTriggerCmd()
+	cmd.SetArgs([]string{"my-schedule"}) // no --namespace
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when required --namespace is missing")
+	}
+}
+
+func TestNewScheduleTriggerCmd_MissingArgErrors(t *testing.T) {
+	cmd := newScheduleTriggerCmd()
+	cmd.SetArgs([]string{"--namespace", "ns"}) // no positional schedule-name
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when positional schedule-name is missing")
+	}
+}

--- a/cmd/podtrace/exporter_from_file_test.go
+++ b/cmd/podtrace/exporter_from_file_test.go
@@ -51,6 +51,50 @@ func TestApplyPayloadToConfig_SplunkCredentialSetsToken(t *testing.T) {
 	}
 }
 
+func TestApplyPayloadToConfig_NilIsNoop(t *testing.T) {
+	defer resetTracingConfig()
+	before := config.OTLPEndpoint
+	applyPayloadToConfig(nil)
+	if config.OTLPEndpoint != before {
+		t.Errorf("nil payload mutated config: OTLPEndpoint=%q", config.OTLPEndpoint)
+	}
+}
+
+func TestApplyPayloadToConfig_Jaeger(t *testing.T) {
+	defer resetTracingConfig()
+	applyPayloadToConfig(&bundle.Payload{
+		Type:     bundle.TypeJaeger,
+		Endpoint: "jaeger:4318",
+	})
+	if config.JaegerEndpoint != "jaeger:4318" {
+		t.Errorf("JaegerEndpoint=%q", config.JaegerEndpoint)
+	}
+}
+
+func TestApplyPayloadToConfig_Zipkin(t *testing.T) {
+	defer resetTracingConfig()
+	applyPayloadToConfig(&bundle.Payload{
+		Type:     bundle.TypeZipkin,
+		Endpoint: "zipkin:9411",
+	})
+	if config.ZipkinEndpoint != "zipkin:9411" {
+		t.Errorf("ZipkinEndpoint=%q", config.ZipkinEndpoint)
+	}
+}
+
+func TestApplyPayloadToConfig_ZeroSampleDoesNotOverride(t *testing.T) {
+	defer resetTracingConfig()
+	config.TracingSampleRate = 0.5
+	applyPayloadToConfig(&bundle.Payload{
+		Type:     bundle.TypeOTLP,
+		Endpoint: "otel:4318",
+		Sample:   0,
+	})
+	if config.TracingSampleRate != 0.5 {
+		t.Errorf("zero sample should not override; got %v", config.TracingSampleRate)
+	}
+}
+
 func TestApplyExporterFromFile_RoundTrip(t *testing.T) {
 	defer resetTracingConfig()
 	dir := t.TempDir()
@@ -119,6 +163,35 @@ func TestApplyExporterFromFile_CredentialFileLoaded(t *testing.T) {
 	}
 	if config.DataDogAPIKey != "dd-key" {
 		t.Errorf("DataDogAPIKey=%q want dd-key", config.DataDogAPIKey)
+	}
+}
+
+func TestApplyExporterFromFile_EnvCredentialWins(t *testing.T) {
+	defer resetTracingConfig()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.yaml")
+	if err := os.WriteFile(path, []byte("type: splunk\nendpoint: splunk:8088\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PODTRACE_EXPORTER_CREDENTIAL", "env-hec-token")
+	t.Setenv("PODTRACE_EXPORTER_CREDENTIAL_FILE", filepath.Join(dir, "ignored"))
+	if err := applyExporterFromFile(path); err != nil {
+		t.Fatalf("applyExporterFromFile: %v", err)
+	}
+	if config.SplunkToken != "env-hec-token" {
+		t.Errorf("SplunkToken=%q want env-hec-token (env credential must win)", config.SplunkToken)
+	}
+}
+
+func TestApplyExporterFromFile_MalformedYAMLErrors(t *testing.T) {
+	defer resetTracingConfig()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.yaml")
+	if err := os.WriteFile(path, []byte("\tnot: [valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyExporterFromFile(path); err == nil {
+		t.Fatal("expected error for malformed bundle YAML")
 	}
 }
 

--- a/cmd/podtrace/helpers_unit_test.go
+++ b/cmd/podtrace/helpers_unit_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsObjectStoreURI(t *testing.T) {
+	cases := []struct {
+		spec string
+		want bool
+	}{
+		{"s3://bucket/key", true},
+		{"gs://bucket/key", true},
+		{"azblob://container/blob", true},
+		{"configmap/default/report", false},
+		{"secret/ns/name", false},
+		{"", false},
+		{"://", true},
+	}
+	for _, c := range cases {
+		if got := isObjectStoreURI(c.spec); got != c.want {
+			t.Errorf("isObjectStoreURI(%q) = %v, want %v", c.spec, got, c.want)
+		}
+	}
+}
+
+// writeResolvedLocation targets a fixed const path (/var/run/podtrace/...).
+// We can't redirect it without editing the source, so exercise the function
+// directly: if the target directory exists and is writable the URI must round
+// -trip; otherwise the helper must surface the write error rather than panic.
+func TestWriteResolvedLocation(t *testing.T) {
+	const uri = "s3://bucket/podtrace/report.txt"
+	err := writeResolvedLocation(uri)
+	if err != nil {
+		t.Logf("writeResolvedLocation returned (expected when %s dir is absent): %v",
+			filepath.Dir(reportLocationFile), err)
+		return
+	}
+	got, readErr := os.ReadFile(reportLocationFile)
+	if readErr != nil {
+		t.Fatalf("read back resolved location: %v", readErr)
+	}
+	if string(got) != uri {
+		t.Fatalf("resolved location = %q, want %q", string(got), uri)
+	}
+}
+
+func TestSelectionIsSpawnable(t *testing.T) {
+	cases := []struct {
+		name string
+		sel  pkgkube.TargetSelection
+		want bool
+	}{
+		{"empty", pkgkube.TargetSelection{}, false},
+		{"pods", pkgkube.TargetSelection{Pods: []string{"web-0"}}, true},
+		{"selector", pkgkube.TargetSelection{PodSelector: "app=api"}, true},
+		{"all-in-namespace", pkgkube.TargetSelection{AllInNamespace: true}, true},
+	}
+	for _, c := range cases {
+		if got := selectionIsSpawnable(c.sel); got != c.want {
+			t.Errorf("%s: selectionIsSpawnable = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestErrorsAs_WrappedExitError(t *testing.T) {
+	base := &nodespawn.ExitError{Code: 7, Node: "node-a"}
+	wrapped := fmt.Errorf("nodespawn run failed: %w", base)
+
+	var target *nodespawn.ExitError
+	if !errorsAs(wrapped, &target) {
+		t.Fatalf("errorsAs returned false for a wrapped *ExitError")
+	}
+	if target == nil || target.Code != 7 || target.Node != "node-a" {
+		t.Fatalf("errorsAs did not assign the unwrapped ExitError: %#v", target)
+	}
+}
+
+func TestErrorsAs_PlainError(t *testing.T) {
+	var target *nodespawn.ExitError
+	if errorsAs(fmt.Errorf("just a plain error"), &target) {
+		t.Fatalf("errorsAs returned true for a non-ExitError chain")
+	}
+	if target != nil {
+		t.Fatalf("target should remain nil, got %#v", target)
+	}
+}
+
+func TestNewChildArgsBuilder(t *testing.T) {
+	cmd := &cobra.Command{Use: "podtrace"}
+	cmd.Flags().String("filter", "", "event filter")
+	cmd.Flags().String("output", "", "output format")
+	cmd.Flags().String("image", "", "spawn image")
+	cmd.Flags().Bool("metrics", false, "expose metrics")
+
+	if err := cmd.Flags().Set("filter", "dns,net"); err != nil {
+		t.Fatalf("set filter: %v", err)
+	}
+	if err := cmd.Flags().Set("image", "ghcr.io/example/podtrace:dev"); err != nil {
+		t.Fatalf("set image: %v", err)
+	}
+	if err := cmd.Flags().Set("metrics", "true"); err != nil {
+		t.Fatalf("set metrics: %v", err)
+	}
+
+	pods := []nodespawn.PodRef{
+		{Namespace: "default", Name: "web-0", ContainerID: "cid-1", ContainerName: "app"},
+		{Namespace: "default", Name: "web-1", ContainerID: "cid-2", ContainerName: "app"},
+		{Namespace: "default", Name: "web-2", ContainerName: "app"},
+	}
+
+	t.Run("passMetrics=false strips metrics and control flags", func(t *testing.T) {
+		build := newChildArgsBuilder(cmd, false)
+		args := build("node-a", pods)
+		joined := strings.Join(args, " ")
+
+		if !contains(args, "--filter=dns,net") {
+			t.Errorf("expected changed --filter flag in args, got %v", args)
+		}
+		if strings.Contains(joined, "--image=") {
+			t.Errorf("spawn-control flag --image must be stripped, got %v", args)
+		}
+		if strings.Contains(joined, "--metrics") {
+			t.Errorf("--metrics must be stripped when passMetrics=false, got %v", args)
+		}
+		if !contains(args, "--preresolved-pod=default/web-0/cid-1/app") {
+			t.Errorf("expected preresolved entry for web-0, got %v", args)
+		}
+		if !contains(args, "--preresolved-pod=default/web-1/cid-2/app") {
+			t.Errorf("expected preresolved entry for web-1, got %v", args)
+		}
+		if strings.Contains(joined, "web-2") {
+			t.Errorf("pod without ContainerID must be skipped, got %v", args)
+		}
+	})
+
+	t.Run("passMetrics=true keeps changed metrics flag", func(t *testing.T) {
+		build := newChildArgsBuilder(cmd, true)
+		args := build("node-a", pods)
+		if !contains(args, "--metrics=true") {
+			t.Errorf("expected --metrics=true when passMetrics=true, got %v", args)
+		}
+	})
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMarshalSessionYAML(t *testing.T) {
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-session",
+			Namespace: "default",
+		},
+	}
+	out, err := marshalSessionYAML(s)
+	if err != nil {
+		t.Fatalf("marshalSessionYAML: %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "apiVersion:") {
+		t.Errorf("expected apiVersion in output, got:\n%s", text)
+	}
+	if !strings.Contains(text, "kind: PodTraceSession") {
+		t.Errorf("expected kind: PodTraceSession in output, got:\n%s", text)
+	}
+	if s.Kind != "PodTraceSession" {
+		t.Errorf("expected Kind stamped on object, got %q", s.Kind)
+	}
+	if s.APIVersion != podtracev1alpha1.GroupVersion.String() {
+		t.Errorf("expected APIVersion stamped, got %q", s.APIVersion)
+	}
+}
+
+func TestPrintSessionYAML(t *testing.T) {
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+	}
+
+	out := captureStdout(t, func() {
+		if err := printSessionYAML(s); err != nil {
+			t.Fatalf("printSessionYAML: %v", err)
+		}
+	})
+	if !strings.Contains(out, "kind: PodTraceSession") {
+		t.Errorf("printSessionYAML output missing kind, got:\n%s", out)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what
+// was written. Restores the original on completion.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	buf := make([]byte, 0, 4096)
+	tmp := make([]byte, 1024)
+	for {
+		n, rerr := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	return string(buf)
+}
+
+func TestWatchOptionsFromFlags(t *testing.T) {
+	save := struct {
+		labels    []string
+		appName   string
+		allNS     bool
+		nsSel     string
+		ns        string
+		exporter  string
+		name      string
+		filter    string
+		sample    int
+		kubecfg   string
+		printOnly bool
+		app       bool
+	}{
+		labels:    watchLabels,
+		appName:   watchAppName,
+		allNS:     watchAllNamespaces,
+		nsSel:     watchNamespaceSelector,
+		ns:        namespace,
+		exporter:  watchExporter,
+		name:      watchName,
+		filter:    eventFilter,
+		sample:    watchSample,
+		kubecfg:   watchKubeconfig,
+		printOnly: watchPrintOnly,
+		app:       watchApplication,
+	}
+	t.Cleanup(func() {
+		watchLabels = save.labels
+		watchAppName = save.appName
+		watchAllNamespaces = save.allNS
+		watchNamespaceSelector = save.nsSel
+		namespace = save.ns
+		watchExporter = save.exporter
+		watchName = save.name
+		eventFilter = save.filter
+		watchSample = save.sample
+		watchKubeconfig = save.kubecfg
+		watchPrintOnly = save.printOnly
+		watchApplication = save.app
+	})
+
+	watchLabels = []string{"  app=api  ", "", "   ", "tier=web"}
+	watchAppName = "  checkout  "
+	watchAllNamespaces = true
+	watchNamespaceSelector = "  team=payments  "
+	namespace = "production"
+	watchExporter = "  otlp-default  "
+	watchName = "  my-trace  "
+	eventFilter = "dns,net"
+	watchSample = 42
+	watchKubeconfig = "/tmp/kubeconfig"
+	watchPrintOnly = true
+	watchApplication = true
+
+	opts := watchOptionsFromFlags()
+
+	wantLabels := []string{"app=api", "tier=web"}
+	gotLabels := append([]string(nil), opts.Labels...)
+	sort.Strings(gotLabels)
+	sort.Strings(wantLabels)
+	if strings.Join(gotLabels, ",") != strings.Join(wantLabels, ",") {
+		t.Errorf("Labels = %v, want %v (trimmed, empties dropped)", opts.Labels, wantLabels)
+	}
+	if opts.AppName != "checkout" {
+		t.Errorf("AppName = %q, want %q", opts.AppName, "checkout")
+	}
+	if !opts.AllNamespaces {
+		t.Errorf("AllNamespaces = false, want true")
+	}
+	if opts.NamespaceSelector != "team=payments" {
+		t.Errorf("NamespaceSelector = %q, want %q", opts.NamespaceSelector, "team=payments")
+	}
+	if opts.Namespace != "production" {
+		t.Errorf("Namespace = %q, want %q", opts.Namespace, "production")
+	}
+	if opts.Exporter != "otlp-default" {
+		t.Errorf("Exporter = %q, want %q", opts.Exporter, "otlp-default")
+	}
+	if opts.Name != "my-trace" {
+		t.Errorf("Name = %q, want %q", opts.Name, "my-trace")
+	}
+	if opts.Filter != "dns,net" {
+		t.Errorf("Filter = %q, want %q", opts.Filter, "dns,net")
+	}
+	if opts.SamplePercent != 42 {
+		t.Errorf("SamplePercent = %d, want 42", opts.SamplePercent)
+	}
+	if opts.Kubeconfig != "/tmp/kubeconfig" {
+		t.Errorf("Kubeconfig = %q, want %q", opts.Kubeconfig, "/tmp/kubeconfig")
+	}
+	if !opts.PrintOnly {
+		t.Errorf("PrintOnly = false, want true")
+	}
+	if !opts.Application {
+		t.Errorf("Application = false, want true")
+	}
+}

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -648,8 +648,6 @@ func runNormalModeWithSource(ctx context.Context, eventChan <-chan *events.Event
 
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
 		case event := <-eventChan:
 			attachSourcePod(event, resolveSource)
 			var k8sCtx map[string]interface{}
@@ -733,18 +731,6 @@ func runDiagnoseModeWithSource(ctx context.Context, eventChan <-chan *events.Eve
 
 	for {
 		select {
-		case <-ctx.Done():
-			diagnostician.Finish()
-			report := diagnostician.GenerateReport()
-			if profilingHandler != nil {
-				report += profilingHandler.GenerateSection(diagnostician.GetEvents(), duration)
-			}
-			finalizeDiagnoseOutputs(ctx, report, diagnostician)
-			if exportFormat != "" {
-				return exportReport(report, exportFormat, diagnostician)
-			}
-			fmt.Println(report)
-			return ctx.Err()
 		case event := <-eventChan:
 			attachSourcePod(event, resolveSource)
 			eventBatch = append(eventBatch, event)

--- a/cmd/podtrace/operator_test.go
+++ b/cmd/podtrace/operator_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -22,10 +23,6 @@ func TestNewOperatorCmd_Metadata(t *testing.T) {
 		}
 	}
 
-	// RunE must be wired; we cannot execute it in a unit test because it
-	// starts a real manager that needs a kubeconfig. End-to-end coverage
-	// lives in envtest (internal/operator/*_test.go) and the kind-cluster
-	// smoke script under test/e2e/.
 	if cmd.RunE == nil {
 		t.Error("RunE is nil — operator subcommand is not wired")
 	}
@@ -33,9 +30,6 @@ func TestNewOperatorCmd_Metadata(t *testing.T) {
 
 func TestNewOperatorCmd_FlagsMapCleanlyToOptions(t *testing.T) {
 	cmd := newOperatorCmd()
-	// Override a couple of flags to non-default values and confirm they
-	// propagate through toOperatorOptions. Keeps the CLI↔library contract
-	// honest without booting a manager.
 	if err := cmd.Flags().Set("system-namespace", "custom-ns"); err != nil {
 		t.Fatal(err)
 	}
@@ -46,15 +40,12 @@ func TestNewOperatorCmd_FlagsMapCleanlyToOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The options struct is owned privately by newOperatorCmd's closure;
-	// we re-derive it via the same translation helper the RunE uses.
 	opts := &operatorOptions{}
 	opts.systemNamespace = cmd.Flag("system-namespace").Value.String()
 	opts.leaderElectNamespace = cmd.Flag("leader-elect-namespace").Value.String()
 	opts.metricsAddr = cmd.Flag("metrics-addr").Value.String()
 	opts.healthAddr = cmd.Flag("health-addr").Value.String()
 	opts.webhookCertDir = cmd.Flag("webhook-cert-dir").Value.String()
-	// bools/ints need typed getters
 	opts.leaderElect, _ = cmd.Flags().GetBool("leader-elect")
 	opts.webhookPort, _ = cmd.Flags().GetInt("webhook-port")
 
@@ -68,8 +59,48 @@ func TestNewOperatorCmd_FlagsMapCleanlyToOptions(t *testing.T) {
 	if runtimeOpts.WebhookPort != 10443 {
 		t.Errorf("WebhookPort=%d want 10443", runtimeOpts.WebhookPort)
 	}
-	// The toOperatorOptions return type is operator.Options by
-	// declaration; no further runtime assertion needed.
+}
+
+func TestToOperatorOptions_EmptyLeaderNSFallsBackToSystemNS(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+	if err := os.Unsetenv("POD_NAMESPACE"); err != nil {
+		t.Fatalf("unset POD_NAMESPACE: %v", err)
+	}
+
+	opts := &operatorOptions{
+		systemNamespace:      "sys-ns",
+		leaderElectNamespace: "",
+	}
+	got := toOperatorOptions(opts)
+	if got.LeaderElectionNamespace != "sys-ns" {
+		t.Errorf("LeaderElectionNamespace=%q, want sys-ns (fallback)", got.LeaderElectionNamespace)
+	}
+}
+
+func TestToOperatorOptions_PodNamespaceEnvOverridesDefault(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "pod-actual-ns")
+
+	opts := &operatorOptions{
+		systemNamespace:      "sys-ns",
+		leaderElectNamespace: "podtrace-system",
+	}
+	got := toOperatorOptions(opts)
+	if got.LeaderElectionNamespace != "pod-actual-ns" {
+		t.Errorf("LeaderElectionNamespace=%q, want pod-actual-ns (env override)", got.LeaderElectionNamespace)
+	}
+}
+
+func TestToOperatorOptions_ExplicitLeaderNSWinsOverEnv(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "pod-actual-ns")
+
+	opts := &operatorOptions{
+		systemNamespace:      "sys-ns",
+		leaderElectNamespace: "explicit-ns",
+	}
+	got := toOperatorOptions(opts)
+	if got.LeaderElectionNamespace != "explicit-ns" {
+		t.Errorf("LeaderElectionNamespace=%q, want explicit-ns", got.LeaderElectionNamespace)
+	}
 }
 
 func TestNewOperatorCmd_LeaderElectDefault(t *testing.T) {

--- a/cmd/podtrace/report_uploader_more_unit_test.go
+++ b/cmd/podtrace/report_uploader_more_unit_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadObjectStoreCredentials_Unset(t *testing.T) {
+	t.Setenv(envObjectStoreCredentialsDir, "")
+	creds, err := loadObjectStoreCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds != nil {
+		t.Fatalf("expected nil credentials when dir unset, got %v", creds)
+	}
+}
+
+func TestLoadObjectStoreCredentials_MissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv(envObjectStoreCredentialsDir, missing)
+
+	creds, err := loadObjectStoreCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds != nil {
+		t.Fatalf("expected nil credentials for missing dir, got %v", creds)
+	}
+}
+
+func TestLoadObjectStoreCredentials_PopulatedDir(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "access-key"), []byte("AKIA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "secret-key"), []byte("s3cr3t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "..hidden"), []byte("ignore"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envObjectStoreCredentialsDir, dir)
+
+	creds, err := loadObjectStoreCredentials()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected populated credentials map, got nil")
+	}
+	if len(creds) != 2 {
+		t.Fatalf("expected 2 credential entries, got %d: %v", len(creds), keysOf(creds))
+	}
+	if string(creds["access-key"]) != "AKIA" {
+		t.Errorf("access-key = %q, want %q", creds["access-key"], "AKIA")
+	}
+	if string(creds["secret-key"]) != "s3cr3t" {
+		t.Errorf("secret-key = %q, want %q", creds["secret-key"], "s3cr3t")
+	}
+	if _, ok := creds["..hidden"]; ok {
+		t.Error("expected '..'-prefixed entry to be skipped")
+	}
+	if _, ok := creds["nested"]; ok {
+		t.Error("expected subdirectory to be skipped")
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestUploadIfPresent_MissingReportFileIsNoOp(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "report.txt")
+	err := uploadIfPresent(context.Background(), reportUploaderOptions{
+		ReportFile:   missing,
+		ReportToSpec: "configmap/ns/name",
+	})
+	if err != nil {
+		t.Fatalf("expected nil for missing report file, got %v", err)
+	}
+}
+
+func TestUploadIfPresent_PresentFileWritesSidecarHandoff(t *testing.T) {
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.txt")
+	if err := os.WriteFile(reportPath, []byte("hello report"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("KUBECONFIG", "")
+
+	err := uploadIfPresent(context.Background(), reportUploaderOptions{
+		ReportFile:   reportPath,
+		ReportToSpec: "configmap/ns/name",
+	})
+	if err == nil {
+		t.Fatal("expected an error from in-cluster client build, got nil (did read short-circuit?)")
+	}
+	t.Logf("reached present-file branch, client build failed as expected: %v", err)
+}
+
+func TestPersistAndReadKeyHint_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	orig := keyHintStateFile
+	keyHintStateFile = filepath.Join(dir, "upload-key-hint.txt")
+	t.Cleanup(func() { keyHintStateFile = orig })
+
+	persistKeyHint("pod-2026-06-08T00-00-00Z.txt")
+
+	got, ok := readPersistedKeyHint()
+	if !ok {
+		t.Fatal("expected persisted key hint to be readable")
+	}
+	if got != "pod-2026-06-08T00-00-00Z.txt" {
+		t.Errorf("hint = %q, want %q", got, "pod-2026-06-08T00-00-00Z.txt")
+	}
+
+	raw, err := os.ReadFile(keyHintStateFile)
+	if err != nil {
+		t.Fatalf("state file not written: %v", err)
+	}
+	if string(raw) != "pod-2026-06-08T00-00-00Z.txt" {
+		t.Errorf("on-disk hint = %q, want %q", raw, "pod-2026-06-08T00-00-00Z.txt")
+	}
+}
+
+func TestReadPersistedKeyHint_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	orig := keyHintStateFile
+	keyHintStateFile = filepath.Join(dir, "absent.txt")
+	t.Cleanup(func() { keyHintStateFile = orig })
+
+	if _, ok := readPersistedKeyHint(); ok {
+		t.Error("expected ok=false when state file does not exist")
+	}
+}

--- a/cmd/podtrace/session_sink_more_unit_test.go
+++ b/cmd/podtrace/session_sink_more_unit_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/diagnose"
+)
+
+// saveSinkGlobals snapshots the package-level sink destination globals
+// and restores them on cleanup so tests do not leak into one another.
+func saveSinkGlobals(t *testing.T) {
+	t.Helper()
+	origSummary := summaryFile
+	origTermination := terminationMessagePath
+	origReportTo := reportTo
+	t.Cleanup(func() {
+		summaryFile = origSummary
+		terminationMessagePath = origTermination
+		reportTo = origReportTo
+	})
+}
+
+func TestFinalizeDiagnoseOutputs_AllEmptyIsNoOp(t *testing.T) {
+	saveSinkGlobals(t)
+	summaryFile = ""
+	terminationMessagePath = ""
+	reportTo = ""
+
+	d := diagnose.NewDiagnostician()
+	finalizeDiagnoseOutputs(context.Background(), "report text", d)
+}
+
+func TestFinalizeDiagnoseOutputs_WritesSummaryFile(t *testing.T) {
+	saveSinkGlobals(t)
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.json")
+
+	summaryFile = summaryPath
+	terminationMessagePath = ""
+	reportTo = ""
+
+	t.Setenv("NODE_NAME", "node-under-test")
+
+	d := diagnose.NewDiagnostician()
+	finalizeDiagnoseOutputs(context.Background(), "report text", d)
+
+	raw, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("summary file not written: %v", err)
+	}
+	var got SessionSummary
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("summary file is not valid JSON: %v", err)
+	}
+	if got.Node != "node-under-test" {
+		t.Errorf("summary.Node = %q, want %q", got.Node, "node-under-test")
+	}
+	if got.TotalEvents != 0 {
+		t.Errorf("summary.TotalEvents = %d, want 0 for an empty diagnostician", got.TotalEvents)
+	}
+}
+
+func TestFinalizeDiagnoseOutputs_WritesTerminationMessage(t *testing.T) {
+	saveSinkGlobals(t)
+	dir := t.TempDir()
+	termPath := filepath.Join(dir, "termination.json")
+
+	summaryFile = ""
+	terminationMessagePath = termPath
+	reportTo = ""
+
+	d := diagnose.NewDiagnostician()
+	finalizeDiagnoseOutputs(context.Background(), "report text", d)
+
+	raw, err := os.ReadFile(termPath)
+	if err != nil {
+		t.Fatalf("termination message not written: %v", err)
+	}
+	var got SessionSummary
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("termination message is not valid JSON: %v", err)
+	}
+}
+
+func TestFinalizeDiagnoseOutputs_LocalAndObjectStoreSink(t *testing.T) {
+	saveSinkGlobals(t)
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.json")
+	termPath := filepath.Join(dir, "termination.json")
+
+	summaryFile = summaryPath
+	terminationMessagePath = termPath
+	reportTo = "s3://bucket/key"
+
+	d := diagnose.NewDiagnostician()
+	finalizeDiagnoseOutputs(context.Background(), "report text", d)
+
+	if _, err := os.Stat(summaryPath); err != nil {
+		t.Errorf("summary file missing: %v", err)
+	}
+	if _, err := os.Stat(termPath); err != nil {
+		t.Errorf("termination message missing: %v", err)
+	}
+}

--- a/internal/agent/append_threshold_attributes_unit_test.go
+++ b/internal/agent/append_threshold_attributes_unit_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func hasAttrKey(attrs []attribute.KeyValue, key string) bool {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAppendThresholdAttributes_NilThresholds(t *testing.T) {
+	e := &sdkEventExporter{cr: CRKey{"ns", "cr"}}
+	in := []attribute.KeyValue{}
+	got := e.appendThresholdAttributes(in, &events.Event{Type: events.EventOpen})
+	if len(got) != 0 {
+		t.Errorf("nil thresholds should not append, got %v", got)
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestAppendThresholdAttributes_Branches(t *testing.T) {
+	ms := int32(1)
+	thresholdNs := uint64(ms) * uint64(config.NSPerMS)
+
+	e := &sdkEventExporter{
+		cr: CRKey{"ns", "cr"},
+		thresholds: &PolicyThresholds{
+			FSSlowMs:         int32Ptr(ms),
+			RTTSpikeMs:       int32Ptr(ms),
+			ErrorRatePercent: int32Ptr(50),
+		},
+	}
+
+	fsAttrs := e.appendThresholdAttributes(nil, &events.Event{
+		Type:      events.EventOpen,
+		LatencyNS: thresholdNs + 1,
+	})
+	if !hasAttrKey(fsAttrs, "podtrace.threshold.fs_slow.tripped") {
+		t.Errorf("expected fs_slow tripped attribute, got %v", fsAttrs)
+	}
+
+	rttAttrs := e.appendThresholdAttributes(nil, &events.Event{
+		Type:      events.EventConnect,
+		LatencyNS: thresholdNs + 1,
+	})
+	if !hasAttrKey(rttAttrs, "podtrace.threshold.rtt_spike.tripped") {
+		t.Errorf("expected rtt_spike tripped attribute, got %v", rttAttrs)
+	}
+
+	errAttrs := e.appendThresholdAttributes(nil, &events.Event{
+		Type:  events.EventOpen,
+		Error: 1,
+	})
+	if !hasAttrKey(errAttrs, "podtrace.threshold.error_rate.observed") {
+		t.Errorf("expected error_rate observed attribute, got %v", errAttrs)
+	}
+
+	noneAttrs := e.appendThresholdAttributes(nil, &events.Event{
+		Type:      events.EventOpen,
+		LatencyNS: 0,
+	})
+	if hasAttrKey(noneAttrs, "podtrace.threshold.fs_slow.tripped") {
+		t.Errorf("did not expect fs_slow attribute below threshold, got %v", noneAttrs)
+	}
+}

--- a/internal/agent/helpers_coverage_unit_test.go
+++ b/internal/agent/helpers_coverage_unit_test.go
@@ -1,0 +1,254 @@
+package agent
+
+import (
+	"math"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// attrMap flattens an OTel attribute slice into a string-keyed lookup
+// for order-independent assertions.
+func attrMap(attrs []attribute.KeyValue) map[string]attribute.Value {
+	out := make(map[string]attribute.Value, len(attrs))
+	for _, kv := range attrs {
+		out[string(kv.Key)] = kv.Value
+	}
+	return out
+}
+
+// TestAppendK8sAttributes_NilAndZero covers the short-circuit branches:
+// a nil bundle and an all-empty bundle must both return attrs untouched.
+func TestAppendK8sAttributes_NilAndZero(t *testing.T) {
+	base := []attribute.KeyValue{attribute.String("pre", "existing")}
+
+	if got := appendK8sAttributes(base, nil); len(got) != len(base) {
+		t.Errorf("nil meta: len=%d, want %d (unchanged)", len(got), len(base))
+	}
+
+	zero := &events.K8sMetadata{}
+	if got := appendK8sAttributes(base, zero); len(got) != len(base) {
+		t.Errorf("zero meta: len=%d, want %d (unchanged)", len(got), len(base))
+	}
+}
+
+// TestAppendK8sAttributes_FullBundle asserts every populated field maps
+// to its semconv key, including the Deployment workload branch.
+func TestAppendK8sAttributes_FullBundle(t *testing.T) {
+	meta := &events.K8sMetadata{
+		Namespace:     "team-a",
+		PodName:       "web-abc",
+		PodUID:        "uid-123",
+		NodeName:      "node-1",
+		ContainerName: "app",
+		WorkloadKind:  "Deployment",
+		WorkloadName:  "web",
+	}
+
+	m := attrMap(appendK8sAttributes(nil, meta))
+
+	want := map[string]string{
+		"k8s.namespace.name":  "team-a",
+		"k8s.pod.name":        "web-abc",
+		"k8s.pod.uid":         "uid-123",
+		"k8s.node.name":       "node-1",
+		"k8s.container.name":  "app",
+		"k8s.deployment.name": "web",
+	}
+	for key, val := range want {
+		got, ok := m[key]
+		if !ok {
+			t.Errorf("missing attribute %q", key)
+			continue
+		}
+		if got.AsString() != val {
+			t.Errorf("attribute %q = %q, want %q", key, got.AsString(), val)
+		}
+	}
+}
+
+// TestAppendK8sAttributes_WorkloadKinds exercises the appendWorkloadAttributes
+// switch: each known kind maps to its specific semconv key, an unknown
+// kind falls through to the generic k8s.workload.* pair, and the
+// Pod/empty kinds emit nothing.
+func TestAppendK8sAttributes_WorkloadKinds(t *testing.T) {
+	cases := []struct {
+		kind    string
+		wantKey string
+	}{
+		{"StatefulSet", "k8s.statefulset.name"},
+		{"DaemonSet", "k8s.daemonset.name"},
+		{"Job", "k8s.job.name"},
+		{"CronJob", "k8s.cronjob.name"},
+		{"ReplicaSet", "k8s.replicaset.name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			meta := &events.K8sMetadata{WorkloadKind: tc.kind, WorkloadName: "wl"}
+			m := attrMap(appendK8sAttributes(nil, meta))
+			if v, ok := m[tc.wantKey]; !ok || v.AsString() != "wl" {
+				t.Errorf("kind %q: missing/incorrect %q (got %v ok=%v)", tc.kind, tc.wantKey, v, ok)
+			}
+		})
+	}
+
+	unknown := &events.K8sMetadata{WorkloadKind: "Rollout", WorkloadName: "argo"}
+	m := attrMap(appendK8sAttributes(nil, unknown))
+	if v, ok := m["k8s.workload.kind"]; !ok || v.AsString() != "Rollout" {
+		t.Errorf("unknown kind: k8s.workload.kind missing/incorrect (got %v ok=%v)", v, ok)
+	}
+	if v, ok := m["k8s.workload.name"]; !ok || v.AsString() != "argo" {
+		t.Errorf("unknown kind: k8s.workload.name missing/incorrect (got %v ok=%v)", v, ok)
+	}
+
+	pod := &events.K8sMetadata{WorkloadKind: "Pod", WorkloadName: "standalone"}
+	pm := attrMap(appendK8sAttributes(nil, pod))
+	for _, k := range []string{"k8s.workload.kind", "k8s.workload.name", "k8s.deployment.name"} {
+		if _, ok := pm[k]; ok {
+			t.Errorf("Pod kind unexpectedly emitted %q", k)
+		}
+	}
+}
+
+// TestLenToInt32_NegativeAndOverflow covers the two clamp branches not
+// already exercised by TestLenToInt32: negative -> 0 and >MaxInt32 ->
+// MaxInt32.
+func TestLenToInt32_NegativeAndOverflow(t *testing.T) {
+	if got := lenToInt32(-5); got != 0 {
+		t.Errorf("negative input: got %d, want 0", got)
+	}
+	if got := lenToInt32(math.MaxInt32); got != math.MaxInt32 {
+		t.Errorf("at-max input: got %d, want %d", got, int32(math.MaxInt32))
+	}
+	if math.MaxInt > math.MaxInt32 {
+		if got := lenToInt32(math.MaxInt32 + 1); got != math.MaxInt32 {
+			t.Errorf("overflow input: got %d, want %d", got, int32(math.MaxInt32))
+		}
+	}
+}
+
+// TestRecordThresholdTripped covers the Metrics recorder and its nil
+// short-circuit. The counter must increment once per call, per label set.
+func TestRecordThresholdTripped(t *testing.T) {
+	// Nil receiver must not panic.
+	var nilM *Metrics
+	nilM.RecordThresholdTripped(CRKey{"ns", "cr"}, "fs_slow")
+
+	m := NewMetrics()
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+
+	m.RecordThresholdTripped(cr, "fs_slow")
+	m.RecordThresholdTripped(cr, "fs_slow")
+	m.RecordThresholdTripped(cr, "rtt_spike")
+
+	if got := counterValue(t, m.ThresholdTripped, map[string]string{
+		"cr_namespace": "ns", "cr_name": "cr", "threshold": "fs_slow",
+	}); got != 2 {
+		t.Errorf("fs_slow counter = %v, want 2", got)
+	}
+	if got := counterValue(t, m.ThresholdTripped, map[string]string{
+		"cr_namespace": "ns", "cr_name": "cr", "threshold": "rtt_spike",
+	}); got != 1 {
+		t.Errorf("rtt_spike counter = %v, want 1", got)
+	}
+}
+
+// TestSDKEventExporter_RecordTrip covers recordTrip: it delegates to the
+// metrics recorder when metrics is set, and is a no-op when nil.
+func TestSDKEventExporter_RecordTrip(t *testing.T) {
+	(&sdkEventExporter{cr: CRKey{"ns", "cr"}}).recordTrip("error_rate")
+
+	m := NewMetrics()
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+	exp := &sdkEventExporter{cr: cr, metrics: m}
+
+	exp.recordTrip("error_rate")
+	exp.recordTrip("error_rate")
+
+	if got := counterValue(t, m.ThresholdTripped, map[string]string{
+		"cr_namespace": "ns", "cr_name": "cr", "threshold": "error_rate",
+	}); got != 2 {
+		t.Errorf("error_rate counter via recordTrip = %v, want 2", got)
+	}
+}
+
+// TestPodEnricher_StatsNilReceiver covers the nil short-circuit of Stats
+// (the branch the populated-path test does not reach) and confirms a
+// populated enricher reports the activity it observed.
+func TestPodEnricher_StatsNilReceiver(t *testing.T) {
+	var nilE *PodEnricher
+	if got := nilE.Stats(); got != (EnricherStats{}) {
+		t.Errorf("nil enricher Stats = %+v, want zero value", got)
+	}
+
+	e := NewPodEnricher()
+	pod := newPodWithOwner("ns", "p", "u1", "n", "Deployment", "web", "web-7d8c9c")
+	e.Snapshot([]PodCgroupEntry{{CgroupID: 1, Pod: pod, ContainerName: "app"}})
+
+	if _, ok := e.Lookup(1); !ok {
+		t.Fatal("expected hit on snapshotted cgroup")
+	}
+	if _, ok := e.Lookup(999); ok {
+		t.Fatal("expected miss on unknown cgroup")
+	}
+
+	s := e.Stats()
+	if s.Hits != 1 {
+		t.Errorf("Stats.Hits = %d, want 1", s.Hits)
+	}
+	if s.Misses != 1 {
+		t.Errorf("Stats.Misses = %d, want 1", s.Misses)
+	}
+	if s.Snapshots != 1 {
+		t.Errorf("Stats.Snapshots = %d, want 1", s.Snapshots)
+	}
+	if s.OwnerResolved != 1 {
+		t.Errorf("Stats.OwnerResolved = %d, want 1", s.OwnerResolved)
+	}
+	if s.CacheSize != 1 {
+		t.Errorf("Stats.CacheSize = %d, want 1", s.CacheSize)
+	}
+}
+
+// TestFallbackLegacyTarget_NoMatch covers the loop path where no pod's
+// cgroup path matches the requested ID, leaving the target set unchanged.
+// On a test host there are no kubepods cgroup roots, so discoverKubepodsRoot
+// returns "" and every cgroupPathForPod returns "" — the canonical no-match
+// case. (The append branch needs a live cgroup whose inode equals the ID,
+// which requires a real kubelet cgroup hierarchy, so it is not unit-testable.)
+func TestFallbackLegacyTarget_NoMatch(t *testing.T) {
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "ns",
+				UID:       "11111111-2222-3333-4444-555555555555",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p2",
+				Namespace: "ns",
+				UID:       "66666666-7777-8888-9999-000000000000",
+			},
+		},
+	}
+
+	out := tracer.TargetSet{}
+	fallbackLegacyTarget(&out, pods, 4242)
+	if len(out) != 0 {
+		t.Errorf("no pod cgroup should match a synthetic ID, got %d targets: %+v", len(out), out)
+	}
+
+	seed := tracer.Target{PodName: "seed", Namespace: "ns"}
+	out2 := tracer.TargetSet{seed}
+	fallbackLegacyTarget(&out2, pods, 4242)
+	if len(out2) != 1 || out2[0].PodName != "seed" {
+		t.Errorf("no-match must preserve existing targets, got %+v", out2)
+	}
+}

--- a/internal/agent/helpers_more_unit_test.go
+++ b/internal/agent/helpers_more_unit_test.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// TestMetricsEngineObserver_AttachDetach exercises the engine observer
+// adapter returned by Metrics.EngineObserver: positive deltas land on the
+// cgroups_attached/detached counters, and non-positive deltas are ignored.
+func TestMetricsEngineObserver_AttachDetach(t *testing.T) {
+	m := NewMetrics()
+	obs := m.EngineObserver()
+	if obs == nil {
+		t.Fatal("EngineObserver returned nil")
+	}
+
+	obs.OnCgroupsAttached(0)
+	obs.OnCgroupsAttached(-3)
+	obs.OnCgroupsDetached(0)
+	obs.OnCgroupsDetached(-1)
+	if got := scrapeMetric(t, m, `cgroups_attached_total`); got != 0 {
+		t.Errorf("non-positive attach delta changed counter: %d", got)
+	}
+	if got := scrapeMetric(t, m, `cgroups_detached_total`); got != 0 {
+		t.Errorf("non-positive detach delta changed counter: %d", got)
+	}
+
+	obs.OnCgroupsAttached(4)
+	obs.OnCgroupsAttached(2)
+	obs.OnCgroupsDetached(3)
+	if got := scrapeMetric(t, m, `cgroups_attached_total`); got != 6 {
+		t.Errorf("cgroups_attached_total = %d, want 6", got)
+	}
+	if got := scrapeMetric(t, m, `cgroups_detached_total`); got != 3 {
+		t.Errorf("cgroups_detached_total = %d, want 3", got)
+	}
+}
+
+// TestIsNetworkLatencyEvent covers every recognized network-latency event
+// type plus a representative negative case.
+func TestIsNetworkLatencyEvent(t *testing.T) {
+	trueCases := []events.EventType{
+		events.EventConnect,
+		events.EventTCPSend,
+		events.EventTCPRecv,
+		events.EventUDPSend,
+		events.EventUDPRecv,
+	}
+	for _, et := range trueCases {
+		if !isNetworkLatencyEvent(et) {
+			t.Errorf("isNetworkLatencyEvent(%v) = false, want true", et)
+		}
+	}
+	for _, et := range []events.EventType{events.EventDNS, events.EventOpen} {
+		if isNetworkLatencyEvent(et) {
+			t.Errorf("isNetworkLatencyEvent(%v) = true, want false", et)
+		}
+	}
+}
+
+// TestContainerStatusIndex_BuildsFromAllStatusLists asserts the index keys
+// off the runtime-stripped container ID and spans regular, init, and
+// ephemeral container statuses while dropping incomplete entries.
+func TestContainerStatusIndex_BuildsFromAllStatusLists(t *testing.T) {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", ContainerID: "containerd://aaaa1111"},
+				{Name: "noid"},                                // missing ID → skipped
+				{Name: "", ContainerID: "crio://bb"},          // missing name → skipped
+				{Name: "empty", ContainerID: "containerd://"}, // empty after scheme → skipped
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "init", ContainerID: "docker://cccc3333"},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debug", ContainerID: "containerd://dddd4444"},
+			},
+		},
+	}
+
+	idx := containerStatusIndex(p)
+	want := map[string]string{
+		"aaaa1111": "app",
+		"cccc3333": "init",
+		"dddd4444": "debug",
+	}
+	if len(idx) != len(want) {
+		t.Fatalf("index size = %d, want %d (%v)", len(idx), len(want), idx)
+	}
+	for id, name := range want {
+		if idx[id] != name {
+			t.Errorf("idx[%q] = %q, want %q", id, idx[id], name)
+		}
+	}
+}
+
+// TestIdentifyContainerCgroup covers the reachable matching branches:
+// per-runtime prefix stripping, prefix-on-either-side matching, the
+// empty-index short-circuit, and the no-match fall-through. The function is
+// pure (operates on the dir string + an in-memory index), so no live cgroup
+// state is required.
+func TestIdentifyContainerCgroup(t *testing.T) {
+	statuses := map[string]string{
+		"aaaa1111bbbb2222": "app",
+		"ffff9999":         "side",
+	}
+
+	cases := []struct {
+		name     string
+		dir      string
+		statuses map[string]string
+		wantName string
+		wantID   string
+	}{
+		{
+			name:     "cri-containerd prefix, dir is prefix of full id",
+			dir:      "cri-containerd-aaaa1111.scope",
+			statuses: statuses,
+			wantName: "app",
+			wantID:   "aaaa1111bbbb2222",
+		},
+		{
+			name:     "crio prefix, full id is prefix of dir",
+			dir:      "crio-ffff9999extra.scope",
+			statuses: statuses,
+			wantName: "side",
+			wantID:   "ffff9999",
+		},
+		{
+			name:     "docker prefix exact match",
+			dir:      "docker-ffff9999.scope",
+			statuses: statuses,
+			wantName: "side",
+			wantID:   "ffff9999",
+		},
+		{
+			name:     "empty index short-circuits",
+			dir:      "cri-containerd-aaaa1111.scope",
+			statuses: map[string]string{},
+			wantName: "",
+			wantID:   "",
+		},
+		{
+			name:     "no matching container",
+			dir:      "cri-containerd-deadbeef.scope",
+			statuses: statuses,
+			wantName: "",
+			wantID:   "",
+		},
+		{
+			name:     "bare prefix leaves empty trimmed id",
+			dir:      "crio-.scope",
+			statuses: statuses,
+			wantName: "",
+			wantID:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, id := identifyContainerCgroup(tc.dir, tc.statuses)
+			if name != tc.wantName || id != tc.wantID {
+				t.Errorf("identifyContainerCgroup(%q) = (%q, %q), want (%q, %q)",
+					tc.dir, name, id, tc.wantName, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestAttachMetricsObserver_OnAttachFailure asserts the observer records a
+// program_attach_failures_total series classified by the backend error, and
+// that nil receivers/metrics are safe no-ops (probe wiring contract).
+func TestAttachMetricsObserver_OnAttachFailure(t *testing.T) {
+	m := NewMetrics()
+	obs := &attachMetricsObserver{metrics: m}
+
+	obs.OnAttachFailure("kprobe_vfs_open", "vfs_open", true, errors.New("operation not permitted"))
+	if got := scrapeMetric(t, m,
+		`program_attach_failures_total{program="kprobe_vfs_open",reason="permission_denied"}`); got != 1 {
+		t.Errorf("OnAttachFailure did not record permission_denied series; got %d", got)
+	}
+
+	(&attachMetricsObserver{metrics: nil}).OnAttachFailure("p", "s", false, errors.New("x"))
+	var nilObs *attachMetricsObserver
+	nilObs.OnAttachFailure("p", "s", false, errors.New("x"))
+}
+
+// TestNoopBackend_SetCgroups verifies SetCgroups replaces the attached set
+// from the supplied targets, skipping entries with an empty CgroupPath.
+func TestNoopBackend_SetCgroups(t *testing.T) {
+	b := newNoopBackend()
+	if err := b.AttachToCgroup("/stale"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := b.SetCgroups([]tracer.CgroupTarget{
+		{CgroupPath: "/c/a", ContainerID: "id-a"},
+		{CgroupPath: "", ContainerID: "skip-me"},
+		{CgroupPath: "/c/b"},
+	})
+	if err != nil {
+		t.Fatalf("SetCgroups: %v", err)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.attached) != 2 {
+		t.Fatalf("attached = %v, want exactly /c/a and /c/b", b.attached)
+	}
+	if _, ok := b.attached["/c/a"]; !ok {
+		t.Error("/c/a missing from attached set")
+	}
+	if _, ok := b.attached["/c/b"]; !ok {
+		t.Error("/c/b missing from attached set")
+	}
+	if _, ok := b.attached["/stale"]; ok {
+		t.Error("SetCgroups should have replaced the prior attached set")
+	}
+	if _, ok := b.attached[""]; ok {
+		t.Error("empty CgroupPath should be skipped")
+	}
+}

--- a/internal/agent/partials_cleanup_unit_test.go
+++ b/internal/agent/partials_cleanup_unit_test.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TestObserveExportDelivery_RecordsAndShortCircuits drives every branch
+// of ObserveExportDelivery: the nil-receiver, nil-error, and
+// non-positive-span guards must all be no-ops, while a real delivery
+// failure must add spanCount to export_delivery_dropped_total under the
+// ClassifyExporterError reason label.
+func TestObserveExportDelivery_RecordsAndShortCircuits(t *testing.T) {
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+
+	var nilM *Metrics
+	nilM.ObserveExportDelivery(cr, 5, errors.New("collector unreachable: no endpoint"))
+
+	m := NewMetrics()
+
+	m.ObserveExportDelivery(cr, 5, nil)
+	m.ObserveExportDelivery(cr, 0, errors.New("missing endpoint for OTLP exporter"))
+	m.ObserveExportDelivery(cr, -3, errors.New("missing endpoint for OTLP exporter"))
+
+	if got := scrapeMetric(t, m, `export_delivery_dropped_total{cr_namespace="ns",cr_name="cr",reason="endpoint_missing"}`); got != 0 {
+		t.Fatalf("guard branches recorded %d, want 0", got)
+	}
+
+	m.ObserveExportDelivery(cr, 4, errors.New("missing endpoint for OTLP exporter"))
+	m.ObserveExportDelivery(cr, 3, errors.New("missing endpoint for OTLP exporter"))
+
+	if got := counterValue(t, m.ExportDeliveryDropped, map[string]string{
+		"cr_namespace": "ns", "cr_name": "cr", "reason": "endpoint_missing",
+	}); got != 7 {
+		t.Errorf("export_delivery_dropped_total = %v, want 7 (4+3)", got)
+	}
+
+	m.ObserveExportDelivery(cr, 2, errors.New("tls handshake failed"))
+	if got := counterValue(t, m.ExportDeliveryDropped, map[string]string{
+		"cr_namespace": "ns", "cr_name": "cr", "reason": "tls_invalid",
+	}); got != 2 {
+		t.Errorf("tls_invalid series = %v, want 2", got)
+	}
+}
+
+// TestDropErrorRateDetector_RemovesAndNilSafe covers both branches of
+// dropErrorRateDetector: the nil-receiver short-circuit, and the
+// delete-from-map path verified indirectly by observing that a dropped
+// detector is reconstructed fresh (and thus does not breach until it
+// re-accumulates a full sample window).
+func TestDropErrorRateDetector_RemovesAndNilSafe(t *testing.T) {
+	var nilM *Metrics
+	nilM.dropErrorRateDetector(CRKey{Namespace: "ns", Name: "gone"})
+
+	m := NewMetrics()
+	cr := CRKey{Namespace: "ns", Name: "cr"}
+
+	breached := false
+	for i := 0; i < errorRateMinSampleSize+5; i++ {
+		if m.ObserveErrorRate(cr, 10, true) {
+			breached = true
+		}
+	}
+	if !breached {
+		t.Fatal("expected a breach edge before drop")
+	}
+
+	m.detectorsMu.Lock()
+	_, present := m.detectors[cr]
+	m.detectorsMu.Unlock()
+	if !present {
+		t.Fatal("detector should be registered before drop")
+	}
+
+	m.dropErrorRateDetector(cr)
+	m.detectorsMu.Lock()
+	_, present = m.detectors[cr]
+	m.detectorsMu.Unlock()
+	if present {
+		t.Error("dropErrorRateDetector left a stale detector in the map")
+	}
+
+	if m.ObserveErrorRate(cr, 10, true) {
+		t.Error("freshly rebuilt detector breached below min sample size")
+	}
+}
+
+// TestNewProbeServer_DefaultStallWindow covers the stallWindow<=0
+// fallback branch of NewProbeServer that the existing probe tests skip
+// (they always pass a positive window). The constructor only builds the
+// struct and records an initial Heartbeat; it binds no port, so this is
+// safe to exercise directly without a listener.
+func TestNewProbeServer_DefaultStallWindow(t *testing.T) {
+	const addr = "127.0.0.1:0"
+
+	s := NewProbeServer(addr, 0)
+	if s == nil {
+		t.Fatal("NewProbeServer returned nil")
+	}
+	if s.Addr != addr {
+		t.Errorf("Addr = %q, want %q", s.Addr, addr)
+	}
+	if s.stall != 90*time.Second {
+		t.Errorf("non-positive stall should default to 90s, got %s", s.stall)
+	}
+	if s.IsReady() {
+		t.Error("pristine ProbeServer should not be ready")
+	}
+	if s.lastHeartbeat.Load() == 0 {
+		t.Error("constructor should record an initial heartbeat")
+	}
+
+	if neg := NewProbeServer(addr, -time.Second); neg.stall != 90*time.Second {
+		t.Errorf("negative stall should default to 90s, got %s", neg.stall)
+	}
+
+	if pos := NewProbeServer(addr, 5*time.Second); pos.stall != 5*time.Second {
+		t.Errorf("positive stall should be preserved, got %s", pos.stall)
+	}
+}
+
+// TestClassifyRuleErr_Arms covers classifyRuleErr directly, hitting the
+// nil guard and the "policy" Contains arm that buildNodeStatusEntry
+// fixtures do not reach, plus a representative prefix arm and the
+// unknown fallback.
+func TestClassifyRuleErr_Arms(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want podtracev1alpha1.NodeStatusReason
+	}{
+		{"NilErr", nil, ""},
+		{"BundleLoad", errors.New("load bundle: boom"), podtracev1alpha1.NodeStatusReasonBundleLoadFailed},
+		{"PodMatch", errors.New("match pods: bad selector"), podtracev1alpha1.NodeStatusReasonPodMatchFailed},
+		{"CgroupResolution", errors.New("resolve cgroup IDs: missing"), podtracev1alpha1.NodeStatusReasonCgroupResolutionFailed},
+		{"ExporterBuild", errors.New("build exporter: unsupported"), podtracev1alpha1.NodeStatusReasonExporterBuildFailed},
+		{"PolicyContains", errors.New("failed to apply policy override"), podtracev1alpha1.NodeStatusReasonPolicyParseError},
+		{"Unknown", errors.New("something exotic happened"), podtracev1alpha1.NodeStatusReasonUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyRuleErr(tc.err); got != tc.want {
+				t.Errorf("classifyRuleErr(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveCgroupIDs_NoCgroupHost covers the reachable path of
+// resolveCgroupIDs on a host without a kubepods hierarchy: scanPodCgroups
+// finds no root and returns no entries, so the result is an empty,
+// non-nil map and a nil error. The live-cgroup-stat branch (inode read
+// from a real kubelet cgroup tree) needs a kubepods root and is not
+// unit-testable here.
+func TestResolveCgroupIDs_NoCgroupHost(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns", UID: types.UID("11111111-2222-3333-4444-555555555555")}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "ns", UID: types.UID("66666666-7777-8888-9999-000000000000")}},
+	}
+
+	got, err := resolveCgroupIDs(pods)
+	if err != nil {
+		t.Fatalf("resolveCgroupIDs returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("resolveCgroupIDs returned a nil map, want non-nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("no kubepods root should yield 0 cgroup IDs, got %d", len(got))
+	}
+
+	empty, err := resolveCgroupIDs(nil)
+	if err != nil || len(empty) != 0 {
+		t.Errorf("nil pods: got (%v, %v), want (empty, nil)", empty, err)
+	}
+}
+
+// TestResolveNodeName_EnvAndFallback drives both branches of
+// ResolveNodeName: the NODE_NAME env-set path (including whitespace
+// trimming) and the unset path that falls back to os.Hostname. The env
+// var is restored automatically by t.Setenv.
+func TestResolveNodeName_EnvAndFallback(t *testing.T) {
+	t.Setenv("NODE_NAME", "  worker-7  ")
+	if got := ResolveNodeName(); got != "worker-7" {
+		t.Errorf("with NODE_NAME set: got %q, want %q", got, "worker-7")
+	}
+
+	t.Setenv("NODE_NAME", "   ")
+	host, hostErr := os.Hostname()
+	got := ResolveNodeName()
+	if hostErr == nil && host != "" {
+		if got != host {
+			t.Errorf("blank NODE_NAME should fall back to hostname %q, got %q", host, got)
+		}
+	} else if got != "" {
+		t.Errorf("blank NODE_NAME and no hostname should yield empty, got %q", got)
+	}
+}

--- a/internal/agent/router_clone_test.go
+++ b/internal/agent/router_clone_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import "testing"
+
+func TestClonePolicySnapshot_Empty(t *testing.T) {
+	out := clonePolicySnapshot(PolicySnapshot{Hash: "h", Generation: 7})
+	if out.Hash != "h" || out.Generation != 7 {
+		t.Errorf("scalar fields not copied: %+v", out)
+	}
+	if out.EffectiveSamplePercent != nil || out.Filters != nil || out.Thresholds != nil {
+		t.Errorf("nil pointers/slices should remain nil: %+v", out)
+	}
+}
+
+func TestClonePolicySnapshot_DeepCopiesAllFields(t *testing.T) {
+	in := PolicySnapshot{
+		EffectiveSamplePercent: i32p(50),
+		Filters:                []string{"a", "b"},
+		Thresholds: &PolicyThresholds{
+			ErrorRatePercent: i32p(5),
+			RTTSpikeMs:       i32p(100),
+			FSSlowMs:         i32p(20),
+		},
+		Hash:       "abc",
+		Generation: 3,
+	}
+	out := clonePolicySnapshot(in)
+
+	*in.EffectiveSamplePercent = 99
+	in.Filters[0] = "mutated"
+	*in.Thresholds.ErrorRatePercent = 99
+	*in.Thresholds.RTTSpikeMs = 999
+	*in.Thresholds.FSSlowMs = 999
+
+	if out.EffectiveSamplePercent == nil || *out.EffectiveSamplePercent != 50 {
+		t.Errorf("EffectiveSamplePercent aliased; got %v", out.EffectiveSamplePercent)
+	}
+	if out.Filters[0] != "a" {
+		t.Errorf("Filters aliased; got %v", out.Filters)
+	}
+	if out.Thresholds == nil {
+		t.Fatal("Thresholds should be non-nil")
+	}
+	if *out.Thresholds.ErrorRatePercent != 5 {
+		t.Errorf("ErrorRatePercent aliased; got %d", *out.Thresholds.ErrorRatePercent)
+	}
+	if *out.Thresholds.RTTSpikeMs != 100 {
+		t.Errorf("RTTSpikeMs aliased; got %d", *out.Thresholds.RTTSpikeMs)
+	}
+	if *out.Thresholds.FSSlowMs != 20 {
+		t.Errorf("FSSlowMs aliased; got %d", *out.Thresholds.FSSlowMs)
+	}
+}
+
+func TestClonePolicySnapshot_ThresholdsWithNilFields(t *testing.T) {
+	in := PolicySnapshot{Thresholds: &PolicyThresholds{}}
+	out := clonePolicySnapshot(in)
+	if out.Thresholds == nil {
+		t.Fatal("Thresholds should be cloned even when fields are nil")
+	}
+	if out.Thresholds == in.Thresholds {
+		t.Error("Thresholds should be a distinct pointer")
+	}
+	if out.Thresholds.ErrorRatePercent != nil || out.Thresholds.RTTSpikeMs != nil || out.Thresholds.FSSlowMs != nil {
+		t.Error("inner pointers should stay nil")
+	}
+}

--- a/internal/agent/sdk_event_exporter_thresholds_test.go
+++ b/internal/agent/sdk_event_exporter_thresholds_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"testing"
+
+	bundlepkg "github.com/podtrace/podtrace/pkg/exporter/bundle"
+)
+
+func i32p(v int32) *int32 { return &v }
+
+func TestPolicyThresholdsFromBundle_Nil(t *testing.T) {
+	if got := policyThresholdsFromBundle(nil); got != nil {
+		t.Errorf("nil input should yield nil, got %+v", got)
+	}
+}
+
+func TestPolicyThresholdsFromBundle_AllFields(t *testing.T) {
+	in := &bundlepkg.Thresholds{
+		ErrorRatePercent: i32p(5),
+		RTTSpikeMs:       i32p(120),
+		FSSlowMs:         i32p(50),
+	}
+	got := policyThresholdsFromBundle(in)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.ErrorRatePercent == nil || *got.ErrorRatePercent != 5 {
+		t.Errorf("ErrorRatePercent = %v, want 5", got.ErrorRatePercent)
+	}
+	if got.RTTSpikeMs == nil || *got.RTTSpikeMs != 120 {
+		t.Errorf("RTTSpikeMs = %v, want 120", got.RTTSpikeMs)
+	}
+	if got.FSSlowMs == nil || *got.FSSlowMs != 50 {
+		t.Errorf("FSSlowMs = %v, want 50", got.FSSlowMs)
+	}
+	*in.ErrorRatePercent = 99
+	if *got.ErrorRatePercent != 5 {
+		t.Error("ErrorRatePercent aliased input pointer; expected a copy")
+	}
+}
+
+func TestPolicyThresholdsFromBundle_PartialFields(t *testing.T) {
+	in := &bundlepkg.Thresholds{RTTSpikeMs: i32p(200)}
+	got := policyThresholdsFromBundle(in)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.ErrorRatePercent != nil {
+		t.Errorf("ErrorRatePercent should be nil, got %v", *got.ErrorRatePercent)
+	}
+	if got.RTTSpikeMs == nil || *got.RTTSpikeMs != 200 {
+		t.Errorf("RTTSpikeMs = %v, want 200", got.RTTSpikeMs)
+	}
+	if got.FSSlowMs != nil {
+		t.Errorf("FSSlowMs should be nil, got %v", *got.FSSlowMs)
+	}
+}

--- a/internal/agent/setup_manager_unit_test.go
+++ b/internal/agent/setup_manager_unit_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// TestAgentSetup_SetupWithManager builds a non-connecting manager (the
+// rest.Config points at an unroutable host) and verifies the agent
+// reconciler wires its watches without error. Manager construction does
+// not dial the apiserver, so this stays a unit test.
+func TestAgentSetup_SetupWithManager(t *testing.T) {
+	scheme, err := newAgentScheme()
+	if err != nil {
+		t.Fatalf("newAgentScheme: %v", err)
+	}
+
+	cfg := &rest.Config{Host: "http://127.0.0.1:1"}
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Skipf("manager construction unavailable in this environment: %v", err)
+	}
+
+	r := &AgentReconciler{
+		Client:          mgr.GetClient(),
+		NodeName:        "node-1",
+		SystemNamespace: "podtrace-system",
+	}
+	if err := r.SetupWithManager(mgr); err != nil {
+		t.Fatalf("SetupWithManager: %v", err)
+	}
+
+	if r.ExporterBuilder == nil {
+		t.Error("ExporterBuilder not defaulted")
+	}
+	if r.CgroupResolver == nil {
+		t.Error("CgroupResolver not defaulted")
+	}
+	if r.PodAttributor == nil {
+		t.Error("PodAttributor not defaulted")
+	}
+}
+
+// TestAgentSetup_FallbackLegacyTarget drives the reachable, no-match
+// branch: with no pods the loop body never runs, and with a pod whose
+// cgroup path cannot be discovered the loop hits its continue arm. On a
+// host without a kubepods cgroup root, discoverKubepodsRoot returns ""
+// so cgroupPathForPod returns "" deterministically — neither branch
+// touches a live cgroup or appends a target.
+func TestAgentSetup_FallbackLegacyTarget(t *testing.T) {
+	var out tracer.TargetSet
+	fallbackLegacyTarget(&out, nil, 12345)
+	if len(out) != 0 {
+		t.Errorf("fallbackLegacyTarget(no pods) appended %d targets, want 0", len(out))
+	}
+
+	pod := &corev1.Pod{}
+	pod.Name, pod.Namespace, pod.UID = "p", "ns", "uid-1"
+	if discoverKubepodsRoot() != "" {
+		t.Skip("host exposes a kubepods cgroup root; skipping no-match branch to avoid live-cgroup dependency")
+	}
+	fallbackLegacyTarget(&out, []*corev1.Pod{pod}, 12345)
+	if len(out) != 0 {
+		t.Errorf("fallbackLegacyTarget(unresolvable pod) appended %d targets, want 0", len(out))
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -756,6 +756,16 @@ func TestGetVersion(t *testing.T) {
 	})
 }
 
+func TestReadVCSRevision_RealImplementation(t *testing.T) {
+	originalReadVCS := readVCSRevision
+	t.Cleanup(func() { readVCSRevision = originalReadVCS })
+
+	got := originalReadVCS()
+	if got != "" && len(got) != 7 {
+		t.Errorf("readVCSRevision()=%q: a non-empty revision must be a 7-char short SHA", got)
+	}
+}
+
 func TestGetUserAgent(t *testing.T) {
 	key := "PODTRACE_VERSION"
 	originalEnv := os.Getenv(key)

--- a/internal/cri/wait_ready_test.go
+++ b/internal/cri/wait_ready_test.go
@@ -1,0 +1,24 @@
+package cri
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+func TestWaitForReady_BecomesReady(t *testing.T) {
+	conn := startFakeCRIServer(t, nil)
+
+	conn.Connect()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := waitForReady(ctx, conn); err != nil {
+		t.Fatalf("waitForReady on a live bufconn server should succeed, got %v", err)
+	}
+	if got := conn.GetState(); got != connectivity.Ready {
+		t.Errorf("connection state = %v, want Ready", got)
+	}
+}

--- a/internal/diagnose/profiling/timeline_partials_unit_test.go
+++ b/internal/diagnose/profiling/timeline_partials_unit_test.go
@@ -1,0 +1,58 @@
+package profiling
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestMinEventTimestamp_Branches(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   []uint64
+		want uint64
+	}{
+		{
+			name: "single event",
+			ts:   []uint64{42},
+			want: 42,
+		},
+		{
+			name: "ascending (origin stays first)",
+			ts:   []uint64{10, 20, 30},
+			want: 10,
+		},
+		{
+			name: "later event smaller updates origin",
+			ts:   []uint64{30, 20, 10},
+			want: 10,
+		},
+		{
+			name: "minimum in the middle",
+			ts:   []uint64{30, 5, 40, 25},
+			want: 5,
+		},
+		{
+			name: "includes zero timestamp",
+			ts:   []uint64{100, 0, 50},
+			want: 0,
+		},
+		{
+			name: "all equal",
+			ts:   []uint64{7, 7, 7},
+			want: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evs := make([]*events.Event, len(tt.ts))
+			for i, ts := range tt.ts {
+				evs[i] = &events.Event{Timestamp: ts}
+			}
+			if got := minEventTimestamp(evs); got != tt.want {
+				t.Fatalf("minEventTimestamp = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/diagnose/report/fastcgi_activity_test.go
+++ b/internal/diagnose/report/fastcgi_activity_test.go
@@ -1,0 +1,158 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestFormatFastCGIActivity(t *testing.T) {
+	duration := 5 * time.Second
+
+	t.Run("empty returns blank", func(t *testing.T) {
+		d := &mockDiagnostician{events: []*events.Event{}}
+		if got := formatFastCGIActivity(d, duration); got != "" {
+			t.Errorf("expected empty string for no FastCGI events, got %q", got)
+		}
+	})
+
+	t.Run("no fastcgi events among others returns blank", func(t *testing.T) {
+		d := &mockDiagnostician{events: []*events.Event{
+			{Type: events.EventDNS, Target: "example.com"},
+			{Type: events.EventTCPSend},
+		}}
+		if got := formatFastCGIActivity(d, duration); got != "" {
+			t.Errorf("expected empty string when no FastCGI events present, got %q", got)
+		}
+	})
+
+	t.Run("full activity exercises every branch", func(t *testing.T) {
+		var evs []*events.Event
+
+		reqs := []*events.Event{
+			{Type: events.EventFastCGIReq, PID: 100, ProcessName: "php-fpm", Details: "GET", Target: "/index.php", Timestamp: 1_000_000_000},
+			{Type: events.EventFastCGIReq, PID: 100, ProcessName: "php-fpm", Details: "GET", Target: "/index.php", Timestamp: 1_100_000_000},
+			{Type: events.EventFastCGIReq, PID: 100, ProcessName: "php-fpm", Details: "POST", Target: "/api/submit", Timestamp: 1_200_000_000},
+			{Type: events.EventFastCGIReq, PID: 200, ProcessName: "php-fpm", Details: "GET /noise\x00", Target: "/admin\x01", Timestamp: 1_300_000_000},
+			{Type: events.EventFastCGIReq, PID: 200, ProcessName: "", Details: "GET", Target: "", Timestamp: 1_400_000_000},
+			{Type: events.EventFastCGIReq, PID: 300, ProcessName: "php-fpm", Details: "PUT", Target: "/index.php", Timestamp: 1_500_000_000},
+		}
+		evs = append(evs, reqs...)
+
+		resps := []*events.Event{
+			{Type: events.EventFastCGIResp, PID: 100, Target: "/index.php", LatencyNS: 500_000, Timestamp: 1_050_000_000},                 // <1ms
+			{Type: events.EventFastCGIResp, PID: 100, Target: "/index.php", LatencyNS: 5_000_000, Timestamp: 1_150_000_000},               // 1-10ms
+			{Type: events.EventFastCGIResp, PID: 100, Target: "/api/submit", LatencyNS: 50_000_000, Timestamp: 1_250_000_000, Error: 500}, // 10-100ms, error
+			{Type: events.EventFastCGIResp, PID: 200, Target: "/admin\x01", LatencyNS: 250_000_000, Timestamp: 1_350_000_000, Error: 502}, // >100ms, error
+			{Type: events.EventFastCGIResp, PID: 200, Target: "", LatencyNS: 800_000, Timestamp: 1_450_000_000},                           // <1ms, URI "/"
+			{Type: events.EventFastCGIResp, PID: 300, Target: "/index.php", LatencyNS: 9_000_000, Timestamp: 1_550_000_000},               // 1-10ms
+		}
+		evs = append(evs, resps...)
+
+		d := &mockDiagnostician{events: evs}
+		got := formatFastCGIActivity(d, duration)
+
+		if got == "" {
+			t.Fatal("expected non-empty output")
+		}
+
+		mustContain := []string{
+			"FastCGI Activity:",
+			"Requests:",
+			"Responses:",
+			"Methods:",
+			"Workers:",
+			"Top URIs:",
+			"Latency distribution:",
+			"Recent events:",
+		}
+		for _, s := range mustContain {
+			if !strings.Contains(got, s) {
+				t.Errorf("expected output to contain %q\n--- output ---\n%s", s, got)
+			}
+		}
+
+		if !strings.Contains(got, "GET: 4") {
+			t.Errorf("expected method breakdown 'GET: 4'\n--- output ---\n%s", got)
+		}
+		if !strings.Contains(got, "POST: 1") {
+			t.Errorf("expected method breakdown 'POST: 1'\n--- output ---\n%s", got)
+		}
+
+		if !strings.Contains(got, "PID 100 (php-fpm): 3 req") {
+			t.Errorf("expected worker line for PID 100\n--- output ---\n%s", got)
+		}
+
+		if !strings.Contains(got, "/index.php") {
+			t.Errorf("expected /index.php in Top URIs\n--- output ---\n%s", got)
+		}
+		if !strings.Contains(got, "p50=") || !strings.Contains(got, "p95=") ||
+			!strings.Contains(got, "p99=") || !strings.Contains(got, "max=") {
+			t.Errorf("expected latency percentiles in Top URIs\n--- output ---\n%s", got)
+		}
+		if !strings.Contains(got, "errors=") {
+			t.Errorf("expected errors=N in Top URIs (app errors present)\n--- output ---\n%s", got)
+		}
+
+		if !strings.Contains(got, "/") {
+			t.Errorf("expected empty URI rendered as '/'\n--- output ---\n%s", got)
+		}
+
+		for _, b := range []string{"<1ms:", "1-10ms:", "10-100ms:", ">100ms:"} {
+			if !strings.Contains(got, b) {
+				t.Errorf("expected latency bucket %q\n--- output ---\n%s", b, got)
+			}
+		}
+
+		if !strings.Contains(got, "RESP") {
+			t.Errorf("expected RESP samples in Recent events\n--- output ---\n%s", got)
+		}
+		if !strings.Contains(got, "status=") {
+			t.Errorf("expected status= in RESP samples\n--- output ---\n%s", got)
+		}
+
+		sampleLines := 0
+		for _, ln := range strings.Split(got, "\n") {
+			if strings.HasPrefix(ln, "    +") {
+				sampleLines++
+			}
+		}
+		if sampleLines != 10 {
+			t.Errorf("expected exactly 10 recent-event sample lines, got %d\n--- output ---\n%s", sampleLines, got)
+		}
+	})
+
+	t.Run("requests only no responses", func(t *testing.T) {
+		d := &mockDiagnostician{events: []*events.Event{
+			{Type: events.EventFastCGIReq, PID: 1, ProcessName: "php-fpm", Details: "GET", Target: "/", Timestamp: 1_000_000_000},
+		}}
+		got := formatFastCGIActivity(d, duration)
+		if !strings.Contains(got, "Requests:") {
+			t.Errorf("expected Requests section\n%s", got)
+		}
+		if strings.Contains(got, "Latency distribution:") {
+			t.Errorf("did not expect latency distribution without responses\n%s", got)
+		}
+		if strings.Contains(got, "Responses:") {
+			t.Errorf("did not expect Responses line without responses\n%s", got)
+		}
+	})
+
+	t.Run("responses only no requests", func(t *testing.T) {
+		d := &mockDiagnostician{events: []*events.Event{
+			{Type: events.EventFastCGIResp, PID: 1, Target: "/", LatencyNS: 2_000_000, Timestamp: 1_000_000_000},
+		}}
+		got := formatFastCGIActivity(d, duration)
+		if !strings.Contains(got, "Responses:") {
+			t.Errorf("expected Responses section\n%s", got)
+		}
+		if strings.Contains(got, "Requests:") {
+			t.Errorf("did not expect Requests line without requests\n%s", got)
+		}
+		if !strings.Contains(got, "Latency distribution:") {
+			t.Errorf("expected latency distribution with responses\n%s", got)
+		}
+	})
+}

--- a/internal/diagnose/report/report_branches_unit_test.go
+++ b/internal/diagnose/report/report_branches_unit_test.go
@@ -1,0 +1,233 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/alerting"
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// These tests drive the remaining uncovered formatting branches in report.go
+// using the package mockDiagnostician: display caps, percentile output, unknown
+// resource types, severity classification, and nil-event guards.
+
+// ─── formatOOMKills: display cap ──────────────────────────────────────────────
+
+func TestFormatOOMKills_ExceedsDisplayCap(t *testing.T) {
+	var oom []*events.Event
+	for i := 0; i < config.MaxOOMKillsDisplay+3; i++ {
+		oom = append(oom, &events.Event{Type: events.EventOOMKill, Target: "proc", Bytes: 1024})
+	}
+	oom = append(oom, &events.Event{Type: events.EventOOMKill, PID: 7, Bytes: 2048})
+
+	out := formatOOMKills(oom)
+	if !strings.Contains(out, "OOM kills:") {
+		t.Errorf("expected OOM kills header, got %q", out)
+	}
+	lines := strings.Count(out, "    - ")
+	if lines != config.MaxOOMKillsDisplay {
+		t.Errorf("expected %d listed kills (cap), got %d", config.MaxOOMKillsDisplay, lines)
+	}
+}
+
+func TestFormatOOMKills_EmptyTargetUsesPID(t *testing.T) {
+	out := formatOOMKills([]*events.Event{
+		{Type: events.EventOOMKill, PID: 42, Bytes: 1024},
+	})
+	if !strings.Contains(out, "PID 42") {
+		t.Errorf("expected PID fallback in output, got %q", out)
+	}
+}
+
+// ─── GenerateIssuesSection: severity classification with alerting manager ─────
+
+func TestGenerateIssuesSection_CriticalAndWarningSeverity(t *testing.T) {
+	original := alerting.GetGlobalManager()
+	mgr, _ := alerting.NewManager()
+	alerting.SetGlobalManager(mgr)
+	t.Cleanup(func() { alerting.SetGlobalManager(original) })
+
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventResourceLimit, TCPState: 0, Error: 96},
+			{Type: events.EventResourceLimit, TCPState: 1, Error: 85},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+
+	out := GenerateIssuesSection(d)
+	if !strings.Contains(out, "Potential Issues Detected") {
+		t.Errorf("expected issues section, got %q", out)
+	}
+}
+
+func TestGenerateIssuesSection_NoIssues(t *testing.T) {
+	d := &mockDiagnostician{
+		events:    []*events.Event{{Type: events.EventDNS}},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	if out := GenerateIssuesSection(d); out != "" {
+		t.Errorf("expected empty issues section, got %q", out)
+	}
+}
+
+// ─── GeneratePoolSection: percentiles + pool cap ──────────────────────────────
+
+func TestGeneratePoolSection_PercentilesAndPoolCap(t *testing.T) {
+	var evts []*events.Event
+	for i := 0; i < config.MaxConnectionTargets+3; i++ {
+		pool := "pool-" + string(rune('a'+i))
+		evts = append(evts,
+			&events.Event{Type: events.EventPoolAcquire, Target: pool},
+			&events.Event{Type: events.EventPoolRelease, Target: pool},
+		)
+	}
+	evts = append(evts,
+		&events.Event{Type: events.EventPoolExhausted, Target: "pool-a", LatencyNS: 5_000_000},
+		&events.Event{Type: events.EventPoolExhausted, Target: "pool-a", LatencyNS: 9_000_000},
+	)
+
+	d := &mockDiagnostician{
+		events:    evts,
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	out := GeneratePoolSection(d, time.Second)
+	if !strings.Contains(out, "Connection Pool") {
+		t.Errorf("expected pool section, got %q", out)
+	}
+	if !strings.Contains(out, "exhaustion events") && !strings.Contains(out, "Pool exhaustion") {
+		t.Errorf("expected exhaustion details in output, got %q", out)
+	}
+}
+
+// ─── GenerateResourceSection: unknown resource type ───────────────────────────
+
+func TestGenerateResourceSection_UnknownResourceType(t *testing.T) {
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventResourceLimit, TCPState: 7, Error: 50, Bytes: 1024},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	out := GenerateResourceSection(d)
+	if !strings.Contains(out, "Resource-7") {
+		t.Errorf("expected Resource-7 label for unknown type, got %q", out)
+	}
+}
+
+// ─── formatProcessActivity: cap + unknown name ────────────────────────────────
+
+func TestFormatProcessActivity_CapAndUnknownName(t *testing.T) {
+	var evts []*events.Event
+	for i := 0; i < config.TopProcessesLimit+5; i++ {
+		evts = append(evts, &events.Event{
+			Type:        events.EventExec,
+			PID:         uint32(1000 + i),
+			ProcessName: "",
+		})
+	}
+	out := formatProcessActivity(evts)
+	if out == "" {
+		t.Fatal("expected non-empty process activity output")
+	}
+	if !strings.Contains(out, "unknown") {
+		t.Errorf("expected 'unknown' name fallback, got %q", out)
+	}
+	listed := strings.Count(out, "    - PID ")
+	if listed != config.TopProcessesLimit {
+		t.Errorf("expected %d listed processes (cap), got %d", config.TopProcessesLimit, listed)
+	}
+}
+
+// ─── GenerateSyscallSection: events present but none categorized ──────────────
+
+func TestGenerateSyscallSection_NoCategorizedEvents(t *testing.T) {
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventDNS, Target: "example.com"},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	if out := GenerateSyscallSection(d, time.Second); out != "" {
+		t.Errorf("expected empty syscall section when no syscall events, got %q", out)
+	}
+}
+
+// ─── formatFastCGIActivity: worker cap, name-fill, method fallback ────────────
+
+func TestFormatFastCGIActivity_NilGuardsAndWorkerCap(t *testing.T) {
+	var reqs []*events.Event
+	reqs = append(reqs, &events.Event{Type: events.EventFastCGIReq, PID: 1, Details: "123", Target: "/x"})
+	reqs = append(reqs,
+		&events.Event{Type: events.EventFastCGIReq, PID: 9, ProcessName: "", Details: "GET", Target: "/a"},
+		&events.Event{Type: events.EventFastCGIReq, PID: 9, ProcessName: "php-fpm", Details: "GET", Target: "/a"},
+	)
+	for i := 0; i < config.TopProcessesLimit+4; i++ {
+		reqs = append(reqs, &events.Event{
+			Type:    events.EventFastCGIReq,
+			PID:     uint32(2000 + i),
+			Details: "GET",
+			Target:  "/p",
+		})
+	}
+
+	d := &mockDiagnostician{
+		events:    reqs,
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	out := formatFastCGIActivity(d, time.Second)
+	if !strings.Contains(out, "FastCGI Activity") {
+		t.Errorf("expected FastCGI activity output, got %q", out)
+	}
+	if !strings.Contains(out, "?: ") {
+		t.Errorf("expected '?' method bucket for method-less request, got %q", out)
+	}
+}
+
+// ─── formatBursts: display cap ────────────────────────────────────────────────
+
+func TestFormatBursts_ExceedsDisplayCap(t *testing.T) {
+	start := time.Now()
+	duration := 10 * time.Second
+	var evts []*events.Event
+	for bucket := 0; bucket < config.MaxBurstsDisplay+5; bucket++ {
+		base := start.Add(time.Duration(bucket) * time.Second)
+		for j := 0; j < 200; j++ {
+			evts = append(evts, &events.Event{
+				Type:      events.EventTCPSend,
+				Timestamp: uint64(base.UnixNano()) + uint64(j),
+			})
+		}
+	}
+	out := formatBursts(evts, start, duration)
+	if out == "" {
+		t.Skip("burst detector returned no bursts for synthetic stream")
+	}
+	listed := strings.Count(out, "    - ")
+	if listed > config.MaxBurstsDisplay {
+		t.Errorf("expected at most %d listed bursts (cap), got %d", config.MaxBurstsDisplay, listed)
+	}
+}
+
+func TestGenerateSyscallSection_WithSyscallEvents(t *testing.T) {
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventExec, PID: 1, ProcessName: "sh"},
+			{Type: events.EventOpen, Target: "/etc/passwd"},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(time.Second),
+	}
+	if out := GenerateSyscallSection(d, time.Second); out == "" {
+		t.Error("expected non-empty syscall section with exec/open events")
+	}
+}

--- a/internal/diagnose/stacktrace/kallsyms_unit_test.go
+++ b/internal/diagnose/stacktrace/kallsyms_unit_test.go
@@ -1,0 +1,146 @@
+package stacktrace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/procfs"
+)
+
+func TestIsSortedAndSortKsyms(t *testing.T) {
+	sorted := []ksym{
+		{Addr: 0x1000, Name: "a"},
+		{Addr: 0x2000, Name: "b"},
+		{Addr: 0x3000, Name: "c"},
+	}
+	if !isSorted(sorted) {
+		t.Fatalf("isSorted returned false for an already-sorted slice")
+	}
+
+	withEqual := []ksym{
+		{Addr: 0x1000, Name: "a"},
+		{Addr: 0x1000, Name: "b"},
+	}
+	if !isSorted(withEqual) {
+		t.Fatalf("isSorted returned false for a slice with equal addresses")
+	}
+
+	unsorted := []ksym{
+		{Addr: 0x3000, Name: "c"},
+		{Addr: 0x1000, Name: "a"},
+		{Addr: 0x2000, Name: "b"},
+	}
+	if isSorted(unsorted) {
+		t.Fatalf("isSorted returned true for an unsorted slice")
+	}
+
+	sortKsyms(unsorted)
+	if !isSorted(unsorted) {
+		t.Fatalf("sortKsyms did not sort the slice: %+v", unsorted)
+	}
+	wantOrder := []string{"a", "b", "c"}
+	for i, want := range wantOrder {
+		if unsorted[i].Name != want {
+			t.Errorf("sortKsyms order: index %d = %q, want %q", i, unsorted[i].Name, want)
+		}
+	}
+}
+
+// writeKallsyms creates a temp dir holding a fake "kallsyms" file with the
+// given content, points config.ProcBasePath at it, and resets the procfs
+// root. It returns a cleanup func that restores the previous state.
+func writeKallsyms(t *testing.T, content string) func() {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "kallsyms"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fake kallsyms: %v", err)
+	}
+	return pointProcfsAt(t, dir)
+}
+
+// pointProcfsAt sets config.ProcBasePath to dir and resets the procfs root,
+// returning a cleanup func that restores the prior path and resets again.
+func pointProcfsAt(t *testing.T, dir string) func() {
+	t.Helper()
+	original := config.ProcBasePath
+	config.ProcBasePath = dir
+	procfs.ResetForTesting()
+	return func() {
+		config.ProcBasePath = original
+		procfs.ResetForTesting()
+	}
+}
+
+func TestKallsymsLoadAndResolve(t *testing.T) {
+	t.Run("sorted", func(t *testing.T) {
+		content := "ffffffff81000000 T _stext\n" +
+			"ffffffff81000100 T do_something\n" +
+			"0000000000000000 t hidden\n" +
+			"badline\n"
+		cleanup := writeKallsyms(t, content)
+		defer cleanup()
+
+		k := &kallsymsLookup{}
+
+		if got := k.Resolve(0); got != "" {
+			t.Errorf("Resolve(0) = %q, want \"\"", got)
+		}
+		if got := k.Resolve(0xffffffff81000010); got != "_stext+0x10" {
+			t.Errorf("Resolve(0xffffffff81000010) = %q, want %q", got, "_stext+0x10")
+		}
+		if got := k.Resolve(0xffffffff81000000); got != "_stext+0x0" {
+			t.Errorf("exact-match Resolve = %q, want %q", got, "_stext+0x0")
+		}
+		if got := k.Resolve(0xffffffff81000100); got != "do_something+0x0" {
+			t.Errorf("Resolve(do_something addr) = %q, want %q", got, "do_something+0x0")
+		}
+		if got := k.Resolve(0xffffffff82000000); got != "" {
+			t.Errorf("Resolve(above maxAddr) = %q, want \"\"", got)
+		}
+		if !k.loaded {
+			t.Errorf("expected loaded=true after a successful load")
+		}
+		if len(k.syms) != 2 {
+			t.Errorf("expected 2 symbols loaded (addr-0 skipped), got %d", len(k.syms))
+		}
+	})
+
+	t.Run("unsorted", func(t *testing.T) {
+		content := "ffffffff81000200 T third\n" +
+			"ffffffff81000000 T first\n" +
+			"ffffffff81000100 T second\n"
+		cleanup := writeKallsyms(t, content)
+		defer cleanup()
+
+		k := &kallsymsLookup{}
+
+		if got := k.Resolve(0xffffffff81000004); got != "first+0x4" {
+			t.Errorf("Resolve(first+4) = %q, want %q", got, "first+0x4")
+		}
+		if got := k.Resolve(0xffffffff81000110); got != "second+0x10" {
+			t.Errorf("Resolve(second+0x10) = %q, want %q", got, "second+0x10")
+		}
+		if got := k.Resolve(0xffffffff81000200); got != "third+0x0" {
+			t.Errorf("Resolve(third) = %q, want %q", got, "third+0x0")
+		}
+		if !isSorted(k.syms) {
+			t.Errorf("load() did not sort symbols: %+v", k.syms)
+		}
+	})
+}
+
+func TestKallsymsLoadMissing(t *testing.T) {
+	dir := t.TempDir()
+	cleanup := pointProcfsAt(t, dir)
+	defer cleanup()
+
+	k := &kallsymsLookup{}
+	if got := k.Resolve(0xffffffff81000010); got != "" {
+		t.Errorf("Resolve with missing kallsyms = %q, want \"\"", got)
+	}
+	if k.loaded {
+		t.Errorf("expected loaded=false when kallsyms is missing")
+	}
+}

--- a/internal/diagnose/stacktrace/stacktrace_test.go
+++ b/internal/diagnose/stacktrace/stacktrace_test.go
@@ -195,6 +195,18 @@ func TestStackResolver_ZeroAddr(t *testing.T) {
 	}
 }
 
+// TestStackResolver_KernelAddress exercises the kernel-address branch:
+// a kernel-range address routes through defaultKallsyms; with no symbols
+// loaded it falls back to the 0x%x hex form rather than touching procfs.
+func TestStackResolver_KernelAddress(t *testing.T) {
+	r := &stackResolver{cache: make(map[string]string)}
+	const kernelAddr = uint64(0xffffffff81000000)
+	got := r.resolve(context.Background(), 1, kernelAddr)
+	if got == "" {
+		t.Fatal("kernel address must resolve to a non-empty string")
+	}
+}
+
 // TestStackResolver_ContextCancelled verifies the ctx.Done early-return path.
 func TestStackResolver_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -238,4 +250,3 @@ func TestStackResolver_CurrentPID(t *testing.T) {
 		t.Errorf("cache hit should return same value: got1=%q got2=%q", got1, got2)
 	}
 }
-

--- a/internal/diagnose/tracker/transient_name_unit_test.go
+++ b/internal/diagnose/tracker/transient_name_unit_test.go
@@ -1,0 +1,18 @@
+package tracker
+
+import "testing"
+
+func TestIsTransientName(t *testing.T) {
+	cases := map[string]bool{
+		"runc-bootstrap[123]": true,
+		"runc:[2:INIT]":       true,
+		"nginx":               false,
+		"":                    false,
+		"runc":                false,
+	}
+	for name, want := range cases {
+		if got := isTransientName(name); got != want {
+			t.Errorf("isTransientName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/internal/dns/ipv6_unit_test.go
+++ b/internal/dns/ipv6_unit_test.go
@@ -1,0 +1,59 @@
+package dns
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIPv6String(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			name: "all zeros",
+			in:   make([]byte, 16),
+			want: "0000:0000:0000:0000:0000:0000:0000:0000",
+		},
+		{
+			name: "loopback ::1",
+			in:   []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			want: "0000:0000:0000:0000:0000:0000:0000:0001",
+		},
+		{
+			name: "full address",
+			in: []byte{
+				0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x00,
+				0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34,
+			},
+			want: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ipv6String(tt.in); got != tt.want {
+				t.Errorf("ipv6String(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+			parsed := net.ParseIP(tt.want)
+			if parsed == nil {
+				t.Fatalf("net.ParseIP(%q) returned nil", tt.want)
+			}
+			if to16 := parsed.To16(); !equalBytes(to16, tt.in) {
+				t.Errorf("net.ParseIP(%q).To16() = %v, want %v", tt.want, to16, tt.in)
+			}
+		})
+	}
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/dns/itoa_unit_test.go
+++ b/internal/dns/itoa_unit_test.go
@@ -1,0 +1,35 @@
+package dns
+
+import "testing"
+
+func TestItoa(t *testing.T) {
+	tests := []struct {
+		in   byte
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{9, "9"},
+		{10, "10"},
+		{99, "99"},
+		{100, "100"},
+		{255, "255"},
+	}
+	for _, tt := range tests {
+		if got := itoa(tt.in); got != tt.want {
+			t.Errorf("itoa(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIPv4String_WithZeroOctets(t *testing.T) {
+	if got := ipv4String([]byte{0, 0, 0, 0}); got != "0.0.0.0" {
+		t.Errorf("ipv4String(0.0.0.0) = %q", got)
+	}
+	if got := ipv4String([]byte{10, 0, 0, 1}); got != "10.0.0.1" {
+		t.Errorf("ipv4String(10.0.0.1) = %q", got)
+	}
+	if got := ipv4String([]byte{192, 168, 1, 255}); got != "192.168.1.255" {
+		t.Errorf("ipv4String = %q", got)
+	}
+}

--- a/internal/ebpf/cache/cpu_unit_test.go
+++ b/internal/ebpf/cache/cpu_unit_test.go
@@ -1,0 +1,102 @@
+package cache
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadUint64LE(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want uint64
+	}{
+		{"zero", []byte{0, 0, 0, 0, 0, 0, 0, 0}, 0},
+		{"one", []byte{1, 0, 0, 0, 0, 0, 0, 0}, 1},
+		{"low byte", []byte{0xff, 0, 0, 0, 0, 0, 0, 0}, 0xff},
+		{"high byte", []byte{0, 0, 0, 0, 0, 0, 0, 1}, 1 << 56},
+		{"all ones", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, ^uint64(0)},
+		{"mixed", []byte{0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0}, 0x12345678},
+		{"trailing bytes ignored", []byte{1, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readUint64LE(tt.in); got != tt.want {
+				t.Errorf("readUint64LE(%v) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCPUTime_Cache(t *testing.T) {
+	ResetCPUTimes()
+	t.Cleanup(ResetCPUTimes)
+
+	if got := GetCPUTime(424242); got.TotalNS != 0 {
+		t.Errorf("GetCPUTime(unknown) = %d, want 0", got.TotalNS)
+	}
+
+	const pid uint32 = 1234
+	const want uint64 = 5_000_000_000
+	cpuTimeMu.Lock()
+	cpuTimes[pid] = ProcessCPUTime{TotalNS: want}
+	cpuTimeMu.Unlock()
+
+	if got := GetCPUTime(pid); got.TotalNS != want {
+		t.Errorf("GetCPUTime(%d) = %d, want %d", pid, got.TotalNS, want)
+	}
+}
+
+func TestResetCPUTimes(t *testing.T) {
+	t.Cleanup(ResetCPUTimes)
+
+	const pid uint32 = 9876
+	cpuTimeMu.Lock()
+	cpuTimes[pid] = ProcessCPUTime{TotalNS: 42}
+	cpuTimeMu.Unlock()
+
+	if got := GetCPUTime(pid); got.TotalNS != 42 {
+		t.Fatalf("precondition: GetCPUTime(%d) = %d, want 42", pid, got.TotalNS)
+	}
+
+	ResetCPUTimes()
+
+	if got := GetCPUTime(pid); got.TotalNS != 0 {
+		t.Errorf("after ResetCPUTimes, GetCPUTime(%d) = %d, want 0", pid, got.TotalNS)
+	}
+}
+
+func TestLoadClockTicks(t *testing.T) {
+	got := loadClockTicks()
+	if got == 0 {
+		t.Fatalf("loadClockTicks() = 0, want positive")
+	}
+	if again := loadClockTicks(); again != got {
+		t.Errorf("loadClockTicks() second call = %d, want %d (memoized)", again, got)
+	}
+}
+
+func TestSnapshotCPUTime_UnreadablePID(t *testing.T) {
+	ResetCPUTimes()
+	t.Cleanup(ResetCPUTimes)
+
+	SnapshotCPUTime(0)
+	if got := GetCPUTime(0); got.TotalNS != 0 {
+		t.Errorf("SnapshotCPUTime(0) recorded %d, want nothing", got.TotalNS)
+	}
+}
+
+func TestSnapshotCPUTime_SelfRecordsEntry(t *testing.T) {
+	ResetCPUTimes()
+	t.Cleanup(ResetCPUTimes)
+
+	self := uint32(os.Getpid())
+	SnapshotCPUTime(self)
+
+	cpuTimeMu.RLock()
+	_, ok := cpuTimes[self]
+	cpuTimeMu.RUnlock()
+	if !ok {
+		t.Errorf("SnapshotCPUTime(self=%d) did not record an entry", self)
+	}
+}

--- a/internal/ebpf/cache/lru_partials_unit_test.go
+++ b/internal/ebpf/cache/lru_partials_unit_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLRUCache_Get_ExpiredInline drives the expired-entry branch *inside*
+// Get (lines that delete the stale element and return false). The existing
+// TestLRUCache_Get_Expired relies on a real sleep, where the background
+// cleanup goroutine may reap the entry first — leaving the inline expiry
+// branch in Get uncovered. Here we forge expiresAt into the past while the
+// element is still present, so Get itself must take the delete-and-evict path.
+func TestLRUCache_Get_ExpiredInline(t *testing.T) {
+	c := NewLRUCache(10, time.Hour)
+	defer c.Close()
+
+	c.Set(123, "stale-process")
+
+	c.mutex.Lock()
+	elem, ok := c.cache[123]
+	if !ok {
+		c.mutex.Unlock()
+		t.Fatalf("expected PID 123 to be present before forcing expiry")
+	}
+	elem.Value.(*cacheEntry).expiresAt = time.Now().Add(-time.Minute)
+	c.mutex.Unlock()
+
+	name, found := c.Get(123)
+	if found {
+		t.Fatalf("expected Get to report miss for expired entry, got %q", name)
+	}
+	if name != "" {
+		t.Fatalf("expected empty name for expired entry, got %q", name)
+	}
+
+	c.mutex.Lock()
+	_, stillInMap := c.cache[123]
+	listLen := c.list.Len()
+	c.mutex.Unlock()
+	if stillInMap {
+		t.Fatalf("expired entry should have been deleted from the map")
+	}
+	if listLen != 0 {
+		t.Fatalf("expired entry should have been removed from the list, len=%d", listLen)
+	}
+}

--- a/internal/events/dns_names_unit_test.go
+++ b/internal/events/dns_names_unit_test.go
@@ -1,0 +1,42 @@
+package events
+
+import "testing"
+
+func TestDNSQTypeName(t *testing.T) {
+	cases := map[uint32]string{
+		1:    "A",
+		28:   "AAAA",
+		5:    "CNAME",
+		33:   "SRV",
+		12:   "PTR",
+		16:   "TXT",
+		15:   "MX",
+		2:    "NS",
+		6:    "SOA",
+		0:    "lookup",
+		9999: "TYPE9999",
+	}
+	for in, want := range cases {
+		if got := dnsQTypeName(in); got != want {
+			t.Errorf("dnsQTypeName(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDNSRCodeName(t *testing.T) {
+	cases := map[int32]string{
+		0:  "NOERROR",
+		1:  "FORMERR",
+		2:  "SERVFAIL",
+		3:  "NXDOMAIN",
+		4:  "NOTIMP",
+		5:  "REFUSED",
+		42: "rcode 42",
+		-1: "rcode -1",
+	}
+	for in, want := range cases {
+		if got := dnsRCodeName(in); got != want {
+			t.Errorf("dnsRCodeName(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/events/k8s_metadata_test.go
+++ b/internal/events/k8s_metadata_test.go
@@ -1,0 +1,36 @@
+package events
+
+import "testing"
+
+func TestK8sMetadata_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		meta K8sMetadata
+		want bool
+	}{
+		{"empty", K8sMetadata{}, true},
+		{"namespace set", K8sMetadata{Namespace: "default"}, false},
+		{"pod name set", K8sMetadata{PodName: "p"}, false},
+		{"pod uid set", K8sMetadata{PodUID: "uid"}, false},
+		{"node name set", K8sMetadata{NodeName: "node1"}, false},
+		{"container name set", K8sMetadata{ContainerName: "c"}, false},
+		{"workload kind set", K8sMetadata{WorkloadKind: "Deployment"}, false},
+		{"workload name set", K8sMetadata{WorkloadName: "web"}, false},
+		{"fully populated", K8sMetadata{
+			Namespace:     "default",
+			PodName:       "p",
+			PodUID:        "uid",
+			NodeName:      "node1",
+			ContainerName: "c",
+			WorkloadKind:  "Deployment",
+			WorkloadName:  "web",
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.meta.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/kubernetes/cgroup_resolve_unit_test.go
+++ b/internal/kubernetes/cgroup_resolve_unit_test.go
@@ -1,0 +1,95 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// withCgroupBase points config.CgroupBasePath at a fresh temp dir for the
+// duration of the test, restoring the previous value on cleanup.
+func withCgroupBase(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := config.CgroupBasePath
+	config.SetCgroupBasePath(dir)
+	t.Cleanup(func() { config.SetCgroupBasePath(orig) })
+	return dir
+}
+
+// ─── statCgroupDirHasProcs ────────────────────────────────────────────────────
+
+func TestStatCgroupDirHasProcs_OutsideBase(t *testing.T) {
+	withCgroupBase(t)
+	if statCgroupDirHasProcs("/some/other/place") {
+		t.Error("expected false for path outside cgroup base")
+	}
+}
+
+func TestStatCgroupDirHasProcs_DirMissing(t *testing.T) {
+	base := withCgroupBase(t)
+	if statCgroupDirHasProcs(filepath.Join(base, "does-not-exist")) {
+		t.Error("expected false for missing cgroup dir")
+	}
+}
+
+func TestStatCgroupDirHasProcs_NoProcsFile(t *testing.T) {
+	base := withCgroupBase(t)
+	dir := filepath.Join(base, "grp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if statCgroupDirHasProcs(dir) {
+		t.Error("expected false when cgroup.procs is absent")
+	}
+}
+
+func TestStatCgroupDirHasProcs_HasProcsFile(t *testing.T) {
+	base := withCgroupBase(t)
+	dir := filepath.Join(base, "grp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("1\n"), 0o644); err != nil {
+		t.Fatalf("write cgroup.procs: %v", err)
+	}
+	if !statCgroupDirHasProcs(dir) {
+		t.Error("expected true when dir contains cgroup.procs")
+	}
+}
+
+// ─── BuildPodInfoFromPreResolved: success path ────────────────────────────────
+
+func TestBuildPodInfoFromPreResolved_Success(t *testing.T) {
+	base := withCgroupBase(t)
+
+	containerID := "abcdef1234567890"
+	target := filepath.Join(base, "kubepods.slice", "pod_"+containerID)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	info, err := BuildPodInfoFromPreResolved(PreResolvedRef{
+		Namespace:     "ns",
+		PodName:       "pod-a",
+		ContainerID:   containerID,
+		ContainerName: "app",
+	})
+	if err != nil {
+		t.Fatalf("BuildPodInfoFromPreResolved: %v", err)
+	}
+	if info.PodName != "pod-a" || info.Namespace != "ns" {
+		t.Errorf("unexpected metadata: %+v", info)
+	}
+	if info.ContainerID != containerID || info.ContainerName != "app" {
+		t.Errorf("unexpected container fields: %+v", info)
+	}
+	if info.CgroupPath == "" {
+		t.Error("expected resolved cgroup path to be populated")
+	}
+	if info.Labels == nil {
+		t.Error("expected non-nil Labels map")
+	}
+}

--- a/internal/kubernetes/nodespawn/pure_extra_test.go
+++ b/internal/kubernetes/nodespawn/pure_extra_test.go
@@ -1,0 +1,64 @@
+package nodespawn
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIndexAfterScheme(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"containerd", "containerd://abc123", len("containerd://")},
+		{"docker", "docker://deadbeef", len("docker://")},
+		{"no scheme", "abc123", -1},
+		{"empty", "", -1},
+		{"only scheme delimiter at end", "x://", len("x://")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := indexAfterScheme(tt.in); got != tt.want {
+				t.Errorf("indexAfterScheme(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTolerationKey(t *testing.T) {
+	sec := int64(30)
+	withSeconds := corev1.Toleration{
+		Key:               "node.kubernetes.io/unreachable",
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &sec,
+	}
+	withoutSeconds := corev1.Toleration{
+		Key:      "dedicated",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "gpu",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
+	keyWith := tolerationKey(withSeconds)
+	keyWithout := tolerationKey(withoutSeconds)
+
+	if keyWith == keyWithout {
+		t.Fatalf("distinct tolerations produced identical keys: %q", keyWith)
+	}
+	// TolerationSeconds value must appear in the key when set.
+	if want := "|30"; keyWith[len(keyWith)-len(want):] != want {
+		t.Errorf("key %q should end with the seconds value %q", keyWith, want)
+	}
+	// Nil TolerationSeconds renders as "nil".
+	if want := "|nil"; keyWithout[len(keyWithout)-len(want):] != want {
+		t.Errorf("key %q should end with %q for nil seconds", keyWithout, want)
+	}
+
+	// Same toleration must hash to the same key (stable dedupe).
+	if tolerationKey(withoutSeconds) != keyWithout {
+		t.Error("tolerationKey is not deterministic")
+	}
+}

--- a/internal/kubernetes/nodespawn/pure_helpers_test.go
+++ b/internal/kubernetes/nodespawn/pure_helpers_test.go
@@ -1,0 +1,43 @@
+package nodespawn
+
+import "testing"
+
+func TestPodRef_PreResolved(t *testing.T) {
+	r := PodRef{
+		Namespace:     "ns1",
+		Name:          "cart-abc",
+		ContainerID:   "deadbeef",
+		ContainerName: "app",
+	}
+	want := "ns1/cart-abc/deadbeef/app"
+	if got := r.PreResolved(); got != want {
+		t.Errorf("PreResolved() = %q, want %q", got, want)
+	}
+
+	r2 := PodRef{Namespace: "ns", Name: "p"}
+	if got, want := r2.PreResolved(), "ns/p//"; got != want {
+		t.Errorf("PreResolved() = %q, want %q", got, want)
+	}
+}
+
+func TestNodeTargets_Empty(t *testing.T) {
+	var empty NodeTargets
+	if !empty.Empty() {
+		t.Errorf("zero-value NodeTargets should be Empty()")
+	}
+
+	if (NodeTargets{NodeNames: []string{}}).Empty() != true {
+		t.Errorf("NodeTargets with empty NodeNames should be Empty()")
+	}
+
+	nonEmpty := NodeTargets{NodeNames: []string{"node-1"}}
+	if nonEmpty.Empty() {
+		t.Errorf("NodeTargets with a node should not be Empty()")
+	}
+}
+
+func TestHostname(t *testing.T) {
+	if got := Hostname(); got == "" {
+		t.Errorf("Hostname() returned empty string")
+	}
+}

--- a/internal/kubernetes/nodespawn/run_helpers_test.go
+++ b/internal/kubernetes/nodespawn/run_helpers_test.go
@@ -1,0 +1,94 @@
+package nodespawn
+
+import (
+	"bytes"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestExitError_Error(t *testing.T) {
+	e := &ExitError{Code: 7, Node: "node-1"}
+	want := `spawn pod on node "node-1" exited with code 7`
+	if got := e.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestPrefixedWriter_PrependsPrefixPerCompleteLine(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	w := newPrefixedWriter(&buf, "[n1] ", &mu)
+
+	n, err := w.Write([]byte("alpha\nbeta\n"))
+	if err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if n != len("alpha\nbeta\n") {
+		t.Errorf("Write returned n=%d, want %d", n, len("alpha\nbeta\n"))
+	}
+	want := "[n1] alpha\n[n1] beta\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestPrefixedWriter_BuffersPartialLineUntilNewline(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	w := newPrefixedWriter(&buf, "P:", &mu)
+
+	if _, err := w.Write([]byte("hel")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("partial write should not flush, got %q", buf.String())
+	}
+
+	if _, err := w.Write([]byte("lo\n")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if got, want := buf.String(), "P:hello\n"; got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+
+	if _, err := w.Write([]byte("tail")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if got, want := buf.String(), "P:hello\n"; got != want {
+		t.Errorf("trailing partial must not flush, output = %q, want %q", got, want)
+	}
+}
+
+func TestIndexByte(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		c    byte
+		want int
+	}{
+		{"found-middle", []byte("abc\ndef"), '\n', 3},
+		{"found-first", []byte("\nrest"), '\n', 0},
+		{"not-found", []byte("abcdef"), '\n', -1},
+		{"empty", []byte(""), 'x', -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := indexByte(tc.in, tc.c); got != tc.want {
+				t.Errorf("indexByte(%q, %q) = %d, want %d", tc.in, tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHostnameFromEnv(t *testing.T) {
+	got := HostnameFromEnv()
+	if got == "" {
+		t.Errorf("HostnameFromEnv() returned empty string")
+	}
+
+	osHost, err := os.Hostname()
+	if err == nil && osHost != "" && got != osHost {
+		t.Errorf("HostnameFromEnv() = %q, want %q", got, osHost)
+	}
+}

--- a/internal/kubernetes/nodespawn/stream_fake_test.go
+++ b/internal/kubernetes/nodespawn/stream_fake_test.go
@@ -1,0 +1,166 @@
+package nodespawn
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+// --- unschedulableReason (pure) ---
+
+func TestUnschedulableReason(t *testing.T) {
+	unschedulable := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:    corev1.PodScheduled,
+				Status:  corev1.ConditionFalse,
+				Reason:  corev1.PodReasonUnschedulable,
+				Message: "0/3 nodes are available: 3 Insufficient cpu.",
+			}},
+		},
+	}
+	if got, want := unschedulableReason(unschedulable), "0/3 nodes are available: 3 Insufficient cpu."; got != want {
+		t.Errorf("unschedulableReason = %q, want %q", got, want)
+	}
+
+	scheduled := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	if got := unschedulableReason(scheduled); got != "" {
+		t.Errorf("scheduled pod should report no reason, got %q", got)
+	}
+
+	if got := unschedulableReason(&corev1.Pod{}); got != "" {
+		t.Errorf("pod with no conditions should report no reason, got %q", got)
+	}
+}
+
+// --- imagePullFailureReason (pure) ---
+
+func TestImagePullFailureReason(t *testing.T) {
+	cases := []struct {
+		reason  string
+		message string
+		want    string
+	}{
+		{"ImagePullBackOff", "Back-off pulling image", "ImagePullBackOff: Back-off pulling image"},
+		{"ErrImagePull", "rpc error: not found", "ErrImagePull: rpc error: not found"},
+		{"InvalidImageName", "couldn't parse image", "InvalidImageName: couldn't parse image"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			p := pendingPodWithContainerWaiting("ns", "spawn", tc.reason, tc.message)
+			if got := imagePullFailureReason(p); got != tc.want {
+				t.Errorf("imagePullFailureReason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	p := pendingPodWithContainerWaiting("ns", "spawn", "ContainerCreating", "still pulling")
+	if got := imagePullFailureReason(p); got != "" {
+		t.Errorf("ContainerCreating should not be an image-pull failure, got %q", got)
+	}
+
+	if got := imagePullFailureReason(&corev1.Pod{}); got != "" {
+		t.Errorf("pod with no container statuses should report no reason, got %q", got)
+	}
+}
+
+// --- waitForPodRunningOrTerminated (fake clientset) ---
+
+// --- WaitForExitCode (fake clientset) ---
+
+func TestWaitForExitCode_TerminatedReturnsExitCode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "podtrace",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 42},
+				},
+			}},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+	if got := WaitForExitCode(ctx, cs, "ns", "spawn"); got != 42 {
+		t.Errorf("WaitForExitCode = %d, want 42", got)
+	}
+}
+
+func TestWaitForExitCode_ContextCancelledReturnsMinusOne(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "podtrace",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+	if got := WaitForExitCode(ctx, cs, "ns", "spawn"); got != -1 {
+		t.Errorf("WaitForExitCode (cancelled) = %d, want -1", got)
+	}
+}
+
+func TestWaitForExitCode_NotFoundReturnsMinusOne(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := fake.NewSimpleClientset() // no such pod
+	if got := WaitForExitCode(ctx, cs, "ns", "missing"); got != -1 {
+		t.Errorf("WaitForExitCode (not found) = %d, want -1", got)
+	}
+}
+
+// --- streamLogs (fake clientset) ---
+
+func TestStreamLogs_CopiesFakeLogStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "podtrace"}},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+
+	var out bytes.Buffer
+	if err := streamLogs(ctx, cs, pod, &out); err != nil {
+		t.Fatalf("streamLogs error: %v", err)
+	}
+	// The fake clientset returns the canned body "fake logs".
+	if got := out.String(); got != "fake logs" {
+		t.Errorf("streamLogs copied %q, want %q", got, "fake logs")
+	}
+}
+
+// --- AttachToPod (fake clientset) ---
+
+func TestAttachToPod_NilPod(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	_, err := AttachToPod(context.Background(), &rest.Config{}, cs, nil, genericiooptions.IOStreams{})
+	if err == nil {
+		t.Fatalf("expected error for nil pod")
+	}
+}

--- a/internal/kubernetes/stat_cgroup_dir_unit_test.go
+++ b/internal/kubernetes/stat_cgroup_dir_unit_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatCgroupDir_OutsideBase(t *testing.T) {
+	withCgroupBase(t)
+	if statCgroupDir("/some/other/place") {
+		t.Error("expected false for path outside cgroup base")
+	}
+}
+
+func TestStatCgroupDir_DirMissing(t *testing.T) {
+	base := withCgroupBase(t)
+	if statCgroupDir(filepath.Join(base, "does-not-exist")) {
+		t.Error("expected false for missing cgroup dir")
+	}
+}
+
+func TestStatCgroupDir_Exists(t *testing.T) {
+	base := withCgroupBase(t)
+	dir := filepath.Join(base, "grp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if !statCgroupDir(dir) {
+		t.Error("expected true when cgroup dir exists under base")
+	}
+}

--- a/internal/kubernetes/target_registry_unit_test.go
+++ b/internal/kubernetes/target_registry_unit_test.go
@@ -1,0 +1,281 @@
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// newCgroupV2Sandbox builds a temporary cgroup-v2 tree containing a kubepods
+// subdirectory for the given container ID and points config.CgroupBasePath at
+// it for the duration of the test. It also disables CRI resolution so
+// resolvePodInfoFromObject falls through to the filesystem walk. It returns the
+// full cgroup path that findCgroupPathV2 is expected to discover.
+func newCgroupV2Sandbox(t *testing.T, containerID string) string {
+	t.Helper()
+
+	base := t.TempDir()
+	if err := os.WriteFile(filepath.Join(base, "cgroup.controllers"), []byte("cpu memory\n"), 0o644); err != nil {
+		t.Fatalf("write cgroup.controllers: %v", err)
+	}
+	cgDir := filepath.Join(base, "kubepods.slice", "container-"+containerID)
+	if err := os.MkdirAll(cgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cgroup dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cgDir, "cgroup.procs"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write cgroup.procs: %v", err)
+	}
+
+	origBase := config.CgroupBasePath
+	config.CgroupBasePath = base
+	t.Setenv("PODTRACE_CRI_RESOLVE", "false")
+	t.Cleanup(func() { config.CgroupBasePath = origBase })
+
+	return cgDir
+}
+
+// runningPod returns a pod whose single container is fully populated so that
+// resolvePodInfoFromObject can succeed (valid 64-char hex container ID).
+func runningPod(uid, ns, name, containerName, containerID string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uid),
+			Namespace: ns,
+			Name:      name,
+			Labels:    map[string]string{"app": "demo"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: name + "-rs"},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: containerName}},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "10.1.2.3",
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: containerName, ContainerID: "containerd://" + containerID},
+			},
+		},
+	}
+}
+
+func TestResolvePodInfoFromObject_SuccessExtractsFields(t *testing.T) {
+	cid := hex64()
+	wantCgroup := newCgroupV2Sandbox(t, cid)
+
+	pod := runningPod("uid-1", "prod", "api-0", "app", cid)
+
+	info, err := resolvePodInfoFromObject(context.Background(), pod, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil PodInfo")
+	}
+	if info.PodName != "api-0" {
+		t.Errorf("PodName: got %q want %q", info.PodName, "api-0")
+	}
+	if info.Namespace != "prod" {
+		t.Errorf("Namespace: got %q want %q", info.Namespace, "prod")
+	}
+	if info.ContainerID != cid {
+		t.Errorf("ContainerID: got %q want %q", info.ContainerID, cid)
+	}
+	if info.ContainerName != "app" {
+		t.Errorf("ContainerName: got %q want %q", info.ContainerName, "app")
+	}
+	if info.PodIP != "10.1.2.3" {
+		t.Errorf("PodIP: got %q want %q", info.PodIP, "10.1.2.3")
+	}
+	if info.OwnerKind != "ReplicaSet" || info.OwnerName != "api-0-rs" {
+		t.Errorf("owner: got %q/%q want ReplicaSet/api-0-rs", info.OwnerKind, info.OwnerName)
+	}
+	if info.Labels["app"] != "demo" {
+		t.Errorf("Labels: got %v want app=demo", info.Labels)
+	}
+	if info.CgroupPath != wantCgroup {
+		t.Errorf("CgroupPath: got %q want %q", info.CgroupPath, wantCgroup)
+	}
+}
+
+func TestResolvePodInfoFromObject_NamedContainerSelected(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-named", Namespace: "ns", Name: "p"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "sidecar"}, {Name: "main"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar", ContainerID: "containerd://" + hex64()},
+				{Name: "main", ContainerID: "containerd://" + cid},
+			},
+		},
+	}
+
+	info, err := resolvePodInfoFromObject(context.Background(), pod, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.ContainerID != cid {
+		t.Errorf("ContainerID: got %q want %q (wrong container selected)", info.ContainerID, cid)
+	}
+	if info.ContainerName != "main" {
+		t.Errorf("ContainerName: got %q want main", info.ContainerName)
+	}
+}
+
+func TestResolvePodInfoFromObject_MissingOptionalFields(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-min", Namespace: "ns", Name: "bare"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c0"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c0", ContainerID: "containerd://" + cid},
+			},
+		},
+	}
+
+	info, err := resolvePodInfoFromObject(context.Background(), pod, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.OwnerKind != "" || info.OwnerName != "" {
+		t.Errorf("expected empty owner, got %q/%q", info.OwnerKind, info.OwnerName)
+	}
+	if info.PodIP != "" {
+		t.Errorf("expected empty PodIP, got %q", info.PodIP)
+	}
+	if len(info.Labels) != 0 {
+		t.Errorf("expected empty labels, got %v", info.Labels)
+	}
+}
+
+func TestHandlePodUpsert_InsertsMatchingPod(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{Namespaces: []string{"prod"}})
+	pod := runningPod("uid-ins", "prod", "api-0", "app", cid)
+
+	tr.handlePodUpsert(pod)
+
+	tr.mu.RLock()
+	got, ok := tr.targets[pod.UID]
+	tr.mu.RUnlock()
+	if !ok {
+		t.Fatal("matching pod was not inserted into targets")
+	}
+	if got.PodName != "api-0" || got.ContainerID != cid {
+		t.Fatalf("stored PodInfo unexpected: %+v", got)
+	}
+
+	snap := tr.Snapshot()
+	if len(snap) != 1 || snap[0].PodName != "api-0" {
+		t.Fatalf("snapshot did not reflect inserted pod: %+v", snap)
+	}
+}
+
+func TestHandlePodUpsert_RespectsMaxTargets(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
+	tr.maxTargets = 1
+	tr.targets[types.UID("existing")] = &PodInfo{PodName: "existing"}
+
+	pod := runningPod("uid-overflow", "ns", "newpod", "app", cid)
+	tr.handlePodUpsert(pod)
+
+	tr.mu.RLock()
+	_, inserted := tr.targets[pod.UID]
+	count := len(tr.targets)
+	tr.mu.RUnlock()
+	if inserted {
+		t.Fatal("new pod should be rejected when max targets reached")
+	}
+	if count != 1 {
+		t.Fatalf("target count: got %d want 1", count)
+	}
+}
+
+func TestHandlePodUpsert_UpdatesExistingAtMaxTargets(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
+	tr.maxTargets = 1
+
+	pod := runningPod("uid-upd", "ns", "p", "app", cid)
+	tr.targets[pod.UID] = &PodInfo{PodName: "stale"}
+
+	tr.handlePodUpsert(pod)
+
+	tr.mu.RLock()
+	got := tr.targets[pod.UID]
+	tr.mu.RUnlock()
+	if got == nil || got.PodName != "p" {
+		t.Fatalf("existing target should be updated at max limit, got %+v", got)
+	}
+}
+
+func TestRebuildFromStore_PopulatesFromInformerStore(t *testing.T) {
+	cid := hex64()
+	newCgroupV2Sandbox(t, cid)
+
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{Namespaces: []string{"prod"}})
+
+	factory := informers.NewSharedInformerFactory(tr.clientset, 0)
+	tr.podInf = factory.Core().V1().Pods().Informer()
+
+	matching := runningPod("uid-a", "prod", "api-0", "app", cid)
+	nonMatching := runningPod("uid-b", "dev", "api-1", "app", hex64())
+	if err := tr.podInf.GetStore().Add(matching); err != nil {
+		t.Fatalf("store add matching: %v", err)
+	}
+	if err := tr.podInf.GetStore().Add(nonMatching); err != nil {
+		t.Fatalf("store add non-matching: %v", err)
+	}
+
+	tr.rebuildFromStore()
+
+	tr.mu.RLock()
+	_, hasMatch := tr.targets[matching.UID]
+	_, hasNonMatch := tr.targets[nonMatching.UID]
+	count := len(tr.targets)
+	tr.mu.RUnlock()
+
+	if !hasMatch {
+		t.Error("matching pod from store was not added to targets")
+	}
+	if hasNonMatch {
+		t.Error("non-matching pod (wrong namespace) must not be added")
+	}
+	if count != 1 {
+		t.Fatalf("target count: got %d want 1", count)
+	}
+}
+
+func TestRebuildFromStore_NoInformerIsNoop(t *testing.T) {
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
+	tr.rebuildFromStore()
+	if len(tr.targets) != 0 {
+		t.Fatalf("expected no targets, got %d", len(tr.targets))
+	}
+}

--- a/internal/ldsoconf/openroot_unit_test.go
+++ b/internal/ldsoconf/openroot_unit_test.go
@@ -1,0 +1,33 @@
+package ldsoconf
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func TestOpenRoot_CachesAcrossCalls(t *testing.T) {
+	withBase(t, t.TempDir())
+
+	first, err := openRoot()
+	if err != nil {
+		t.Fatalf("first openRoot: %v", err)
+	}
+	second, err := openRoot()
+	if err != nil {
+		t.Fatalf("second openRoot: %v", err)
+	}
+	if first != second {
+		t.Errorf("expected cached root to be reused, got distinct instances")
+	}
+	if first.Name() != config.LdSoConfBasePath {
+		t.Errorf("root name = %q, want %q", first.Name(), config.LdSoConfBasePath)
+	}
+}
+
+func TestOpenRoot_ErrorOnMissingBase(t *testing.T) {
+	withBase(t, "/no/such/ldso/base")
+	if _, err := openRoot(); err == nil {
+		t.Fatal("expected error for missing base directory")
+	}
+}

--- a/internal/metricsexporter/promexporter_server_test.go
+++ b/internal/metricsexporter/promexporter_server_test.go
@@ -1,0 +1,98 @@
+package metricsexporter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// TestRateLimitMiddleware_Throttled drives enough requests through the shared
+// limiter to exhaust its burst, exercising the 429 branch of rateLimitMiddleware
+// that the allowed-only tests do not reach.
+func TestRateLimitMiddleware_Throttled(t *testing.T) {
+	original := limiter
+	limiter = rate.NewLimiter(rate.Every(time.Second/time.Duration(config.RateLimitPerSec)), config.RateLimitBurst)
+	t.Cleanup(func() { limiter = original })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := rateLimitMiddleware(next)
+
+	var sawOK, sawThrottled bool
+	for i := 0; i < 200; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		switch rr.Code {
+		case http.StatusOK:
+			sawOK = true
+		case http.StatusTooManyRequests:
+			sawThrottled = true
+		default:
+			t.Fatalf("unexpected status code %d", rr.Code)
+		}
+		if sawOK && sawThrottled {
+			break
+		}
+	}
+
+	if !sawOK {
+		t.Errorf("expected at least one allowed (200) response")
+	}
+	if !sawThrottled {
+		t.Errorf("expected at least one throttled (429) response after exhausting burst")
+	}
+}
+
+// TestStartServer_RejectNonLoopback exercises the StartServer branch that
+// rejects a non-loopback metrics address when the insecure-allow flag is unset
+// and falls back to the default loopback address.
+func TestStartServer_RejectNonLoopback(t *testing.T) {
+	t.Setenv("PODTRACE_METRICS_ADDR", "8.8.8.8:0")
+
+	srv := StartServer()
+	if srv == nil {
+		t.Fatalf("expected non-nil server")
+	}
+	defer srv.Shutdown()
+
+	if srv.server.Addr == "8.8.8.8:0" {
+		t.Errorf("expected non-loopback address to be rejected and replaced with default, got %q", srv.server.Addr)
+	}
+}
+
+// TestStartServer_WithPprof exercises the pprof-enabled branch of StartServer,
+// which registers the /debug/pprof handlers and logs the pprof notice.
+func TestStartServer_WithPprof(t *testing.T) {
+	t.Setenv("PODTRACE_METRICS_ADDR", "127.0.0.1:0")
+	t.Setenv("PODTRACE_METRICS_INSECURE_ALLOW_ANY_ADDR", "1")
+	t.Setenv("PODTRACE_METRICS_ENABLE_PPROF", "1")
+
+	srv := StartServer()
+	if srv == nil {
+		t.Fatalf("expected non-nil server")
+	}
+	defer srv.Shutdown()
+
+	// Drive the registered pprof handler directly via the server's mux to
+	// confirm the pprof routes were wired up without binding to a real port.
+	mux, ok := srv.server.Handler.(*http.ServeMux)
+	if !ok {
+		t.Fatalf("expected server handler to be *http.ServeMux")
+	}
+	h, pattern := mux.Handler(httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	if pattern == "" {
+		t.Fatalf("expected /debug/pprof/ to be registered when pprof is enabled")
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected pprof index to return 200, got %d", rr.Code)
+	}
+}

--- a/internal/operator/conditions_equal_unit_test.go
+++ b/internal/operator/conditions_equal_unit_test.go
@@ -1,0 +1,91 @@
+package operator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestConditionsEqual_Branches(t *testing.T) {
+	base := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: "OK", Message: "all good"},
+		{Type: "Synced", Status: metav1.ConditionFalse, Reason: "Pending", Message: "waiting"},
+	}
+
+	tests := []struct {
+		name string
+		a    []metav1.Condition
+		b    []metav1.Condition
+		want bool
+	}{
+		{
+			name: "equal",
+			a:    base,
+			b:    []metav1.Condition{base[1], base[0]},
+			want: true,
+		},
+		{
+			name: "different length",
+			a:    base,
+			b:    base[:1],
+			want: false,
+		},
+		{
+			name: "missing type",
+			a:    base,
+			b:    []metav1.Condition{base[0], {Type: "Other", Status: metav1.ConditionTrue}},
+			want: false,
+		},
+		{
+			name: "status differs",
+			a:    base,
+			b: []metav1.Condition{
+				base[0],
+				{Type: "Synced", Status: metav1.ConditionTrue, Reason: "Pending", Message: "waiting"},
+			},
+			want: false,
+		},
+		{
+			name: "message differs",
+			a:    base,
+			b: []metav1.Condition{
+				base[0],
+				{Type: "Synced", Status: metav1.ConditionFalse, Reason: "Pending", Message: "changed"},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := conditionsEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("conditionsEqual() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReportToSpecFromReportRef_ObjectStoreAndNil(t *testing.T) {
+	if got := reportToSpecFromReportRef(nil); got != "" {
+		t.Errorf("nil session should be empty, got %q", got)
+	}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://bucket/key"},
+			},
+		},
+	}
+	if got := reportToSpecFromReportRef(s); got != "s3://bucket/key" {
+		t.Errorf("objectstore spec: %q", got)
+	}
+
+	// ReportRef present but no populated variant falls through to "".
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{}
+	if got := reportToSpecFromReportRef(s); got != "" {
+		t.Errorf("empty ref should be empty, got %q", got)
+	}
+}

--- a/internal/operator/exporter_bundle_branches_test.go
+++ b/internal/operator/exporter_bundle_branches_test.go
@@ -1,0 +1,77 @@
+package operator
+
+import (
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestRenderBundlePayload_MissingVariantErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  podtracev1alpha1.ExporterType
+	}{
+		{"jaeger", podtracev1alpha1.ExporterTypeJaeger},
+		{"zipkin", podtracev1alpha1.ExporterTypeZipkin},
+		{"splunk", podtracev1alpha1.ExporterTypeSplunk},
+		{"datadog", podtracev1alpha1.ExporterTypeDataDog},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := renderBundlePayload(nil, ec("missing-"+tc.name, podtracev1alpha1.ExporterConfigSpec{
+				Type: tc.typ,
+			}), nil)
+			if err == nil {
+				t.Fatalf("expected error when spec.%s is nil for type=%s", tc.name, tc.typ)
+			}
+		})
+	}
+}
+
+func TestRenderBundlePayload_DataDogExplicitEndpoint(t *testing.T) {
+	data, secret, err := renderBundlePayload(nil, ec("dd-ep", podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeDataDog,
+		DataDog: &podtracev1alpha1.DataDogExporter{
+			Site:            "datadoghq.eu",
+			Endpoint:        "dd-custom:4318",
+			APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api"},
+		},
+	}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil || secret.Name != "dd" {
+		t.Fatalf("expected DataDog credential ref, got %+v", secret)
+	}
+	if data["site"] != "datadoghq.eu" {
+		t.Errorf("site=%q want datadoghq.eu", data["site"])
+	}
+	if data["endpoint"] != "dd-custom:4318" {
+		t.Errorf("explicit endpoint not honored: %q", data["endpoint"])
+	}
+}
+
+func TestRenderBundlePayload_TargetNamespacesSorted(t *testing.T) {
+	data, _, err := renderBundlePayload(nil, ec("ns", podtracev1alpha1.ExporterConfigSpec{
+		Type:   podtracev1alpha1.ExporterTypeJaeger,
+		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
+	}), []string{"team-c", "team-a", "team-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data["target_namespaces"] != "team-a,team-b,team-c" {
+		t.Errorf("target_namespaces=%q want sorted CSV", data["target_namespaces"])
+	}
+}
+
+func TestResolvePolicyStatus_NilInputs(t *testing.T) {
+	if got := resolvePolicyStatus(nil, nil); got != nil {
+		t.Errorf("resolvePolicyStatus(nil, nil)=%+v want nil", got)
+	}
+}
+
+func TestSynthBundleForHash_Nil(t *testing.T) {
+	if got := synthBundleForHash(nil); got != nil {
+		t.Errorf("synthBundleForHash(nil)=%+v want nil", got)
+	}
+}

--- a/internal/operator/exporter_bundle_view_test.go
+++ b/internal/operator/exporter_bundle_view_test.go
@@ -1,0 +1,29 @@
+package operator
+
+import "testing"
+
+func TestBundleViewFromData_NilOnError(t *testing.T) {
+	if got := bundleViewFromData(nil); got != nil {
+		t.Errorf("expected nil payload on error, got %+v", got)
+	}
+
+	if got := bundleViewFromData(map[string]string{"version": "v999"}); got != nil {
+		t.Errorf("expected nil payload for unsupported version, got %+v", got)
+	}
+}
+
+func TestBundleViewFromData_ValidData(t *testing.T) {
+	got := bundleViewFromData(map[string]string{
+		"type":     "otlp",
+		"endpoint": "otel:4318",
+	})
+	if got == nil {
+		t.Fatal("expected non-nil payload for valid data")
+	}
+	if string(got.Type) != "otlp" {
+		t.Errorf("Type = %q, want otlp", got.Type)
+	}
+	if got.Endpoint != "otel:4318" {
+		t.Errorf("Endpoint = %q, want otel:4318", got.Endpoint)
+	}
+}

--- a/internal/operator/finalizer_unit_test.go
+++ b/internal/operator/finalizer_unit_test.go
@@ -1,0 +1,276 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+const finTestSysNS = "podtrace-system"
+
+// finTestSession returns a PodTraceSession with a stable UID/namespace used
+// across the cleanup tests.
+func finTestSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sess",
+			Namespace: "team-a",
+			UID:       types.UID("sess-uid"),
+		},
+	}
+}
+
+// finSessionJob builds a per-node session Job in the system namespace with the
+// label set cleanupPodTraceSessionChildren lists by.
+func finSessionJob(name, node string, withUID bool) *batchv1.Job {
+	j := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: finTestSysNS,
+			Labels: map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: "sess",
+				LabelSessionNS:   "team-a",
+				LabelNodeName:    node,
+			},
+		},
+	}
+	if withUID {
+		j.UID = types.UID("job-" + name)
+	}
+	return j
+}
+
+// TestFin_CleanupSessionChildren_DeletesAll seeds the full child set (a Job,
+// the bundle ConfigMap + Secret, the object-store creds Secret, and the
+// per-session Role + RoleBinding) and asserts cleanupPodTraceSessionChildren
+// removes every one of them.
+func TestFin_CleanupSessionChildren_DeletesAll(t *testing.T) {
+	s := finTestSession()
+	scheme := newOperatorScheme(t)
+
+	job := finSessionJob("job-n1", "n1", true)
+	bundleCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: SessionBundleName(s.UID), Namespace: finTestSysNS}}
+	bundleSec := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: SessionBundleName(s.UID), Namespace: finTestSysNS}}
+	credsSec := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: SessionObjectStoreCredsName(s.UID), Namespace: finTestSysNS}}
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: SessionReportRoleName(s.UID), Namespace: s.Namespace}}
+	rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: SessionReportRoleBindingName(s.UID), Namespace: s.Namespace}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(job, bundleCM, bundleSec, credsSec, role, rb).Build()
+
+	ctx := context.Background()
+	if err := cleanupPodTraceSessionChildren(ctx, c, s, finTestSysNS); err != nil {
+		t.Fatalf("cleanup error = %v, want nil", err)
+	}
+
+	mustBeGone := func(name, ns string, obj client.Object) {
+		err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, obj)
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("%T %s/%s still present (err=%v), want NotFound", obj, ns, name, err)
+		}
+	}
+	mustBeGone(job.Name, finTestSysNS, &batchv1.Job{})
+	mustBeGone(bundleCM.Name, finTestSysNS, &corev1.ConfigMap{})
+	mustBeGone(credsSec.Name, finTestSysNS, &corev1.Secret{})
+	mustBeGone(role.Name, s.Namespace, &rbacv1.Role{})
+	mustBeGone(rb.Name, s.Namespace, &rbacv1.RoleBinding{})
+}
+
+// TestFin_CleanupSessionChildren_NothingToDelete covers the idempotent path:
+// with no children present every Delete returns NotFound (ignored) and the
+// Job list is empty, so cleanup succeeds without error.
+func TestFin_CleanupSessionChildren_NothingToDelete(t *testing.T) {
+	s := finTestSession()
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).Build()
+
+	if err := cleanupPodTraceSessionChildren(context.Background(), c, s, finTestSysNS); err != nil {
+		t.Fatalf("cleanup with no children error = %v, want nil", err)
+	}
+}
+
+// TestFin_CleanupSessionChildren_SkipsZeroUIDJob covers the j.UID == "" guard:
+// a listed Job without a UID is skipped (never Deleted). We assert the Job is
+// still present after cleanup and that a real Delete would have been a no-op by
+// failing the test if the interceptor's Delete is ever invoked for that Job.
+func TestFin_CleanupSessionChildren_SkipsZeroUIDJob(t *testing.T) {
+	s := finTestSession()
+	noUIDJob := finSessionJob("job-noid", "n1", false)
+
+	deleteCalledForJob := false
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithObjects(noUIDJob).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if j, ok := obj.(*batchv1.Job); ok && j.Name == "job-noid" {
+					deleteCalledForJob = true
+				}
+				return cl.Delete(ctx, obj, opts...)
+			},
+		}).Build()
+
+	if err := cleanupPodTraceSessionChildren(context.Background(), c, s, finTestSysNS); err != nil {
+		t.Fatalf("cleanup error = %v, want nil", err)
+	}
+	if deleteCalledForJob {
+		t.Errorf("Delete was called for the zero-UID Job; it should be skipped")
+	}
+}
+
+// TestFin_CleanupSessionChildren_ListError covers the list-Jobs failure branch.
+func TestFin_CleanupSessionChildren_ListError(t *testing.T) {
+	s := finTestSession()
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return errors.New("list boom")
+			},
+		}).Build()
+
+	err := cleanupPodTraceSessionChildren(context.Background(), c, s, finTestSysNS)
+	if err == nil {
+		t.Fatal("expected error from list failure, got nil")
+	}
+	if got := err.Error(); !contains(got, "list session Jobs") {
+		t.Errorf("error = %q, want it to mention list session Jobs", got)
+	}
+}
+
+// TestFin_CleanupSessionChildren_JobDeleteError covers the non-NotFound error
+// branch of the per-Job Delete loop.
+func TestFin_CleanupSessionChildren_JobDeleteError(t *testing.T) {
+	s := finTestSession()
+	job := finSessionJob("job-n1", "n1", true)
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithObjects(job).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*batchv1.Job); ok {
+					return errors.New("delete job boom")
+				}
+				return nil
+			},
+		}).Build()
+
+	err := cleanupPodTraceSessionChildren(context.Background(), c, s, finTestSysNS)
+	if err == nil {
+		t.Fatal("expected error from Job delete failure, got nil")
+	}
+	if got := err.Error(); !contains(got, "delete Job") {
+		t.Errorf("error = %q, want it to mention delete Job", got)
+	}
+}
+
+// TestFin_CleanupSessionChildren_RBACError covers the cleanupSessionReportRBAC
+// failure branch: the bundle deletes succeed but the RBAC Role/RoleBinding
+// delete returns a non-NotFound error.
+func TestFin_CleanupSessionChildren_RBACError(t *testing.T) {
+	s := finTestSession()
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				switch obj.(type) {
+				case *rbacv1.Role, *rbacv1.RoleBinding:
+					return errors.New("rbac delete boom")
+				default:
+					return nil
+				}
+			},
+		}).Build()
+
+	err := cleanupPodTraceSessionChildren(context.Background(), c, s, finTestSysNS)
+	if err == nil {
+		t.Fatal("expected error from RBAC delete failure, got nil")
+	}
+	if got := err.Error(); !contains(got, "session RBAC") {
+		t.Errorf("error = %q, want it to mention session RBAC", got)
+	}
+}
+
+// TestFin_ScheduleReconcile_GetError covers the non-NotFound Get error path at
+// the top of Reconcile.
+func TestFin_ScheduleReconcile_GetError(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(newOperatorScheme(t)).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errors.New("get boom")
+			},
+		}).Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: c.Scheme(), nowFn: func() time.Time { return fixedScheduleNow }}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "x", Namespace: "default"},
+	})
+	if err == nil {
+		t.Fatal("expected error from Get failure, got nil")
+	}
+	if got := err.Error(); !contains(got, "get PodTraceSchedule") {
+		t.Errorf("error = %q, want it to mention get PodTraceSchedule", got)
+	}
+}
+
+// TestFin_ScheduleReconcile_NamespaceTerminating covers the
+// ensureSessionForRun Forbidden+"being terminated" branch: a due schedule
+// whose session creation is rejected because the namespace is terminating
+// must exit cleanly (no error, empty result) rather than stack-trace.
+func TestFin_ScheduleReconcile_NamespaceTerminating(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "due",
+			Namespace:         "default",
+			UID:               "due-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-24 * time.Hour)),
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(newOperatorScheme(t)).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*podtracev1alpha1.PodTraceSession); ok {
+					return apierrors.NewForbidden(
+						podtracev1alpha1.GroupVersion.WithResource("podtracesessions").GroupResource(),
+						"due-session",
+						errors.New("unable to create new content in namespace default because it is being terminated"),
+					)
+				}
+				return nil
+			},
+		}).Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: c.Scheme(), nowFn: func() time.Time { return fixedScheduleNow }}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile(namespace terminating) error = %v, want nil", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Fatalf("Reconcile(namespace terminating) result = %+v, want empty", res)
+	}
+}

--- a/internal/operator/naming_test.go
+++ b/internal/operator/naming_test.go
@@ -18,15 +18,16 @@ import (
 //     result.
 func TestSessionJobName_Properties(t *testing.T) {
 	cases := []struct {
-		name    string
-		uid     types.UID
-		node    string
+		name     string
+		uid      types.UID
+		node     string
 		mustHave string
 	}{
 		{"simple", "abcdef1234567890", "ip-10-0-1-4", "pts-abcdef123456"},
 		{"dotted-fqdn", "abcdef1234567890", "node-1.prod.example.com", "pts-abcdef123456"},
 		{"uppercase", "abcdef1234567890", "Node-Upper", "pts-abcdef123456"},
 		{"short-uid", "ab12", "node-a", "pts-ab12"},
+		{"long-node-truncates", "abcdef1234567890", "very-long-node-name-that-keeps-going-and-going-and-going-forever", "pts-abcdef123456"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/operator/normalize_filters_unit_test.go
+++ b/internal/operator/normalize_filters_unit_test.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"reflect"
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestNormalizeFilters_Branches(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []podtracev1alpha1.EventFilter
+		want []string
+	}{
+		{
+			name: "empty input returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "trims, drops empties, dedups and sorts",
+			in: []podtracev1alpha1.EventFilter{
+				"  net ",
+				"dns",
+				"",
+				"  ",
+				"net",
+				"cpu",
+			},
+			want: []string{"cpu", "dns", "net"},
+		},
+		{
+			name: "all empty returns empty slice",
+			in:   []podtracev1alpha1.EventFilter{"", "   "},
+			want: []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeFilters(tc.in)
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("normalizeFilters() = %v, want nil", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("normalizeFilters() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/operator/podtraceschedule_reconcile_unit_test.go
+++ b/internal/operator/podtraceschedule_reconcile_unit_test.go
@@ -1,0 +1,293 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// fixedNow is a stable timestamp used across the schedule reconcile tests
+// so cron math and history GC never depend on the wall clock.
+var fixedScheduleNow = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+
+func newScheduleReconciler(t *testing.T, objs ...client.Object) (*PodTraceScheduleReconciler, *runtime.Scheme) {
+	t.Helper()
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(objs...).
+		Build()
+	return &PodTraceScheduleReconciler{
+		Client: c,
+		Scheme: s,
+		nowFn:  func() time.Time { return fixedScheduleNow },
+	}, s
+}
+
+// TestPodTraceScheduleReconcile_NotFound exercises the IsNotFound exit path:
+// a request for a name that does not exist returns an empty result, no error.
+func TestPodTraceScheduleReconcile_NotFound(t *testing.T) {
+	r, _ := newScheduleReconciler(t)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile(not found) error = %v, want nil", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Fatalf("Reconcile(not found) result = %+v, want empty", res)
+	}
+}
+
+// TestPodTraceScheduleReconcile_CreatesSession reconciles a valid schedule and
+// asserts a child session is created and status is written back.
+func TestPodTraceScheduleReconcile_CreatesSession(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "every5",
+			Namespace:         "default",
+			UID:               "sch-uid-1",
+			Generation:        7,
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-24 * time.Hour)),
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Metadata: podtracev1alpha1.PodTraceSessionTemplateMetadata{
+					Labels:      map[string]string{"team": "obs"},
+					Annotations: map[string]string{"note": "scheduled"},
+				},
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+
+	res, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile error = %v, want nil", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("Reconcile RequeueAfter = %v, want > 0", res.RequeueAfter)
+	}
+
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions.Items) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions.Items))
+	}
+	child := sessions.Items[0]
+	if !isOwnedBy(&child, sch) {
+		t.Fatalf("created session %s not owned by schedule", child.Name)
+	}
+	if child.Labels["podtrace.io/schedule"] != sch.Name {
+		t.Errorf("session schedule label = %q, want %q", child.Labels["podtrace.io/schedule"], sch.Name)
+	}
+	if child.Labels["team"] != "obs" {
+		t.Errorf("template label not propagated: %v", child.Labels)
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace}, &got); err != nil {
+		t.Fatalf("get schedule: %v", err)
+	}
+	if got.Status.ObservedGeneration != sch.Generation {
+		t.Errorf("ObservedGeneration = %d, want %d", got.Status.ObservedGeneration, sch.Generation)
+	}
+	if len(got.Status.Conditions) == 0 {
+		t.Errorf("expected at least one status condition, got none")
+	}
+	if got.Status.LastScheduleTime == nil {
+		t.Errorf("expected LastScheduleTime to be set after a triggered run")
+	}
+}
+
+// TestEnsureSessionForRun_And_Ownership covers ensureSessionForRun creating a
+// session, listOwnedSessions + isOwnedBy filtering by owner UID.
+func TestEnsureSessionForRun_And_Ownership(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner-sched",
+			Namespace: "default",
+			UID:       "owner-uid",
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+
+	foreign := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreign",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: podtracev1alpha1.GroupVersion.String(),
+				Kind:       "PodTraceSchedule",
+				Name:       "someone-else",
+				UID:        "other-uid",
+			}},
+		},
+	}
+
+	r, _ := newScheduleReconciler(t, sch, foreign)
+	ctx := context.Background()
+
+	runTime := fixedScheduleNow
+	session, created, err := r.ensureSessionForRun(ctx, sch, runTime)
+	if err != nil {
+		t.Fatalf("ensureSessionForRun error = %v", err)
+	}
+	if !created {
+		t.Fatalf("ensureSessionForRun created = false, want true on first call")
+	}
+	if !isOwnedBy(session, sch) {
+		t.Fatalf("ensured session not owned by schedule")
+	}
+
+	_, created2, err := r.ensureSessionForRun(ctx, sch, runTime)
+	if err != nil {
+		t.Fatalf("ensureSessionForRun (2nd) error = %v", err)
+	}
+	if created2 {
+		t.Errorf("ensureSessionForRun second call created = true, want false (idempotent)")
+	}
+
+	owned, err := r.listOwnedSessions(ctx, sch)
+	if err != nil {
+		t.Fatalf("listOwnedSessions error = %v", err)
+	}
+	if len(owned) != 1 {
+		t.Fatalf("listOwnedSessions returned %d, want 1 (foreign must be filtered)", len(owned))
+	}
+	if owned[0].Name != session.Name {
+		t.Errorf("owned session = %q, want %q", owned[0].Name, session.Name)
+	}
+}
+
+// TestApplyHistoryLimits_GCOldest builds several completed/failed sessions with
+// distinct completion times and asserts gcOldest / applyHistoryLimits keep only
+// the newest within the configured limits.
+func TestApplyHistoryLimits_GCOldest(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gc-sched",
+			Namespace: "default",
+			UID:       "gc-uid",
+		},
+	}
+	keepSucc := int32(1)
+	keepFail := int32(0)
+	sch.Spec.SuccessfulSessionsHistoryLimit = &keepSucc
+	sch.Spec.FailedSessionsHistoryLimit = &keepFail
+
+	mk := func(name string, state podtracev1alpha1.SessionState, completedAt time.Time) *podtracev1alpha1.PodTraceSession {
+		ct := metav1.NewTime(completedAt)
+		return &podtracev1alpha1.PodTraceSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: podtracev1alpha1.GroupVersion.String(),
+					Kind:       "PodTraceSchedule",
+					Name:       sch.Name,
+					UID:        sch.UID,
+				}},
+			},
+			Status: podtracev1alpha1.PodTraceSessionStatus{
+				State:          state,
+				CompletionTime: &ct,
+			},
+		}
+	}
+
+	oldSucc := mk("succ-old", podtracev1alpha1.SessionStateCompleted, fixedScheduleNow.Add(-2*time.Hour))
+	newSucc := mk("succ-new", podtracev1alpha1.SessionStateCompleted, fixedScheduleNow.Add(-1*time.Hour))
+	fail1 := mk("fail-1", podtracev1alpha1.SessionStateFailed, fixedScheduleNow.Add(-90*time.Minute))
+	fail2 := mk("fail-2", podtracev1alpha1.SessionStateFailed, fixedScheduleNow.Add(-30*time.Minute))
+
+	r, _ := newScheduleReconciler(t, sch, oldSucc, newSucc, fail1, fail2)
+	ctx := context.Background()
+
+	succeeded := []podtracev1alpha1.PodTraceSession{*oldSucc, *newSucc}
+	failed := []podtracev1alpha1.PodTraceSession{*fail1, *fail2}
+
+	if err := r.applyHistoryLimits(ctx, sch, succeeded, failed); err != nil {
+		t.Fatalf("applyHistoryLimits error = %v", err)
+	}
+
+	owned, err := r.listOwnedSessions(ctx, sch)
+	if err != nil {
+		t.Fatalf("listOwnedSessions error = %v", err)
+	}
+	remaining := map[string]bool{}
+	for _, s := range owned {
+		remaining[s.Name] = true
+	}
+
+	if remaining["succ-old"] {
+		t.Errorf("succ-old should have been GCed (keep=1)")
+	}
+	if !remaining["succ-new"] {
+		t.Errorf("succ-new should remain (newest within keep=1)")
+	}
+	if remaining["fail-1"] || remaining["fail-2"] {
+		t.Errorf("failed sessions should be fully GCed (keep=0): %v", remaining)
+	}
+
+	if err := r.gcOldest(ctx, []podtracev1alpha1.PodTraceSession{*newSucc}, 5); err != nil {
+		t.Fatalf("gcOldest no-op error = %v", err)
+	}
+}
+
+// TestParseSchedule covers the bad-timezone error path and the happy path.
+func TestParseSchedule(t *testing.T) {
+	r, _ := newScheduleReconciler(t)
+
+	bad := "Not/AZone"
+	schBadTZ := &podtracev1alpha1.PodTraceSchedule{
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			TimeZone: &bad,
+		},
+	}
+	if _, _, err := r.parseSchedule(schBadTZ); err == nil {
+		t.Errorf("parseSchedule(bad timezone) error = nil, want error")
+	}
+
+	good := "UTC"
+	schGood := &podtracev1alpha1.PodTraceSchedule{
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			TimeZone: &good,
+		},
+	}
+	parsed, loc, err := r.parseSchedule(schGood)
+	if err != nil {
+		t.Fatalf("parseSchedule(valid) error = %v, want nil", err)
+	}
+	if parsed == nil || loc == nil {
+		t.Fatalf("parseSchedule(valid) returned nil sched/loc")
+	}
+	if next := parsed.Next(fixedScheduleNow); !next.After(fixedScheduleNow) {
+		t.Errorf("parsed schedule Next = %v, want after %v", next, fixedScheduleNow)
+	}
+}

--- a/internal/operator/podtraceschedule_refreshstatus_test.go
+++ b/internal/operator/podtraceschedule_refreshstatus_test.go
@@ -1,0 +1,63 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestRefreshStatus_ActiveAndLastSuccess(t *testing.T) {
+	r := &PodTraceScheduleReconciler{}
+
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "sch", Namespace: "team-a", Generation: 9},
+	}
+
+	active := []podtracev1alpha1.PodTraceSession{
+		{ObjectMeta: metav1.ObjectMeta{Name: "z-sess", Namespace: "team-a", UID: types.UID("u-z"), ResourceVersion: "10"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "a-sess", Namespace: "team-a", UID: types.UID("u-a"), ResourceVersion: "11"}},
+	}
+	last := metav1.NewTime(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+
+	r.refreshStatus(sch, active, &last)
+
+	if len(sch.Status.Active) != 2 {
+		t.Fatalf("Active len=%d want 2", len(sch.Status.Active))
+	}
+	if sch.Status.Active[0].Name != "a-sess" || sch.Status.Active[1].Name != "z-sess" {
+		t.Errorf("Active not sorted by name: %v", []string{sch.Status.Active[0].Name, sch.Status.Active[1].Name})
+	}
+	if sch.Status.Active[0].Kind != "PodTraceSession" {
+		t.Errorf("Active[0].Kind=%q want PodTraceSession", sch.Status.Active[0].Kind)
+	}
+	if sch.Status.Active[0].UID != types.UID("u-a") {
+		t.Errorf("Active[0].UID=%q want u-a", sch.Status.Active[0].UID)
+	}
+	if sch.Status.LastSuccessfulTime == nil || !sch.Status.LastSuccessfulTime.Equal(&last) {
+		t.Errorf("LastSuccessfulTime=%v want %v", sch.Status.LastSuccessfulTime, last)
+	}
+	if sch.Status.ObservedGeneration != 9 {
+		t.Errorf("ObservedGeneration=%d want 9", sch.Status.ObservedGeneration)
+	}
+}
+
+func TestRefreshStatus_NoActiveNoLastSuccess(t *testing.T) {
+	r := &PodTraceScheduleReconciler{}
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "sch", Generation: 3},
+	}
+	r.refreshStatus(sch, nil, nil)
+	if len(sch.Status.Active) != 0 {
+		t.Errorf("Active should be empty, got %d", len(sch.Status.Active))
+	}
+	if sch.Status.LastSuccessfulTime != nil {
+		t.Errorf("LastSuccessfulTime should stay nil when lastSuccess is nil")
+	}
+	if sch.Status.ObservedGeneration != 3 {
+		t.Errorf("ObservedGeneration=%d want 3", sch.Status.ObservedGeneration)
+	}
+}

--- a/internal/operator/reconcilers_deep_unit_test.go
+++ b/internal/operator/reconcilers_deep_unit_test.go
@@ -1,0 +1,983 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// ─── PodTraceSessionReconciler.Reconcile — deeper branches ───────────
+
+// TestDeepReconcile_Session_BadObjectStoreURI drives the early
+// ValidateObjectStoreReference branch: an invalid objectStore URI marks
+// the session Failed via Degraded and returns no error.
+func TestDeepReconcile_Session_BadObjectStoreURI(t *testing.T) {
+	const sysNS, ns = "ns-sys", "default"
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "s", Namespace: ns, UID: "uid-s",
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "ftp://nope"},
+			},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s).Build()
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: s.Name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(s), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Errorf("state = %q, want Failed", got.Status.State)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue) {
+		t.Errorf("expected Degraded=True, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Session_ExporterNotFound drives the path where pods
+// match (target nodes resolved) but the referenced ExporterConfig is
+// missing: Degraded=True/ExporterNotFound, requeue, no error.
+func TestDeepReconcile_Session_ExporterNotFound(t *testing.T) {
+	const sysNS, ns = "ns-sys", "default"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: ns, Labels: map[string]string{"a": "b"}},
+		Spec:       corev1.PodSpec{NodeName: "n1"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "s", Namespace: ns, UID: "uid-s",
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "missing-ec"},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s, pod).Build()
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: s.Name, Namespace: ns},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected positive RequeueAfter when exporter missing")
+	}
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(s), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue) {
+		t.Errorf("expected Degraded=True, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Session_FullFanOut drives the full happy path: pods
+// matched, ExporterConfig present, bundle/SA/RBAC ensured, Jobs created,
+// status rolled up. This is the deepest branch of Reconcile.
+func TestDeepReconcile_Session_FullFanOut(t *testing.T) {
+	const sysNS, ns = "ns-sys", "default"
+	pods := []client.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: ns, Labels: map[string]string{"a": "b"}},
+			Spec:       corev1.PodSpec{NodeName: "n1"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: ns, Labels: map[string]string{"a": "b"}},
+			Spec:       corev1.PodSpec{NodeName: "n2"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	}
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "s", Namespace: ns, UID: "uid-s", Generation: 3,
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	objs := append(pods, s, ec)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(objs...).Build()
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: s.Name, Namespace: ns},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected positive RequeueAfter for non-terminal session")
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(s), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.ObservedGeneration != s.Generation {
+		t.Errorf("ObservedGeneration = %d, want %d", got.Status.ObservedGeneration, s.Generation)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReconciled, metav1.ConditionTrue) {
+		t.Errorf("expected Reconciled=True, got %+v", got.Status.Conditions)
+	}
+	if len(got.Status.Jobs) != 2 {
+		t.Errorf("expected 2 Job refs, got %d", len(got.Status.Jobs))
+	}
+	bundleName := SessionBundleName(s.UID)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: bundleName, Namespace: sysNS}, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("session bundle ConfigMap missing: %v", err)
+	}
+}
+
+// TestDeepReconcile_Session_DeletionRunsCleanup drives the deletion path:
+// a session with a deletion timestamp cleans up children and clears the
+// finalizer.
+func TestDeepReconcile_Session_DeletionRunsCleanup(t *testing.T) {
+	const sysNS, ns = "ns-sys", "default"
+	now := metav1.Now()
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "s", Namespace: ns, UID: "uid-s",
+			Finalizers:        []string{FinalizerCleanup},
+			DeletionTimestamp: &now,
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s).Build()
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: s.Name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	err := c.Get(context.Background(), client.ObjectKeyFromObject(s), &podtracev1alpha1.PodTraceSession{})
+	if err == nil {
+		var leftover podtracev1alpha1.PodTraceSession
+		_ = c.Get(context.Background(), client.ObjectKeyFromObject(s), &leftover)
+		if len(leftover.Finalizers) != 0 {
+			t.Errorf("finalizer should have been removed, got %v", leftover.Finalizers)
+		}
+	}
+}
+
+// TestDeepReconcile_ResolveTargetNodes_NamespaceSelector drives the
+// cluster-wide list + allowlist filter branch of resolveTargetNodes (the
+// existing test only covers the own-namespace + podRefs branches).
+func TestDeepReconcile_ResolveTargetNodes_NamespaceSelector(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "allowed", Labels: map[string]string{"team": "obs"}}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "denied"}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p-allowed", Namespace: "allowed", Labels: map[string]string{"app": "x"}},
+			Spec:       corev1.PodSpec{NodeName: "n-allowed"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p-denied", Namespace: "denied", Labels: map[string]string{"app": "x"}},
+			Spec:       corev1.PodSpec{NodeName: "n-denied"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	).Build()
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "obs"}},
+		},
+	}
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme}
+	nodes, namespaces, err := r.resolveTargetNodes(context.Background(), s)
+	if err != nil {
+		t.Fatalf("resolveTargetNodes: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0] != "n-allowed" {
+		t.Errorf("nodes = %v, want [n-allowed]", nodes)
+	}
+	if len(namespaces) != 1 || namespaces[0] != "allowed" {
+		t.Errorf("namespaces = %v, want [allowed]", namespaces)
+	}
+}
+
+// TestDeepReconcile_ResolveTargetNodes_EmptyAllowlist drives the
+// "selector set but no namespaces match" short-circuit (no pods listed).
+func TestDeepReconcile_ResolveTargetNodes_EmptyAllowlist(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "x", Labels: map[string]string{"app": "x"}},
+			Spec:       corev1.PodSpec{NodeName: "n1"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	).Build()
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "nomatch"}},
+		},
+	}
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme}
+	nodes, namespaces, err := r.resolveTargetNodes(context.Background(), s)
+	if err != nil {
+		t.Fatalf("resolveTargetNodes: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Errorf("nodes = %v, want empty (no namespaces match)", nodes)
+	}
+	if namespaces == nil || len(namespaces) != 0 {
+		t.Errorf("namespaces = %v, want empty non-nil slice", namespaces)
+	}
+}
+
+// ─── PodTraceScheduleReconciler.Reconcile — deeper branches ──────────
+
+func newScheduleSpec(schedule string) podtracev1alpha1.PodTraceScheduleSpec {
+	return podtracev1alpha1.PodTraceScheduleSpec{
+		Schedule: schedule,
+		SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+			Spec: podtracev1alpha1.PodTraceSessionSpec{},
+		},
+	}
+}
+
+// TestDeepReconcile_Schedule_Suspended drives the suspend short-circuit:
+// no session is created, Paused=True is recorded, and history GC still runs.
+func TestDeepReconcile_Schedule_Suspended(t *testing.T) {
+	suspend := true
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "suspended", Namespace: "default", UID: "sus-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+	}
+	sch.Spec.Suspend = &suspend
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+	res, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != scheduleResyncCeiling {
+		t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, scheduleResyncCeiling)
+	}
+
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions.Items) != 0 {
+		t.Errorf("suspended schedule should create no sessions, got %d", len(sessions.Items))
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionPaused, metav1.ConditionTrue) {
+		t.Errorf("expected Paused=True, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_BadTimezone drives the parseSchedule error
+// branch through Reconcile: Degraded=True/ScheduleInvalid, no requeue, nil err.
+func TestDeepReconcile_Schedule_BadTimezone(t *testing.T) {
+	bad := "Not/AZone"
+	spec := newScheduleSpec("*/5 * * * *")
+	spec.TimeZone = &bad
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "badtz", Namespace: "default", UID: "tz-uid"},
+		Spec:       spec,
+	}
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+	res, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("RequeueAfter = %v, want 0 (invalid schedule is not re-queued)", res.RequeueAfter)
+	}
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue) {
+		t.Errorf("expected Degraded=True, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_FutureNextRunNoTrigger drives the
+// now.Before(nextRun) branch: a schedule that just ran (LastScheduleTime
+// set to now) is not due again, so no new session is created.
+func TestDeepReconcile_Schedule_FutureNextRunNoTrigger(t *testing.T) {
+	last := metav1.NewTime(fixedScheduleNow)
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "future", Namespace: "default", UID: "fut-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+		Status: podtracev1alpha1.PodTraceScheduleStatus{
+			LastScheduleTime: &last,
+		},
+	}
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+	res, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Errorf("expected positive RequeueAfter for not-yet-due schedule, got %v", res.RequeueAfter)
+	}
+
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions.Items) != 0 {
+		t.Errorf("not-due schedule should create no sessions, got %d", len(sessions.Items))
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReconciled, metav1.ConditionTrue) {
+		t.Errorf("expected Reconciled=True, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_ForbidConcurrent drives the Forbid policy
+// branch: an active child session blocks a new run from being triggered.
+func TestDeepReconcile_Schedule_ForbidConcurrent(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "forbid", Namespace: "default", UID: "forbid-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+	}
+	sch.Spec.ConcurrencyPolicy = podtracev1alpha1.ForbidConcurrent
+
+	active := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "active-child", Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: podtracev1alpha1.GroupVersion.String(),
+				Kind:       "PodTraceSchedule",
+				Name:       sch.Name,
+				UID:        sch.UID,
+			}},
+		},
+		Status: podtracev1alpha1.PodTraceSessionStatus{State: podtracev1alpha1.SessionStateRunning},
+	}
+
+	r, _ := newScheduleReconciler(t, sch, active)
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions.Items) != 1 {
+		t.Errorf("Forbid should not create a new session while one is active, got %d", len(sessions.Items))
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !conditionHasReason(got.Status.Conditions, ConditionReconciled, "Forbidden") {
+		t.Errorf("expected Reconciled reason Forbidden, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_MaxActiveSessions drives the
+// MaxActiveSessions safety-valve branch.
+func TestDeepReconcile_Schedule_MaxActiveSessions(t *testing.T) {
+	cap := int32(1)
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "maxactive", Namespace: "default", UID: "max-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+	}
+	sch.Spec.MaxActiveSessions = &cap
+
+	active := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "active-child", Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: podtracev1alpha1.GroupVersion.String(),
+				Kind:       "PodTraceSchedule",
+				Name:       sch.Name,
+				UID:        sch.UID,
+			}},
+		},
+		Status: podtracev1alpha1.PodTraceSessionStatus{State: podtracev1alpha1.SessionStateRunning},
+	}
+
+	r, _ := newScheduleReconciler(t, sch, active)
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !conditionHasReason(got.Status.Conditions, ConditionReconciled, "ActiveLimitReached") {
+		t.Errorf("expected Reconciled reason ActiveLimitReached, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_ReplaceConcurrent drives the Replace policy
+// branch: active sessions are deleted before a new run is triggered.
+func TestDeepReconcile_Schedule_ReplaceConcurrent(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "replace", Namespace: "default", UID: "replace-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+	}
+	sch.Spec.ConcurrencyPolicy = podtracev1alpha1.ReplaceConcurrent
+
+	active := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-child", Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: podtracev1alpha1.GroupVersion.String(),
+				Kind:       "PodTraceSchedule",
+				Name:       sch.Name,
+				UID:        sch.UID,
+			}},
+		},
+		Status: podtracev1alpha1.PodTraceSessionStatus{State: podtracev1alpha1.SessionStateRunning},
+	}
+
+	r, _ := newScheduleReconciler(t, sch, active)
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if err := r.Get(ctx, client.ObjectKeyFromObject(active), &podtracev1alpha1.PodTraceSession{}); err == nil {
+		t.Error("Replace should have deleted the stale active session")
+	}
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !conditionHasReason(got.Status.Conditions, ConditionReconciled, "Triggered") {
+		t.Errorf("expected Reconciled reason Triggered, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_Schedule_MissedDeadline drives the
+// StartingDeadlineSeconds missed-run branch. CreationTimestamp far in the
+// past makes nextRun stale and now past the deadline window.
+func TestDeepReconcile_Schedule_MissedDeadline(t *testing.T) {
+	deadline := int64(1) // 1s window; nextRun is hours stale.
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "missed", Namespace: "default", UID: "missed-uid",
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-24 * time.Hour)),
+		},
+		Spec: newScheduleSpec("*/5 * * * *"),
+	}
+	sch.Spec.StartingDeadlineSeconds = &deadline
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sch), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !conditionHasReason(got.Status.Conditions, ConditionReconciled, "MissedDeadline") {
+		t.Errorf("expected Reconciled reason MissedDeadline, got %+v", got.Status.Conditions)
+	}
+	if got.Status.LastScheduleTime == nil {
+		t.Error("expected LastScheduleTime to be advanced past the missed run")
+	}
+}
+
+// ─── TracerConfigReconciler.Reconcile — deeper branches ──────────────
+
+// TestDeepReconcile_TracerConfig_CustomNamespace drives Reconcile with a
+// spec.systemNamespace override, asserting the DaemonSet lands there and
+// status is rolled up (ReadyAgents/DesiredAgents both 0 → Ready=False).
+func TestDeepReconcile_TracerConfig_CustomNamespace(t *testing.T) {
+	const customNS = "custom-sys"
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", UID: "tc-uid", Generation: 4},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: customNS},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).Build()
+
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "fallback-sys"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tc.Name},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var ds appsv1.DaemonSet
+	if err := c.Get(context.Background(), types.NamespacedName{Name: AgentDaemonSetName(), Namespace: customNS}, &ds); err != nil {
+		t.Errorf("DaemonSet not created in custom namespace %s: %v", customNS, err)
+	}
+
+	var got podtracev1alpha1.TracerConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Name: tc.Name}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.ObservedGeneration != tc.Generation {
+		t.Errorf("ObservedGeneration = %d, want %d", got.Status.ObservedGeneration, tc.Generation)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReconciled, metav1.ConditionTrue) {
+		t.Errorf("expected Reconciled=True, got %+v", got.Status.Conditions)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReady, metav1.ConditionFalse) {
+		t.Errorf("expected Ready=False (0 desired agents), got %+v", got.Status.Conditions)
+	}
+}
+
+// ─── ApplicationTraceReconciler.Reconcile — deeper branches ──────────
+
+// TestDeepReconcile_ApplicationTrace_HappyPath drives Reconcile end-to-end:
+// child PodTrace created with translated appSelector, status aggregated,
+// Reconciled/Ready conditions set, patchStatus persists.
+func TestDeepReconcile_ApplicationTrace_HappyPath(t *testing.T) {
+	const ns = "default"
+	app := &podtracev1alpha1.ApplicationTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "app1", Namespace: ns, UID: "app-uid", Generation: 2},
+		Spec: podtracev1alpha1.ApplicationTraceSpec{
+			Selectors:   []metav1.LabelSelector{{MatchLabels: map[string]string{"app": "x"}}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).Build()
+
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var pt podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Name: app.Name, Namespace: ns}, &pt); err != nil {
+		t.Fatalf("child PodTrace not created: %v", err)
+	}
+	if pt.Spec.AppSelector == nil || len(pt.Spec.AppSelector.MatchSelectors) != 1 {
+		t.Errorf("appSelector not translated: %+v", pt.Spec.AppSelector)
+	}
+	if pt.Labels[LabelApplication] != app.Name {
+		t.Errorf("application label = %q, want %q", pt.Labels[LabelApplication], app.Name)
+	}
+
+	var got podtracev1alpha1.ApplicationTrace
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(app), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.PodTraceRef != app.Name {
+		t.Errorf("PodTraceRef = %q, want %q", got.Status.PodTraceRef, app.Name)
+	}
+	if got.Status.ObservedGeneration != app.Generation {
+		t.Errorf("ObservedGeneration = %d, want %d", got.Status.ObservedGeneration, app.Generation)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReconciled, metav1.ConditionTrue) {
+		t.Errorf("expected Reconciled=True, got %+v", got.Status.Conditions)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionReady, metav1.ConditionFalse) {
+		t.Errorf("expected Ready=False (child not ready), got %+v", got.Status.Conditions)
+	}
+}
+
+// TestDeepReconcile_ApplicationTrace_Paused drives the spec.paused branch
+// (Paused=True condition) while still ensuring the child PodTrace.
+func TestDeepReconcile_ApplicationTrace_Paused(t *testing.T) {
+	const ns = "default"
+	app := &podtracev1alpha1.ApplicationTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-paused", Namespace: ns, UID: "appp-uid"},
+		Spec: podtracev1alpha1.ApplicationTraceSpec{
+			Selectors:   []metav1.LabelSelector{{MatchLabels: map[string]string{"app": "x"}}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+			Paused:      true,
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).Build()
+
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var got podtracev1alpha1.ApplicationTrace
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(app), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionPaused, metav1.ConditionTrue) {
+		t.Errorf("expected Paused=True, got %+v", got.Status.Conditions)
+	}
+	var pt podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Name: app.Name, Namespace: ns}, &pt); err != nil {
+		t.Fatal(err)
+	}
+	if !pt.Spec.Paused {
+		t.Error("child PodTrace should inherit spec.paused")
+	}
+}
+
+// ─── PodTraceReconciler.Reconcile — DataDog bundle (syncExporterBundle) ──
+
+// TestDeepReconcile_PodTrace_DataDogBundleWithSecret drives the
+// syncExporterBundle credential-Secret branch: a DataDog exporter whose
+// API key lives in a user-namespace Secret produces both the bundle
+// ConfigMap and the paired Secret in the system namespace.
+func TestDeepReconcile_PodTrace_DataDogBundleWithSecret(t *testing.T) {
+	const sysNS, ns = "podtrace-system", "default"
+	pct := int32(50)
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pt", Namespace: ns, UID: "uid-dd",
+			Finalizers: []string{FinalizerCleanup},
+			Generation: 5,
+		},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:      &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			ExporterRef:   podtracev1alpha1.LocalObjectReference{Name: "dd"},
+			SamplePercent: &pct,
+			Filters:       []podtracev1alpha1.EventFilter{"network", "filesystem"},
+		},
+	}
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeDataDog,
+			DataDog: &podtracev1alpha1.DataDogExporter{
+				Site:            "datadoghq.eu",
+				APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd-creds", Key: "api-key"},
+			},
+		},
+	}
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-creds", Namespace: ns},
+		Data:       map[string][]byte{"api-key": []byte("secret-key")},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec, sec).Build()
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	bundleName := ExporterBundleName(pt.UID)
+	var cm corev1.ConfigMap
+	if err := c.Get(context.Background(), types.NamespacedName{Name: bundleName, Namespace: sysNS}, &cm); err != nil {
+		t.Fatalf("bundle ConfigMap missing: %v", err)
+	}
+	if cm.Data["type"] != "datadog" || cm.Data["site"] != "datadoghq.eu" {
+		t.Errorf("bundle data wrong: %+v", cm.Data)
+	}
+	if cm.Data["header_secret_name"] != "DD-API-KEY" {
+		t.Errorf("expected header_secret_name DD-API-KEY, got %q", cm.Data["header_secret_name"])
+	}
+	var bundleSec corev1.Secret
+	if err := c.Get(context.Background(), types.NamespacedName{Name: bundleName, Namespace: sysNS}, &bundleSec); err != nil {
+		t.Fatalf("bundle Secret missing: %v", err)
+	}
+	if string(bundleSec.Data["credential"]) != "secret-key" {
+		t.Errorf("credential = %q, want secret-key", bundleSec.Data["credential"])
+	}
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(pt), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionPolicyApplied, metav1.ConditionTrue) {
+		t.Errorf("expected PolicyApplied=True, got %+v", got.Status.Conditions)
+	}
+	if got.Status.Policy == nil {
+		t.Error("expected status.Policy to be resolved")
+	}
+}
+
+// TestDeepReconcile_PodTrace_BundleSyncError drives the syncExporterBundle
+// failure branch: a DataDog exporter whose credential Secret is missing
+// sets Degraded/PolicyApplied=False and requeues without error.
+func TestDeepReconcile_PodTrace_BundleSyncError(t *testing.T) {
+	const sysNS, ns = "podtrace-system", "default"
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pt", Namespace: ns, UID: "uid-err",
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "dd"},
+		},
+	}
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeDataDog,
+			DataDog: &podtracev1alpha1.DataDogExporter{
+				APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "absent-creds", Key: "api-key"},
+			},
+		},
+	}
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec).Build()
+
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: ns},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected positive RequeueAfter on bundle sync error")
+	}
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(pt), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionDegraded, metav1.ConditionTrue) {
+		t.Errorf("expected Degraded=True, got %+v", got.Status.Conditions)
+	}
+	if !hasCondition(got.Status.Conditions, ConditionPolicyApplied, metav1.ConditionFalse) {
+		t.Errorf("expected PolicyApplied=False, got %+v", got.Status.Conditions)
+	}
+}
+
+// ─── ensureSessionObjectStoreCredentials ─────────────────────────────
+
+// TestDeepReconcile_SessionObjectStoreCreds covers all branches of the
+// standalone helper: no-op (no ReportRef), no-op (no secret ref), missing
+// source Secret error, and the happy-path copy into the system namespace.
+func TestDeepReconcile_SessionObjectStoreCreds(t *testing.T) {
+	const sysNS, ns = "ns-sys", "team-a"
+	scheme := newOperatorScheme(t)
+
+	if name, err := ensureSessionObjectStoreCredentials(context.Background(),
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		&podtracev1alpha1.PodTraceSession{}, sysNS); err != nil || name != "" {
+		t.Errorf("nil ReportRef: name=%q err=%v, want empty/nil", name, err)
+	}
+
+	sNoCreds := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns, UID: "uid-nc"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k"},
+			},
+		},
+	}
+	if name, err := ensureSessionObjectStoreCredentials(context.Background(),
+		fake.NewClientBuilder().WithScheme(scheme).Build(), sNoCreds, sysNS); err != nil || name != "" {
+		t.Errorf("no creds ref: name=%q err=%v, want empty/nil", name, err)
+	}
+
+	sMissing := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns, UID: "uid-miss"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ObjectStore: &podtracev1alpha1.ObjectStoreReference{
+					URI:                  "s3://b/k",
+					CredentialsSecretRef: &corev1.LocalObjectReference{Name: "absent"},
+				},
+			},
+		},
+	}
+	if _, err := ensureSessionObjectStoreCredentials(context.Background(),
+		fake.NewClientBuilder().WithScheme(scheme).Build(), sMissing, sysNS); err == nil {
+		t.Error("expected error when source Secret is missing")
+	}
+
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "obj-creds", Namespace: ns},
+		Data:       map[string][]byte{"access_key_id": []byte("AKIA"), "secret_access_key": []byte("shh")},
+	}
+	sOK := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns, UID: "uid-ok"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ObjectStore: &podtracev1alpha1.ObjectStoreReference{
+					URI:                  "s3://b/k",
+					CredentialsSecretRef: &corev1.LocalObjectReference{Name: "obj-creds"},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
+	dstName, err := ensureSessionObjectStoreCredentials(context.Background(), c, sOK, sysNS)
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if dstName != SessionObjectStoreCredsName(sOK.UID) {
+		t.Errorf("dstName = %q, want %q", dstName, SessionObjectStoreCredsName(sOK.UID))
+	}
+	var dst corev1.Secret
+	if err := c.Get(context.Background(), types.NamespacedName{Name: dstName, Namespace: sysNS}, &dst); err != nil {
+		t.Fatalf("copied Secret missing: %v", err)
+	}
+	if string(dst.Data["access_key_id"]) != "AKIA" || string(dst.Data["secret_access_key"]) != "shh" {
+		t.Errorf("copied Secret data wrong: %+v", dst.Data)
+	}
+	if dst.Labels[LabelSessionName] != sOK.Name {
+		t.Errorf("session label not set on copy: %+v", dst.Labels)
+	}
+}
+
+// ─── exporter_bundle.go policy lifters ───────────────────────────────
+
+// TestDeepReconcile_PolicyLifters covers the nil branch of
+// policyFromPodTrace / policyFromSession (the populated branch is already
+// exercised elsewhere).
+func TestDeepReconcile_PolicyLifters(t *testing.T) {
+	if policyFromPodTrace(nil) != nil {
+		t.Error("policyFromPodTrace(nil) should be nil")
+	}
+	if policyFromSession(nil) != nil {
+		t.Error("policyFromSession(nil) should be nil")
+	}
+
+	pct := int32(25)
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Generation: 9},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Filters:       []podtracev1alpha1.EventFilter{"network"},
+			SamplePercent: &pct,
+		},
+	}
+	p := policyFromPodTrace(pt)
+	if p == nil || p.Generation != 9 || p.SamplePercent == nil || *p.SamplePercent != 25 {
+		t.Errorf("policyFromPodTrace lifted wrong: %+v", p)
+	}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Generation: 4},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Filters: []podtracev1alpha1.EventFilter{"cpu"},
+		},
+	}
+	ps := policyFromSession(s)
+	if ps == nil || ps.Generation != 4 || len(ps.Filters) != 1 {
+		t.Errorf("policyFromSession lifted wrong: %+v", ps)
+	}
+}
+
+// conditionHasReason reports whether the named condition exists with the
+// expected Reason.
+func conditionHasReason(conds []metav1.Condition, condType, reason string) bool {
+	for _, c := range conds {
+		if c.Type == condType {
+			return c.Reason == reason
+		}
+	}
+	return false
+}

--- a/internal/operator/reconcilers_errorpaths_unit_test.go
+++ b/internal/operator/reconcilers_errorpaths_unit_test.go
@@ -1,0 +1,857 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// These tests drive the error-return branches of the reconcilers and
+// their status helpers — branches a plain fake client can't reach
+// because it never fails. controller-runtime's interceptor support lets
+// us inject a synthetic error from a single client method while
+// delegating every other call to the real underlying WithWatch client.
+
+func errInternal() error {
+	return apierrors.NewInternalError(errors.New("synthetic interceptor failure"))
+}
+
+func errConflict(resource, name string) error {
+	return apierrors.NewConflict(
+		schema.GroupResource{Group: "podtrace.io", Resource: resource},
+		name,
+		errors.New("synthetic conflict"),
+	)
+}
+
+// ─── PodTraceScheduleReconciler ──────────────────────────────────────
+
+// patchStatus conflict: Status().Update returns Conflict -> patchStatus
+// swallows it and returns nil, so the whole Reconcile returns no error.
+func TestErrPath_Schedule_PatchStatusConflictSwallowed(t *testing.T) {
+	sch := scheduleForErrPaths()
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errConflict("podtraceschedules", sch.Name)
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("conflict on status update must be swallowed, got err=%v", err)
+	}
+}
+
+// patchStatus non-conflict: Status().Update returns a generic error ->
+// patchStatus wraps it -> Reconcile returns the error.
+func TestErrPath_Schedule_PatchStatusError(t *testing.T) {
+	sch := scheduleForErrPaths()
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err == nil {
+		t.Fatal("expected wrapped status-update error from Reconcile")
+	}
+}
+
+// listOwnedSessions error: List of child sessions fails -> Reconcile
+// returns the wrapped error early.
+func TestErrPath_Schedule_ListOwnedSessionsError(t *testing.T) {
+	sch := scheduleForErrPaths()
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(sch).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.PodTraceSessionList); ok {
+					return errInternal()
+				}
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	}); err == nil {
+		t.Fatal("expected listOwnedSessions error from Reconcile")
+	}
+
+	if _, err := r.listOwnedSessions(context.Background(), sch); err == nil {
+		t.Fatal("expected listOwnedSessions to surface List error")
+	}
+}
+
+// gcOldest Delete error: applyHistoryLimits -> gcOldest -> Delete fails
+// with a non-NotFound error -> wrapped error returned.
+func TestErrPath_Schedule_GcOldestDeleteError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	sessions := []podtracev1alpha1.PodTraceSession{
+		completedSession("old", fixedScheduleNow.Add(-2*time.Hour)),
+		completedSession("new", fixedScheduleNow.Add(-1*time.Hour)),
+	}
+	if err := r.gcOldest(context.Background(), sessions, 1); err == nil {
+		t.Fatal("expected gcOldest to surface Delete error")
+	}
+}
+
+// Reconcile Get error: a non-NotFound Get failure must propagate as a
+// wrapped error (the NotFound short-circuit is already covered).
+func TestErrPath_Schedule_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "any", Namespace: "default"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from Reconcile")
+	}
+}
+
+// ─── PodTraceSessionReconciler ───────────────────────────────────────
+
+// Reconcile Get error: non-NotFound Get failure -> wrapped error.
+func TestErrPath_Session_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "any", Namespace: "team-a"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from session Reconcile")
+	}
+}
+
+// Final Status().Update conflict: a fully-resolving session reaches the
+// terminal Status().Update; a Conflict there must requeue (no error).
+func TestErrPath_Session_FinalStatusUpdateConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errConflict("podtracesessions", session.Name)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("final status conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on status conflict, got %+v", res)
+	}
+}
+
+// Final Status().Update generic error: wrapped and returned.
+func TestErrPath_Session_FinalStatusUpdateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	}); err == nil {
+		t.Fatal("expected final status-update error from session Reconcile")
+	}
+}
+
+// nodesAtCapacity List error fans into Reconcile: listing session Jobs
+// fails -> Reconcile returns the wrapped error. Requires a TracerConfig
+// with a non-zero per-node cap so the capacity branch executes.
+func TestErrPath_Session_NodesAtCapacityListError(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{MaxConcurrentSessionsPerNode: 1},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec, tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*batchv1.JobList); ok {
+					return errInternal()
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	}); err == nil {
+		t.Fatal("expected nodesAtCapacity List error from session Reconcile")
+	}
+}
+
+// ExporterConfig Get error (non-NotFound) inside session Reconcile ->
+// wrapped error returned.
+func TestErrPath_Session_ExporterGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*podtracev1alpha1.ExporterConfig); ok {
+					return errInternal()
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	}); err == nil {
+		t.Fatal("expected ExporterConfig Get error from session Reconcile")
+	}
+}
+
+// ─── PodTraceReconciler ──────────────────────────────────────────────
+
+// Reconcile Get error: non-NotFound Get -> wrapped error.
+func TestErrPath_PodTrace_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "any", Namespace: "team-a"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from PodTrace Reconcile")
+	}
+}
+
+// syncExporterBundle error: the bundle ConfigMap CreateOrUpdate fails ->
+// Reconcile records BundleSync degraded and requeues (no error, 60s).
+func TestErrPath_PodTrace_SyncExporterBundleError(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceWithFinalizer()
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return errInternal()
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("bundle-sync failure is recorded in status, not returned; got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue after bundle-sync failure, got %+v", res)
+	}
+}
+
+// Final Status().Update conflict on the happy path -> requeue, no error.
+func TestErrPath_PodTrace_FinalStatusUpdateConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceWithFinalizer()
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errConflict("podtraces", pt.Name)
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("status conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on status conflict, got %+v", res)
+	}
+}
+
+// Final Status().Update generic error -> wrapped error returned.
+func TestErrPath_PodTrace_FinalStatusUpdateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceWithFinalizer()
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err == nil {
+		t.Fatal("expected final status-update error from PodTrace Reconcile")
+	}
+}
+
+// ─── ExporterConfigReconciler ────────────────────────────────────────
+
+// Reconcile Get error: non-NotFound Get -> wrapped error.
+func TestErrPath_ExporterConfig_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ec", Namespace: "team-a"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from ExporterConfig Reconcile")
+	}
+}
+
+// Status().Patch conflict: the EC reconciler uses Status().Patch (not
+// Update); a Conflict there requeues after 1s with no error.
+func TestErrPath_ExporterConfig_StatusPatchConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithObjects(ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+				return errConflict("exporterconfigs", ec.Name)
+			},
+		}).
+		Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: s}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ec.Name, Namespace: ec.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("status-patch conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on status-patch conflict, got %+v", res)
+	}
+}
+
+// Status().Patch generic error -> wrapped error returned.
+func TestErrPath_ExporterConfig_StatusPatchError(t *testing.T) {
+	s := newOperatorScheme(t)
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithObjects(ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ec.Name, Namespace: ec.Namespace},
+	}); err == nil {
+		t.Fatal("expected status-patch error from ExporterConfig Reconcile")
+	}
+}
+
+// ─── ApplicationTraceReconciler ──────────────────────────────────────
+
+// patchStatus conflict (the 40%-covered helper): Status().Update returns
+// Conflict -> patchStatus swallows -> Reconcile returns no error.
+func TestErrPath_ApplicationTrace_PatchStatusConflictSwallowed(t *testing.T) {
+	s := newOperatorScheme(t)
+	app := mkApp()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errConflict("applicationtraces", app.Name)
+			},
+		}).
+		Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace},
+	}); err != nil {
+		t.Fatalf("conflict on status update must be swallowed, got err=%v", err)
+	}
+}
+
+// patchStatus generic error -> wrapped error from Reconcile.
+func TestErrPath_ApplicationTrace_PatchStatusError(t *testing.T) {
+	s := newOperatorScheme(t)
+	app := mkApp()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace},
+	}); err == nil {
+		t.Fatal("expected wrapped status-update error from ApplicationTrace Reconcile")
+	}
+}
+
+// Reconcile Get error: non-NotFound Get -> wrapped error.
+func TestErrPath_ApplicationTrace_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "shop", Namespace: "demo"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from ApplicationTrace Reconcile")
+	}
+}
+
+// ensureChildPodTrace error path: the child-PodTrace CreateOrUpdate fails
+// -> Reconcile sets ChildPodTrace degraded, patches status, then returns
+// the original error.
+func TestErrPath_ApplicationTrace_EnsureChildError(t *testing.T) {
+	s := newOperatorScheme(t)
+	app := mkApp()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*podtracev1alpha1.PodTrace); ok {
+					return errInternal()
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: app.Name, Namespace: app.Namespace},
+	}); err == nil {
+		t.Fatal("expected ensureChildPodTrace error from ApplicationTrace Reconcile")
+	}
+}
+
+// ─── TracerConfigReconciler ──────────────────────────────────────────
+
+// Reconcile Get error: non-NotFound Get -> wrapped error.
+func TestErrPath_TracerConfig_ReconcileGetError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	}); err == nil {
+		t.Fatal("expected Get error to propagate from TracerConfig Reconcile")
+	}
+}
+
+// ensureAgentRBAC error: the first Create (ServiceAccount) fails ->
+// Reconcile sets RBACError degraded and returns the error.
+func TestErrPath_TracerConfig_RBACCreateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					return errInternal()
+				}
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	}); err == nil {
+		t.Fatal("expected RBAC create error from TracerConfig Reconcile")
+	}
+}
+
+// ensureAgentDaemonSet error: RBAC succeeds, but the DaemonSet Create
+// fails -> DaemonSetError degraded and error returned.
+func TestErrPath_TracerConfig_DaemonSetCreateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.DaemonSet); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	}); err == nil {
+		t.Fatal("expected DaemonSet create error from TracerConfig Reconcile")
+	}
+}
+
+// ensureAgentDaemonSet conflict: a Conflict from the DaemonSet
+// CreateOrUpdate requeues silently (no error). We inject the conflict on
+// the DaemonSet Create so RBAC creation still succeeds first.
+func TestErrPath_TracerConfig_DaemonSetConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.DaemonSet); ok {
+					return errConflict("daemonsets", AgentDaemonSetName())
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	})
+	if err != nil {
+		t.Fatalf("DaemonSet conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on DaemonSet conflict, got %+v", res)
+	}
+}
+
+// Final Status().Update conflict: RBAC + DaemonSet succeed, the terminal
+// status update conflicts -> requeue, no error.
+func TestErrPath_TracerConfig_FinalStatusUpdateConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errConflict("tracerconfigs", tc.Name)
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	})
+	if err != nil {
+		t.Fatalf("final status conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on status conflict, got %+v", res)
+	}
+}
+
+// Final Status().Update generic error -> wrapped error returned.
+func TestErrPath_TracerConfig_FinalStatusUpdateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	}); err == nil {
+		t.Fatal("expected final status-update error from TracerConfig Reconcile")
+	}
+}
+
+// ─── shared builders for these error-path tests ──────────────────────
+
+// scheduleForErrPaths returns a valid schedule that, with fixedScheduleNow,
+// reaches the create-session + patchStatus path of Reconcile.
+func scheduleForErrPaths() *podtracev1alpha1.PodTraceSchedule {
+	return &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "every5",
+			Namespace:         "default",
+			UID:               "sch-err-uid",
+			Generation:        3,
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-24 * time.Hour)),
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+}
+
+func completedSession(name string, completedAt time.Time) podtracev1alpha1.PodTraceSession {
+	ct := metav1.NewTime(completedAt)
+	return podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: podtracev1alpha1.PodTraceSessionStatus{
+			State:          podtracev1alpha1.SessionStateCompleted,
+			CompletionTime: &ct,
+		},
+	}
+}
+
+// runnableSession returns a session past the finalizer-set requeue (the
+// cleanup finalizer is already present) so Reconcile proceeds to the
+// fan-out and final status update.
+func runnableSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "sess",
+			Namespace:  "team-a",
+			UID:        "sess-uid",
+			Generation: 1,
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+}
+
+func runningPod(name, ns, node string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+		Spec:       corev1.PodSpec{NodeName: node},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func otlpExporter(name, ns string) *podtracev1alpha1.ExporterConfig {
+	return &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Generation: 1},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+}
+
+// podTraceWithFinalizer returns a PodTrace past the finalizer-set
+// requeue so Reconcile proceeds to syncExporterBundle + status update.
+func podTraceWithFinalizer() *podtracev1alpha1.PodTrace {
+	return &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pt",
+			Namespace:  "team-a",
+			UID:        "pt-uid",
+			Generation: 1,
+			Finalizers: []string{FinalizerCleanup},
+		},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+}

--- a/internal/operator/reconcilers_fakeclient_unit_test.go
+++ b/internal/operator/reconcilers_fakeclient_unit_test.go
@@ -1,0 +1,330 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// ─── ExporterConfigReconciler watch-handler map functions ────────────
+
+// TestFakeReconcile_SecretToExporterConfigs verifies the Secret watch
+// handler enqueues only ECs in the Secret's namespace that reference
+// the changed Secret by name, and returns nil for a non-Secret object.
+func TestFakeReconcile_SecretToExporterConfigs(t *testing.T) {
+	const ns = "team-a"
+	scheme := newOperatorScheme(t)
+
+	referencing := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec-ref", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{
+				Endpoint:          "o:4317",
+				Protocol:          podtracev1alpha1.OTLPProtocolHTTP,
+				HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "creds"},
+			},
+		},
+	}
+	other := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec-other", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "o:4317", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(referencing, other).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	got := r.secretToExporterConfigs(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: ns},
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d requests, want 1", len(got))
+	}
+	if got[0].Name != "ec-ref" || got[0].Namespace != ns {
+		t.Errorf("unexpected request %+v", got[0])
+	}
+
+	if got := r.secretToExporterConfigs(context.Background(), &corev1.Pod{}); got != nil {
+		t.Errorf("non-Secret input should return nil, got %v", got)
+	}
+}
+
+// TestFakeReconcile_PodTraceToExporterConfig verifies the PodTrace watch
+// handler maps to the referenced ExporterConfig and short-circuits on
+// empty ExporterRef / wrong type.
+func TestFakeReconcile_PodTraceToExporterConfig(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "ns"},
+		Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"}},
+	}
+	got := r.podTraceToExporterConfig(context.Background(), pt)
+	if len(got) != 1 || got[0].Name != "ec" || got[0].Namespace != "ns" {
+		t.Fatalf("unexpected requests %+v", got)
+	}
+
+	if got := r.podTraceToExporterConfig(context.Background(), &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "ns"},
+	}); got != nil {
+		t.Errorf("empty ExporterRef should return nil, got %v", got)
+	}
+
+	if got := r.podTraceToExporterConfig(context.Background(), &corev1.Pod{}); got != nil {
+		t.Errorf("non-PodTrace input should return nil, got %v", got)
+	}
+}
+
+// TestFakeReconcile_SessionToExporterConfig mirrors the PodTrace handler
+// for PodTraceSession objects.
+func TestFakeReconcile_SessionToExporterConfig(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Spec:       podtracev1alpha1.PodTraceSessionSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"}},
+	}
+	got := r.sessionToExporterConfig(context.Background(), s)
+	if len(got) != 1 || got[0].Name != "ec" || got[0].Namespace != "ns" {
+		t.Fatalf("unexpected requests %+v", got)
+	}
+
+	if got := r.sessionToExporterConfig(context.Background(), &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+	}); got != nil {
+		t.Errorf("empty ExporterRef should return nil, got %v", got)
+	}
+
+	if got := r.sessionToExporterConfig(context.Background(), &corev1.Pod{}); got != nil {
+		t.Errorf("non-Session input should return nil, got %v", got)
+	}
+}
+
+// ─── PodTraceReconciler helpers ──────────────────────────────────────
+
+// TestFakeReconcile_NamespaceToPodTraces enqueues only PodTraces that
+// declare a NamespaceSelector.
+func TestFakeReconcile_NamespaceToPodTraces(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	withSelector := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-sel", Namespace: "ns"},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "ec"},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "a"}},
+		},
+	}
+	withoutSelector := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-sel", Namespace: "ns"},
+		Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(withSelector, withoutSelector).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme}
+
+	got := r.namespaceToPodTraces(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "any"},
+	})
+	if len(got) != 1 || got[0].Name != "with-sel" {
+		t.Fatalf("expected only the selector-bearing PodTrace, got %+v", got)
+	}
+}
+
+// TestFakeReconcile_LoadCredentialSecret covers the happy path plus both
+// error branches (missing Secret, missing key).
+func TestFakeReconcile_LoadCredentialSecret(t *testing.T) {
+	const ns = "team-a"
+	scheme := newOperatorScheme(t)
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: ns},
+		Data:       map[string][]byte{"token": []byte("s3cr3t")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sec).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	out, err := r.loadCredentialSecret(context.Background(), ns,
+		podtracev1alpha1.SecretKeySelector{Name: "creds", Key: "token"})
+	if err != nil {
+		t.Fatalf("loadCredentialSecret: %v", err)
+	}
+	if string(out["credential"]) != "s3cr3t" {
+		t.Errorf("credential = %q, want s3cr3t", out["credential"])
+	}
+
+	if _, err := r.loadCredentialSecret(context.Background(), ns,
+		podtracev1alpha1.SecretKeySelector{Name: "absent", Key: "token"}); err == nil {
+		t.Error("expected error for missing Secret")
+	}
+
+	if _, err := r.loadCredentialSecret(context.Background(), ns,
+		podtracev1alpha1.SecretKeySelector{Name: "creds", Key: "nope"}); err == nil {
+		t.Error("expected error for missing key")
+	}
+}
+
+// ─── PodTraceSessionReconciler helpers ───────────────────────────────
+
+// TestFakeReconcile_NamespaceToPodTraceSessions enqueues only non-terminal
+// PodTraceSessions that declare a NamespaceSelector.
+func TestFakeReconcile_NamespaceToPodTraceSessions(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	active := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "active", Namespace: "ns"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "ec"},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "a"}},
+		},
+	}
+	terminal := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "done", Namespace: "ns"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ExporterRef:       podtracev1alpha1.LocalObjectReference{Name: "ec"},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "a"}},
+		},
+		Status: podtracev1alpha1.PodTraceSessionStatus{State: podtracev1alpha1.SessionStateCompleted},
+	}
+	noSelector := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-sel", Namespace: "ns"},
+		Spec:       podtracev1alpha1.PodTraceSessionSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(active, terminal, noSelector).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme}
+
+	got := r.namespaceToPodTraceSessions(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "any"},
+	})
+	if len(got) != 1 || got[0].Name != "active" {
+		t.Fatalf("expected only the active selector-bearing session, got %+v", got)
+	}
+}
+
+// TestFakeReconcile_NodesAtCapacity verifies node-capacity accounting:
+// a node with cap active Jobs from OTHER sessions is over; the
+// reconciling session's own Jobs and completed Jobs don't count.
+func TestFakeReconcile_NodesAtCapacity(t *testing.T) {
+	const ns = "team-a"
+	scheme := newOperatorScheme(t)
+
+	sessionJob := func(name, sessName, sessNS, node string, succeeded int32) *batchv1.Job {
+		return &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "podtrace-system",
+				Labels: map[string]string{
+					LabelManagedBy:   ManagedByValue,
+					LabelComponent:   ComponentSession,
+					LabelSessionName: sessName,
+					LabelSessionNS:   sessNS,
+					LabelNodeName:    node,
+				},
+			},
+			Status: batchv1.JobStatus{Succeeded: succeeded},
+		}
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		sessionJob("j1", "other", ns, "n1", 0),
+		sessionJob("j2", "other", ns, "n2", 1),
+		sessionJob("j3", "self", ns, "n3", 0),
+	).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	over, err := r.nodesAtCapacity(context.Background(),
+		[]string{"n1", "n2", "n3"}, 1, ns, "self")
+	if err != nil {
+		t.Fatalf("nodesAtCapacity: %v", err)
+	}
+	if len(over) != 1 || over[0] != "n1" {
+		t.Errorf("expected only n1 over capacity, got %v", over)
+	}
+}
+
+// TestFakeReconcile_EnsureJobs creates one Job per target node in the
+// system namespace and returns every Job owned by the session.
+func TestFakeReconcile_EnsureJobs(t *testing.T) {
+	const ns, sysNS = "team-a", "podtrace-system"
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: ns, UID: "uid-s"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+
+	jobs, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"})
+	if err != nil {
+		t.Fatalf("ensureJobs: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 owned Jobs, got %d", len(jobs))
+	}
+
+	for _, node := range []string{"n1", "n2"} {
+		var job batchv1.Job
+		key := types.NamespacedName{Name: SessionJobName(s.UID, node), Namespace: sysNS}
+		if err := c.Get(context.Background(), key, &job); err != nil {
+			t.Fatalf("job for %s missing: %v", node, err)
+		}
+		if job.Labels[LabelNodeName] != node {
+			t.Errorf("job for %s has node label %q", node, job.Labels[LabelNodeName])
+		}
+		if len(job.Spec.Template.Spec.Containers) == 0 {
+			t.Errorf("job for %s has no containers (spec not built)", node)
+		}
+	}
+
+	jobs2, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"})
+	if err != nil {
+		t.Fatalf("second ensureJobs: %v", err)
+	}
+	if len(jobs2) != 2 {
+		t.Errorf("expected ensureJobs to stay at 2 Jobs, got %d", len(jobs2))
+	}
+}
+
+// ─── runtime.go pure helpers ─────────────────────────────────────────
+
+func TestFakeReconcile_DefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.SystemNamespace != "podtrace-system" {
+		t.Errorf("SystemNamespace = %q, want podtrace-system", opts.SystemNamespace)
+	}
+	if !opts.LeaderElection {
+		t.Error("LeaderElection should default to true")
+	}
+	if opts.LeaderElectionID != "podtrace-operator.podtrace.io" {
+		t.Errorf("LeaderElectionID = %q", opts.LeaderElectionID)
+	}
+	if opts.WebhookPort != 9443 {
+		t.Errorf("WebhookPort = %d, want 9443", opts.WebhookPort)
+	}
+}
+
+func TestFakeReconcile_LeaderElectionID(t *testing.T) {
+	if got := leaderElectionID(Options{LeaderElectionID: "custom.id"}); got != "custom.id" {
+		t.Errorf("explicit ID = %q, want custom.id", got)
+	}
+	if got := leaderElectionID(Options{}); got != "podtrace-operator.podtrace.io" {
+		t.Errorf("empty ID should fall back to default, got %q", got)
+	}
+}
+
+var _ client.Client = fake.NewClientBuilder().Build()

--- a/internal/operator/reconcilers_more_unit_test.go
+++ b/internal/operator/reconcilers_more_unit_test.go
@@ -1,0 +1,462 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func newUnstartedManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+	cfg := &rest.Config{Host: "http://127.0.0.1:1"}
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 newOperatorScheme(t),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Skipf("cannot construct controller-runtime manager in this sandbox: %v", err)
+	}
+	return mgr
+}
+
+func TestMore_SetupWithManager_AllReconcilers(t *testing.T) {
+	mgr := newUnstartedManager(t)
+
+	if err := registerExporterConfigIndexers(context.Background(), mgr); err != nil {
+		t.Logf("registerExporterConfigIndexers unavailable in sandbox (expected): %v", err)
+	}
+
+	cl := mgr.GetClient()
+	sc := mgr.GetScheme()
+
+	setups := []struct {
+		name  string
+		setup func(ctrl.Manager) error
+	}{
+		{"PodTraceSchedule", (&PodTraceScheduleReconciler{Client: cl, Scheme: sc}).SetupWithManager},
+		{"PodTrace", (&PodTraceReconciler{Client: cl, Scheme: sc, SystemNamespace: "podtrace-system"}).SetupWithManager},
+		{"PodTraceSession", (&PodTraceSessionReconciler{Client: cl, Scheme: sc, SystemNamespace: "podtrace-system"}).SetupWithManager},
+		{"ExporterConfig", (&ExporterConfigReconciler{Client: cl, Scheme: sc}).SetupWithManager},
+		{"ApplicationTrace", (&ApplicationTraceReconciler{Client: cl, Scheme: sc}).SetupWithManager},
+		{"TracerConfig", (&TracerConfigReconciler{Client: cl, Scheme: sc, SystemNamespace: "podtrace-system"}).SetupWithManager},
+	}
+	for _, s := range setups {
+		if err := s.setup(mgr); err != nil {
+			t.Errorf("%s.SetupWithManager: %v", s.name, err)
+		}
+	}
+}
+
+func TestMore_PodTrace_DeletionRemovesFinalizer(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err != nil {
+		t.Fatalf("deletion path must succeed, got %v", err)
+	}
+}
+
+func TestMore_PodTrace_DeletionCleanupError(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return errInternal()
+				}
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err == nil {
+		t.Fatal("expected cleanup error from PodTrace deletion path")
+	}
+}
+
+func TestMore_PodTrace_DeletionFinalizerConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+				return errConflict("podtraces", pt.Name)
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("finalizer-clear conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on finalizer-clear conflict, got %+v", res)
+	}
+}
+
+func TestMore_PodTrace_DeletionFinalizerError(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err == nil {
+		t.Fatal("expected finalizer-clear error from PodTrace deletion path")
+	}
+}
+
+func TestMore_PodTrace_PausedShortCircuit(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceWithFinalizer()
+	pt.Spec.Paused = true
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err != nil {
+		t.Fatalf("paused path must succeed, got %v", err)
+	}
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace}, &got); err != nil {
+		t.Fatalf("get PodTrace: %v", err)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionPaused); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Paused=True condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestMore_PodTrace_NamespaceSelectorInvalid(t *testing.T) {
+	s := newOperatorScheme(t)
+	pt := podTraceWithFinalizer()
+	pt.Spec.NamespaceSelector = &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "team",
+			Operator: "BogusOperator",
+			Values:   []string{"a"},
+		}},
+	}
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		WithObjects(pt, ec).
+		Build()
+	r := &PodTraceReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace},
+	}); err != nil {
+		t.Fatalf("invalid namespace selector is recorded in status, not returned; got %v", err)
+	}
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pt.Name, Namespace: pt.Namespace}, &got); err != nil {
+		t.Fatalf("get PodTrace: %v", err)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionDegraded); cond == nil || cond.Reason != "NamespaceSelectorInvalid" {
+		t.Fatalf("expected NamespaceSelectorInvalid degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestMore_Session_DeletionRemovesFinalizer(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := sessionBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	}); err != nil {
+		t.Fatalf("session deletion path must succeed, got %v", err)
+	}
+}
+
+func TestMore_Session_DeletionCleanupError(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := sessionBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*rbacv1.RoleBinding); ok {
+					return errInternal()
+				}
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	}); err == nil {
+		t.Fatal("expected cleanup error from session deletion path")
+	}
+}
+
+func TestMore_Session_DeletionFinalizerConflictRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := sessionBeingDeleted()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+				return errConflict("podtracesessions", sess.Name)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("finalizer-clear conflict must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on finalizer-clear conflict, got %+v", res)
+	}
+}
+
+func TestMore_Session_ObjectStoreURIInvalid(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := runnableSession()
+	sess.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "ftp://not-supported/key"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	}); err != nil {
+		t.Fatalf("invalid objectstore URI is recorded in status, not returned; got %v", err)
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace}, &got); err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Fatalf("expected Failed state, got %q", got.Status.State)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionDegraded); cond == nil || cond.Reason != "ObjectStoreURIInvalid" {
+		t.Fatalf("expected ObjectStoreURIInvalid degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestMore_Session_ObjectStoreCredsMissing(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := runnableSession()
+	sess.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{
+			URI:                  "s3://bucket/key",
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "absent-creds"},
+		},
+	}
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess, pod, ec).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("missing creds is recorded in status, not returned; got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue on missing objectstore creds, got %+v", res)
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace}, &got); err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionDegraded); cond == nil || cond.Reason != "ObjectStoreCreds" {
+		t.Fatalf("expected ObjectStoreCreds degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestMore_Session_ServiceAccountError(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess, pod, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	}); err == nil {
+		t.Fatal("expected SessionSA error from session Reconcile")
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace}, &got); err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionDegraded); cond == nil || cond.Reason != "SessionSA" {
+		t.Fatalf("expected SessionSA degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestMore_Session_ReportRBACError(t *testing.T) {
+	s := newOperatorScheme(t)
+	sess := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(sess, pod, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*rbacv1.Role); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace},
+	}); err == nil {
+		t.Fatal("expected SessionRBAC error from session Reconcile")
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: sess.Name, Namespace: sess.Namespace}, &got); err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if cond := findCondition(got.Status.Conditions, ConditionDegraded); cond == nil || cond.Reason != "SessionRBAC" {
+		t.Fatalf("expected SessionRBAC degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func findCondition(conds []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == condType {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+func podTraceBeingDeleted() *podtracev1alpha1.PodTrace {
+	now := metav1.NewTime(time.Now())
+	return &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pt-del",
+			Namespace:         "team-a",
+			UID:               "pt-del-uid",
+			Generation:        1,
+			Finalizers:        []string{FinalizerCleanup},
+			DeletionTimestamp: &now,
+		},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+}
+
+func sessionBeingDeleted() *podtracev1alpha1.PodTraceSession {
+	now := metav1.NewTime(time.Now())
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "sess-del",
+			Namespace:         "team-a",
+			UID:               "sess-del-uid",
+			Generation:        1,
+			Finalizers:        []string{FinalizerCleanup},
+			DeletionTimestamp: &now,
+		},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+}

--- a/internal/operator/session_bundle_errorpath_test.go
+++ b/internal/operator/session_bundle_errorpath_test.go
@@ -1,0 +1,123 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestEnsureSessionExporterBundle_ConfigMapCreateError(t *testing.T) {
+	scheme := newSessionBundleScheme(t)
+	ec := newOTLPExporter("prod-otlp", "team-a")
+	boom := errors.New("apiserver down")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return boom
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-cm-err"},
+	}
+	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	if err == nil {
+		t.Fatal("expected error when ConfigMap reconcile fails")
+	}
+	if !strings.Contains(err.Error(), "ConfigMap") {
+		t.Errorf("error %q should mention ConfigMap", err.Error())
+	}
+}
+
+func TestEnsureSessionExporterBundle_SecretCreateError(t *testing.T) {
+	scheme := newSessionBundleScheme(t)
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: "team-a", UID: "ec-dd-secret-err"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeDataDog,
+			DataDog: &podtracev1alpha1.DataDogExporter{
+				APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd-creds", Key: "api_key"},
+			},
+		},
+	}
+	userSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-creds", Namespace: "team-a"},
+		Data:       map[string][]byte{"api_key": []byte("k")},
+	}
+	boom := errors.New("secret store unavailable")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, userSecret).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Secret); ok && key.Namespace == "podtrace-system" {
+					return boom
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-secret-err"},
+	}
+	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	if err == nil {
+		t.Fatal("expected error when companion Secret reconcile fails")
+	}
+	if !strings.Contains(err.Error(), "Secret") {
+		t.Errorf("error %q should mention Secret", err.Error())
+	}
+}
+
+func TestEnsureSessionExporterBundle_MissingCredentialSecretErrors(t *testing.T) {
+	scheme := newSessionBundleScheme(t)
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: "team-a", UID: "ec-dd-missing"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeDataDog,
+			DataDog: &podtracev1alpha1.DataDogExporter{
+				APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "absent-secret", Key: "api_key"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-missing-cred"},
+	}
+	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	if err == nil {
+		t.Fatal("expected error when credential Secret is absent")
+	}
+	if !strings.Contains(err.Error(), "credential") {
+		t.Errorf("error %q should mention credential", err.Error())
+	}
+}
+
+func TestLoadCredentialSecret_MissingKeyErrors(t *testing.T) {
+	scheme := newSessionBundleScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "team-a"},
+		Data:       map[string][]byte{"wrong_key": []byte("x")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	_, err := loadCredentialSecret(context.Background(), c, "team-a",
+		podtracev1alpha1.SecretKeySelector{Name: "creds", Key: "api_key"})
+	if err == nil {
+		t.Fatal("expected error when referenced key is absent")
+	}
+	if !strings.Contains(err.Error(), "api_key") {
+		t.Errorf("error %q should name the missing key", err.Error())
+	}
+}

--- a/internal/operator/session_bundle_test.go
+++ b/internal/operator/session_bundle_test.go
@@ -139,6 +139,12 @@ func TestEnsureSessionExporterBundle_WithCredentialCreatesSecret(t *testing.T) {
 	}
 }
 
+func TestMarshalBundleToYAML_DecodeError(t *testing.T) {
+	if _, err := marshalBundleToYAML(nil); err == nil {
+		t.Fatal("expected error when ConfigMap data is nil")
+	}
+}
+
 func TestMarshalBundleToYAML_RoundTrip(t *testing.T) {
 	cmData := map[string]string{
 		"type":          "otlp",

--- a/internal/operator/session_helpers_unit_test.go
+++ b/internal/operator/session_helpers_unit_test.go
@@ -1,0 +1,490 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestSess_TerminalCompletedNoCompletionTimeIsNoOp(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	session.Status.State = podtracev1alpha1.SessionStateCompleted
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("terminal session no-op must not error, got %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("terminal session with nil CompletionTime must not requeue, got %+v", res)
+	}
+}
+
+func TestSess_TerminalFailedWithinTTLRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	session.Status.State = podtracev1alpha1.SessionStateFailed
+	now := metav1.Now()
+	session.Status.CompletionTime = &now
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("terminal session within TTL must not error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("terminal session within TTL must requeue, got %+v", res)
+	}
+}
+
+func TestSess_NodeAtCapacityRequeues(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{MaxConcurrentSessionsPerNode: 1},
+	}
+	otherJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-session-job",
+			Namespace: "podtrace-system",
+			Labels: map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: "other-session",
+				LabelSessionNS:   "team-b",
+				LabelNodeName:    "n1",
+			},
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec, tc, otherJob).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("node-at-capacity must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue when node at capacity, got %+v", res)
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: session.Name, Namespace: session.Namespace}, &got); err != nil {
+		t.Fatalf("re-get session: %v", err)
+	}
+	if !hasDegradedReason(got.Status.Conditions, "NodeCapacity") {
+		t.Fatalf("expected NodeCapacity degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestSess_EnsureJobsCreateError(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*batchv1.Job); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	}); err == nil {
+		t.Fatal("expected ensureJobs create error from session Reconcile")
+	}
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Name: session.Name, Namespace: session.Namespace}, &got); err != nil {
+		t.Fatalf("re-get session: %v", err)
+	}
+	if !hasDegradedReason(got.Status.Conditions, "EnsureJobs") {
+		t.Fatalf("expected EnsureJobs degraded condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestSess_PopulateSummariesListError(t *testing.T) {
+	s := newOperatorScheme(t)
+	session := runnableSession()
+	pod := runningPod("p1", "team-a", "n1", map[string]string{"a": "b"})
+	ec := otlpExporter("ec", "team-a")
+	now := metav1.Now()
+	ownedJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SessionJobName(session.UID, "n1"),
+			Namespace: "podtrace-system",
+			Labels: map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: session.Name,
+				LabelSessionNS:   session.Namespace,
+				LabelNodeName:    "n1",
+			},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1, CompletionTime: &now},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(session, pod, ec, ownedJob).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.PodList); ok {
+					return errInternal()
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: session.Name, Namespace: session.Namespace},
+	}); err == nil {
+		t.Fatal("expected populateSessionSummaries pod-list error from session Reconcile")
+	}
+}
+
+func hasDegradedReason(conds []metav1.Condition, reason string) bool {
+	for _, c := range conds {
+		if c.Type == ConditionDegraded && c.Status == metav1.ConditionTrue && c.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSess_MakeSessionJobRefsEmpty(t *testing.T) {
+	refs := makeSessionJobRefs(nil)
+	if len(refs) != 0 {
+		t.Fatalf("expected zero refs for empty input, got %d", len(refs))
+	}
+}
+
+func TestSess_MakeSessionJobRefsPopulated(t *testing.T) {
+	start := metav1.NewTime(time.Date(2026, 6, 8, 11, 0, 0, 0, time.UTC))
+	complete := metav1.NewTime(time.Date(2026, 6, 8, 11, 5, 0, 0, time.UTC))
+	backoff := int32(0)
+
+	running := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "job-running",
+			Labels: map[string]string{LabelNodeName: "n1"},
+		},
+		Spec:   batchv1.JobSpec{BackoffLimit: &backoff},
+		Status: batchv1.JobStatus{Active: 1, StartTime: &start},
+	}
+	failed := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "job-failed",
+			Labels: map[string]string{LabelNodeName: "n2"},
+		},
+		Spec:   batchv1.JobSpec{BackoffLimit: &backoff},
+		Status: batchv1.JobStatus{Failed: 1, StartTime: &start, CompletionTime: &complete},
+	}
+
+	refs := makeSessionJobRefs([]batchv1.Job{running, failed})
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %d", len(refs))
+	}
+
+	if refs[0].Node != "n1" || refs[0].Name != "job-running" {
+		t.Fatalf("unexpected running ref: %+v", refs[0])
+	}
+	if refs[0].Completed {
+		t.Fatalf("running Job must not be marked completed: %+v", refs[0])
+	}
+	if refs[0].StartTime == nil || refs[0].CompletionTime != nil {
+		t.Fatalf("running Job ref should carry StartTime and no CompletionTime: %+v", refs[0])
+	}
+	if refs[0].Message != "" {
+		t.Fatalf("running Job must not carry a failure message: %+v", refs[0])
+	}
+
+	if !refs[1].Completed {
+		t.Fatalf("failed Job past backoff limit must be marked completed: %+v", refs[1])
+	}
+	if refs[1].CompletionTime == nil || refs[1].StartTime == nil {
+		t.Fatalf("failed Job ref should carry both timestamps: %+v", refs[1])
+	}
+	if refs[1].Message != "Job failed" {
+		t.Fatalf("failed Job ref should carry the failure message, got %q", refs[1].Message)
+	}
+}
+
+func finishedJob(name, ns, node string) *batchv1.Job {
+	now := metav1.Now()
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{LabelNodeName: node},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1, CompletionTime: &now},
+	}
+}
+
+func podForJob(jobName, ns string, terminated *corev1.ContainerStateTerminated) *corev1.Pod {
+	cs := corev1.ContainerStatus{Name: "podtrace"}
+	if terminated != nil {
+		cs.State = corev1.ContainerState{Terminated: terminated}
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName + "-abc",
+			Namespace: ns,
+			Labels:    map[string]string{"job-name": jobName},
+		},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
+	}
+}
+
+func TestSess_ReadTerminationSummaryParsesMessage(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := finishedJob("job-1", "podtrace-system", "n1")
+	pod := podForJob("job-1", "podtrace-system", &corev1.ContainerStateTerminated{
+		Message: `{"totalEvents":42,"netEvents":7,"node":"n1"}`,
+	})
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+
+	summary, err := readTerminationSummaryForJob(context.Background(), c, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("expected a decoded summary, got nil")
+	}
+	if summary.TotalEvents != 42 || summary.NetEvents != 7 || summary.Node != "n1" {
+		t.Fatalf("summary not parsed correctly: %+v", summary)
+	}
+}
+
+func TestSess_ReadTerminationSummaryUnfinishedJob(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-pending", Namespace: "podtrace-system"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	summary, err := readTerminationSummaryForJob(context.Background(), c, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("unfinished Job must yield nil summary, got %+v", summary)
+	}
+}
+
+func TestSess_ReadTerminationSummaryEmptyMessage(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := finishedJob("job-empty", "podtrace-system", "n1")
+	pod := podForJob("job-empty", "podtrace-system", &corev1.ContainerStateTerminated{Message: ""})
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+
+	summary, err := readTerminationSummaryForJob(context.Background(), c, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("empty termination message must yield nil summary, got %+v", summary)
+	}
+}
+
+func TestSess_ReadTerminationSummaryMalformedMessage(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := finishedJob("job-bad", "podtrace-system", "n1")
+	pod := podForJob("job-bad", "podtrace-system", &corev1.ContainerStateTerminated{Message: "{not-json"})
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+
+	summary, err := readTerminationSummaryForJob(context.Background(), c, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("malformed termination message must yield nil summary, got %+v", summary)
+	}
+}
+
+func TestSess_ReadTerminationSummaryNoTerminatedContainer(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := finishedJob("job-running-pod", "podtrace-system", "n1")
+	pod := podForJob("job-running-pod", "podtrace-system", nil)
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+
+	summary, err := readTerminationSummaryForJob(context.Background(), c, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("non-terminated container must yield nil summary, got %+v", summary)
+	}
+}
+
+func TestSess_ReadTerminationSummaryListError(t *testing.T) {
+	s := newOperatorScheme(t)
+	job := finishedJob("job-list-err", "podtrace-system", "n1")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*corev1.PodList); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	if _, err := readTerminationSummaryForJob(context.Background(), c, job); err == nil {
+		t.Fatal("expected pod-list error to surface")
+	}
+}
+
+func gcSession(name string, state podtracev1alpha1.SessionState, completedAt time.Time) podtracev1alpha1.PodTraceSession {
+	ct := metav1.NewTime(completedAt)
+	return podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status: podtracev1alpha1.PodTraceSessionStatus{
+			State:          state,
+			CompletionTime: &ct,
+		},
+	}
+}
+
+func TestSess_ApplyHistoryLimitsSuccessfulDeleteError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	limit := int32(1)
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "sch", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			SuccessfulSessionsHistoryLimit: &limit,
+		},
+	}
+	succeeded := []podtracev1alpha1.PodTraceSession{
+		gcSession("succ-old", podtracev1alpha1.SessionStateCompleted, fixedScheduleNow.Add(-2*time.Hour)),
+		gcSession("succ-new", podtracev1alpha1.SessionStateCompleted, fixedScheduleNow.Add(-1*time.Hour)),
+	}
+
+	err := r.applyHistoryLimits(context.Background(), sch, succeeded, nil)
+	if err == nil {
+		t.Fatal("expected applyHistoryLimits to surface successful-history gc error")
+	}
+	if got := err.Error(); !contains(got, "gc successful") {
+		t.Fatalf("expected wrapped 'gc successful' error, got %q", got)
+	}
+}
+
+func TestSess_ApplyHistoryLimitsFailedDeleteError(t *testing.T) {
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return errInternal()
+			},
+		}).
+		Build()
+	r := &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+
+	limit := int32(1)
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "sch", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			FailedSessionsHistoryLimit: &limit,
+		},
+	}
+	failed := []podtracev1alpha1.PodTraceSession{
+		gcSession("fail-old", podtracev1alpha1.SessionStateFailed, fixedScheduleNow.Add(-2*time.Hour)),
+		gcSession("fail-new", podtracev1alpha1.SessionStateFailed, fixedScheduleNow.Add(-1*time.Hour)),
+	}
+
+	err := r.applyHistoryLimits(context.Background(), sch, nil, failed)
+	if err == nil {
+		t.Fatal("expected applyHistoryLimits to surface failed-history gc error")
+	}
+	if got := err.Error(); !contains(got, "gc failed") {
+		t.Fatalf("expected wrapped 'gc failed' error, got %q", got)
+	}
+}
+
+func TestSess_NewSchemeRegistersTypes(t *testing.T) {
+	sc, err := NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme returned error: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("NewScheme returned nil scheme")
+	}
+	if !sc.Recognizes(podtracev1alpha1.GroupVersion.WithKind("PodTraceSession")) {
+		t.Fatal("scheme does not recognize PodTraceSession")
+	}
+	if !sc.Recognizes(corev1.SchemeGroupVersion.WithKind("Pod")) {
+		t.Fatal("scheme does not recognize core Pod")
+	}
+}

--- a/internal/operator/session_summary_test.go
+++ b/internal/operator/session_summary_test.go
@@ -130,6 +130,66 @@ func TestPopulateSessionSummaries_UnfinishedJobsContributeZero(t *testing.T) {
 	}
 }
 
+func TestPopulateSessionSummaries_NodeFromSummaryAndSkipsForeignContainers(t *testing.T) {
+	scheme := newSummaryScheme(t)
+	now := metav1.Now()
+
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pts-nolabel", Namespace: "podtrace-system",
+		},
+		Status: batchv1.JobStatus{Succeeded: 1, CompletionTime: &now},
+	}
+	raw, _ := json.Marshal(sessionSummaryJSON{TotalEvents: 77, Node: "node-from-summary"})
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pts-nolabel-xyz",
+			Namespace: "podtrace-system",
+			Labels:    map[string]string{"job-name": "pts-nolabel"},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "istio-proxy",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{Message: "ignored"},
+					},
+				},
+				{
+					Name: "podtrace",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{Message: string(raw)},
+					},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	s := &podtracev1alpha1.PodTraceSession{
+		Status: podtracev1alpha1.PodTraceSessionStatus{
+			Jobs: []podtracev1alpha1.SessionJobRef{{Node: "node-from-summary", Name: "pts-nolabel"}},
+		},
+	}
+	if err := populateSessionSummaries(context.Background(), c, s, []batchv1.Job{job}); err != nil {
+		t.Fatalf("populateSessionSummaries: %v", err)
+	}
+	if s.Status.Jobs[0].EventCount != 77 {
+		t.Errorf("EventCount=%d want 77 (node resolved from summary.Node)", s.Status.Jobs[0].EventCount)
+	}
+	if s.Status.Summary == nil || s.Status.Summary.TotalEvents != 77 {
+		t.Errorf("Summary not aggregated: %+v", s.Status.Summary)
+	}
+}
+
+func TestPopulateSessionSummaries_NilSessionIsNoop(t *testing.T) {
+	scheme := newSummaryScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if err := populateSessionSummaries(context.Background(), c, nil, nil); err != nil {
+		t.Errorf("nil session should be a no-op, got %v", err)
+	}
+}
+
 func TestPopulateSessionSummaries_MalformedMessageIsNonFatal(t *testing.T) {
 	scheme := newSummaryScheme(t)
 	now := metav1.Now()

--- a/internal/operator/small_partials_unit_test.go
+++ b/internal/operator/small_partials_unit_test.go
@@ -1,0 +1,286 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// ─── runtime.go NewScheme ─────────────────────────────────────────────
+
+func TestSmall_NewScheme_RegistersPodtraceTypes(t *testing.T) {
+	s, err := NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	if s == nil {
+		t.Fatal("NewScheme returned nil scheme")
+	}
+	gvk := podtracev1alpha1.GroupVersion.WithKind("PodTrace")
+	if !s.Recognizes(gvk) {
+		t.Errorf("scheme does not recognize %v", gvk)
+	}
+	if len(s.AllKnownTypes()) == 0 {
+		t.Error("scheme has no known types")
+	}
+}
+
+// ─── podtraceschedule_controller.go now ───────────────────────────────
+
+func TestSmall_ScheduleReconciler_Now(t *testing.T) {
+	r := &PodTraceScheduleReconciler{}
+	before := time.Now()
+	got := r.now()
+	after := time.Now()
+	if got.Before(before) || got.After(after) {
+		t.Errorf("now() = %v, want within [%v, %v]", got, before, after)
+	}
+
+	pinned := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	r.nowFn = func() time.Time { return pinned }
+	if g := r.now(); !g.Equal(pinned) {
+		t.Errorf("now() = %v, want pinned %v", g, pinned)
+	}
+}
+
+// ─── podtraceschedule_controller.go keyFor ────────────────────────────
+
+func TestSmall_ScheduleReconciler_KeyFor(t *testing.T) {
+	completion := metav1.NewTime(time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC))
+	creation := metav1.NewTime(time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC))
+
+	withCompletion := podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creation},
+		Status:     podtracev1alpha1.PodTraceSessionStatus{CompletionTime: &completion},
+	}
+	if got := keyFor(withCompletion); !got.Equal(completion.Time) {
+		t.Errorf("keyFor(withCompletion) = %v, want %v", got, completion.Time)
+	}
+
+	noCompletion := podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: creation},
+	}
+	if got := keyFor(noCompletion); !got.Equal(creation.Time) {
+		t.Errorf("keyFor(noCompletion) = %v, want %v", got, creation.Time)
+	}
+}
+
+// ─── podtraceschedule_controller.go applyHistoryLimits ────────────────
+
+func TestSmall_ScheduleReconciler_ApplyHistoryLimits(t *testing.T) {
+	r := &PodTraceScheduleReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).Build(),
+		Scheme: newOperatorScheme(t),
+	}
+	ctx := context.Background()
+
+	bare := &podtracev1alpha1.PodTraceSchedule{}
+	if err := r.applyHistoryLimits(ctx, bare, nil, nil); err != nil {
+		t.Fatalf("applyHistoryLimits(both nil) = %v", err)
+	}
+
+	limit := int32(0)
+	failedOnly := &podtracev1alpha1.PodTraceSchedule{
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{FailedSessionsHistoryLimit: &limit},
+	}
+	if err := r.applyHistoryLimits(ctx, failedOnly, nil, nil); err != nil {
+		t.Fatalf("applyHistoryLimits(failed only) = %v", err)
+	}
+
+	both := &podtracev1alpha1.PodTraceSchedule{
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			SuccessfulSessionsHistoryLimit: &limit,
+			FailedSessionsHistoryLimit:     &limit,
+		},
+	}
+	if err := r.applyHistoryLimits(ctx, both, nil, nil); err != nil {
+		t.Fatalf("applyHistoryLimits(both set) = %v", err)
+	}
+}
+
+// ─── podtracesession_metrics.go uploadDurationSeconds ─────────────────
+
+func TestSmall_UploadDurationSeconds(t *testing.T) {
+	noStart := &podtracev1alpha1.PodTraceSession{}
+	if got := uploadDurationSeconds(noStart); got != 0 {
+		t.Errorf("uploadDurationSeconds(no start) = %v, want 0", got)
+	}
+
+	start := metav1.NewTime(time.Now().Add(-2 * time.Second))
+	withStart := &podtracev1alpha1.PodTraceSession{
+		Status: podtracev1alpha1.PodTraceSessionStatus{StartTime: &start},
+	}
+	if got := uploadDurationSeconds(withStart); got <= 0 {
+		t.Errorf("uploadDurationSeconds(past start) = %v, want > 0", got)
+	}
+
+	reportUploadDuration.Reset()
+	defer reportUploadDuration.Reset()
+	obs, err := reportUploadDuration.GetMetricWithLabelValues("s3", "success")
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	obs.Observe(uploadDurationSeconds(withStart))
+	collector, ok := obs.(prometheus.Metric)
+	if !ok {
+		t.Fatal("histogram observer is not a prometheus.Metric")
+	}
+	var pb dto.Metric
+	if err := collector.Write(&pb); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if pb.GetHistogram().GetSampleCount() != 1 {
+		t.Errorf("histogram sample count = %d, want 1", pb.GetHistogram().GetSampleCount())
+	}
+}
+
+// ─── session_bundle.go marshalBundleToYAML ────────────────────────────
+
+func TestSmall_MarshalBundleToYAML(t *testing.T) {
+	out, err := marshalBundleToYAML(map[string]string{
+		"type":     "otlp",
+		"endpoint": "collector:4317",
+		"protocol": "grpc",
+	})
+	if err != nil {
+		t.Fatalf("marshalBundleToYAML(valid) = %v", err)
+	}
+	if !strings.Contains(out, "collector:4317") {
+		t.Errorf("YAML output missing endpoint, got:\n%s", out)
+	}
+
+	if _, err := marshalBundleToYAML(nil); err == nil {
+		t.Error("marshalBundleToYAML(nil) = nil error, want error")
+	}
+}
+
+// ─── session_bundle.go loadCredentialSecret ───────────────────────────
+
+func TestSmall_LoadCredentialSecret(t *testing.T) {
+	ctx := context.Background()
+	ref := podtracev1alpha1.SecretKeySelector{Name: "creds", Key: "token"}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("s3cr3t")},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).WithObjects(secret).Build()
+	data, err := loadCredentialSecret(ctx, c, "ns", ref)
+	if err != nil {
+		t.Fatalf("loadCredentialSecret(found) = %v", err)
+	}
+	if string(data["credential"]) != "s3cr3t" {
+		t.Errorf("credential = %q, want %q", data["credential"], "s3cr3t")
+	}
+
+	noKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "ns"},
+		Data:       map[string][]byte{"other": []byte("x")},
+	}
+	cNoKey := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).WithObjects(noKey).Build()
+	if _, err := loadCredentialSecret(ctx, cNoKey, "ns", ref); err == nil {
+		t.Error("loadCredentialSecret(missing key) = nil error, want error")
+	}
+
+	cEmpty := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).Build()
+	if _, err := loadCredentialSecret(ctx, cEmpty, "ns", ref); err == nil {
+		t.Error("loadCredentialSecret(not found) = nil error, want error")
+	}
+}
+
+// ─── bootstrap.go Start ───────────────────────────────────────────────
+
+func TestSmall_Bootstrap_Start(t *testing.T) {
+	ctx := context.Background()
+
+	existing := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	cExisting := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).WithObjects(existing).Build()
+	b := &BootstrapDefaultTracerConfig{Client: cExisting, SystemNamespace: "podtrace-system"}
+	if err := b.Start(ctx); err != nil {
+		t.Fatalf("Start(existing) = %v", err)
+	}
+
+	t.Setenv(BootstrapImageEnv, "")
+	cEmpty := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).Build()
+	bNoImage := &BootstrapDefaultTracerConfig{Client: cEmpty, SystemNamespace: "podtrace-system"}
+	if err := bNoImage.Start(ctx); err != nil {
+		t.Fatalf("Start(no image) = %v", err)
+	}
+
+	cCreate := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).Build()
+	bCreate := &BootstrapDefaultTracerConfig{
+		Client:          cCreate,
+		SystemNamespace: "podtrace-system",
+		FallbackImage:   "ghcr.io/gma1k/podtrace:test",
+	}
+	if err := bCreate.Start(ctx); err != nil {
+		t.Fatalf("Start(create) = %v", err)
+	}
+	var created podtracev1alpha1.TracerConfig
+	if err := cCreate.Get(ctx, types.NamespacedName{Name: DefaultTracerConfigName}, &created); err != nil {
+		t.Fatalf("expected created TracerConfig: %v", err)
+	}
+	if created.Spec.Image != "ghcr.io/gma1k/podtrace:test" {
+		t.Errorf("created image = %q, want fallback", created.Spec.Image)
+	}
+
+	cListErr := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return errors.New("list boom")
+			},
+		}).Build()
+	bListErr := &BootstrapDefaultTracerConfig{Client: cListErr, SystemNamespace: "podtrace-system"}
+	if err := bListErr.Start(ctx); err != nil {
+		t.Fatalf("Start(list error) = %v, want nil (skip)", err)
+	}
+
+	cAlready := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return apierrors.NewAlreadyExists(
+					podtracev1alpha1.GroupVersion.WithResource("tracerconfigs").GroupResource(),
+					DefaultTracerConfigName)
+			},
+		}).Build()
+	bAlready := &BootstrapDefaultTracerConfig{
+		Client:          cAlready,
+		SystemNamespace: "podtrace-system",
+		FallbackImage:   "ghcr.io/gma1k/podtrace:test",
+	}
+	if err := bAlready.Start(ctx); err != nil {
+		t.Fatalf("Start(already exists) = %v, want nil (defer)", err)
+	}
+
+	cCreateErr := fake.NewClientBuilder().WithScheme(newOperatorScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return errors.New("create boom")
+			},
+		}).Build()
+	bCreateErr := &BootstrapDefaultTracerConfig{
+		Client:          cCreateErr,
+		SystemNamespace: "podtrace-system",
+		FallbackImage:   "ghcr.io/gma1k/podtrace:test",
+	}
+	if err := bCreateErr.Start(ctx); err == nil {
+		t.Error("Start(create error) = nil, want wrapped error")
+	}
+}

--- a/internal/operator/tracerconfig_daemonset_optfields_test.go
+++ b/internal/operator/tracerconfig_daemonset_optfields_test.go
@@ -1,0 +1,64 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func envValue(env []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestBuildAgentDaemonSetSpec_OptionalAgentFields(t *testing.T) {
+	dpcOff := false
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.ImagePullPolicy = corev1.PullAlways
+		x.Spec.Agent.LogLevel = "debug"
+		x.Spec.Agent.EventBufferSize = 4096
+		x.Spec.Agent.DNSPacketCapture = &dpcOff
+		x.Spec.Agent.StatusReportInterval = &metav1.Duration{Duration: 15 * time.Second}
+	}), "podtrace-system")
+
+	c := spec.Template.Spec.Containers[0]
+
+	if c.ImagePullPolicy != corev1.PullAlways {
+		t.Errorf("ImagePullPolicy=%q want Always", c.ImagePullPolicy)
+	}
+	if v, ok := envValue(c.Env, "PODTRACE_LOG_LEVEL"); !ok || v != "debug" {
+		t.Errorf("PODTRACE_LOG_LEVEL=%q ok=%v want debug", v, ok)
+	}
+	if v, ok := envValue(c.Env, "PODTRACE_EVENT_BUFFER_SIZE"); !ok || v != "4096" {
+		t.Errorf("PODTRACE_EVENT_BUFFER_SIZE=%q ok=%v want 4096", v, ok)
+	}
+	if v, ok := envValue(c.Env, "PODTRACE_DNS_PACKET_CAPTURE"); !ok || v != "false" {
+		t.Errorf("PODTRACE_DNS_PACKET_CAPTURE=%q ok=%v want false", v, ok)
+	}
+
+	joined := ""
+	for _, a := range c.Args {
+		joined += a + " "
+	}
+	if !contains(joined, "--status-report-interval 15s") {
+		t.Errorf("--status-report-interval not wired: %v", c.Args)
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_DNSPacketCaptureEnabledOmitsEnv(t *testing.T) {
+	dpcOn := true
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.Agent.DNSPacketCapture = &dpcOn
+	}), "podtrace-system")
+	if _, ok := envValue(spec.Template.Spec.Containers[0].Env, "PODTRACE_DNS_PACKET_CAPTURE"); ok {
+		t.Error("PODTRACE_DNS_PACKET_CAPTURE must be absent when capture is enabled")
+	}
+}

--- a/internal/procfs/procfs_branches_test.go
+++ b/internal/procfs/procfs_branches_test.go
@@ -1,0 +1,42 @@
+package procfs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStat_RootOpenFails(t *testing.T) {
+	withProcBase(t, "/no/such/proc/base")
+	_, err := Stat("self/stat")
+	if err == nil {
+		t.Fatal("expected error when root cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "procfs") {
+		t.Errorf("error should be wrapped with procfs prefix, got %v", err)
+	}
+}
+
+func TestStat_MissingRelative(t *testing.T) {
+	withProcBase(t, t.TempDir())
+	if _, err := Stat("does-not-exist"); err == nil {
+		t.Fatal("expected error for missing relative path")
+	}
+}
+
+func TestOpen_RootOpenFails(t *testing.T) {
+	withProcBase(t, "/no/such/proc/base")
+	_, err := Open("self/maps")
+	if err == nil {
+		t.Fatal("expected error when root cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "procfs") {
+		t.Errorf("error should be wrapped with procfs prefix, got %v", err)
+	}
+}
+
+func TestOpen_MissingRelative(t *testing.T) {
+	withProcBase(t, t.TempDir())
+	if _, err := Open("does-not-exist"); err == nil {
+		t.Fatal("expected error for missing relative path")
+	}
+}

--- a/internal/procfs/readlink_unit_test.go
+++ b/internal/procfs/readlink_unit_test.go
@@ -1,0 +1,46 @@
+package procfs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadlink_Success(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+	withProcBase(t, dir)
+
+	got, err := Readlink("link")
+	if err != nil {
+		t.Fatalf("Readlink returned error: %v", err)
+	}
+	if got != target {
+		t.Errorf("Readlink = %q, want %q", got, target)
+	}
+}
+
+func TestReadlink_MissingLink(t *testing.T) {
+	withProcBase(t, t.TempDir())
+	if _, err := Readlink("does-not-exist"); err == nil {
+		t.Fatal("expected error for missing link")
+	}
+}
+
+func TestReadlink_RootOpenFails(t *testing.T) {
+	withProcBase(t, "/no/such/proc/base")
+	_, err := Readlink("self/exe")
+	if err == nil {
+		t.Fatal("expected error when root cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "procfs") {
+		t.Errorf("error should be wrapped with procfs prefix, got %v", err)
+	}
+}

--- a/internal/profiling/correlator_unit_test.go
+++ b/internal/profiling/correlator_unit_test.go
@@ -1,0 +1,101 @@
+package profiling
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSafeInt64(t *testing.T) {
+	cases := []struct {
+		name string
+		in   uint64
+		want int64
+	}{
+		{"zero", 0, 0},
+		{"normal", 42, 42},
+		{"maxInt64", uint64(math.MaxInt64), math.MaxInt64},
+		{"overflow", uint64(math.MaxInt64) + 1, math.MaxInt64},
+		{"maxUint64", math.MaxUint64, math.MaxInt64},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeInt64(tc.in); got != tc.want {
+				t.Errorf("safeInt64(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"under limit", "hello", 10, "hello"},
+		{"exactly at limit", "hello", 5, "hello"},
+		{"over limit", "hello world", 8, "hello..."},
+		{"single char over", "abcdef", 5, "ab..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncate(tc.s, tc.maxLen); got != tc.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tc.s, tc.maxLen, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"negative", -1, "?"},
+		{"zero", 0, "0B"},
+		{"bytes", 512, "512B"},
+		{"kb boundary", 1024, "1.0KB"},
+		{"kb", 1536, "1.5KB"},
+		{"mb boundary", 1024 * 1024, "1.0MB"},
+		{"mb", 1024 * 1024 * 3 / 2, "1.5MB"},
+		{"gb boundary", 1024 * 1024 * 1024, "1.0GB"},
+		{"huge", math.MaxInt64, "8589934592.0GB"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatBytes(tc.in); got != tc.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBPFTimestampToWall verifies conversion using the package clock offset.
+// GetClockOffset() caches a value via sync.Once on first use; this test asserts
+// the conversion is consistent with that cached offset (covering both the
+// normal path and the MaxInt64 clamp branch) without mutating production state.
+func TestBPFTimestampToWall(t *testing.T) {
+	offset := GetClockOffset()
+
+	const bpfNS = uint64(1_000_000_000) // 1s since boot
+	got := BPFTimestampToWall(bpfNS)
+	want := time.Unix(0, int64(bpfNS)+offset)
+	if !got.Equal(want) {
+		t.Errorf("BPFTimestampToWall(%d) = %v, want %v", bpfNS, got, want)
+	}
+
+	gotZero := BPFTimestampToWall(0)
+	wantZero := time.Unix(0, offset)
+	if !gotZero.Equal(wantZero) {
+		t.Errorf("BPFTimestampToWall(0) = %v, want %v", gotZero, wantZero)
+	}
+
+	gotBig := BPFTimestampToWall(math.MaxUint64)
+	wantBig := time.Unix(0, int64(math.MaxInt64)+offset)
+	if !gotBig.Equal(wantBig) {
+		t.Errorf("BPFTimestampToWall(MaxUint64) = %v, want %v", gotBig, wantBig)
+	}
+}

--- a/internal/profiling/doprofile_unit_test.go
+++ b/internal/profiling/doprofile_unit_test.go
@@ -1,0 +1,161 @@
+package profiling
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// These tests drive doProfile directly against a loopback httptest server to
+// exercise the success-path merge branches (heap available, goroutine
+// available, CPU metadata) that the indirect Run-based tests do not reach.
+
+func TestDoProfile_HeapAvailable_MergesResult(t *testing.T) {
+	const heapText = `heap profile: 1: 1024 [1: 1024] @ heap/1048576
+1: 1024 [1: 1024] @
+#	0x0	example.com/pkg.Alloc+0x0	file.go:1
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(heapText))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port := mustParseAddr(t, srv.Listener.Addr().String())
+	h := NewHandler(host, []int{port})
+	h.profiler.foundPort = port
+
+	h.doProfile(context.Background(), ProfileHeap, 0)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result after heap doProfile")
+	}
+	if res.HeapProfile == nil || !res.HeapProfile.Available {
+		t.Error("expected available heap profile to be stored")
+	}
+	if !res.PprofAvailable {
+		t.Error("expected PprofAvailable=true after available heap fetch")
+	}
+	if res.PodIP != host {
+		t.Errorf("expected PodIP=%q, got %q", host, res.PodIP)
+	}
+}
+
+func TestDoProfile_GoroutineAvailable_MergesResult(t *testing.T) {
+	const goroutineText = `goroutine 1 [running]:
+main.main()
+
+goroutine 2 [chan receive]:
+runtime.gopark()
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(goroutineText))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port := mustParseAddr(t, srv.Listener.Addr().String())
+	h := NewHandler(host, []int{port})
+	h.profiler.foundPort = port
+
+	h.doProfile(context.Background(), ProfileGoroutine, 0)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result after goroutine doProfile")
+	}
+	if res.GoroutineProfile == nil || !res.GoroutineProfile.Available {
+		t.Error("expected available goroutine profile to be stored")
+	}
+	if res.GoroutineProfile.GoroutineCount != 2 {
+		t.Errorf("expected GoroutineCount=2, got %d", res.GoroutineProfile.GoroutineCount)
+	}
+	if !res.PprofAvailable {
+		t.Error("expected PprofAvailable=true after available goroutine fetch")
+	}
+}
+
+func TestDoProfile_HeapFetchError_NoEndpoint(t *testing.T) {
+	h := NewHandler("10.0.0.1", []int{})
+	h.doProfile(context.Background(), ProfileHeap, 0)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result even on fetch error")
+	}
+	if res.HeapProfile == nil {
+		t.Fatal("expected heap profile struct to be stored")
+	}
+	if res.HeapProfile.Available {
+		t.Error("expected Available=false on fetch error")
+	}
+	if res.HeapProfile.Error == "" {
+		t.Error("expected non-empty Error on fetch failure")
+	}
+	if res.PprofAvailable {
+		t.Error("expected PprofAvailable=false when heap fetch failed")
+	}
+}
+
+func TestDoProfile_GoroutineFetchError_NoEndpoint(t *testing.T) {
+	h := NewHandler("10.0.0.1", []int{})
+	h.doProfile(context.Background(), ProfileGoroutine, 0)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result even on goroutine fetch error")
+	}
+	if res.GoroutineProfile == nil || res.GoroutineProfile.Available {
+		t.Error("expected unavailable goroutine profile to be stored")
+	}
+}
+
+func TestDoProfile_CPU_SetsMetadataOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("fake-cpu-profile-data"))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port := mustParseAddr(t, srv.Listener.Addr().String())
+	h := NewHandler(host, []int{port})
+	h.profiler.foundPort = port
+
+	h.doProfile(context.Background(), ProfileCPU, 0)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result after CPU doProfile")
+	}
+	if !res.PprofAvailable {
+		t.Error("expected PprofAvailable=true after successful CPU fetch")
+	}
+	if res.HeapProfile != nil || res.GoroutineProfile != nil {
+		t.Error("CPU profile should not populate heap/goroutine profiles")
+	}
+}
+
+func TestDoProfile_CPU_FetchError_NoEndpoint(t *testing.T) {
+	h := NewHandler("10.0.0.1", []int{})
+	h.doProfile(context.Background(), ProfileCPU, 2*time.Second)
+
+	res := h.GetResult()
+	if res == nil {
+		t.Fatal("expected non-nil result even on CPU fetch error")
+	}
+	if res.PprofAvailable {
+		t.Error("expected PprofAvailable=false when CPU fetch failed")
+	}
+}
+
+func TestDoProfile_DefaultDurationApplied(t *testing.T) {
+	if config.ProfilingDefaultDuration <= 0 {
+		t.Fatalf("expected positive default profiling duration, got %v", config.ProfilingDefaultDuration)
+	}
+}

--- a/internal/reportsink/objectstore/gcs_unit_test.go
+++ b/internal/reportsink/objectstore/gcs_unit_test.go
@@ -1,0 +1,26 @@
+package objectstore
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestLoggingGCSShouldRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error not retryable", errors.New("permanent failure"), false},
+		{"unexpected EOF retryable", io.ErrUnexpectedEOF, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loggingGCSShouldRetry(tt.err); got != tt.want {
+				t.Errorf("loggingGCSShouldRetry(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reportsink/objectstore/retry_log_test.go
+++ b/internal/reportsink/objectstore/retry_log_test.go
@@ -35,6 +35,22 @@ func (r *recordingLogger) OnAttempt(backend, method, url string, status, attempt
 	})
 }
 
+func TestCounterFor_ReturnsSameCounterForSameKey(t *testing.T) {
+	p := newAzureRetryLogPolicy()
+	first := p.counterFor("PUT example.com/blob")
+	first.Add(3)
+	second := p.counterFor("PUT example.com/blob")
+	if first != second {
+		t.Fatal("counterFor returned a different counter for the same key")
+	}
+	if got := second.Load(); got != 3 {
+		t.Errorf("cached counter lost state: got %d want 3", got)
+	}
+	if other := p.counterFor("GET example.com/blob"); other == first {
+		t.Error("distinct keys must not share a counter")
+	}
+}
+
 func TestLoggingTransport_AttemptsIncrementPerSameURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/internal/reportsink/objectstore/sink_unit_test.go
+++ b/internal/reportsink/objectstore/sink_unit_test.go
@@ -1,0 +1,152 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── defaultRetryLogger.OnAttempt ─────────────────────────────────────────────
+
+func TestDefaultRetryLogger_OnAttempt_WithError(t *testing.T) {
+	var l defaultRetryLogger
+	l.OnAttempt("s3", "PUT", "https://example/obj", 503, 2, 10*time.Millisecond, errors.New("boom"))
+}
+
+func TestDefaultRetryLogger_OnAttempt_NoError(t *testing.T) {
+	var l defaultRetryLogger
+	l.OnAttempt("gs", "PUT", "https://example/obj", 200, 1, time.Millisecond, nil)
+}
+
+// ─── New / parseURI error branches ────────────────────────────────────────────
+
+func TestNew_UnsupportedScheme(t *testing.T) {
+	_, err := New(context.Background(), Config{URI: "ftp://host/key"})
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+	if !strings.Contains(err.Error(), "unsupported URI scheme") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EmptyURI(t *testing.T) {
+	_, err := New(context.Background(), Config{URI: ""})
+	if err == nil {
+		t.Fatal("expected error for empty URI")
+	}
+	if !strings.Contains(err.Error(), "empty URI") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_MalformedURI(t *testing.T) {
+	// Control character makes url.Parse fail inside parseURI.
+	_, err := New(context.Background(), Config{URI: "s3://bucket/\x7f"})
+	if err == nil {
+		t.Fatal("expected parse error for malformed URI")
+	}
+	if !strings.Contains(err.Error(), "parse URI") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseURI_MalformedURL(t *testing.T) {
+	_, err := parseURI("s3://bucket/\x7f")
+	if err == nil {
+		t.Fatal("expected parse error for control character in URI")
+	}
+}
+
+func TestValidateURI_Malformed(t *testing.T) {
+	if err := ValidateURI("s3://bucket/\x7f"); err == nil {
+		t.Fatal("expected ValidateURI to reject malformed URI")
+	}
+}
+
+// ─── newAzureSink credential branches ─────────────────────────────────────────
+
+// fakeAccountKey is a valid base64 string accepted by NewSharedKeyCredential.
+const fakeAccountKey = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+
+func TestNewAzureSink_DefaultEndpoint(t *testing.T) {
+	// No endpoint cred → endpoint is derived from the account host. Uses a
+	// shared-key credential so no network/default-credential chain is touched.
+	sink, err := New(context.Background(), Config{
+		URI: "azblob://devstoreaccount1/reports/",
+		Credentials: map[string][]byte{
+			azureSecretKeyAccountKey: []byte(fakeAccountKey),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New (default endpoint): %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+}
+
+func TestNewAzureSink_BadAccountKey(t *testing.T) {
+	// Non-base64 account key fails NewSharedKeyCredential synchronously.
+	_, err := New(context.Background(), Config{
+		URI: "azblob://devstoreaccount1/reports/",
+		Credentials: map[string][]byte{
+			azureSecretKeyAccountKey: []byte("not-valid-base64!!!"),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid shared-key credential")
+	}
+	if !strings.Contains(err.Error(), "shared key credential") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewAzureSink_SPNCredential(t *testing.T) {
+	// Service-principal branch: NewClientSecretCredential validates input
+	// format synchronously without contacting Azure AD.
+	sink, err := New(context.Background(), Config{
+		URI: "azblob://devstoreaccount1/reports/",
+		Credentials: map[string][]byte{
+			azureSecretKeyTenantID:     []byte("11111111-1111-1111-1111-111111111111"),
+			azureSecretKeyClientID:     []byte("22222222-2222-2222-2222-222222222222"),
+			azureSecretKeyClientSecret: []byte("super-secret"),
+			azureSecretKeyEndpoint:     []byte("https://devstoreaccount1.blob.core.windows.net"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New (SPN): %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+}
+
+func TestNewAzureSink_DefaultCredential(t *testing.T) {
+	// No credentials → falls through to NewDefaultAzureCredential, which
+	// builds a lazy credential chain without making network calls.
+	sink, err := New(context.Background(), Config{
+		URI: "azblob://devstoreaccount1/reports/",
+	})
+	if err != nil {
+		t.Fatalf("New (default credential): %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+}
+
+// ─── newGCSSink service-account JSON branch ───────────────────────────────────
+
+func TestNewGCSSink_BadServiceAccountJSON(t *testing.T) {
+	// Malformed service-account JSON fails credentials.DetectDefault
+	// synchronously, before any network access.
+	_, err := New(context.Background(), Config{
+		URI: "gs://bucket/reports/",
+		Credentials: map[string][]byte{
+			gcsSecretKeyServiceAccountJSON: []byte("{not valid json"),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed service account JSON")
+	}
+	if !strings.Contains(err.Error(), "service account JSON") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/resource/monitor.go
+++ b/internal/resource/monitor.go
@@ -44,11 +44,24 @@ type ResourceLimit struct {
 	ResourceType uint32
 }
 
+type bpfLimitMap interface {
+	Put(key, value interface{}) error
+	Delete(key interface{}) error
+}
+
+type limitMapValue struct {
+	LimitBytes   uint64
+	UsageBytes   uint64
+	LastUpdateNS uint64
+	ResourceType uint32
+	_            [4]byte
+}
+
 type ResourceMonitor struct {
 	cgroupPath    string
 	cgroupInode   uint64
-	limitsMap     *ebpf.Map
-	alertsMap     *ebpf.Map
+	limitsMap     bpfLimitMap
+	alertsMap     bpfLimitMap
 	eventChan     chan<- *events.Event
 	mu            sync.RWMutex
 	limits        map[uint32]*ResourceLimit
@@ -67,13 +80,17 @@ func NewResourceMonitor(cgroupPath string, limitsMap, alertsMap *ebpf.Map, event
 	rm := &ResourceMonitor{
 		cgroupPath:    cgroupPath,
 		cgroupInode:   inode,
-		limitsMap:     limitsMap,
-		alertsMap:     alertsMap,
 		eventChan:     eventChan,
 		limits:        make(map[uint32]*ResourceLimit),
 		checkInterval: config.ResourceMonitorInterval,
 		stopCh:        make(chan struct{}),
 		namespace:     namespace,
+	}
+	if limitsMap != nil {
+		rm.limitsMap = limitsMap
+	}
+	if alertsMap != nil {
+		rm.alertsMap = alertsMap
 	}
 
 	if err := rm.readLimits(); err != nil {
@@ -313,13 +330,7 @@ func (rm *ResourceMonitor) syncToBPF() error {
 
 	for resourceType, limit := range rm.limits {
 		key := rm.cgroupInode
-		value := struct {
-			LimitBytes   uint64
-			UsageBytes   uint64
-			LastUpdateNS uint64
-			ResourceType uint32
-			_            [4]byte
-		}{
+		value := limitMapValue{
 			LimitBytes:   limit.LimitBytes,
 			UsageBytes:   limit.UsageBytes,
 			LastUpdateNS: limit.LastUpdateNS,

--- a/internal/resource/monitor_alerts_unit_test.go
+++ b/internal/resource/monitor_alerts_unit_test.go
@@ -1,0 +1,437 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/podtrace/podtrace/internal/alerting"
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+type fakeBPFMap struct {
+	mu      sync.Mutex
+	entries map[uint64]interface{}
+}
+
+func newFakeBPFMap() *fakeBPFMap {
+	return &fakeBPFMap{entries: make(map[uint64]interface{})}
+}
+
+func (f *fakeBPFMap) Put(key, value interface{}) error {
+	k, ok := key.(uint64)
+	if !ok {
+		return fmt.Errorf("fakeBPFMap.Put: key must be uint64, got %T", key)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries[k] = value
+	return nil
+}
+
+func (f *fakeBPFMap) Delete(key interface{}) error {
+	k, ok := key.(uint64)
+	if !ok {
+		return fmt.Errorf("fakeBPFMap.Delete: key must be uint64, got %T", key)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, exists := f.entries[k]; !exists {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	return nil
+}
+
+func (f *fakeBPFMap) get(key uint64) (interface{}, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.entries[key]
+	return v, ok
+}
+
+// recordingSender captures alerts handed to the global alerting manager.
+type recordingSender struct {
+	ch chan *alerting.Alert
+}
+
+func (r *recordingSender) Send(_ context.Context, alert *alerting.Alert) error {
+	select {
+	case r.ch <- alert:
+	default:
+	}
+	return nil
+}
+
+func (r *recordingSender) Name() string { return "recording" }
+
+func waitForResourceAlert(t *testing.T, ch chan *alerting.Alert) bool {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case a := <-ch:
+			if a.Source != "resource_monitor" {
+				continue
+			}
+			if a.Namespace != "test-ns" {
+				t.Errorf("alert namespace = %q, want test-ns", a.Namespace)
+			}
+			return true
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+// useEnabledAlertManager installs a global alerting manager that is enabled
+// and routes alerts to a recording sender, restoring prior state afterwards.
+// Returns the channel alerts land on.
+func useEnabledAlertManager(t *testing.T) chan *alerting.Alert {
+	t.Helper()
+
+	origEnabled := config.AlertingEnabled
+	origWebhook := config.AlertWebhookURL
+	config.AlertingEnabled = true
+	config.AlertWebhookURL = "http://127.0.0.1:0/unused"
+
+	mgr, err := alerting.NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if !mgr.IsEnabled() {
+		t.Fatalf("expected enabled alerting manager")
+	}
+
+	rec := &recordingSender{ch: make(chan *alerting.Alert, 16)}
+	mgr.AddSender(rec)
+
+	origMgr := alerting.GetGlobalManager()
+	alerting.SetGlobalManager(mgr)
+
+	t.Cleanup(func() {
+		alerting.SetGlobalManager(origMgr)
+		_ = mgr.Shutdown(context.Background())
+		config.AlertingEnabled = origEnabled
+		config.AlertWebhookURL = origWebhook
+	})
+
+	return rec.ch
+}
+
+// newMonitorWithFakeMaps builds a ResourceMonitor whose limits/alerts maps are
+// the supplied in-memory fakes, using a temp cgroup dir so the inode lookup in
+// NewResourceMonitor succeeds. Pass nil to leave a map unset (nil-guard path).
+func newMonitorWithFakeMaps(t *testing.T, limitsMap, alertsMap *fakeBPFMap, eventChan chan *events.Event) *ResourceMonitor {
+	t.Helper()
+	tmpDir := t.TempDir()
+	useCgroupBase(t, tmpDir)
+	cgroupPath := filepath.Join(tmpDir, "cg")
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		t.Fatalf("mkdir cgroup: %v", err)
+	}
+	rm, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
+	if err != nil {
+		t.Fatalf("NewResourceMonitor() error = %v", err)
+	}
+	// Inject the fakes directly (same package). The interface fields stay nil
+	// when a fake isn't supplied, preserving the nil-guard behaviour.
+	if limitsMap != nil {
+		rm.limitsMap = limitsMap
+	}
+	if alertsMap != nil {
+		rm.alertsMap = alertsMap
+	}
+	return rm
+}
+
+func TestSyncToBPF_WritesLimitsToMap(t *testing.T) {
+	limitsMap := newFakeBPFMap()
+	rm := newMonitorWithFakeMaps(t, limitsMap, nil, nil)
+
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceCPU: {
+			LimitBytes:   100000,
+			UsageBytes:   50000,
+			LastUpdateNS: 12345,
+			ResourceType: ResourceCPU,
+		},
+		ResourceMemory: {
+			LimitBytes:   1 << 30,
+			UsageBytes:   1 << 20,
+			LastUpdateNS: 67890,
+			ResourceType: ResourceMemory,
+		},
+	}
+	rm.mu.Unlock()
+
+	if err := rm.syncToBPF(); err != nil {
+		t.Fatalf("syncToBPF() error = %v", err)
+	}
+
+	// All resource types share the cgroup-inode key, so the map holds one
+	// entry: whichever type was written last. Assert it matches that type.
+	raw, ok := limitsMap.get(rm.cgroupInode)
+	if !ok {
+		t.Fatalf("expected an entry at cgroup inode %d", rm.cgroupInode)
+	}
+	got, ok := raw.(limitMapValue)
+	if !ok {
+		t.Fatalf("map value has unexpected type %T", raw)
+	}
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	expected := rm.limits[got.ResourceType]
+	if expected == nil {
+		t.Fatalf("map holds unknown resource type %d", got.ResourceType)
+	}
+	if got.LimitBytes != expected.LimitBytes ||
+		got.UsageBytes != expected.UsageBytes ||
+		got.LastUpdateNS != expected.LastUpdateNS {
+		t.Errorf("map value mismatch: got %+v, expected limit %d usage %d updated %d",
+			got, expected.LimitBytes, expected.UsageBytes, expected.LastUpdateNS)
+	}
+}
+
+func TestSyncToBPF_EmptyLimits(t *testing.T) {
+	limitsMap := newFakeBPFMap()
+	rm := newMonitorWithFakeMaps(t, limitsMap, nil, nil)
+
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{}
+	rm.mu.Unlock()
+
+	if err := rm.syncToBPF(); err != nil {
+		t.Fatalf("syncToBPF() error = %v", err)
+	}
+	if _, ok := limitsMap.get(rm.cgroupInode); ok {
+		t.Errorf("expected no entry in map")
+	}
+}
+
+func TestSyncToBPF_NilMapIsNoOp(t *testing.T) {
+	rm := newMonitorWithFakeMaps(t, nil, nil, nil)
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceCPU: {LimitBytes: 100, UsageBytes: 50, ResourceType: ResourceCPU},
+	}
+	rm.mu.Unlock()
+	if err := rm.syncToBPF(); err != nil {
+		t.Fatalf("syncToBPF() with nil map should be a no-op, got %v", err)
+	}
+}
+
+func TestCheckAlerts_AlertLevels(t *testing.T) {
+	tests := []struct {
+		name          string
+		usage         uint64
+		limit         uint64
+		wantLevel     uint32
+		wantEntry     bool
+		wantEvent     bool
+		wantManagerOn bool
+	}{
+		{name: "no breach", usage: 10, limit: 100, wantLevel: AlertNone, wantEntry: false, wantEvent: false, wantManagerOn: false},
+		{name: "warning", usage: 85, limit: 100, wantLevel: AlertWarning, wantEntry: true, wantEvent: true, wantManagerOn: true},
+		{name: "critical", usage: 92, limit: 100, wantLevel: AlertCritical, wantEntry: true, wantEvent: true, wantManagerOn: true},
+		{name: "emergency", usage: 99, limit: 100, wantLevel: AlertEmergency, wantEntry: true, wantEvent: true, wantManagerOn: true},
+		{name: "over 100 clamps to emergency", usage: 250, limit: 100, wantLevel: AlertEmergency, wantEntry: true, wantEvent: true, wantManagerOn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alertCh := useEnabledAlertManager(t)
+			alertsMap := newFakeBPFMap()
+			eventChan := make(chan *events.Event, 4)
+			rm := newMonitorWithFakeMaps(t, nil, alertsMap, eventChan)
+
+			// Seed a prior warning so the "no breach" case exercises the
+			// delete-existing branch.
+			if err := alertsMap.Put(rm.cgroupInode, uint32(AlertWarning)); err != nil {
+				t.Fatalf("seed alertsMap: %v", err)
+			}
+
+			rm.mu.Lock()
+			rm.limits = map[uint32]*ResourceLimit{
+				ResourceMemory: {
+					LimitBytes:   tt.limit,
+					UsageBytes:   tt.usage,
+					ResourceType: ResourceMemory,
+				},
+			}
+			rm.mu.Unlock()
+
+			rm.checkAlerts()
+
+			raw, ok := alertsMap.get(rm.cgroupInode)
+			if !tt.wantEntry {
+				if ok {
+					t.Errorf("expected alertsMap entry deleted, but found %v", raw)
+				}
+			} else {
+				if !ok {
+					t.Fatalf("expected alertsMap entry")
+				}
+				if level := raw.(uint32); level != tt.wantLevel {
+					t.Errorf("alertsMap level = %d, want %d", level, tt.wantLevel)
+				}
+			}
+
+			select {
+			case ev := <-eventChan:
+				if !tt.wantEvent {
+					t.Errorf("unexpected event emitted: %+v", ev)
+				} else {
+					if ev.Type != events.EventResourceLimit {
+						t.Errorf("event type = %v, want EventResourceLimit", ev.Type)
+					}
+					if ev.LatencyNS != tt.limit {
+						t.Errorf("event LatencyNS(limit) = %d, want %d", ev.LatencyNS, tt.limit)
+					}
+					if ev.Bytes != tt.usage {
+						t.Errorf("event Bytes(usage) = %d, want %d", ev.Bytes, tt.usage)
+					}
+				}
+			case <-time.After(200 * time.Millisecond):
+				if tt.wantEvent {
+					t.Error("expected an event but none was emitted")
+				}
+			}
+
+			if tt.wantManagerOn {
+				if !waitForResourceAlert(t, alertCh) {
+					t.Error("expected alerting manager to receive a resource_monitor alert")
+				}
+			}
+		})
+	}
+}
+
+func TestCheckAlerts_BenignDeleteWhenAbsent(t *testing.T) {
+	alertsMap := newFakeBPFMap()
+	eventChan := make(chan *events.Event, 4)
+	rm := newMonitorWithFakeMaps(t, nil, alertsMap, eventChan)
+
+	// Below the warning threshold and no prior entry: checkAlerts attempts a
+	// Delete that returns ErrKeyNotExist, which must be treated as benign.
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceMemory: {LimitBytes: 100, UsageBytes: 10, ResourceType: ResourceMemory},
+	}
+	rm.mu.Unlock()
+
+	rm.checkAlerts()
+
+	if _, ok := alertsMap.get(rm.cgroupInode); ok {
+		t.Errorf("expected no alertsMap entry")
+	}
+}
+
+func TestCheckAlerts_NilMapIsNoOp(t *testing.T) {
+	rm := newMonitorWithFakeMaps(t, nil, nil, make(chan *events.Event, 1))
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceMemory: {LimitBytes: 100, UsageBytes: 96, ResourceType: ResourceMemory},
+	}
+	rm.mu.Unlock()
+	// Must not panic on a nil alertsMap.
+	rm.checkAlerts()
+}
+
+func TestCheckAlerts_ZeroAndUnlimitedSkipped(t *testing.T) {
+	alertsMap := newFakeBPFMap()
+	eventChan := make(chan *events.Event, 4)
+	rm := newMonitorWithFakeMaps(t, nil, alertsMap, eventChan)
+
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceCPU:    {LimitBytes: 0, UsageBytes: 5, ResourceType: ResourceCPU},
+		ResourceMemory: {LimitBytes: ^uint64(0), UsageBytes: 5, ResourceType: ResourceMemory},
+	}
+	rm.mu.Unlock()
+
+	rm.checkAlerts()
+
+	if _, ok := alertsMap.get(rm.cgroupInode); ok {
+		t.Errorf("expected no alertsMap entry")
+	}
+	select {
+	case ev := <-eventChan:
+		t.Errorf("expected no event, got %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestCheckAlerts_UnknownResourceTypeLabel(t *testing.T) {
+	useEnabledAlertManager(t)
+	alertsMap := newFakeBPFMap()
+	eventChan := make(chan *events.Event, 4)
+	rm := newMonitorWithFakeMaps(t, nil, alertsMap, eventChan)
+
+	const unknownType uint32 = 99
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		unknownType: {LimitBytes: 100, UsageBytes: 96, ResourceType: unknownType},
+	}
+	rm.mu.Unlock()
+
+	rm.checkAlerts()
+
+	raw, ok := alertsMap.get(rm.cgroupInode)
+	if !ok {
+		t.Fatalf("expected alertsMap entry")
+	}
+	if level := raw.(uint32); level != AlertEmergency {
+		t.Errorf("level = %d, want %d (emergency)", level, AlertEmergency)
+	}
+	select {
+	case ev := <-eventChan:
+		if ev.TCPState != unknownType {
+			t.Errorf("event TCPState(resourceType) = %d, want %d", ev.TCPState, unknownType)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Error("expected an event for unknown resource type")
+	}
+}
+
+func TestCheckAlerts_ChannelFullDoesNotBlock(t *testing.T) {
+	useEnabledAlertManager(t)
+	alertsMap := newFakeBPFMap()
+	eventChan := make(chan *events.Event, 1)
+	eventChan <- &events.Event{}
+	rm := newMonitorWithFakeMaps(t, nil, alertsMap, eventChan)
+
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceMemory: {LimitBytes: 100, UsageBytes: 96, ResourceType: ResourceMemory},
+	}
+	rm.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		rm.checkAlerts()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("checkAlerts blocked on a full event channel")
+	}
+
+	// The map write still happened despite the dropped event.
+	raw, ok := alertsMap.get(rm.cgroupInode)
+	if !ok {
+		t.Fatalf("expected alertsMap entry")
+	}
+	if level := raw.(uint32); level != AlertEmergency {
+		t.Errorf("level = %d, want %d", level, AlertEmergency)
+	}
+}

--- a/internal/sysfs/sysfs_branches_test.go
+++ b/internal/sysfs/sysfs_branches_test.go
@@ -1,0 +1,65 @@
+package sysfs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCgroupOpen_RootOpenFails(t *testing.T) {
+	withCgroupBase(t, "/no/such/cgroup/base")
+	_, err := CgroupOpen("cgroup.procs")
+	if err == nil {
+		t.Fatal("expected error when cgroup root cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "sysfs") {
+		t.Errorf("error should be wrapped with sysfs prefix, got %v", err)
+	}
+}
+
+func TestCgroupOpen_Success(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "memory.max"), []byte("max\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withCgroupBase(t, dir)
+	f, err := CgroupOpen("memory.max")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+}
+
+func TestCgroupStat_RootOpenFails(t *testing.T) {
+	withCgroupBase(t, "/no/such/cgroup/base")
+	_, err := CgroupStat("cgroup.procs")
+	if err == nil {
+		t.Fatal("expected error when cgroup root cannot be opened")
+	}
+	if !strings.Contains(err.Error(), "sysfs") {
+		t.Errorf("error should be wrapped with sysfs prefix, got %v", err)
+	}
+}
+
+func TestCgroupStat_Success(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cpu.max"), []byte("max 100000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withCgroupBase(t, dir)
+	fi, err := CgroupStat("cpu.max")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fi.IsDir() {
+		t.Errorf("expected a regular file, got directory")
+	}
+}
+
+func TestCgroupStat_MissingRelative(t *testing.T) {
+	withCgroupBase(t, t.TempDir())
+	if _, err := CgroupStat("does-not-exist"); err == nil {
+		t.Fatal("expected error for missing relative path")
+	}
+}

--- a/internal/system/checks_selinux_test.go
+++ b/internal/system/checks_selinux_test.go
@@ -1,0 +1,20 @@
+package system
+
+import "testing"
+
+// TestCheckSELinux_DoesNotPanic exercises CheckSELinux end to end. The
+// function reads hardcoded host paths and only logs (never returns), so we
+// assert only that it runs to completion. With the skip env set it takes the
+// not-enforcing early-return branch deterministically; without it, whichever
+// host branch applies is exercised.
+func TestCheckSELinux_DoesNotPanic(t *testing.T) {
+	t.Run("skip-env-set-not-enforcing", func(t *testing.T) {
+		t.Setenv("PODTRACE_SKIP_SELINUX_CHECK", "1")
+		CheckSELinux() // selinuxEnforcing returns (false, "") -> early return
+	})
+
+	t.Run("host-state", func(t *testing.T) {
+		t.Setenv("PODTRACE_SKIP_SELINUX_CHECK", "0")
+		CheckSELinux() // whichever detection branch the host yields
+	})
+}

--- a/internal/system/checks_unit_test.go
+++ b/internal/system/checks_unit_test.go
@@ -1,0 +1,50 @@
+package system
+
+import (
+	"os"
+	"testing"
+)
+
+// TestSelinuxEnforcing_SkipEnv covers the PODTRACE_SKIP_SELINUX_CHECK=1 branch,
+// which short-circuits to (false, "") regardless of host state.
+func TestSelinuxEnforcing_SkipEnv(t *testing.T) {
+	t.Setenv("PODTRACE_SKIP_SELINUX_CHECK", "1")
+
+	enforcing, how := selinuxEnforcing()
+	if enforcing {
+		t.Errorf("selinuxEnforcing() = (%v, %q), want (false, \"\") when skip env set", enforcing, how)
+	}
+	if how != "" {
+		t.Errorf("selinuxEnforcing() source = %q, want empty when skip env set", how)
+	}
+}
+
+// TestSelinuxEnforcing_Default exercises the detection path with the skip env
+// unset. The function reads hardcoded host paths (/sys/fs/selinux,
+// /proc/cmdline); we don't assert a specific value because it depends on the
+// host, only that it returns consistently and does not panic. On a typical
+// non-SELinux host this covers the final "not enforcing" return.
+func TestSelinuxEnforcing_Default(t *testing.T) {
+	if err := os.Unsetenv("PODTRACE_SKIP_SELINUX_CHECK"); err != nil {
+		t.Fatalf("unset PODTRACE_SKIP_SELINUX_CHECK: %v", err)
+	}
+
+	enforcing, how := selinuxEnforcing()
+	if enforcing && how == "" {
+		t.Errorf("selinuxEnforcing() reported enforcing with empty source")
+	}
+	if !enforcing && how != "" {
+		t.Errorf("selinuxEnforcing() reported not-enforcing but non-empty source %q", how)
+	}
+	t.Logf("selinuxEnforcing() = (%v, %q) on this host", enforcing, how)
+}
+
+// TestCheckRequirements verifies the aggregate check runs to completion without
+// panicking and returns a nil/non-nil error consistently. On the test host the
+// kernel is well above the 5.8 minimum, so this exercises the version-parse,
+// AtLeast-pass, and BTF-probe branches.
+func TestCheckRequirements(t *testing.T) {
+	if err := CheckRequirements(); err != nil {
+		t.Logf("CheckRequirements() returned error (unexpected on a modern kernel): %v", err)
+	}
+}

--- a/internal/tracing/context/generate_test.go
+++ b/internal/tracing/context/generate_test.go
@@ -1,0 +1,40 @@
+package context
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestGenerateTraceID_FormatAndUniqueness(t *testing.T) {
+	seen := make(map[string]struct{}, 64)
+	for i := 0; i < 64; i++ {
+		id := generateTraceID()
+		if len(id) != 32 {
+			t.Fatalf("trace ID length = %d, want 32 (%q)", len(id), id)
+		}
+		if _, err := hex.DecodeString(id); err != nil {
+			t.Fatalf("trace ID is not valid hex: %v", err)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate trace ID generated: %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestGenerateSpanID_FormatAndUniqueness(t *testing.T) {
+	seen := make(map[string]struct{}, 64)
+	for i := 0; i < 64; i++ {
+		id := generateSpanID()
+		if len(id) != 16 {
+			t.Fatalf("span ID length = %d, want 16 (%q)", len(id), id)
+		}
+		if _, err := hex.DecodeString(id); err != nil {
+			t.Fatalf("span ID is not valid hex: %v", err)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate span ID generated: %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+}

--- a/internal/tracing/exporter/datadog_spantype_unit_test.go
+++ b/internal/tracing/exporter/datadog_spantype_unit_test.go
@@ -1,0 +1,49 @@
+package exporter
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func spanWithEvent(t events.EventType) *tracker.Span {
+	return &tracker.Span{
+		Events: []*events.Event{{Type: t}},
+	}
+}
+
+func TestSpanType_AllBranches(t *testing.T) {
+	cases := []struct {
+		name string
+		span *tracker.Span
+		want string
+	}{
+		{"http", spanWithEvent(events.EventHTTPReq), "web"},
+		{"db", spanWithEvent(events.EventDBQuery), "db"},
+		{"grpc", spanWithEvent(events.EventGRPCMethod), "rpc"},
+		{"default unmatched", spanWithEvent(events.EventConnect), "custom"},
+		{"no events", &tracker.Span{Events: nil}, "custom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := spanType(tc.span); got != tc.want {
+				t.Errorf("spanType(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSpanType_FirstMatchWins confirms the function returns on the first
+// classifiable event in the slice rather than the last.
+func TestSpanType_FirstMatchWins(t *testing.T) {
+	span := &tracker.Span{
+		Events: []*events.Event{
+			{Type: events.EventHTTPReq},
+			{Type: events.EventDBQuery},
+		},
+	}
+	if got := spanType(span); got != "web" {
+		t.Errorf("spanType() = %q, want %q (first match)", got, "web")
+	}
+}

--- a/internal/tracing/exporter/otlp_unit_test.go
+++ b/internal/tracing/exporter/otlp_unit_test.go
@@ -1,0 +1,145 @@
+package exporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// ─── normalizeOTLPHTTPEndpoint ────────────────────────────────────────────────
+
+func TestNormalizeOTLPHTTPEndpoint_EmptyUsesDefault(t *testing.T) {
+	urlStr, _, err := normalizeOTLPHTTPEndpoint("")
+	if err != nil {
+		t.Fatalf("unexpected error for empty endpoint: %v", err)
+	}
+	if urlStr == "" {
+		t.Error("expected a non-empty default endpoint URL")
+	}
+}
+
+func TestNormalizeOTLPHTTPEndpoint_SchemelessHostPort(t *testing.T) {
+	urlStr, insecure, err := normalizeOTLPHTTPEndpoint("localhost:4318")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !insecure {
+		t.Error("expected insecure=true for loopback http endpoint")
+	}
+	if !strings.HasPrefix(urlStr, "http://") {
+		t.Errorf("expected http:// prefix, got %q", urlStr)
+	}
+}
+
+func TestNormalizeOTLPHTTPEndpoint_HTTPSReturnsSecure(t *testing.T) {
+	urlStr, insecure, err := normalizeOTLPHTTPEndpoint("https://collector.example:4318")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if insecure {
+		t.Error("expected insecure=false for https endpoint")
+	}
+	if !strings.HasPrefix(urlStr, "https://") {
+		t.Errorf("expected https:// prefix, got %q", urlStr)
+	}
+}
+
+func TestNormalizeOTLPHTTPEndpoint_MalformedURL(t *testing.T) {
+	_, _, err := normalizeOTLPHTTPEndpoint("http://\x7f/bad")
+	if err == nil {
+		t.Fatal("expected parse error for malformed URL")
+	}
+	if !strings.Contains(err.Error(), "parse OTLP endpoint") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeOTLPHTTPEndpoint_BadScheme(t *testing.T) {
+	_, _, err := normalizeOTLPHTTPEndpoint("ftp://collector.example:4318")
+	if err == nil {
+		t.Fatal("expected error for non-http(s) scheme")
+	}
+	if !strings.Contains(err.Error(), "scheme") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeOTLPHTTPEndpoint_RemoteCleartextRejected(t *testing.T) {
+	_, _, err := normalizeOTLPHTTPEndpoint("http://collector.example:4318")
+	if err == nil {
+		t.Fatal("expected error refusing cleartext http to non-loopback host")
+	}
+	if !strings.Contains(err.Error(), "cleartext") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ─── exportSpan DNS event branch ──────────────────────────────────────────────
+
+func TestOTLPExporter_exportSpan_DNSEvent(t *testing.T) {
+	exporter, err := NewOTLPExporter("http://localhost:4318", 1.0)
+	if err != nil {
+		t.Skipf("failed to create exporter: %v", err)
+	}
+	defer func() { _ = exporter.Shutdown(context.Background()) }()
+
+	span := &tracker.Span{
+		TraceID:   "12345678901234567890123456789012",
+		SpanID:    "1234567890123456",
+		Operation: "dns-lookup",
+		StartTime: time.Now(),
+		Duration:  5 * time.Millisecond,
+		Events: []*events.Event{
+			{
+				Type:         events.EventDNS,
+				Target:       "example.com",
+				Timestamp:    uint64(time.Now().UnixNano()),
+				LatencyNS:    2_000_000,
+				TCPState:     1,               // dns.question.type
+				Error:        0,               // dns.response.code
+				Details:      "93.184.216.34", // dns.resolved
+				DNSServerIP:  0x08080808,      // dns.server (non-zero → emitted)
+				DNSTransport: 1,               // dns.transport=tcp
+			},
+		},
+	}
+
+	if err := exporter.exportSpan(context.Background(), span, &tracker.Trace{TraceID: "t"}); err != nil {
+		t.Errorf("exportSpan() unexpected error: %v", err)
+	}
+}
+
+func TestOTLPExporter_exportSpan_DNSEvent_MinimalFields(t *testing.T) {
+	exporter, err := NewOTLPExporter("http://localhost:4318", 1.0)
+	if err != nil {
+		t.Skipf("failed to create exporter: %v", err)
+	}
+	defer func() { _ = exporter.Shutdown(context.Background()) }()
+
+	span := &tracker.Span{
+		TraceID:   "12345678901234567890123456789012",
+		SpanID:    "1234567890123456",
+		Operation: "dns-lookup",
+		StartTime: time.Now(),
+		Duration:  5 * time.Millisecond,
+		Events: []*events.Event{
+			{
+				Type:         events.EventDNS,
+				Target:       "example.com",
+				Timestamp:    uint64(time.Now().UnixNano()),
+				LatencyNS:    1_000_000,
+				Details:      "",
+				DNSServerIP:  0,
+				DNSTransport: 0,
+			},
+		},
+	}
+
+	if err := exporter.exportSpan(context.Background(), span, &tracker.Trace{TraceID: "t"}); err != nil {
+		t.Errorf("exportSpan() unexpected error: %v", err)
+	}
+}

--- a/internal/tracing/graph/update_node_unit_test.go
+++ b/internal/tracing/graph/update_node_unit_test.go
@@ -1,0 +1,35 @@
+package graph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+)
+
+func TestUpdateNode_MissingNodeIsNoOp(t *testing.T) {
+	gb := NewGraphBuilder()
+	gb.updateNode("missing", &tracker.Span{Duration: time.Second, Error: true})
+	if _, ok := gb.nodes["missing"]; ok {
+		t.Fatal("updateNode must not create a node for an unknown id")
+	}
+}
+
+func TestUpdateNode_AccumulatesAndCountsErrors(t *testing.T) {
+	gb := NewGraphBuilder()
+	gb.nodes["svc"] = &Node{ID: "svc"}
+
+	gb.updateNode("svc", &tracker.Span{Duration: 2 * time.Second, Error: false})
+	gb.updateNode("svc", &tracker.Span{Duration: 3 * time.Second, Error: true})
+
+	n := gb.nodes["svc"]
+	if n.RequestCount != 2 {
+		t.Errorf("RequestCount = %d, want 2", n.RequestCount)
+	}
+	if n.ErrorCount != 1 {
+		t.Errorf("ErrorCount = %d, want 1", n.ErrorCount)
+	}
+	if n.TotalLatency != 5*time.Second {
+		t.Errorf("TotalLatency = %v, want 5s", n.TotalLatency)
+	}
+}

--- a/internal/tracing/manager_exporttraces_test.go
+++ b/internal/tracing/manager_exporttraces_test.go
@@ -1,0 +1,84 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/alerting"
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestManager_ExportTraces_AllFiveExporters_Populated drives a populated batch
+// through every configured exporter (OTLP, Jaeger, Splunk, DataDog, Zipkin) at
+// sample rate 1.0, exercising each exporter's non-nil branch and the successful
+// (err == nil) export path in a single deterministic pass.
+func TestManager_ExportTraces_AllFiveExporters_Populated(t *testing.T) {
+	originalOTLP := config.OTLPEndpoint
+	originalJaeger := config.JaegerEndpoint
+	originalSplunk := config.SplunkEndpoint
+	originalDataDog := config.DataDogEndpoint
+	originalZipkin := config.ZipkinEndpoint
+	originalSampleRate := config.TracingSampleRate
+	originalTracing := config.TracingEnabled
+	originalAlerting := alerting.GetGlobalManager()
+
+	config.TracingEnabled = true
+	config.TracingSampleRate = 1.0
+	config.OTLPEndpoint = "http://localhost:4317"
+	config.JaegerEndpoint = "http://localhost:14268/api/traces"
+	config.SplunkEndpoint = "http://localhost:8088/services/collector"
+	config.DataDogEndpoint = "http://localhost:8126/v0.4/traces"
+	config.ZipkinEndpoint = "http://localhost:9411/api/v2/spans"
+
+	defer func() {
+		config.OTLPEndpoint = originalOTLP
+		config.JaegerEndpoint = originalJaeger
+		config.SplunkEndpoint = originalSplunk
+		config.DataDogEndpoint = originalDataDog
+		config.ZipkinEndpoint = originalZipkin
+		config.TracingSampleRate = originalSampleRate
+		config.TracingEnabled = originalTracing
+		alerting.SetGlobalManager(originalAlerting)
+	}()
+
+	alertManager, _ := alerting.NewManager()
+	alerting.SetGlobalManager(alertManager)
+
+	manager, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if manager.otlpExporter == nil {
+		t.Error("expected OTLP exporter to be constructed")
+	}
+	if manager.jaegerExporter == nil {
+		t.Error("expected Jaeger exporter to be constructed")
+	}
+	if manager.splunkExporter == nil {
+		t.Error("expected Splunk exporter to be constructed")
+	}
+	if manager.datadogExporter == nil {
+		t.Error("expected DataDog exporter to be constructed")
+	}
+	if manager.zipkinExporter == nil {
+		t.Error("expected Zipkin exporter to be constructed")
+	}
+
+	if manager.GetTraceCount() != 0 {
+		t.Fatalf("expected empty tracker, got %d traces", manager.GetTraceCount())
+	}
+	manager.exportTraces()
+
+	manager.traceTracker.ProcessEvent(&events.Event{
+		Type:    events.EventHTTPReq,
+		TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
+		SpanID:  "00f067aa0ba902b7",
+	}, nil)
+
+	if manager.GetTraceCount() == 0 {
+		t.Fatalf("expected at least one trace after ProcessEvent")
+	}
+
+	manager.exportTraces()
+}

--- a/internal/webhook/v1alpha1/podtrace_update_branch_test.go
+++ b/internal/webhook/v1alpha1/podtrace_update_branch_test.go
@@ -1,0 +1,59 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	webhookv1alpha1 "github.com/podtrace/podtrace/internal/webhook/v1alpha1"
+)
+
+// TestPodTraceValidator_UpdateUnchangedSpecShortCircuits covers the
+// early-return branch in ValidateUpdate: when the spec is unchanged the
+// validator must skip revalidation entirely. This is asserted by pointing
+// exporterRef at a non-existent ExporterConfig — a metadata-only update
+// (e.g. clearing a finalizer) on an otherwise-invalid spec must still be
+// allowed so resources never wedge.
+func TestPodTraceValidator_UpdateUnchangedSpecShortCircuits(t *testing.T) {
+	c := newClientWithExporter(t, "default", "")
+	v := &webhookv1alpha1.PodTraceCustomValidator{Client: c}
+
+	spec := podtracev1alpha1.PodTraceSpec{
+		Selector:    validSelector(),
+		ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ghost"},
+	}
+	oldPT := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pt", Namespace: "default",
+			Finalizers: []string{"podtrace.io/cleanup"},
+		},
+		Spec: spec,
+	}
+	newPT := oldPT.DeepCopy()
+	newPT.Finalizers = nil
+
+	if _, err := v.ValidateUpdate(context.Background(), oldPT, newPT); err != nil {
+		t.Fatalf("unchanged-spec update must short-circuit and pass, got %v", err)
+	}
+}
+
+// TestPodTraceValidator_UpdateNilOldRevalidates covers the branch where
+// oldPT is nil: the short-circuit guard is skipped and the new object is
+// validated. A valid new object must pass.
+func TestPodTraceValidator_UpdateNilOldRevalidates(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceCustomValidator{Client: c}
+
+	newPT := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceSpec{
+			Selector:    validSelector(),
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		},
+	}
+	if _, err := v.ValidateUpdate(context.Background(), nil, newPT); err != nil {
+		t.Fatalf("nil-old update with valid spec must pass, got %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/setup_webhook_unit_test.go
+++ b/internal/webhook/v1alpha1/setup_webhook_unit_test.go
@@ -1,0 +1,69 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	webhookv1alpha1 "github.com/podtrace/podtrace/internal/webhook/v1alpha1"
+)
+
+func newNonConnectingManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+	s := newSetupScheme(t)
+	cfg := &rest.Config{Host: "http://127.0.0.1:1"}
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 s,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Skipf("could not build non-connecting manager: %v", err)
+	}
+	return mgr
+}
+
+func newSetupScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme.AddToScheme: %v", err)
+	}
+	if err := podtracev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestSetupExporterConfigWebhookWithManager(t *testing.T) {
+	mgr := newNonConnectingManager(t)
+	if err := webhookv1alpha1.SetupExporterConfigWebhookWithManager(mgr); err != nil {
+		t.Fatalf("SetupExporterConfigWebhookWithManager: %v", err)
+	}
+}
+
+func TestSetupPodTraceWebhookWithManager(t *testing.T) {
+	mgr := newNonConnectingManager(t)
+	if err := webhookv1alpha1.SetupPodTraceWebhookWithManager(mgr); err != nil {
+		t.Fatalf("SetupPodTraceWebhookWithManager: %v", err)
+	}
+}
+
+func TestSetupPodTraceScheduleWebhookWithManager(t *testing.T) {
+	mgr := newNonConnectingManager(t)
+	if err := webhookv1alpha1.SetupPodTraceScheduleWebhookWithManager(mgr); err != nil {
+		t.Fatalf("SetupPodTraceScheduleWebhookWithManager: %v", err)
+	}
+}
+
+func TestSetupPodTraceSessionWebhookWithManager(t *testing.T) {
+	mgr := newNonConnectingManager(t)
+	if err := webhookv1alpha1.SetupPodTraceSessionWebhookWithManager(mgr); err != nil {
+		t.Fatalf("SetupPodTraceSessionWebhookWithManager: %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/webhook_update_unit_test.go
+++ b/internal/webhook/v1alpha1/webhook_update_unit_test.go
@@ -1,0 +1,85 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	webhookv1alpha1 "github.com/podtrace/podtrace/internal/webhook/v1alpha1"
+)
+
+func TestExporterConfigValidator_Update(t *testing.T) {
+	v := &webhookv1alpha1.ExporterConfigCustomValidator{}
+	ctx := context.Background()
+
+	valid := podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeOTLP,
+		OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "localhost:4317"},
+	}
+
+	t.Run("unchanged spec short-circuits", func(t *testing.T) {
+		old := &podtracev1alpha1.ExporterConfig{Spec: valid}
+		newEC := &podtracev1alpha1.ExporterConfig{Spec: valid}
+		if _, err := v.ValidateUpdate(ctx, old, newEC); err != nil {
+			t.Fatalf("unchanged spec should pass, got %v", err)
+		}
+	})
+
+	t.Run("changed spec is revalidated and valid", func(t *testing.T) {
+		old := &podtracev1alpha1.ExporterConfig{Spec: podtracev1alpha1.ExporterConfigSpec{Type: "stdout"}}
+		newEC := &podtracev1alpha1.ExporterConfig{Spec: valid}
+		if _, err := v.ValidateUpdate(ctx, old, newEC); err != nil {
+			t.Fatalf("valid changed spec should pass, got %v", err)
+		}
+	})
+
+	t.Run("changed spec that is invalid is rejected", func(t *testing.T) {
+		old := &podtracev1alpha1.ExporterConfig{Spec: valid}
+		newEC := &podtracev1alpha1.ExporterConfig{Spec: podtracev1alpha1.ExporterConfigSpec{Type: podtracev1alpha1.ExporterTypeOTLP}}
+		if _, err := v.ValidateUpdate(ctx, old, newEC); err == nil {
+			t.Fatal("invalid changed spec should be rejected")
+		}
+	})
+
+	t.Run("nil old falls through to validation", func(t *testing.T) {
+		newEC := &podtracev1alpha1.ExporterConfig{Spec: valid}
+		if _, err := v.ValidateUpdate(ctx, nil, newEC); err != nil {
+			t.Fatalf("nil old with valid spec should pass, got %v", err)
+		}
+	})
+
+	t.Run("delete always allowed", func(t *testing.T) {
+		if _, err := v.ValidateDelete(ctx, &podtracev1alpha1.ExporterConfig{Spec: valid}); err != nil {
+			t.Fatalf("delete should always pass, got %v", err)
+		}
+	})
+}
+
+func TestScheduleValidator_UpdateAndDelete(t *testing.T) {
+	v := &webhookv1alpha1.PodTraceScheduleCustomValidator{}
+	ctx := context.Background()
+
+	valid := podtracev1alpha1.PodTraceScheduleSpec{Schedule: "*/5 * * * *"}
+
+	t.Run("unchanged spec short-circuits", func(t *testing.T) {
+		old := &podtracev1alpha1.PodTraceSchedule{Spec: valid}
+		newS := &podtracev1alpha1.PodTraceSchedule{Spec: valid}
+		if _, err := v.ValidateUpdate(ctx, old, newS); err != nil {
+			t.Fatalf("unchanged spec should pass, got %v", err)
+		}
+	})
+
+	t.Run("changed spec with bad cron is rejected", func(t *testing.T) {
+		old := &podtracev1alpha1.PodTraceSchedule{Spec: valid}
+		newS := &podtracev1alpha1.PodTraceSchedule{Spec: podtracev1alpha1.PodTraceScheduleSpec{Schedule: "not a cron"}}
+		if _, err := v.ValidateUpdate(ctx, old, newS); err == nil {
+			t.Fatal("bad cron should be rejected on update")
+		}
+	})
+
+	t.Run("delete always allowed", func(t *testing.T) {
+		if _, err := v.ValidateDelete(ctx, &podtracev1alpha1.PodTraceSchedule{Spec: valid}); err != nil {
+			t.Fatalf("delete should always pass, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## test: Improve unit coverage and fix mode-loop select bug

Raises CI-scoped unit-test coverage (`./cmd/... ./internal/...`) from 76.9% to 86.4%, almost entirely through new `*_test.go` files, plus two small production fixes uncovered along the way.

### Production fixes
- **`cmd/podtrace/main.go`**: `runDiagnoseModeWithSource` and `runNormalModeWithSource` each had two `case <-ctx.Done():` arms in one `select`, so on cancellation Go picked randomly between returning `ctx.Err()` (no report) and returning `nil` (full report), non-deterministic exit code and output. Removed the stray arm in both; cancellation now deterministically emits the final report and returns `nil`.
- **`internal/resource/monitor.go`**: introduced a minimal `bpfLimitMap` (`Put`/`Delete`) interface so `checkAlerts`/`syncToBPF` are unit-testable with an in-memory fake instead of requiring a real eBPF map (CAP_BPF). The constructor assigns maps only when non-nil to preserve the existing nil-guards.