### PR TITLE
feat: revive dead eBPF probes and correct event data semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(VMLINUX_GEN):
 	@cp bpf/vmlinux.h "$(VMLINUX_GEN)"
 endif
 
-$(BPF_OBJ): $(VMLINUX_GEN) bpf/podtrace.bpf.c bpf/*.h bpf/network.c bpf/filesystem.c bpf/cpu.c bpf/memory.c
+$(BPF_OBJ): $(VMLINUX_GEN) bpf/podtrace.bpf.c bpf/*.h bpf/*.c
 	@mkdir -p $(dir $(BPF_OBJ))
 	$(CLANG) $(BPF_CFLAGS) -Ibpf -I. -c bpf/podtrace.bpf.c -o $(BPF_OBJ)
 

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -132,9 +132,12 @@ struct __sk_buff {
 
 #define AF_INET 2
 #define AF_INET6 10
+#define IPPROTO_TCP 6
 #define EAGAIN 11
 #define HEX_ADDR_LEN 16
 #define COMM_LEN 16
+
+#define PAGE_FAULT_SAMPLE_RATE 64
 
 #ifndef BPF_MAP_TYPE_RINGBUF
 #define BPF_MAP_TYPE_RINGBUF 27

--- a/bpf/cpu.c
+++ b/bpf/cpu.c
@@ -5,63 +5,89 @@
 #include "events.h"
 #include "helpers.h"
 
+/* EVENT_SCHED_SWITCH carries OFF-CPU (blocked/runqueue-wait) time. The
+ * previous implementation stamped at switch-IN and emitted at switch-OUT,
+ * which measures the ON-CPU slice — the exact inverse of the "thread
+ * blocked" message every consumer renders.
+ *
+ * Measuring off-CPU time needs the stamp at switch-out and the delta at the
+ * next switch-in. But at switch-in the current task is still `prev` (the
+ * tracepoint fires before the context switch completes), so emitting there
+ * would attribute the event to the wrong task's cgroup/comm. Instead the
+ * blocked interval is parked in sched_pending_blocked and emitted at the
+ * task's NEXT switch-out, when the task itself is current and
+ * get_event_buf() fills the right identity — which also lets the event carry
+ * the task's TGID like every other event type (the old code emitted the raw
+ * TID). */
+struct sched_switch_args {
+	unsigned short common_type;
+	unsigned char common_flags;
+	unsigned char common_preempt_count;
+	int common_pid;
+	char prev_comm[16];
+	u32 prev_pid;
+	int prev_prio;
+	long prev_state;
+	char next_comm[16];
+	u32 next_pid;
+	int next_prio;
+};
+_Static_assert(__builtin_offsetof(struct sched_switch_args, prev_comm) == 8, "sched_switch: prev_comm must be at offset 8");
+_Static_assert(__builtin_offsetof(struct sched_switch_args, prev_pid) == 24, "sched_switch: prev_pid must be at offset 24");
+_Static_assert(__builtin_offsetof(struct sched_switch_args, prev_state) == 32, "sched_switch: prev_state must be at offset 32");
+_Static_assert(__builtin_offsetof(struct sched_switch_args, next_comm) == 40, "sched_switch: next_comm must be at offset 40");
+_Static_assert(__builtin_offsetof(struct sched_switch_args, next_pid) == 56, "sched_switch: next_pid must be at offset 56");
+
 SEC("tp/sched/sched_switch")
 int tracepoint_sched_switch(void *ctx) {
-	struct {
-		unsigned short common_type;
-		unsigned char common_flags;
-		unsigned char common_preempt_count;
-		int common_pid;
-		char prev_comm[16];
-		u32 prev_pid;
-		int prev_prio;
-		long prev_state;
-		char next_comm[16];
-		u32 next_pid;
-		int next_prio;
-	} args_local = {};
-	bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx);
+	struct sched_switch_args args_local = {};
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
+		return 0;
+	}
 
 	u32 prev_pid = args_local.prev_pid;
 	u32 next_pid = args_local.next_pid;
-	u64 timestamp = bpf_ktime_get_ns();
-	
+	u64 now = bpf_ktime_get_ns();
+
+	/* The task coming on-CPU just finished an off-CPU interval. */
+	if (next_pid > 0) {
+		u64 *out_ts = bpf_map_lookup_elem(&sched_out_ts, &next_pid);
+		if (out_ts) {
+			u64 blocked = now > *out_ts ? now - *out_ts : 0;
+			bpf_map_delete_elem(&sched_out_ts, &next_pid);
+			if (blocked > MIN_LATENCY_NS) {
+				bpf_map_update_elem(&sched_pending_blocked, &next_pid, &blocked, BPF_ANY);
+			}
+		}
+	}
+
+	/* The task going off-CPU is current here: emit its parked interval with
+	 * correct attribution, then stamp this switch-out. */
 	if (prev_pid > 0) {
-		u64 key = get_key(prev_pid, 0);
-		u64 *block_start = bpf_map_lookup_elem(&start_times, &key);
-		
-		if (block_start) {
-			u64 block_time = calc_latency(*block_start);
-			if (block_time > MIN_LATENCY_NS) {
-				struct event *e = get_event_buf();
-				if (!e) {
-					bpf_map_delete_elem(&start_times, &key);
-					return 0;
-				}
-				e->timestamp = timestamp;
-				e->pid = prev_pid;
+		u64 *pending = bpf_map_lookup_elem(&sched_pending_blocked, &prev_pid);
+		if (pending) {
+			u64 blocked = *pending;
+			bpf_map_delete_elem(&sched_pending_blocked, &prev_pid);
+
+			struct event *e = get_event_buf();
+			if (e) {
+				e->timestamp = now;
+				e->pid = bpf_get_current_pid_tgid() >> 32;
 				e->type = EVENT_SCHED_SWITCH;
-				e->latency_ns = block_time;
+				e->latency_ns = blocked;
 				e->error = 0;
 				e->bytes = 0;
 				e->tcp_state = 0;
 				e->target[0] = '\0';
 				e->details[0] = '\0';
-				__builtin_memcpy(e->comm, args_local.prev_comm, sizeof(e->comm));
 
-				capture_user_stack(ctx, prev_pid, 0, e);
+				capture_user_stack(ctx, e->pid, prev_pid, e);
 				bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 			}
-			bpf_map_delete_elem(&start_times, &key);
 		}
+		bpf_map_update_elem(&sched_out_ts, &prev_pid, &now, BPF_ANY);
 	}
-	
-	if (next_pid > 0) {
-		u64 new_key = get_key(next_pid, 0);
-		u64 now = bpf_ktime_get_ns();
-		bpf_map_update_elem(&start_times, &new_key, &now, BPF_ANY);
-	}
-	
+
 	return 0;
 }
 
@@ -69,7 +95,7 @@ SEC("kprobe/do_futex")
 int kprobe_do_futex(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_FUTEX);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	long *uaddr = (long *)PT_REGS_PARM1(ctx);
@@ -100,7 +126,7 @@ SEC("kretprobe/do_futex")
 int kretprobe_do_futex(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_FUTEX);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -140,7 +166,7 @@ SEC("uprobe/pthread_mutex_lock")
 int uprobe_pthread_mutex_lock(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_PTHREAD_MUTEX);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	void *mutex = (void *)PT_REGS_PARM1(ctx);
@@ -177,7 +203,7 @@ SEC("uretprobe/pthread_mutex_lock")
 int uretprobe_pthread_mutex_lock(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_PTHREAD_MUTEX);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;

--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -172,7 +172,9 @@ static __always_inline void emit_encrypted_dns(struct __sk_buff *skb, u8 is_v6, 
 	} else {
 		__u32 daddr = 0;
 		if (bpf_skb_load_bytes(skb, 16, &daddr, sizeof(daddr)) == 0) {
-			format_ip_port(daddr, port, e->target);
+			/* daddr is network order; format_ip_port expects host order.
+			 * The raw field stays network order for the Go consumers. */
+			format_ip_port(__builtin_bswap32(daddr), port, e->target);
 			e->dns_server_ip = daddr;
 		}
 	}
@@ -368,8 +370,11 @@ int dns_ingress(struct __sk_buff *skb) {
 		if (atype == DNS_TYPE_A) {
 			__u32 ip = 0;
 			if (bpf_skb_load_bytes(skb, rdata, &ip, sizeof(ip)) == 0) {
+				/* Map key stays network order (the connect probes look it
+				 * up with the raw sockaddr address); only the displayed
+				 * string needs host order. */
 				bpf_map_update_elem(&dns_resolved, &ip, q->name, BPF_ANY);
-				format_ip_port(ip, 0, e->details);
+				format_ip_port(__builtin_bswap32(ip), 0, e->details);
 				wrote_detail = 1;
 			}
 		} else if (atype == DNS_TYPE_AAAA) {

--- a/bpf/fastcgi.c
+++ b/bpf/fastcgi.c
@@ -31,45 +31,8 @@
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
 
-static __always_inline void *msghdr_user_base(struct msghdr *msg, u64 *avail)
-{
-	if (!msg)
-		return NULL;
-	u8 it = BPF_CORE_READ(msg, msg_iter.iter_type);
-	if (it == ITER_UBUF) {
-		void *ubuf = (void *)BPF_CORE_READ(msg, msg_iter.ubuf);
-		size_t count = BPF_CORE_READ(msg, msg_iter.count);
-		size_t off = BPF_CORE_READ(msg, msg_iter.iov_offset);
-		if (avail)
-			*avail = count;
-		if (!ubuf)
-			return NULL;
-		return (u8 *)ubuf + off;
-	}
-	if (it == ITER_IOVEC) {
-		const struct iovec *iov = BPF_CORE_READ(msg, msg_iter.__iov);
-		if (!iov)
-			return NULL;
-		struct iovec iov_entry;
-		if (bpf_probe_read_kernel(&iov_entry, sizeof(iov_entry), iov) != 0)
-			return NULL;
-		if (avail)
-			*avail = iov_entry.iov_len;
-		return iov_entry.iov_base;
-	}
-	return NULL;
-}
-
-static __always_inline int read_msghdr_data(struct msghdr *msg, void *buf, u32 buf_size)
-{
-	if (!buf || buf_size == 0)
-		return -1;
-	u64 avail = 0;
-	void *base = msghdr_user_base(msg, &avail);
-	if (!base || avail < buf_size)
-		return -1;
-	return bpf_probe_read_user(buf, buf_size, base);
-}
+/* msghdr_user_base / read_msghdr_data now live in protocols.h, shared with
+ * the gRPC inspector. */
 
 /* -----------------------------------------------------------------------
  * kprobe/unix_stream_recvmsg — save msghdr* for kretprobe use
@@ -152,9 +115,6 @@ int kretprobe_unix_stream_recvmsg(struct pt_regs *ctx)
 		bpf_map_delete_elem(&fastcgi_pending, &key);
 		if (p.expected_body_bytes != 0 && (u32)rc_bytes == p.expected_body_bytes) {
 			request_id = (u16)p.request_id;
-			/* Cap to FCGI_PARAMS_SCAN_LEN; trailing padding bytes
-			 * (the size mismatch we account for here) live past
-			 * the NV pairs and don't enter the scan window. */
 			content_len = p.expected_body_bytes > FCGI_PARAMS_SCAN_LEN
 				? FCGI_PARAMS_SCAN_LEN
 				: (u16)p.expected_body_bytes;
@@ -205,7 +165,6 @@ emit_params: ;
 	struct event *e = get_event_buf();
 	if (!e) return 0;
 
-	/* Read PARAMS body — scan for REQUEST_URI */
 	u8 params[FCGI_PARAMS_SCAN_LEN] = {};
 	u32 scan_len = content_len < FCGI_PARAMS_SCAN_LEN ? content_len : FCGI_PARAMS_SCAN_LEN;
 
@@ -230,20 +189,23 @@ emit_params: ;
 			    params[i+4] == 'E' && params[i+5] == 'S' && params[i+6] == 'T' &&
 			    params[i+7] == '_' && params[i+8] == 'U' && params[i+9] == 'R' &&
 			    params[i+10] == 'I') {
-				u32 j;
-				for (j = i + 11; j < i + 16 && j + 1 < FCGI_PARAMS_SCAN_LEN; j++) {
-					if (params[j] == '/') {
-						/* Copy URI into event buffer.
-						 * Max is min(remaining bytes, MAX_STRING_LEN-1). */
-						u32 copy = FCGI_PARAMS_SCAN_LEN - j;
-						if (copy >= MAX_STRING_LEN)
-							copy = MAX_STRING_LEN - 1;
-						bpf_probe_read_kernel(e->target, copy & (MAX_STRING_LEN - 1),
-						                     &params[j]);
-						e->target[MAX_STRING_LEN - 1] = '\0';
-						found_uri = 1;
-						break;
+				/* Indices are masked to keep every params[] offset provably
+				 * in-bounds for the verifier (the guards already bound them
+				 * logically; 128 is a power of two so the mask is free). */
+				u32 vstart = (i + 11) & (FCGI_PARAMS_SCAN_LEN - 1);
+				if (params[vstart] == '/') {
+					u32 copy = FCGI_PARAMS_SCAN_LEN - vstart;
+					if (i >= 2) {
+						u8 vlen = params[(i - 1) & (FCGI_PARAMS_SCAN_LEN - 1)];
+						if ((vlen & FCGI_NV_LEN_4BYTE) == 0 && vlen > 0 && vlen < copy)
+							copy = vlen;
 					}
+					if (copy >= MAX_STRING_LEN)
+						copy = MAX_STRING_LEN - 1;
+					bpf_probe_read_kernel(e->target, copy & (MAX_STRING_LEN - 1),
+					                     &params[vstart]);
+					e->target[copy & (MAX_STRING_LEN - 1)] = '\0';
+					found_uri = 1;
 				}
 			}
 		}
@@ -255,28 +217,28 @@ emit_params: ;
 			    params[i+7] == '_' && params[i+8] == 'M' && params[i+9] == 'E' &&
 			    params[i+10] == 'T' && params[i+11] == 'H' && params[i+12] == 'O' &&
 			    params[i+13] == 'D') {
-				/* Value follows: typical methods are GET/POST/PUT 3-6 chars */
-				u32 j;
-				for (j = i + 14; j < FCGI_PARAMS_SCAN_LEN && j < i + 20; j++) {
-					/* Skip non-alpha (NV length bytes) to find the method text */
-					if ((params[j] >= 'A' && params[j] <= 'Z') ||
-					    (params[j] >= 'a' && params[j] <= 'z')) {
-						u32 copy = 15;
-						if (j + copy > FCGI_PARAMS_SCAN_LEN)
-							copy = FCGI_PARAMS_SCAN_LEN - j;
-						bpf_probe_read_kernel(e->details, copy & 0xF,
-						                     &params[j]);
-						e->details[15] = '\0';
-						found_method = 1;
-						break;
+				u32 vstart = (i + 14) & (FCGI_PARAMS_SCAN_LEN - 1);
+				u8 c0 = params[vstart];
+				if ((c0 >= 'A' && c0 <= 'Z') || (c0 >= 'a' && c0 <= 'z')) {
+					u32 copy = 15;
+					if (i >= 2) {
+						u8 vlen = params[(i - 1) & (FCGI_PARAMS_SCAN_LEN - 1)];
+						if ((vlen & FCGI_NV_LEN_4BYTE) == 0 && vlen > 0 && vlen < copy)
+							copy = vlen;
 					}
+					if (vstart + copy > FCGI_PARAMS_SCAN_LEN)
+						copy = FCGI_PARAMS_SCAN_LEN - vstart;
+					bpf_probe_read_kernel(e->details, copy & 0xF,
+					                     &params[vstart]);
+					e->details[copy & 0xF] = '\0';
+					found_method = 1;
 				}
 			}
 		}
 	}
 
 	if (!found_uri && !found_method)
-		return 0;  /* Not a PARAMS record we can decode */
+		return 0;
 
 	if (!found_uri) e->target[0] = '\0';
 	if (!found_method) e->details[0] = '\0';

--- a/bpf/filesystem.c
+++ b/bpf/filesystem.c
@@ -10,7 +10,7 @@ SEC("kprobe/vfs_write")
 int kprobe_vfs_write(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_WRITE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	
@@ -29,7 +29,7 @@ SEC("kprobe/vfs_read")
 int kprobe_vfs_read(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_READ);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	
@@ -48,7 +48,7 @@ SEC("kretprobe/vfs_read")
 int kretprobe_vfs_read(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_READ);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -97,7 +97,7 @@ SEC("kretprobe/vfs_write")
 int kretprobe_vfs_write(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_WRITE);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -146,7 +146,7 @@ SEC("kprobe/vfs_fsync")
 int kprobe_vfs_fsync(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_FSYNC);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	
@@ -165,7 +165,7 @@ SEC("kretprobe/vfs_fsync")
 int kretprobe_vfs_fsync(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_FSYNC);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {

--- a/bpf/grpc.c
+++ b/bpf/grpc.c
@@ -63,28 +63,21 @@ int kprobe_grpc_tcp_sendmsg(struct pt_regs *ctx)
 	if (dport != GRPC_DEFAULT_PORT)
 		return 0;
 
-	/* Read first GRPC_INSPECT_LEN bytes from send buffer */
+	/* Read first GRPC_INSPECT_LEN bytes from the send buffer via the shared
+	 * iov_iter resolver, which handles both ITER_IOVEC and ITER_UBUF (the
+	 * plain send()/write() shape on kernels >= 6.0). */
 	struct msghdr *msg = (struct msghdr *)PT_REGS_PARM2(ctx);
-	if (!msg)
-		return 0;
-
-	const struct iovec *iov = BPF_CORE_READ(msg, msg_iter.__iov);
-	if (!iov)
-		return 0;
-
-	struct iovec iov_entry;
-	if (bpf_probe_read_kernel(&iov_entry, sizeof(iov_entry), iov) != 0)
-		return 0;
-
-	if (!iov_entry.iov_base || iov_entry.iov_len < HTTP2_FRAME_HDR)
+	u64 avail = 0;
+	void *base = msghdr_user_base(msg, &avail);
+	if (!base || avail < HTTP2_FRAME_HDR)
 		return 0;
 
 	u8 buf[GRPC_INSPECT_LEN] = {};
-	u32 read_len = (u32)iov_entry.iov_len;
+	u32 read_len = (u32)avail;
 	if (read_len > GRPC_INSPECT_LEN)
 		read_len = GRPC_INSPECT_LEN;
 	/* Do not use (read_len & (N-1)) unless N is a power of two; GRPC_INSPECT_LEN is 50. */
-	if (bpf_probe_read_user(buf, read_len, iov_entry.iov_base) != 0)
+	if (bpf_probe_read_user(buf, read_len, base) != 0)
 		return 0;
 
 	/* Check HTTP/2 frame type (byte 3 in the 9-byte frame header) */
@@ -96,10 +89,9 @@ int kprobe_grpc_tcp_sendmsg(struct pt_regs *ctx)
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	u64 key = get_key(pid, tid);
 
-	/* Check for the HTTP/2 client connection preface (initial SETTINGS frame).
-	 * The preface starts with "PRI * HTTP/2.0" — skip it (not a gRPC call). */
-	if (buf[0] == 'P' && buf[1] == 'R' && buf[2] == 'I')
-		return 0;
+	/* (No preface check needed: the "PRI * HTTP/2.0" preface has ' ' at
+	 * byte 3, which the HTTP2_HEADERS frame-type check above already
+	 * rejects.) */
 
 	/* Scan for '/' in the HPACK payload */
 	u32 path_start = 0;

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -10,6 +10,18 @@ static inline u64 get_key(u32 pid, u32 tid) {
 	return ((u64)pid << 32) | tid;
 }
 
+static inline struct pair_key make_pair_key(u32 pair) {
+	struct pair_key k = {};
+	k.pid_tgid = bpf_get_current_pid_tgid();
+	k.pair = pair;
+	return k;
+}
+
+static inline void record_start_time(const struct pair_key *key) {
+	u64 ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&start_times, key, &ts, BPF_ANY);
+}
+
 static inline u64 calc_latency(u64 start) {
 	u64 now = bpf_ktime_get_ns();
 	return now > start ? now - start : 0;
@@ -95,7 +107,7 @@ static inline u64 build_stack_key(u32 pid, u32 tid, u64 timestamp) {
 	return h;
 }
 
-static inline struct event *get_event_buf(void) {
+static inline struct event *get_event_buf_unfiltered(void) {
 	u32 zero = 0;
 	struct event *e = bpf_map_lookup_elem(&event_buf, &zero);
 	if (e) {
@@ -104,24 +116,28 @@ static inline struct event *get_event_buf(void) {
 		bpf_get_current_comm(&e->comm, sizeof(e->comm));
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
-		/* Capture network namespace inum for multi-tenant correlation */
 		struct task_struct *__task = (struct task_struct *)bpf_get_current_task();
 		if (__task) {
 			e->net_ns_id = BPF_CORE_READ(__task, nsproxy, net_ns, ns.inum);
 		}
 #endif
+	}
+	return e;
+}
 
-		/* In-kernel prefilter:
-		 * - empty target_cgroup_ids map => allow all
-		 * - non-empty map => allow only keys present in map */
-		u64 probe_key = 0;
-		u8 *probe_val = bpf_map_lookup_elem(&target_cgroup_ids, &probe_key);
-		if (probe_val) {
-			u64 cgid = e->cgroup_id;
-			u8 *allowed = bpf_map_lookup_elem(&target_cgroup_ids, &cgid);
-			if (!allowed) {
-				return NULL;
-			}
+static inline struct event *get_event_buf(void) {
+	struct event *e = get_event_buf_unfiltered();
+	if (!e) {
+		return NULL;
+	}
+
+	u32 zero = 0;
+	u32 *enabled = bpf_map_lookup_elem(&cgroup_filter_enabled, &zero);
+	if (enabled && *enabled) {
+		u64 cgid = e->cgroup_id;
+		u8 *allowed = bpf_map_lookup_elem(&target_cgroup_ids, &cgid);
+		if (!allowed) {
+			return NULL;
 		}
 	}
 	return e;

--- a/bpf/kafka.c
+++ b/bpf/kafka.c
@@ -42,7 +42,7 @@ int uprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_TOPIC_NEW);
 
 	const char *topic = (const char *)PT_REGS_PARM2(ctx);
 	if (!topic)
@@ -59,7 +59,7 @@ int uretprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_TOPIC_NEW);
 
 	/* Return value = rd_kafka_topic_t* */
 	u64 topic_ptr = (u64)PT_REGS_RC(ctx);
@@ -88,7 +88,7 @@ int uprobe_rd_kafka_produce(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_PRODUCE);
 	u64 ts  = bpf_ktime_get_ns();
 
 	u64 rkt_ptr = (u64)PT_REGS_PARM1(ctx);
@@ -114,7 +114,7 @@ int uretprobe_rd_kafka_produce(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_PRODUCE);
 
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)
@@ -175,7 +175,7 @@ int uprobe_rd_kafka_consumer_poll(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_POLL);
 	u64 ts  = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -186,7 +186,7 @@ int uretprobe_rd_kafka_consumer_poll(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_KAFKA_POLL);
 
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -16,17 +16,56 @@ struct {
 	__uint(max_entries, 2 * 1024 * 1024);
 } events SEC(".maps");
 
+enum probe_pair {
+	PAIR_TCP_CONNECT_V4 = 1,
+	PAIR_TCP_CONNECT_V6,
+	PAIR_TCP_SENDMSG,
+	PAIR_TCP_RECVMSG,
+	PAIR_UDP_SENDMSG,
+	PAIR_UDP_RECVMSG,
+	PAIR_GETADDRINFO,
+	PAIR_HTTP_REQUEST,
+	PAIR_HTTP_RESPONSE,
+	PAIR_PQEXEC,
+	PAIR_MYSQL_QUERY,
+	PAIR_SSL_CONNECT,
+	PAIR_SSL_ACCEPT,
+	PAIR_SSL_DO_HANDSHAKE,
+	PAIR_GNUTLS_HANDSHAKE,
+	PAIR_MBEDTLS_HANDSHAKE,
+	PAIR_OPENAT,
+	PAIR_VFS_UNLINK,
+	PAIR_VFS_RENAME,
+	PAIR_VFS_READ,
+	PAIR_VFS_WRITE,
+	PAIR_VFS_FSYNC,
+	PAIR_FUTEX,
+	PAIR_PTHREAD_MUTEX,
+	PAIR_REDIS_COMMAND,
+	PAIR_REDIS_COMMAND_ARGV,
+	PAIR_MEMCACHED,
+	PAIR_KAFKA_TOPIC_NEW,
+	PAIR_KAFKA_PRODUCE,
+	PAIR_KAFKA_POLL,
+};
+
+struct pair_key {
+	u64 pid_tgid;
+	u32 pair;
+	u32 _pad;
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
-	__type(key, u64);
+	__uint(max_entries, 4096);
+	__type(key, struct pair_key);
 	__type(value, u64);
 } start_times SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } dns_targets SEC(".maps");
 
@@ -48,15 +87,19 @@ struct dns_query_state {
 	u8 server_ip6[16];
 };
 
+/* LRU: queries that never get an answer (timeouts, drops) would otherwise
+ * accumulate until the map is full and every new query fails to record. */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, struct dns_flow_key);
 	__type(value, struct dns_query_state);
 } dns_inflight SEC(".maps");
 
+/* LRU: nothing ever prunes resolved-name entries, so a long-lived agent
+ * would stop learning new IP->name mappings once a plain hash filled up. */
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 8192);
 	__type(key, u32);
 	__type(value, char[MAX_STRING_LEN]);
@@ -67,7 +110,7 @@ struct dns_v6key {
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 8192);
 	__type(key, struct dns_v6key);
 	__type(value, char[MAX_STRING_LEN]);
@@ -104,21 +147,21 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } lock_targets SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } db_queries SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } syscall_paths SEC(".maps");
 
@@ -150,14 +193,54 @@ struct {
 	__type(value, u32);
 } cgroup_alerts SEC(".maps");
 
-/* Allowed cgroup IDs for in-kernel prefiltering.
- * Empty map means "allow all". */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, u64);
 	__type(value, u8);
 } target_cgroup_ids SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u32);
+} cgroup_filter_enabled SEC(".maps");
+
+struct connect_addr {
+	u16 family;
+	u16 port_be;  /* network order */
+	u32 addr_be;  /* IPv4, network order */
+	u8 addr6[16]; /* IPv6 */
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, struct pair_key);
+	__type(value, struct connect_addr);
+} connect_addrs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} sched_out_ts SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} sched_pending_blocked SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u64);
+} page_fault_seq SEC(".maps");
 
 struct pool_state {
 	u64 last_use_ns;
@@ -186,7 +269,6 @@ struct {
 	__type(value, u32);
 } pool_db_types SEC(".maps");
 
-/* alert_thresholds[0]=warn%, [1]=crit%, [2]=emerg% — written from Go at startup */
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 3);
@@ -194,8 +276,6 @@ struct {
 	__type(value, u32);
 } alert_thresholds SEC(".maps");
 
-/* event_buf is a scratch slot that each probe fills before pushing into the
- * ring buffer. */
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
@@ -203,9 +283,6 @@ struct {
 	__type(value, struct event);
 } event_buf SEC(".maps");
 
-/* --- PROTOCOL ADAPTER MAPS (Redis, Memcached, FastCGI, gRPC, Kafka) --- */
-
-/* FastCGI request state — keyed by pid<<32|requestId (BTF-only) */
 struct fastcgi_req {
 	u64 start_ns;
 	char uri[MAX_STRING_LEN];
@@ -218,19 +295,13 @@ struct {
 	__type(value, struct fastcgi_req);
 } fastcgi_reqs SEC(".maps");
 
-/* Saved msghdr* for unix_stream_recvmsg kretprobe (BTF-only FastCGI) */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
-	__type(value, u64);  /* msghdr pointer cast to u64 */
+	__type(value, u64);
 } recvmsg_args SEC(".maps");
 
-/* Pending FastCGI PARAMS body — populated when a worker reads an
- * 8-byte PARAMS record header in one recvmsg, consumed when the
- * matching content_len-byte body arrives in the next recvmsg.
- * Keyed by (tgid<<32|tid). LRU keeps it bounded under churn even if
- * a body never arrives (worker died, request aborted).            */
 struct fcgi_pending {
 	u32 request_id;
 	u32 expected_body_bytes;
@@ -242,23 +313,20 @@ struct {
 	__type(value, struct fcgi_pending);
 } fastcgi_pending SEC(".maps");
 
-/* Redis: pid<<32|tid → first word of redisCommand format string */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } redis_cmds SEC(".maps");
 
-/* Memcached: pid<<32|tid → "get/set/del key" operation string */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } memcached_ops SEC(".maps");
 
-/* gRPC: pid<<32|tid → "/Service/Method" path (BTF-only h2c inspection) */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
@@ -266,32 +334,27 @@ struct {
 	__type(value, char[MAX_STRING_LEN]);
 } grpc_methods SEC(".maps");
 
-/* Kafka: rd_kafka_topic_t* → topic name string (populated by rd_kafka_topic_new) */
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 256);
-	__type(key, u64);  /* rd_kafka_topic_t* cast to u64 */
-	__type(value, char[MAX_STRING_LEN]);
-} kafka_topic_names SEC(".maps");
-
-/* Kafka: pid<<32|tid → topic name (temporary during rd_kafka_topic_new call) */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 256);
 	__type(key, u64);
 	__type(value, char[MAX_STRING_LEN]);
+} kafka_topic_names SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 256);
+	__type(key, struct pair_key);
+	__type(value, char[MAX_STRING_LEN]);
 } kafka_topic_tmp SEC(".maps");
 
-/* Shared pending byte count for protocol uprobes (Redis, Memcached, Kafka) */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);  /* pid<<32|tid */
-	__type(value, u64); /* byte count captured at uprobe entry */
+	__type(key, struct pair_key);
+	__type(value, u64);
 } proto_bytes SEC(".maps");
 
-/* stack_buf is a scratch slot for bpf_get_stack(). Same percpu reasoning as
- * event_buf: a shared slot races between CPUs and produces corrupted frames. */
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);

--- a/bpf/memcached.c
+++ b/bpf/memcached.c
@@ -3,9 +3,11 @@
  * Memcached tracing via libmemcached uprobes.
  *
  * Hooks:
- *   uprobe/memcached_get     — memcached_return_t memcached_get(
+ *   uprobe/memcached_get     — char *memcached_get(
  *                                  memcached_st*, const char *key, size_t klen,
  *                                  size_t *vlen, uint32_t *flags, memcached_return_t *err)
+ *                                  (returns the VALUE buffer; NULL = miss/error,
+ *                                  status goes to the *err out-parameter)
  *   uprobe/memcached_set     — memcached_return_t memcached_set(
  *                                  memcached_st*, const char *key, size_t klen,
  *                                  const char *val, size_t vlen, time_t exp, uint32_t flags)
@@ -30,7 +32,7 @@
 #define MC_OP_SET "set "
 #define MC_OP_DEL "del "
 
-static __always_inline void mc_store_op(u64 key, u64 ts,
+static __always_inline void mc_store_op(const struct pair_key *key, u64 ts,
 	const char *op_prefix, u32 prefix_len,
 	const char *mc_key, u64 bytes_val)
 {
@@ -45,14 +47,19 @@ static __always_inline void mc_store_op(u64 key, u64 ts,
 	if (remaining > 0)
 		bpf_probe_read_user_str(buf + prefix_len, remaining, mc_key);
 
-	bpf_map_update_elem(&memcached_ops, &key, buf, BPF_ANY);
-	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	bpf_map_update_elem(&memcached_ops, key, buf, BPF_ANY);
+	bpf_map_update_elem(&start_times, key, &ts, BPF_ANY);
 	if (bytes_val > 0)
-		bpf_map_update_elem(&proto_bytes, &key, &bytes_val, BPF_ANY);
+		bpf_map_update_elem(&proto_bytes, key, &bytes_val, BPF_ANY);
 }
 
-static __always_inline int mc_emit(struct pt_regs *ctx, u64 key, u32 pid, u32 tid)
+/* ret_is_pointer: memcached_get returns char* (NULL = miss/error), while
+ * set/delete return memcached_return_t. Treating the GET pointer as a status
+ * reported the low 32 bits of a heap pointer as a "nonzero error" on success
+ * and 0 (success) on failure. */
+static __always_inline int mc_emit(struct pt_regs *ctx, u32 pid, u32 tid, int ret_is_pointer)
 {
+	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)
 		return 0;
@@ -71,7 +78,10 @@ static __always_inline int mc_emit(struct pt_regs *ctx, u64 key, u32 pid, u32 ti
 	e->pid        = pid;
 	e->type       = EVENT_MEMCACHED_CMD;
 	e->latency_ns = latency;
-	e->error      = (s32)PT_REGS_RC(ctx);  /* memcached_return_t */
+	if (ret_is_pointer)
+		e->error = PT_REGS_RC(ctx) == 0 ? -1 : 0;
+	else
+		e->error = (s32)PT_REGS_RC(ctx);  /* memcached_return_t */
 	e->tcp_state  = 0;
 
 	u64 *bptr = bpf_map_lookup_elem(&proto_bytes, &key);
@@ -100,10 +110,10 @@ int uprobe_memcached_get(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;
-	mc_store_op(key, bpf_ktime_get_ns(), MC_OP_GET, 4, mc_key, 0);
+	mc_store_op(&key, bpf_ktime_get_ns(), MC_OP_GET, 4, mc_key, 0);
 	return 0;
 }
 
@@ -112,7 +122,7 @@ int uretprobe_memcached_get(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	return mc_emit(ctx, get_key(pid, tid), pid, tid);
+	return mc_emit(ctx, pid, tid, 1);
 }
 
 /* uprobe/memcached_set — PARM2=key, PARM3=klen, PARM4=val, PARM5=vlen */
@@ -121,11 +131,11 @@ int uprobe_memcached_set(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;
 	u64 vlen = (u64)PT_REGS_PARM5(ctx);
-	mc_store_op(key, bpf_ktime_get_ns(), MC_OP_SET, 4, mc_key, vlen);
+	mc_store_op(&key, bpf_ktime_get_ns(), MC_OP_SET, 4, mc_key, vlen);
 	return 0;
 }
 
@@ -134,7 +144,7 @@ int uretprobe_memcached_set(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	return mc_emit(ctx, get_key(pid, tid), pid, tid);
+	return mc_emit(ctx, pid, tid, 0);
 }
 
 /* uprobe/memcached_delete — PARM2=key, PARM3=klen */
@@ -143,10 +153,10 @@ int uprobe_memcached_delete(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;
-	mc_store_op(key, bpf_ktime_get_ns(), MC_OP_DEL, 4, mc_key, 0);
+	mc_store_op(&key, bpf_ktime_get_ns(), MC_OP_DEL, 4, mc_key, 0);
 	return 0;
 }
 
@@ -155,5 +165,5 @@ int uretprobe_memcached_delete(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	return mc_emit(ctx, get_key(pid, tid), pid, tid);
+	return mc_emit(ctx, pid, tid, 0);
 }

--- a/bpf/memory.c
+++ b/bpf/memory.c
@@ -11,7 +11,20 @@ int tracepoint_page_fault_user(void *ctx) {
 	// For stability, avoid relying on tracepoint "common_pid" field offsets here and use the
 	// current task PID from bpf_get_current_pid_tgid().
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	
+
+	/* Sample 1 in PAGE_FAULT_SAMPLE_RATE faults per CPU. Emitting every
+	 * fault (each with a user-stack capture) saturates the ring buffer and
+	 * evicts every other event type on busy workloads. */
+	u32 zero = 0;
+	u64 *seq = bpf_map_lookup_elem(&page_fault_seq, &zero);
+	if (!seq) {
+		return 0;
+	}
+	*seq += 1;
+	if (*seq % PAGE_FAULT_SAMPLE_RATE != 0) {
+		return 0;
+	}
+
 	struct event *e = get_event_buf();
 	if (!e) {
 		return 0;
@@ -31,28 +44,44 @@ int tracepoint_page_fault_user(void *ctx) {
 	return 0;
 }
 
-SEC("tp/oom/oom_kill_process")
-int tracepoint_oom_kill_process(void *ctx) {
-	struct {
-		unsigned short common_type;
-		unsigned char common_flags;
-		unsigned char common_preempt_count;
-		int common_pid;
-		char comm[16];
-		u32 pid;
-		u32 tid;
-		u64 totalpages;
-		u64 points;
-		u64 victim_points;
-		const char *constraint;
-		u32 constraint_kind;
-		u32 gfp_mask;
-		int order;
-	} args_local;
-	
-	bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx);
-	
-	struct event *e = get_event_buf();
+/* There is no tp/oom/oom_kill_process tracepoint upstream — the oom group
+ * exposes mark_victim (one fire per killed task). The previous handler
+ * targeted the nonexistent name and silently never attached, so
+ * EVENT_OOM_KILL was dead on every mainline kernel.
+ *
+ * mark_victim's guaranteed field on all kernels since 4.19 is `int pid` at
+ * offset 8. Kernel 6.10 added comm (__data_loc), total_vm, rss counters and
+ * uid behind it. The pinned struct matches the 6.10+ layout; the __data_loc
+ * descriptor for comm is sanity-checked before use so pre-6.10 kernels
+ * (where those bytes are past the record) degrade to a pid-only event
+ * instead of emitting garbage. */
+struct oom_mark_victim_args {
+	unsigned short common_type;
+	unsigned char common_flags;
+	unsigned char common_preempt_count;
+	int common_pid;
+	int pid;
+	unsigned int comm_loc;  /* __data_loc char[] comm, kernels >= 6.10 */
+	u64 total_vm;           /* kernels >= 6.10 */
+	u64 anon_rss;
+	u64 file_rss;
+	u64 shmem_rss;
+};
+_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, pid) == 8, "mark_victim: pid must be at offset 8");
+_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, comm_loc) == 12, "mark_victim: comm __data_loc must be at offset 12");
+_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, total_vm) == 16, "mark_victim: total_vm must be at offset 16");
+
+SEC("tp/oom/mark_victim")
+int tracepoint_oom_mark_victim(void *ctx) {
+	struct oom_mark_victim_args args_local = {};
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
+		return 0;
+	}
+
+	/* mark_victim fires in the OOM-killing task's context, not the
+	 * victim's, so skip the in-kernel cgroup prefilter and let the
+	 * userspace filter judge the victim PID. */
+	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
 	}
@@ -61,14 +90,22 @@ int tracepoint_oom_kill_process(void *ctx) {
 	e->type = EVENT_OOM_KILL;
 	e->latency_ns = 0;
 	e->error = 0;
-	e->bytes = args_local.totalpages * PAGE_SIZE;
+	e->bytes = 0;
 	e->tcp_state = 0;
-	/* Same pattern as sched_switch: get_event_buf() filled e->comm with the
-	 * OOM-killer task's name (typically a kthread), but e->pid points at the
-	 * victim. Overwrite comm with the victim's name from the tracepoint. */
-	__builtin_memcpy(e->comm, args_local.comm, sizeof(e->comm));
-	bpf_probe_read_kernel_str(e->target, sizeof(e->target), args_local.comm);
-	
+	e->target[0] = '\0';
+
+	/* Resolve the victim comm from the __data_loc descriptor, but only when
+	 * it looks like one (offset within the record page, length bounded by
+	 * TASK_COMM_LEN) — on pre-6.10 kernels these bytes are not part of the
+	 * record and must be ignored. */
+	unsigned short comm_off = (unsigned short)(args_local.comm_loc & 0xffff);
+	unsigned short comm_len = (unsigned short)(args_local.comm_loc >> 16);
+	if (comm_off >= sizeof(struct oom_mark_victim_args) && comm_off < 4096 &&
+	    comm_len > 0 && comm_len <= COMM_LEN + 1) {
+		bpf_probe_read_kernel_str(e->target, COMM_LEN, (char *)ctx + comm_off);
+		__builtin_memcpy(e->comm, e->target, COMM_LEN);
+	}
+
 	capture_user_stack(ctx, e->pid, 0, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	return 0;

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -5,25 +5,54 @@
 #include "events.h"
 #include "helpers.h"
 
+/* The destination sockaddr must be captured at kprobe entry: by the time the
+ * kretprobe fires, the argument registers have been clobbered by the function
+ * body. PARM2 is the KERNEL copy of the caller's sockaddr (the syscall layer
+ * runs move_addr_to_kernel before tcp_v4/v6_connect), so it is read with
+ * bpf_probe_read_kernel. */
 SEC("kprobe/tcp_v4_connect")
 int kprobe_tcp_connect(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
-	u64 ts = bpf_ktime_get_ns();
-	
-	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	struct pair_key key = make_pair_key(PAIR_TCP_CONNECT_V4);
+	record_start_time(&key);
+
+	void *uaddr = (void *)PT_REGS_PARM2(ctx);
+	if (uaddr) {
+		struct sockaddr_in sa;
+		if (bpf_probe_read_kernel(&sa, sizeof(sa), uaddr) == 0 &&
+		    sa.sin_family == AF_INET) {
+			struct connect_addr ca = {};
+			ca.family = AF_INET;
+			ca.port_be = sa.sin_port;
+			ca.addr_be = sa.sin_addr.s_addr;
+			bpf_map_update_elem(&connect_addrs, &key, &ca, BPF_ANY);
+		}
+	}
 	return 0;
 }
 
 SEC("kprobe/tcp_v6_connect")
 int kprobe_tcp_v6_connect(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
-	u64 ts = bpf_ktime_get_ns();
-	
-	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	struct pair_key key = make_pair_key(PAIR_TCP_CONNECT_V6);
+	record_start_time(&key);
+
+	void *uaddr = (void *)PT_REGS_PARM2(ctx);
+	if (uaddr) {
+		struct {
+			u16 sin6_family;
+			u16 sin6_port;
+			u32 sin6_flowinfo;
+			u8  sin6_addr[16];
+			u32 sin6_scope_id;
+		} sa6;
+		if (bpf_probe_read_kernel(&sa6, sizeof(sa6), uaddr) == 0 &&
+		    sa6.sin6_family == AF_INET6) {
+			struct connect_addr ca = {};
+			ca.family = AF_INET6;
+			ca.port_be = sa6.sin6_port;
+			__builtin_memcpy(ca.addr6, sa6.sin6_addr, 16);
+			bpf_map_update_elem(&connect_addrs, &key, &ca, BPF_ANY);
+		}
+	}
 	return 0;
 }
 
@@ -31,7 +60,7 @@ SEC("kretprobe/tcp_v6_connect")
 int kretprobe_tcp_v6_connect(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_CONNECT_V6);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -52,36 +81,22 @@ int kretprobe_tcp_v6_connect(struct pt_regs *ctx) {
 	e->bytes = 0;
 	e->tcp_state = 0;
 	e->target[0] = '\0';
-	
-	void *uaddr = (void *)PT_REGS_PARM2(ctx);
-	if (uaddr) {
-		u16 family;
-		if (bpf_probe_read_user(&family, sizeof(family), uaddr) == 0) {
-			if (family == AF_INET6) {
-				struct {
-					u16 sin6_family;
-					u16 sin6_port;
-					u32 sin6_flowinfo;
-					u8  sin6_addr[16];
-					u32 sin6_scope_id;
-				} addr6;
-				if (bpf_probe_read_user(&addr6, sizeof(addr6), uaddr) == 0) {
-					u16 port = __builtin_bswap16(addr6.sin6_port);
-					format_ipv6_port(addr6.sin6_addr, port, e->target);
-					struct dns_v6key k6 = {};
-					__builtin_memcpy(k6.addr, addr6.sin6_addr, 16);
-					char *resolved = bpf_map_lookup_elem(&dns_resolved6, &k6);
-					if (resolved) {
-						__builtin_memcpy(e->details, resolved, MAX_STRING_LEN);
-					} else {
-						e->details[0] = '\0';
-					}
-				}
-			}
+	e->details[0] = '\0';
+
+	struct connect_addr *ca = bpf_map_lookup_elem(&connect_addrs, &key);
+	if (ca && ca->family == AF_INET6) {
+		u16 port = __builtin_bswap16(ca->port_be);
+		format_ipv6_port(ca->addr6, port, e->target);
+		struct dns_v6key k6 = {};
+		__builtin_memcpy(k6.addr, ca->addr6, 16);
+		char *resolved = bpf_map_lookup_elem(&dns_resolved6, &k6);
+		if (resolved) {
+			__builtin_memcpy(e->details, resolved, MAX_STRING_LEN);
 		}
 	}
 	capture_user_stack(ctx, pid, tid, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
+	bpf_map_delete_elem(&connect_addrs, &key);
 	bpf_map_delete_elem(&start_times, &key);
 	return 0;
 }
@@ -90,7 +105,7 @@ SEC("kretprobe/tcp_v4_connect")
 int kretprobe_tcp_connect(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_CONNECT_V4);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -110,37 +125,23 @@ int kretprobe_tcp_connect(struct pt_regs *ctx) {
 	e->error = PT_REGS_RC(ctx);
 	e->bytes = 0;
 	e->tcp_state = 0;
-	
-	struct sockaddr_in addr;
-	void *uaddr = (void *)PT_REGS_PARM2(ctx);
-	if (uaddr) {
-		if (bpf_probe_read_user(&addr, sizeof(addr), uaddr) == 0) {
-			if (addr.sin_family == AF_INET) {
-				u16 port = __builtin_bswap16(addr.sin_port);
-				u32 ip_be;
-				if (bpf_probe_read_user(&ip_be, sizeof(ip_be), &addr.sin_addr.s_addr) == 0) {
-					u32 ip = __builtin_bswap32(ip_be);
-					format_ip_port(ip, port, e->target);
-					char *resolved = bpf_map_lookup_elem(&dns_resolved, &ip_be);
-					if (resolved) {
-						__builtin_memcpy(e->details, resolved, MAX_STRING_LEN);
-					} else {
-						e->details[0] = '\0';
-					}
-				} else {
-					e->target[0] = '\0';
-				}
-			} else {
-				e->target[0] = '\0';
-			}
-		} else {
-			e->target[0] = '\0';
+	e->target[0] = '\0';
+	e->details[0] = '\0';
+
+	struct connect_addr *ca = bpf_map_lookup_elem(&connect_addrs, &key);
+	if (ca && ca->family == AF_INET) {
+		u16 port = __builtin_bswap16(ca->port_be);
+		u32 ip = __builtin_bswap32(ca->addr_be);
+		format_ip_port(ip, port, e->target);
+		u32 ip_be = ca->addr_be;
+		char *resolved = bpf_map_lookup_elem(&dns_resolved, &ip_be);
+		if (resolved) {
+			__builtin_memcpy(e->details, resolved, MAX_STRING_LEN);
 		}
-	} else {
-		e->target[0] = '\0';
 	}
 	capture_user_stack(ctx, pid, tid, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
+	bpf_map_delete_elem(&connect_addrs, &key);
 	bpf_map_delete_elem(&start_times, &key);
 	return 0;
 }
@@ -149,7 +150,7 @@ SEC("kprobe/tcp_sendmsg")
 int kprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_SENDMSG);
 	u64 ts = bpf_ktime_get_ns();
 	
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -160,7 +161,7 @@ SEC("kretprobe/tcp_sendmsg")
 int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_SENDMSG);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 
 	if (!start_ts) {
@@ -173,13 +174,17 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 		bytes = (u64)ret;
 	}
 
-	/* Save latency now so we can reuse it for the optional gRPC event below */
 	u64 latency_ns = calc_latency(*start_ts);
+
+	/* socket_conns and grpc_methods are cross-probe blackboards written by
+	 * other probes (http_request uprobe, grpc sendmsg kprobe) and stay keyed
+	 * by the plain thread key. */
+	u64 conn_key = get_key(pid, tid);
 
 	struct event *e = get_event_buf();
 	if (!e) {
 		bpf_map_delete_elem(&start_times, &key);
-		bpf_map_delete_elem(&grpc_methods, &key);
+		bpf_map_delete_elem(&grpc_methods, &conn_key);
 		return 0;
 	}
 	e->timestamp = bpf_ktime_get_ns();
@@ -190,10 +195,12 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	e->bytes = bytes;
 	e->tcp_state = 0;
 
-	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &key);
+	/* Look up without deleting: the entry belongs to the in-flight
+	 * http_request pair, which removes it when the request returns.
+	 * Deleting here starved the HTTP/Redis consumers of their URL. */
+	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (conn_ptr) {
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), conn_ptr);
-		bpf_map_delete_elem(&socket_conns, &key);
 	} else {
 		e->target[0] = '\0';
 	}
@@ -203,7 +210,7 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 
 	/* If kprobe_grpc_tcp_sendmsg detected an HTTP/2 gRPC method path,
 	 * emit an additional EVENT_GRPC_METHOD event for that send. */
-	char *grpc_method_ptr = bpf_map_lookup_elem(&grpc_methods, &key);
+	char *grpc_method_ptr = bpf_map_lookup_elem(&grpc_methods, &conn_key);
 	if (grpc_method_ptr) {
 		struct event *eg = get_event_buf();
 		if (eg) {
@@ -219,7 +226,7 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 			capture_user_stack(ctx, pid, tid, eg);
 			bpf_ringbuf_output(&events, eg, sizeof(*eg), 0);
 		}
-		bpf_map_delete_elem(&grpc_methods, &key);
+		bpf_map_delete_elem(&grpc_methods, &conn_key);
 	}
 
 	return 0;
@@ -229,7 +236,7 @@ SEC("kprobe/tcp_recvmsg")
 int kprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_RECVMSG);
 	u64 ts = bpf_ktime_get_ns();
 	
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -240,7 +247,7 @@ SEC("kretprobe/tcp_recvmsg")
 int kretprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_TCP_RECVMSG);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -265,11 +272,12 @@ int kretprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	e->error = ret < 0 ? ret : 0;
 	e->bytes = bytes;
 	e->tcp_state = 0;
-	
-	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &key);
+
+	/* Same blackboard semantics as the sendmsg kretprobe: read-only. */
+	u64 conn_key = get_key(pid, tid);
+	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (conn_ptr) {
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), conn_ptr);
-		bpf_map_delete_elem(&socket_conns, &key);
 	} else {
 		e->target[0] = '\0';
 	}
@@ -283,7 +291,7 @@ SEC("uprobe/getaddrinfo")
 int uprobe_getaddrinfo(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_GETADDRINFO);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	
@@ -301,7 +309,7 @@ SEC("uretprobe/getaddrinfo")
 int uretprobe_getaddrinfo(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_GETADDRINFO);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -342,27 +350,57 @@ int uretprobe_getaddrinfo(struct pt_regs *ctx) {
 	return 0;
 }
 
-SEC("tp/tcp/tcp_set_state")
-int tracepoint_tcp_set_state(void *ctx) {
+/* tcp:tcp_set_state was removed in kernel 4.16 (replaced by
+ * sock:inet_sock_set_state, commit 563e0bb0dc74), so this handler targets the
+ * replacement. Layout pinned to the upstream trace event (verified against a
+ * live kernel format file); sport/dport are stored in HOST byte order by the
+ * tracepoint (TP_STORE_ADDR_PORTS applies ntohs), the address byte arrays are
+ * in network order. */
+struct inet_sock_set_state_args {
+	unsigned short common_type;
+	unsigned char common_flags;
+	unsigned char common_preempt_count;
+	int common_pid;
+	const void *skaddr;
+	int oldstate;
+	int newstate;
+	__u16 sport;
+	__u16 dport;
+	__u16 family;
+	__u16 protocol;
+	__u8 saddr[4];
+	__u8 daddr[4];
+	__u8 saddr_v6[16];
+	__u8 daddr_v6[16];
+};
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, skaddr) == 8, "inet_sock_set_state: skaddr must be at offset 8");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, oldstate) == 16, "inet_sock_set_state: oldstate must be at offset 16");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, newstate) == 20, "inet_sock_set_state: newstate must be at offset 20");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, sport) == 24, "inet_sock_set_state: sport must be at offset 24");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, dport) == 26, "inet_sock_set_state: dport must be at offset 26");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, family) == 28, "inet_sock_set_state: family must be at offset 28");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, protocol) == 30, "inet_sock_set_state: protocol must be at offset 30");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, saddr) == 32, "inet_sock_set_state: saddr must be at offset 32");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, daddr) == 36, "inet_sock_set_state: daddr must be at offset 36");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, saddr_v6) == 40, "inet_sock_set_state: saddr_v6 must be at offset 40");
+_Static_assert(__builtin_offsetof(struct inet_sock_set_state_args, daddr_v6) == 56, "inet_sock_set_state: daddr_v6 must be at offset 56");
+
+SEC("tp/sock/inet_sock_set_state")
+int tracepoint_inet_sock_set_state(void *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	
-	struct {
-		unsigned short common_type;
-		unsigned char common_flags;
-		unsigned char common_preempt_count;
-		int common_pid;
-		const void *skaddr;
-		int oldstate;
-		int newstate;
-		__u16 sport;
-		__u16 dport;
-		__u32 saddr;
-		__u32 daddr;
-	} args_local;
-	
-	bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx);
-	
-	struct event *e = get_event_buf();
+
+	struct inet_sock_set_state_args args_local;
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
+		return 0;
+	}
+	if (args_local.protocol != IPPROTO_TCP) {
+		return 0;
+	}
+
+	/* State changes often fire in softirq context where the current task is
+	 * a bystander, so skip the in-kernel cgroup prefilter and let the
+	 * userspace filter decide. */
+	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
 	}
@@ -374,35 +412,67 @@ int tracepoint_tcp_set_state(void *ctx) {
 	e->bytes = 0;
 	e->tcp_state = args_local.newstate;
 	e->target[0] = '\0';
-	
-	u16 dport = __builtin_bswap16(args_local.dport);
-	u32 daddr = __builtin_bswap32(args_local.daddr);
-	
-	if (daddr != 0) {
-		format_ip_port(daddr, dport, e->target);
+
+	if (args_local.family == AF_INET6) {
+		format_ipv6_port(args_local.daddr_v6, args_local.dport, e->target);
+	} else {
+		u32 daddr = ((u32)args_local.daddr[0] << 24) |
+		            ((u32)args_local.daddr[1] << 16) |
+		            ((u32)args_local.daddr[2] << 8) |
+		            (u32)args_local.daddr[3];
+		if (daddr != 0) {
+			format_ip_port(daddr, args_local.dport, e->target);
+		}
 	}
 	capture_user_stack(ctx, pid, 0, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	return 0;
 }
 
+/* Layout pinned to the post-5.10 tcp_event_sk_skb class (skbaddr, skaddr,
+ * state, then ports/family/addresses; `family` landed in v5.10). The previous
+ * hand-written struct used a pre-5.10 layout, so sport/dport were read from
+ * inside `state` and daddr landed on family+saddr — bogus retransmit targets
+ * on any modern kernel. Same bug class as the fixed net_dev_xmit handler;
+ * same _Static_assert treatment. Ports are in HOST byte order. */
+struct tcp_retransmit_skb_args {
+	unsigned short common_type;
+	unsigned char common_flags;
+	unsigned char common_preempt_count;
+	int common_pid;
+	const void *skbaddr;
+	const void *skaddr;
+	int state;
+	__u16 sport;
+	__u16 dport;
+	__u16 family;
+	__u8 saddr[4];
+	__u8 daddr[4];
+	__u8 saddr_v6[16];
+	__u8 daddr_v6[16];
+};
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, skbaddr) == 8, "tcp_retransmit_skb: skbaddr must be at offset 8");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, skaddr) == 16, "tcp_retransmit_skb: skaddr must be at offset 16");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, state) == 24, "tcp_retransmit_skb: state must be at offset 24");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, sport) == 28, "tcp_retransmit_skb: sport must be at offset 28");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, dport) == 30, "tcp_retransmit_skb: dport must be at offset 30");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, family) == 32, "tcp_retransmit_skb: family must be at offset 32");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, saddr) == 34, "tcp_retransmit_skb: saddr must be at offset 34");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, daddr) == 38, "tcp_retransmit_skb: daddr must be at offset 38");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, saddr_v6) == 42, "tcp_retransmit_skb: saddr_v6 must be at offset 42");
+_Static_assert(__builtin_offsetof(struct tcp_retransmit_skb_args, daddr_v6) == 58, "tcp_retransmit_skb: daddr_v6 must be at offset 58");
+
 SEC("tp/tcp/tcp_retransmit_skb")
 int tracepoint_tcp_retransmit_skb(void *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	struct {
-		unsigned short common_type;
-		unsigned char common_flags;
-		unsigned char common_preempt_count;
-		int common_pid;
-		const void *skaddr;
-		const void *skbaddr;
-		__u16 sport;
-		__u16 dport;
-		__u32 saddr;
-		__u32 daddr;
-	} args_local;
-	bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx);
-	struct event *e = get_event_buf();
+	struct tcp_retransmit_skb_args args_local;
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
+		return 0;
+	}
+
+	/* Retransmits fire from timers/softirq where the current task is a
+	 * bystander; skip the in-kernel cgroup prefilter. */
+	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
 	}
@@ -414,10 +484,17 @@ int tracepoint_tcp_retransmit_skb(void *ctx) {
 	e->bytes = 0;
 	e->tcp_state = 0;
 	e->target[0] = '\0';
-	u16 dport = __builtin_bswap16(args_local.dport);
-	u32 daddr = __builtin_bswap32(args_local.daddr);
-	if (daddr != 0) {
-		format_ip_port(daddr, dport, e->target);
+
+	if (args_local.family == AF_INET6) {
+		format_ipv6_port(args_local.daddr_v6, args_local.dport, e->target);
+	} else {
+		u32 daddr = ((u32)args_local.daddr[0] << 24) |
+		            ((u32)args_local.daddr[1] << 16) |
+		            ((u32)args_local.daddr[2] << 8) |
+		            (u32)args_local.daddr[3];
+		if (daddr != 0) {
+			format_ip_port(daddr, args_local.dport, e->target);
+		}
 	}
 	capture_user_stack(ctx, pid, 0, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
@@ -446,7 +523,8 @@ int tracepoint_net_dev_xmit(void *ctx) {
 	if (args_local.rc == 0) {
 		return 0;
 	}
-	struct event *e = get_event_buf();
+	/* Softirq context: current task is a bystander, skip the prefilter. */
+	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
 	}
@@ -468,7 +546,7 @@ SEC("kprobe/udp_sendmsg")
 int kprobe_udp_sendmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_UDP_SENDMSG);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -478,7 +556,7 @@ SEC("kretprobe/udp_sendmsg")
 int kretprobe_udp_sendmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_UDP_SENDMSG);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -515,7 +593,7 @@ SEC("kprobe/udp_recvmsg")
 int kprobe_udp_recvmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_UDP_RECVMSG);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -525,7 +603,7 @@ SEC("kretprobe/udp_recvmsg")
 int kretprobe_udp_recvmsg(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_UDP_RECVMSG);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -562,7 +640,7 @@ SEC("uprobe/http_request")
 int uprobe_http_request(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_HTTP_REQUEST);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	
@@ -570,7 +648,8 @@ int uprobe_http_request(struct pt_regs *ctx) {
 	if (url) {
 		char url_buf[MAX_STRING_LEN] = {};
 		bpf_probe_read_user_str(url_buf, sizeof(url_buf), url);
-		bpf_map_update_elem(&socket_conns, &key, url_buf, BPF_ANY);
+		u64 conn_key = get_key(pid, tid);
+		bpf_map_update_elem(&socket_conns, &conn_key, url_buf, BPF_ANY);
 	}
 	return 0;
 }
@@ -579,7 +658,7 @@ SEC("uretprobe/http_request")
 int uretprobe_http_request(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_HTTP_REQUEST);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -599,10 +678,11 @@ int uretprobe_http_request(struct pt_regs *ctx) {
 	e->bytes = 0;
 	e->tcp_state = 0;
 	
-	char *url_ptr = bpf_map_lookup_elem(&socket_conns, &key);
+	u64 conn_key = get_key(pid, tid);
+	char *url_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (url_ptr) {
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), url_ptr);
-		bpf_map_delete_elem(&socket_conns, &key);
+		bpf_map_delete_elem(&socket_conns, &conn_key);
 	} else {
 		e->target[0] = '\0';
 	}
@@ -616,7 +696,7 @@ SEC("uprobe/http_response")
 int uprobe_http_response(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_HTTP_RESPONSE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -626,7 +706,7 @@ SEC("uretprobe/http_response")
 int uretprobe_http_response(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_HTTP_RESPONSE);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	
 	if (!start_ts) {
@@ -663,7 +743,7 @@ SEC("uprobe/PQexec")
 int uprobe_PQexec(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_PQEXEC);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	char *query = (char *)PT_REGS_PARM2(ctx);
@@ -686,7 +766,7 @@ SEC("uretprobe/PQexec")
 int uretprobe_PQexec(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_PQEXEC);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -701,8 +781,10 @@ int uretprobe_PQexec(struct pt_regs *ctx) {
 	e->pid = pid;
 	e->type = EVENT_DB_QUERY;
 	e->latency_ns = latency;
+	/* PQexec returns PGresult* — NULL on failure, a heap pointer on
+	 * success. Storing the pointer as a status inverted the meaning. */
 	long ret = PT_REGS_RC(ctx);
-	e->error = ret;
+	e->error = ret == 0 ? -1 : 0;
 	e->bytes = 0;
 	e->tcp_state = 0;
 	char *qptr = bpf_map_lookup_elem(&db_queries, &key);
@@ -722,7 +804,7 @@ SEC("uprobe/mysql_real_query")
 int uprobe_mysql_real_query(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MYSQL_QUERY);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	const char *query = (const char *)PT_REGS_PARM2(ctx);
@@ -745,7 +827,7 @@ SEC("uretprobe/mysql_real_query")
 int uretprobe_mysql_real_query(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MYSQL_QUERY);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -780,7 +862,7 @@ SEC("uprobe/SSL_connect")
 int uprobe_SSL_connect(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_CONNECT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -790,7 +872,7 @@ SEC("uretprobe/SSL_connect")
 int uretprobe_SSL_connect(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_CONNECT);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -819,7 +901,7 @@ SEC("uprobe/SSL_accept")
 int uprobe_SSL_accept(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_ACCEPT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -829,7 +911,7 @@ SEC("uretprobe/SSL_accept")
 int uretprobe_SSL_accept(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_ACCEPT);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -858,7 +940,7 @@ SEC("uprobe/SSL_do_handshake")
 int uprobe_SSL_do_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_DO_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -868,7 +950,7 @@ SEC("uretprobe/SSL_do_handshake")
 int uretprobe_SSL_do_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_SSL_DO_HANDSHAKE);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -897,7 +979,7 @@ SEC("uprobe/gnutls_handshake")
 int uprobe_gnutls_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_GNUTLS_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -907,7 +989,7 @@ SEC("uretprobe/gnutls_handshake")
 int uretprobe_gnutls_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_GNUTLS_HANDSHAKE);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -936,7 +1018,7 @@ SEC("uprobe/mbedtls_ssl_handshake")
 int uprobe_mbedtls_ssl_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MBEDTLS_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 	return 0;
@@ -946,7 +1028,7 @@ SEC("uretprobe/mbedtls_ssl_handshake")
 int uretprobe_mbedtls_ssl_handshake(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_MBEDTLS_HANDSHAKE);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;

--- a/bpf/protocols.h
+++ b/bpf/protocols.h
@@ -48,4 +48,53 @@
  * strict 6.x kernels (verifier limit = 1M processed instructions). */
 #define FCGI_PARAMS_SCAN_LEN 128
 
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+/* Resolve the user-space data pointer behind a struct msghdr, handling both
+ * iov_iter shapes: ITER_IOVEC (writev/sendmsg with an iovec array) and
+ * ITER_UBUF (plain send()/write(), kernels >= 6.0, where the union member is
+ * the buffer pointer itself, not a pointer to an iovec). Shared by the
+ * FastCGI and gRPC inspectors — gRPC used to read msg_iter.__iov
+ * unconditionally, which on >= 6.0 either missed plain send() entirely or
+ * scanned a garbage pointer. */
+static __always_inline void *msghdr_user_base(struct msghdr *msg, u64 *avail)
+{
+	if (!msg)
+		return NULL;
+	u8 it = BPF_CORE_READ(msg, msg_iter.iter_type);
+	if (it == ITER_UBUF) {
+		void *ubuf = (void *)BPF_CORE_READ(msg, msg_iter.ubuf);
+		size_t count = BPF_CORE_READ(msg, msg_iter.count);
+		size_t off = BPF_CORE_READ(msg, msg_iter.iov_offset);
+		if (avail)
+			*avail = count;
+		if (!ubuf)
+			return NULL;
+		return (u8 *)ubuf + off;
+	}
+	if (it == ITER_IOVEC) {
+		const struct iovec *iov = BPF_CORE_READ(msg, msg_iter.__iov);
+		if (!iov)
+			return NULL;
+		struct iovec iov_entry;
+		if (bpf_probe_read_kernel(&iov_entry, sizeof(iov_entry), iov) != 0)
+			return NULL;
+		if (avail)
+			*avail = iov_entry.iov_len;
+		return iov_entry.iov_base;
+	}
+	return NULL;
+}
+
+static __always_inline int read_msghdr_data(struct msghdr *msg, void *buf, u32 buf_size)
+{
+	if (!buf || buf_size == 0)
+		return -1;
+	u64 avail = 0;
+	void *base = msghdr_user_base(msg, &avail);
+	if (!base || avail < buf_size)
+		return -1;
+	return bpf_probe_read_user(buf, buf_size, base);
+}
+#endif /* PODTRACE_VMLINUX_FROM_BTF */
+
 #endif /* PODTRACE_PROTOCOLS_H */

--- a/bpf/redis.c
+++ b/bpf/redis.c
@@ -24,7 +24,7 @@
 
 /* Store the command name from the format string PARM2.
  * Truncates at the first space or '%' (format verbs follow the command). */
-static __always_inline void redis_store_cmd(u64 key, const char *format_ptr, u64 ts)
+static __always_inline void redis_store_cmd(const struct pair_key *key, const char *format_ptr, u64 ts)
 {
 	char buf[MAX_STRING_LEN] = {};
 	bpf_probe_read_user_str(buf, sizeof(buf), format_ptr);
@@ -38,13 +38,14 @@ static __always_inline void redis_store_cmd(u64 key, const char *format_ptr, u64
 		}
 	}
 
-	bpf_map_update_elem(&redis_cmds, &key, buf, BPF_ANY);
-	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	bpf_map_update_elem(&redis_cmds, key, buf, BPF_ANY);
+	bpf_map_update_elem(&start_times, key, &ts, BPF_ANY);
 }
 
 /* Emit the EVENT_REDIS_CMD event from a uretprobe context. */
-static __always_inline int redis_emit(struct pt_regs *ctx, u64 key, u32 pid, u32 tid)
+static __always_inline int redis_emit(struct pt_regs *ctx, u32 pair, u32 pid, u32 tid)
 {
+	struct pair_key key = make_pair_key(pair);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)
 		return 0;
@@ -74,8 +75,9 @@ static __always_inline int redis_emit(struct pt_regs *ctx, u64 key, u32 pid, u32
 	else
 		e->details[0] = '\0';
 
-	/* Server target (populated by tcp_connect probes into socket_conns) */
-	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &key);
+	/* Server target (URL blackboard written by the http_request uprobe) */
+	u64 conn_key = get_key(pid, tid);
+	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (conn_ptr)
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), conn_ptr);
 	else
@@ -95,12 +97,12 @@ int uprobe_redisCommand(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_REDIS_COMMAND);
 	u64 ts  = bpf_ktime_get_ns();
 
 	const char *fmt = (const char *)PT_REGS_PARM2(ctx);
 	if (fmt)
-		redis_store_cmd(key, fmt, ts);
+		redis_store_cmd(&key, fmt, ts);
 	return 0;
 }
 
@@ -109,7 +111,7 @@ int uretprobe_redisCommand(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	return redis_emit(ctx, get_key(pid, tid), pid, tid);
+	return redis_emit(ctx, PAIR_REDIS_COMMAND, pid, tid);
 }
 
 /* uprobe/redisCommandArgv — PARM3 = const char **argv, argv[0] = command */
@@ -118,7 +120,7 @@ int uprobe_redisCommandArgv(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_REDIS_COMMAND_ARGV);
 	u64 ts  = bpf_ktime_get_ns();
 
 	/* PARM3 = const char **argv; argv[0] is the command name */
@@ -144,5 +146,5 @@ int uretprobe_redisCommandArgv(struct pt_regs *ctx)
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	return redis_emit(ctx, get_key(pid, tid), pid, tid);
+	return redis_emit(ctx, PAIR_REDIS_COMMAND_ARGV, pid, tid);
 }

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -5,60 +5,52 @@
 #include "events.h"
 #include "helpers.h"
 
-SEC("kprobe/do_execveat_common")
-int kprobe_do_execveat_common(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
-	u64 ts = bpf_ktime_get_ns();
-	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+/* exec events come from the stable sched:sched_process_exec tracepoint.
+ * The previous kprobe pair targeted do_execveat_common, which (a) was never
+ * registered in the Go attach tables, so the programs were dead weight, and
+ * (b) is a static function that compilers routinely emit as
+ * do_execveat_common.isra.0, so a plain kprobe cannot attach reliably; it
+ * also read PARM2 — a kernel `struct filename *` — with
+ * bpf_probe_read_user_str, which always failed, leaving the target empty. */
+struct sched_process_exec_args {
+	unsigned short common_type;
+	unsigned char common_flags;
+	unsigned char common_preempt_count;
+	int common_pid;
+	unsigned int filename_loc; /* __data_loc char[] */
+	int pid;
+	int old_pid;
+};
+_Static_assert(__builtin_offsetof(struct sched_process_exec_args, filename_loc) == 8, "sched_process_exec: filename __data_loc must be at offset 8");
+_Static_assert(__builtin_offsetof(struct sched_process_exec_args, pid) == 12, "sched_process_exec: pid must be at offset 12");
 
-	const char *filename = (const char *)PT_REGS_PARM2(ctx);
-	if (filename) {
-		char buf[MAX_STRING_LEN] = {};
-		bpf_probe_read_user_str(buf, sizeof(buf), filename);
-		bpf_map_update_elem(&syscall_paths, &key, buf, BPF_ANY);
-	}
-
-	return 0;
-}
-
-SEC("kretprobe/do_execveat_common")
-int kretprobe_do_execveat_common(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
-	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
-	if (!start_ts) {
+SEC("tp/sched/sched_process_exec")
+int tracepoint_sched_process_exec(void *ctx) {
+	struct sched_process_exec_args args_local = {};
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
 		return 0;
 	}
 
-	u64 latency = calc_latency(*start_ts);
-	s64 ret = PT_REGS_RC(ctx);
-
+	/* Fires in the exec'ing task's own context, so the cgroup prefilter
+	 * applies cleanly. */
 	struct event *e = get_event_buf();
 	if (!e) {
 		return 0;
 	}
 	e->timestamp = bpf_ktime_get_ns();
-	e->pid = pid;
+	e->pid = bpf_get_current_pid_tgid() >> 32;
 	e->type = EVENT_EXEC;
-	e->latency_ns = latency;
-	e->error = ret < 0 ? ret : 0;
+	e->latency_ns = 0;
+	e->error = 0;
 	e->bytes = 0;
 	e->tcp_state = 0;
+	e->target[0] = '\0';
 
-	char *path = bpf_map_lookup_elem(&syscall_paths, &key);
-	if (path) {
-		bpf_probe_read_kernel_str(e->target, sizeof(e->target), path);
-		bpf_map_delete_elem(&syscall_paths, &key);
-	} else {
-		e->target[0] = '\0';
-	}
+	unsigned short name_off = (unsigned short)(args_local.filename_loc & 0xffff);
+	bpf_probe_read_kernel_str(e->target, sizeof(e->target), (char *)ctx + name_off);
 
-	capture_user_stack(ctx, pid, tid, e);
+	capture_user_stack(ctx, e->pid, 0, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
-	bpf_map_delete_elem(&start_times, &key);
 	return 0;
 }
 
@@ -109,7 +101,7 @@ SEC("kprobe/do_sys_openat2")
 int kprobe_do_sys_openat2(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_OPENAT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 
@@ -127,7 +119,7 @@ SEC("kretprobe/do_sys_openat2")
 int kretprobe_do_sys_openat2(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_OPENAT);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts) {
 		return 0;
@@ -166,13 +158,23 @@ SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_UNLINK);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
-	/* PARM3 = struct dentry * of the entry being unlinked */
-	struct dentry *de = (struct dentry *)PT_REGS_PARM3(ctx);
+	/* 5.12 added a mnt_userns/mnt_idmap first argument, moving the dentry
+	 * from PARM2 to PARM3. struct renamedata (also introduced in 5.12) is
+	 * the CO-RE probe for which side of that boundary the running kernel
+	 * is on. */
+	/* Read both candidate registers up front: selecting the register first
+	 * and dereferencing afterwards makes clang emit ctx+variable_offset,
+	 * which the verifier rejects ("dereference of modified ctx ptr"). */
+	struct dentry *de_parm2 = (struct dentry *)PT_REGS_PARM2(ctx);
+	barrier_var(de_parm2);
+	struct dentry *de_parm3 = (struct dentry *)PT_REGS_PARM3(ctx);
+	barrier_var(de_parm3);
+	struct dentry *de = bpf_core_type_exists(struct renamedata) ? de_parm3 : de_parm2;
 	if (de) {
 		char buf[MAX_STRING_LEN] = {};
 		const unsigned char *name = BPF_CORE_READ(de, d_name.name);
@@ -189,7 +191,7 @@ SEC("kretprobe/vfs_unlink")
 int kretprobe_vfs_unlink(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_UNLINK);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)
 		return 0;
@@ -226,15 +228,16 @@ int kretprobe_vfs_unlink(struct pt_regs *ctx) {
 
 /*
  * vfs_rename kprobe: signature varies across kernel versions.
- * Pre-6.3: vfs_rename(old_dir, old_dentry, new_dir, new_dentry, ...) — PARM2 and PARM4.
- * 6.3+:    vfs_rename(struct renamedata *) — single struct pointer.
- * This probe targets the pre-6.3 layout and is optional.
+ * Pre-5.12: vfs_rename(old_dir, old_dentry, new_dir, new_dentry, ...) — PARM2 and PARM4.
+ * 5.12+:    vfs_rename(struct renamedata *) — single struct pointer (PARM1).
+ * (The boundary is 5.12, commit 9fe61450972d, not 6.3 as previously noted.)
+ * bpf_core_type_exists(struct renamedata) selects the layout at load time.
  */
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_RENAME);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 
@@ -243,8 +246,23 @@ int kprobe_vfs_rename(struct pt_regs *ctx) {
 	 * Use fixed compile-time offsets so the BPF verifier can bound stack
 	 * writes — variable-offset writes (buf[idx]) are often rejected on 6.x.
 	 * Layout: [0 .. HALF-2] old name, [HALF-1] '>', [HALF .. END] new name. */
-	struct dentry *old_de = (struct dentry *)PT_REGS_PARM2(ctx);
-	struct dentry *new_de = (struct dentry *)PT_REGS_PARM4(ctx);
+	/* Same modified-ctx-pointer consideration as vfs_unlink: pull all
+	 * candidate registers out of ctx first, then select. */
+	struct renamedata *rd = (struct renamedata *)PT_REGS_PARM1(ctx);
+	barrier_var(rd);
+	struct dentry *old_parm2 = (struct dentry *)PT_REGS_PARM2(ctx);
+	barrier_var(old_parm2);
+	struct dentry *new_parm4 = (struct dentry *)PT_REGS_PARM4(ctx);
+	barrier_var(new_parm4);
+	struct dentry *old_de;
+	struct dentry *new_de;
+	if (bpf_core_type_exists(struct renamedata)) {
+		old_de = (struct dentry *)BPF_CORE_READ(rd, old_dentry);
+		new_de = (struct dentry *)BPF_CORE_READ(rd, new_dentry);
+	} else {
+		old_de = old_parm2;
+		new_de = new_parm4;
+	}
 	if (old_de && new_de) {
 		char buf[MAX_STRING_LEN] = {};
 		const unsigned char *old_name = BPF_CORE_READ(old_de, d_name.name);
@@ -264,7 +282,7 @@ SEC("kretprobe/vfs_rename")
 int kretprobe_vfs_rename(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	u64 key = get_key(pid, tid);
+	struct pair_key key = make_pair_key(PAIR_VFS_RENAME);
 	u64 *start_ts = bpf_map_lookup_elem(&start_times, &key);
 	if (!start_ts)
 		return 0;
@@ -299,11 +317,15 @@ int kretprobe_vfs_rename(struct pt_regs *ctx) {
 	return 0;
 }
 
-SEC("kprobe/__close_fd")
-int kprobe___close_fd(struct pt_regs *ctx) {
+/* __close_fd(files, fd) was removed in kernel 5.11 and replaced by
+ * close_fd(fd) — the fd moves from PARM2 to PARM1. The old probe targeted
+ * the removed symbol (and was never registered for attach), so EVENT_CLOSE
+ * never fired. */
+SEC("kprobe/close_fd")
+int kprobe_close_fd(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
-	unsigned int fd = (unsigned int)PT_REGS_PARM2(ctx);
+	unsigned int fd = (unsigned int)PT_REGS_PARM1(ctx);
 
 	struct event *e = get_event_buf();
 	if (!e) {

--- a/hack/bpfloadtest/main.go
+++ b/hack/bpfloadtest/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+func main() {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		fmt.Println("rlimit:", err)
+	}
+	spec, err := ebpf.LoadCollectionSpec(os.Args[1])
+	if err != nil {
+		fmt.Println("SPEC FAIL:", err)
+		os.Exit(1)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		fmt.Printf("VERIFIER FAIL: %v\n", err)
+		os.Exit(1)
+	}
+	defer coll.Close()
+	fmt.Printf("VERIFIER OK: %d programs loaded\n", len(coll.Programs))
+}

--- a/internal/diagnose/profiling/cpu_profiling.go
+++ b/internal/diagnose/profiling/cpu_profiling.go
@@ -25,20 +25,10 @@ func GenerateCPUUsageReport(allEvents []*events.Event, duration time.Duration) s
 	durationSec := duration.Seconds()
 	totalCPUPercent := 0.0
 
-	cpuTimeFromSched := make(map[uint32]uint64)
-	for _, e := range allEvents {
-		if e == nil || e.Type != events.EventSchedSwitch {
-			continue
-		}
-		cpuTimeFromSched[e.PID] += e.LatencyNS
-	}
-
 	pidCPUTimes := make(map[uint32]cpuTimeInfo)
 	for _, info := range pidActivity {
 		var totalNS uint64
-		if ns, ok := cpuTimeFromSched[info.Pid]; ok && ns > 0 {
-			totalNS = ns
-		} else if proc := getProcessCPUTime(info.Pid); proc.totalNS > 0 {
+		if proc := getProcessCPUTime(info.Pid); proc.totalNS > 0 {
 			totalNS = proc.totalNS
 		}
 		if totalNS > 0 {

--- a/internal/ebpf/probes/groups.go
+++ b/internal/ebpf/probes/groups.go
@@ -12,82 +12,84 @@ const (
 	GroupMemory     ProbeGroup = "memory"
 	GroupCPU        ProbeGroup = "cpu"
 	GroupPool       ProbeGroup = "pool"
-	GroupCache      ProbeGroup = "cache"      // Redis, Memcached
-	GroupMessaging  ProbeGroup = "messaging"  // Kafka
-	GroupFastCGI    ProbeGroup = "fastcgi"    // PHP-FPM / FastCGI unix socket probes
+	GroupCache      ProbeGroup = "cache"     // Redis, Memcached
+	GroupMessaging  ProbeGroup = "messaging" // Kafka
+	GroupFastCGI    ProbeGroup = "fastcgi"   // PHP-FPM / FastCGI unix socket probes
 )
 
 // probeGroupMap maps each BPF program name to its ProbeGroup.
 // Programs absent from this map are treated as GroupNetwork by default.
 var probeGroupMap = map[string]ProbeGroup{
 	// Network
-	"kprobe_tcp_connect":          GroupNetwork,
-	"kretprobe_tcp_connect":       GroupNetwork,
-	"kprobe_tcp_v6_connect":       GroupNetwork,
-	"kretprobe_tcp_v6_connect":    GroupNetwork,
-	"kprobe_tcp_sendmsg":          GroupNetwork,
-	"kretprobe_tcp_sendmsg":       GroupNetwork,
-	"kprobe_tcp_recvmsg":          GroupNetwork,
-	"kretprobe_tcp_recvmsg":       GroupNetwork,
-	"kprobe_udp_sendmsg":          GroupNetwork,
-	"kretprobe_udp_sendmsg":       GroupNetwork,
-	"kprobe_udp_recvmsg":          GroupNetwork,
-	"kretprobe_udp_recvmsg":       GroupNetwork,
-	"tracepoint_tcp_set_state":    GroupNetwork,
-	"tracepoint_tcp_retransmit_skb": GroupNetwork,
-	"tracepoint_net_dev_xmit":    GroupNetwork,
+	"kprobe_tcp_connect":             GroupNetwork,
+	"kretprobe_tcp_connect":          GroupNetwork,
+	"kprobe_tcp_v6_connect":          GroupNetwork,
+	"kretprobe_tcp_v6_connect":       GroupNetwork,
+	"kprobe_tcp_sendmsg":             GroupNetwork,
+	"kretprobe_tcp_sendmsg":          GroupNetwork,
+	"kprobe_tcp_recvmsg":             GroupNetwork,
+	"kretprobe_tcp_recvmsg":          GroupNetwork,
+	"kprobe_udp_sendmsg":             GroupNetwork,
+	"kretprobe_udp_sendmsg":          GroupNetwork,
+	"kprobe_udp_recvmsg":             GroupNetwork,
+	"kretprobe_udp_recvmsg":          GroupNetwork,
+	"tracepoint_inet_sock_set_state": GroupNetwork,
+	"tracepoint_tcp_retransmit_skb":  GroupNetwork,
+	"tracepoint_net_dev_xmit":        GroupNetwork,
 
 	// FileSystem
-	"kprobe_vfs_write":          GroupFileSystem,
-	"kretprobe_vfs_write":       GroupFileSystem,
-	"kprobe_vfs_read":           GroupFileSystem,
-	"kretprobe_vfs_read":        GroupFileSystem,
-	"kprobe_vfs_fsync":          GroupFileSystem,
-	"kretprobe_vfs_fsync":       GroupFileSystem,
-	"kprobe_do_sys_openat2":     GroupFileSystem,
-	"kretprobe_do_sys_openat2":  GroupFileSystem,
-	"kprobe_vfs_unlink":         GroupFileSystem,
-	"kretprobe_vfs_unlink":      GroupFileSystem,
-	"kprobe_vfs_rename":         GroupFileSystem,
-	"kretprobe_vfs_rename":      GroupFileSystem,
+	"kprobe_vfs_write":         GroupFileSystem,
+	"kretprobe_vfs_write":      GroupFileSystem,
+	"kprobe_vfs_read":          GroupFileSystem,
+	"kretprobe_vfs_read":       GroupFileSystem,
+	"kprobe_vfs_fsync":         GroupFileSystem,
+	"kretprobe_vfs_fsync":      GroupFileSystem,
+	"kprobe_do_sys_openat2":    GroupFileSystem,
+	"kretprobe_do_sys_openat2": GroupFileSystem,
+	"kprobe_vfs_unlink":        GroupFileSystem,
+	"kretprobe_vfs_unlink":     GroupFileSystem,
+	"kprobe_vfs_rename":        GroupFileSystem,
+	"kretprobe_vfs_rename":     GroupFileSystem,
+	"kprobe_close_fd":          GroupFileSystem,
 
 	// CPU
-	"tracepoint_sched_switch":       GroupCPU,
-	"kprobe_do_futex":               GroupCPU,
-	"kretprobe_do_futex":            GroupCPU,
+	"tracepoint_sched_switch": GroupCPU,
+	"kprobe_do_futex":         GroupCPU,
+	"kretprobe_do_futex":      GroupCPU,
 
 	// Memory
-	"tracepoint_page_fault_user":  GroupMemory,
-	"tracepoint_oom_kill_process": GroupMemory,
+	"tracepoint_page_fault_user": GroupMemory,
+	"tracepoint_oom_mark_victim": GroupMemory,
 
 	// Process (grouped under CPU for simplicity)
 	"tracepoint_sched_process_fork": GroupCPU,
+	"tracepoint_sched_process_exec": GroupCPU,
 
 	// TLS (uprobes attached separately via SetContainerID)
-	"uprobe_getaddrinfo":              GroupTLS,
-	"uretprobe_getaddrinfo":           GroupTLS,
-	"uprobe_pthread_mutex_lock":       GroupTLS,
-	"uretprobe_pthread_mutex_lock":    GroupTLS,
+	"uprobe_getaddrinfo":           GroupTLS,
+	"uretprobe_getaddrinfo":        GroupTLS,
+	"uprobe_pthread_mutex_lock":    GroupTLS,
+	"uretprobe_pthread_mutex_lock": GroupTLS,
 
 	// Database
-	"uprobe_PQexec":   GroupDatabase,
+	"uprobe_PQexec":    GroupDatabase,
 	"uretprobe_PQexec": GroupDatabase,
 
 	// Pool
-	"uprobe_pool_acquire":  GroupPool,
+	"uprobe_pool_acquire":    GroupPool,
 	"uretprobe_pool_acquire": GroupPool,
 
 	// Cache (Redis / Memcached)
-	"uprobe_redisCommand":         GroupCache,
-	"uretprobe_redisCommand":      GroupCache,
-	"uprobe_redisCommandArgv":     GroupCache,
-	"uretprobe_redisCommandArgv":  GroupCache,
-	"uprobe_memcached_get":        GroupCache,
-	"uretprobe_memcached_get":     GroupCache,
-	"uprobe_memcached_set":        GroupCache,
-	"uretprobe_memcached_set":     GroupCache,
-	"uprobe_memcached_delete":     GroupCache,
-	"uretprobe_memcached_delete":  GroupCache,
+	"uprobe_redisCommand":        GroupCache,
+	"uretprobe_redisCommand":     GroupCache,
+	"uprobe_redisCommandArgv":    GroupCache,
+	"uretprobe_redisCommandArgv": GroupCache,
+	"uprobe_memcached_get":       GroupCache,
+	"uretprobe_memcached_get":    GroupCache,
+	"uprobe_memcached_set":       GroupCache,
+	"uretprobe_memcached_set":    GroupCache,
+	"uprobe_memcached_delete":    GroupCache,
+	"uretprobe_memcached_delete": GroupCache,
 
 	// Messaging (Kafka)
 	"uprobe_rd_kafka_topic_new":        GroupMessaging,

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -50,6 +50,7 @@ var optionalProbes = map[string]string{
 	"kprobe_do_sys_openat2":    "do_sys_openat2",
 	"kretprobe_do_sys_openat2": "do_sys_openat2",
 	"kprobe_vfs_unlink":        "vfs_unlink",
+	"kprobe_close_fd":          "close_fd",
 	"kretprobe_vfs_unlink":     "vfs_unlink",
 	"kprobe_vfs_rename":        "vfs_rename",
 	"kretprobe_vfs_rename":     "vfs_rename",
@@ -185,12 +186,13 @@ type tracepointSpec struct {
 // (hot re-attach) so the two paths can never drift.
 var tracepointProbes = []tracepointSpec{
 	{"tracepoint_sched_switch", "sched", "sched_switch", "CPU/scheduling tracking unavailable"},
-	{"tracepoint_tcp_set_state", "tcp", "tcp_set_state", ""},
+	{"tracepoint_inet_sock_set_state", "sock", "inet_sock_set_state", "TCP state-change tracking unavailable"},
 	{"tracepoint_tcp_retransmit_skb", "tcp", "tcp_retransmit_skb", "TCP retransmission tracking unavailable"},
 	{"tracepoint_net_dev_xmit", "net", "net_dev_xmit", "Network device error tracking unavailable"},
 	{"tracepoint_page_fault_user", "exceptions", "page_fault_user", "Page fault tracking unavailable"},
-	{"tracepoint_oom_kill_process", "oom", "oom_kill_process", ""},
+	{"tracepoint_oom_mark_victim", "oom", "mark_victim", "OOM kill tracking unavailable"},
 	{"tracepoint_sched_process_fork", "sched", "sched_process_fork", "Process fork tracking unavailable"},
+	{"tracepoint_sched_process_exec", "sched", "sched_process_exec", "Process exec tracking unavailable"},
 }
 
 // attachTracepointSpec attaches one tracepoint, returning (link, true) on

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -436,13 +436,13 @@ func TestAttachProbes_AllProbeTypes(t *testing.T) {
 func TestAttachProbes_WithTracepoints(t *testing.T) {
 	coll := &ebpf.Collection{
 		Programs: map[string]*ebpf.Program{
-			"tracepoint_sched_switch":       {},
-			"tracepoint_tcp_set_state":      {},
-			"tracepoint_tcp_retransmit_skb": {},
-			"tracepoint_net_dev_xmit":       {},
-			"tracepoint_page_fault_user":    {},
-			"tracepoint_oom_kill_process":   {},
-			"tracepoint_sched_process_fork": {},
+			"tracepoint_sched_switch":        {},
+			"tracepoint_inet_sock_set_state": {},
+			"tracepoint_tcp_retransmit_skb":  {},
+			"tracepoint_net_dev_xmit":        {},
+			"tracepoint_page_fault_user":     {},
+			"tracepoint_oom_mark_victim":     {},
+			"tracepoint_sched_process_fork":  {},
 		},
 	}
 
@@ -478,7 +478,7 @@ func TestAttachProbes_TracepointPermissionDenied(t *testing.T) {
 func TestAttachProbes_TracepointNotFound(t *testing.T) {
 	coll := &ebpf.Collection{
 		Programs: map[string]*ebpf.Program{
-			"tracepoint_tcp_set_state": {},
+			"tracepoint_inet_sock_set_state": {},
 		},
 	}
 
@@ -1558,11 +1558,11 @@ func TestAttachPoolProbes_WithPrograms(t *testing.T) {
 			"uprobe_sqlite3_step":          {},
 			"uretprobe_sqlite3_step":       {},
 			"uprobe_PQconnectStart":        {},
-			"uretprobe_PQfinish":            {},
-			"uprobe_PQexec_pool":            {},
-			"uprobe_mysql_real_connect":     {},
-			"uretprobe_mysql_close":         {},
-			"uprobe_mysql_real_query_pool":  {},
+			"uretprobe_PQfinish":           {},
+			"uprobe_PQexec_pool":           {},
+			"uprobe_mysql_real_connect":    {},
+			"uretprobe_mysql_close":        {},
+			"uprobe_mysql_real_query_pool": {},
 		},
 	}
 
@@ -2033,7 +2033,7 @@ func TestFindLibcInContainer_AllPaths(t *testing.T) {
 func TestProbeAttachError_Unwrap(t *testing.T) {
 	originalErr := fmt.Errorf("original error")
 	err := NewProbeAttachError("test_probe", originalErr)
-	
+
 	unwrapped := err.Unwrap()
 	if unwrapped != originalErr {
 		t.Errorf("Unwrap() = %v, want %v", unwrapped, originalErr)

--- a/internal/ebpf/probes/tracepoints_test.go
+++ b/internal/ebpf/probes/tracepoints_test.go
@@ -1,0 +1,47 @@
+package probes
+
+import "testing"
+
+// TestTracepointProbes_TargetsExistUpstream is a regression test for two
+// silent dead probes: tcp:tcp_set_state was removed in kernel 4.16 (replaced
+// by sock:inet_sock_set_state) and oom:oom_kill_process never existed
+// upstream (the oom group exposes mark_victim). Both were registered with the
+// removed/nonexistent names, so the attach failed silently on every mainline
+// kernel and EVENT_TCP_STATE / EVENT_OOM_KILL were never produced.
+func TestTracepointProbes_TargetsExistUpstream(t *testing.T) {
+	byProgram := make(map[string]tracepointSpec, len(tracepointProbes))
+	for _, tp := range tracepointProbes {
+		byProgram[tp.prog] = tp
+	}
+
+	for program, want := range map[string]struct{ category, event string }{
+		"tracepoint_inet_sock_set_state": {"sock", "inet_sock_set_state"},
+		"tracepoint_oom_mark_victim":     {"oom", "mark_victim"},
+	} {
+		tp, ok := byProgram[program]
+		if !ok {
+			t.Errorf("tracepointProbes is missing program %q", program)
+			continue
+		}
+		if tp.category != want.category || tp.event != want.event {
+			t.Errorf("%s targets %s/%s, want %s/%s", program, tp.category, tp.event, want.category, want.event)
+		}
+	}
+
+	for _, removed := range []string{"tracepoint_tcp_set_state", "tracepoint_oom_kill_process"} {
+		if _, ok := byProgram[removed]; ok {
+			t.Errorf("tracepointProbes still registers %q, whose tracepoint does not exist on mainline kernels", removed)
+		}
+	}
+}
+
+// TestTracepointProbes_NoSilentFailures: an empty failMsg suppressed the
+// attach-failure log line entirely, which is how the two dead tracepoints
+// above went unnoticed. Every tracepoint must carry a message.
+func TestTracepointProbes_NoSilentFailures(t *testing.T) {
+	for _, tp := range tracepointProbes {
+		if tp.failMsg == "" {
+			t.Errorf("tracepoint %s/%s (%s) has an empty failMsg; attach failures would be silent", tp.category, tp.event, tp.prog)
+		}
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -82,8 +82,8 @@ type Tracer struct {
 	resourceMonitor          *resource.ResourceMonitor
 	cgroupPath               string
 	cgroupPaths              []string
-	useUserspaceCgroupFilter bool
-	targetCgroupID           uint64
+	useUserspaceCgroupFilter atomic.Bool
+	targetCgroupID           atomic.Uint64
 	targetCgroupIDs          atomic.Pointer[map[uint64]struct{}]
 	cgroupWriteMu            sync.Mutex
 	cpAnalyzer               *criticalpath.Analyzer
@@ -233,16 +233,16 @@ func NewTracer() (*Tracer, error) {
 	processCache := cache.NewLRUCache(config.CacheMaxSize, ttl)
 
 	t := &Tracer{
-		collection:               coll,
-		links:                    links,
-		probeGroups:              probeGroups,
-		intentionallyDisabled:    map[probes.ProbeGroup]struct{}{},
-		reader:                   rd,
-		filter:                   filter.NewCgroupFilter(),
-		processNameCache:         processCache,
-		pathCache:                cache.NewPathCache(),
-		useUserspaceCgroupFilter: true,
+		collection:            coll,
+		links:                 links,
+		probeGroups:           probeGroups,
+		intentionallyDisabled: map[probes.ProbeGroup]struct{}{},
+		reader:                rd,
+		filter:                filter.NewCgroupFilter(),
+		processNameCache:      processCache,
+		pathCache:             cache.NewPathCache(),
 	}
+	t.useUserspaceCgroupFilter.Store(true)
 	t.storeCgroupIDs(map[uint64]struct{}{})
 
 	if config.CriticalPathEnabled {
@@ -271,7 +271,7 @@ func (t *Tracer) SetCgroups(cgroupPaths []string) error {
 		t.cgroupWriteMu.Lock()
 		t.cgroupPaths = nil
 		t.cgroupPath = ""
-		t.targetCgroupID = 0
+		t.targetCgroupID.Store(0)
 		t.storeCgroupIDs(map[uint64]struct{}{})
 		t.filter.SetCgroupPaths(nil)
 		if err := t.syncTargetCgroupMap(); err != nil {
@@ -331,7 +331,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 	var newIDs map[uint64]struct{}
 	if replace {
 		allPaths = normalized
-		t.targetCgroupID = 0
+		t.targetCgroupID.Store(0)
 		newIDs = make(map[uint64]struct{}, len(normalized))
 	} else {
 		seen := make(map[string]struct{}, len(t.cgroupPaths)+len(normalized))
@@ -375,8 +375,8 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		for _, cgroupPath := range newPaths {
 			if cgid, err := getCgroupIDFromPath(cgroupPath); err == nil && cgid != 0 {
 				newIDs[cgid] = struct{}{}
-				if t.targetCgroupID == 0 {
-					t.targetCgroupID = cgid
+				if t.targetCgroupID.Load() == 0 {
+					t.targetCgroupID.Store(cgid)
 				}
 			} else if err != nil {
 				logger.Debug("Could not get cgroup ID from path", zap.Error(err), zap.String("cgroup_path", cgroupPath))
@@ -400,7 +400,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 			logger.Debug("Set target cgroup IDs for in-kernel filtering", zap.Int("count", len(newIDs)))
 		}
 		if len(newIDs) > 0 && os.Getenv("PODTRACE_DISABLE_USERSPACE_CGROUP_FILTER") == "1" {
-			t.useUserspaceCgroupFilter = false
+			t.useUserspaceCgroupFilter.Store(false)
 		}
 	} else {
 		t.storeCgroupIDs(newIDs)
@@ -410,7 +410,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		zap.Int("cgroup_count", len(t.cgroupPaths)),
 		zap.Uint32("container_pid", t.containerPID),
 		zap.Int("target_cgroup_id_count", len(newIDs)),
-		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter),
+		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()),
 		zap.Bool("replace", replace))
 	return nil
 }
@@ -426,18 +426,36 @@ func (t *Tracer) syncTargetCgroupMap() error {
 
 	ids := t.loadCgroupIDs()
 
-	// Clear existing keys.
-	var key uint64
-	var val uint8
-	iter := targetMap.Iterate()
-	keys := make([]uint64, 0, len(ids))
-	for iter.Next(&key, &val) {
-		keys = append(keys, key)
-	}
-	for _, k := range keys {
-		_ = targetMap.Delete(&k)
+	// When the target set empties, disable the filter before draining the
+	// map so there is no window where the flag is on and the allowlist is
+	// empty (which would drop every event in the kernel).
+	if len(ids) == 0 {
+		if err := t.setCgroupFilterEnabled(false); err != nil {
+			return err
+		}
 	}
 
+	// Diff-based sync: delete stale keys and upsert current ones. The old
+	// clear-then-repopulate approach opened a window during which the
+	// allowlist was empty on every resync.
+	var key uint64
+	var val uint8
+	stale := make([]uint64, 0)
+	iter := targetMap.Iterate()
+	for iter.Next(&key, &val) {
+		if _, want := ids[key]; !want {
+			stale = append(stale, key)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("iterate target_cgroup_ids: %w", err)
+	}
+	for _, k := range stale {
+		staleKey := k
+		if err := targetMap.Delete(&staleKey); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return err
+		}
+	}
 	one := uint8(1)
 	for cgid := range ids {
 		cgidCopy := cgid
@@ -445,7 +463,32 @@ func (t *Tracer) syncTargetCgroupMap() error {
 			return err
 		}
 	}
+
+	if len(ids) > 0 {
+		return t.setCgroupFilterEnabled(true)
+	}
 	return nil
+}
+
+// setCgroupFilterEnabled flips the dedicated flag the BPF side consults
+// before applying the in-kernel cgroup prefilter. The previous design probed
+// target_cgroup_ids for key 0 to decide whether the filter was active, but
+// the Go side never writes key 0 (real cgroup IDs are never 0), so the
+// prefilter silently allowed everything.
+func (t *Tracer) setCgroupFilterEnabled(enabled bool) error {
+	if t.collection == nil || t.collection.Maps == nil {
+		return nil
+	}
+	flagMap, ok := t.collection.Maps["cgroup_filter_enabled"]
+	if !ok || flagMap == nil {
+		return nil
+	}
+	var zero uint32
+	val := uint32(0)
+	if enabled {
+		val = 1
+	}
+	return flagMap.Update(&zero, &val, ebpf.UpdateAny)
 }
 
 func readFirstPIDFromCgroupProcs(cgroupPath string) uint32 {
@@ -593,22 +636,29 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		go t.serveManagementAPI(ctx, config.ManagementPort)
 	}
 
-	var eventsCollected int64
-	var eventsFiltered int64
-	var eventsParsed int64
-	var filteringDisabled bool
+	// Shared between the monitoring goroutine and the event-reader
+	// goroutine below, so they must be atomic.
+	var eventsCollected atomic.Int64
+	var eventsFiltered atomic.Int64
+	var eventsParsed atomic.Int64
+	var filteringDisabled atomic.Bool
 	startTime := time.Now()
-	eventCollectionTicker := time.NewTicker(5 * time.Second)
-	defer eventCollectionTicker.Stop()
 
 	logger.Info("Starting event collection",
 		zap.String("cgroup_path", t.cgroupPath),
 		zap.Uint32("container_pid", t.containerPID),
-		zap.Uint64("target_cgroup_id", t.targetCgroupID),
+		zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
 		zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
-		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter))
+		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
 
 	go func() {
+		// The ticker must live inside this goroutine: it used to be created
+		// in Start() with a deferred Stop(), which fired as soon as Start()
+		// returned — the ticker never delivered a tick, leaving the
+		// filter-auto-disable fallback and the attachment diagnostics below
+		// permanently dead.
+		eventCollectionTicker := time.NewTicker(5 * time.Second)
+		defer eventCollectionTicker.Stop()
 		filterAutoDisableHintLogged := false
 		for {
 			select {
@@ -616,19 +666,19 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 				return
 			case <-eventCollectionTicker.C:
 				elapsed := time.Since(startTime)
-				if !filteringDisabled && eventsParsed > 10 && eventsCollected == 0 && elapsed > 10*time.Second {
+				if !filteringDisabled.Load() && eventsParsed.Load() > 10 && eventsCollected.Load() == 0 && elapsed > 10*time.Second {
 					if config.AllowCgroupFilterAutoDisable() {
 						logger.Warn("Events being parsed but all filtered - disabling filtering as fallback",
-							zap.Int64("events_parsed", eventsParsed),
-							zap.Int64("events_filtered", eventsFiltered),
-							zap.Int64("events_collected", eventsCollected),
-							zap.Uint64("target_cgroup_id", t.targetCgroupID),
+							zap.Int64("events_parsed", eventsParsed.Load()),
+							zap.Int64("events_filtered", eventsFiltered.Load()),
+							zap.Int64("events_collected", eventsCollected.Load()),
+							zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
 							zap.String("cgroup_path", t.cgroupPath),
-							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter))
-						filteringDisabled = true
+							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
+						filteringDisabled.Store(true)
 						t.cgroupWriteMu.Lock()
-						t.useUserspaceCgroupFilter = false
-						t.targetCgroupID = 0
+						t.useUserspaceCgroupFilter.Store(false)
+						t.targetCgroupID.Store(0)
 						t.storeCgroupIDs(map[uint64]struct{}{})
 						if err := t.syncTargetCgroupMap(); err == nil {
 							logger.Info("Cleared kernel-side cgroup filter")
@@ -637,27 +687,27 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 					} else if !filterAutoDisableHintLogged {
 						filterAutoDisableHintLogged = true
 						logger.Warn("Events parsed but all filtered; automatic cgroup filter disable not applied. Set PODTRACE_ALLOW_CGROUP_FILTER_DISABLE=1 to allow clearing cgroup filters as a last resort",
-							zap.Int64("events_parsed", eventsParsed),
-							zap.Int64("events_filtered", eventsFiltered),
-							zap.Int64("events_collected", eventsCollected),
+							zap.Int64("events_parsed", eventsParsed.Load()),
+							zap.Int64("events_filtered", eventsFiltered.Load()),
+							zap.Int64("events_collected", eventsCollected.Load()),
 							zap.String("cgroup_path", t.cgroupPath))
 					}
-				} else if eventsParsed == 0 && elapsed > 15*time.Second {
+				} else if eventsParsed.Load() == 0 && elapsed > 15*time.Second {
 					logger.Warn("No events parsed from ring buffer after 15 seconds - check eBPF program attachment",
-						zap.Uint64("target_cgroup_id", t.targetCgroupID),
+						zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
 						zap.String("cgroup_path", t.cgroupPath),
 						zap.Duration("elapsed", elapsed),
 						zap.Int("links_attached", len(t.links)))
 					logger.Warn("If running in a container (e.g. DaemonSet), ensure host /sys/fs/cgroup and /proc are mounted and PODTRACE_CGROUP_BASE / PODTRACE_PROC_BASE point at them; see installation doc 'Running as a DaemonSet'")
-				} else if eventsCollected == 0 && eventsParsed > 0 && elapsed > 10*time.Second {
+				} else if eventsCollected.Load() == 0 && eventsParsed.Load() > 0 && elapsed > 10*time.Second {
 					logger.Warn("Events parsed but none collected - filtering may be too strict",
-						zap.Int64("events_parsed", eventsParsed),
-						zap.Int64("events_filtered", eventsFiltered),
-						zap.Uint64("target_cgroup_id", t.targetCgroupID),
+						zap.Int64("events_parsed", eventsParsed.Load()),
+						zap.Int64("events_filtered", eventsFiltered.Load()),
+						zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
 						zap.String("cgroup_path", t.cgroupPath),
-						zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter),
+						zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()),
 						zap.Duration("elapsed", elapsed))
-					if t.useUserspaceCgroupFilter {
+					if t.useUserspaceCgroupFilter.Load() {
 						logger.Warn("Running in a container (e.g. DaemonSet)? Set PODTRACE_CGROUP_BASE and PODTRACE_PROC_BASE to the host's cgroup and proc mount paths so the target pod's cgroup is visible and filtering can match events",
 							zap.String("cgroup_base", config.CgroupBasePath),
 							zap.String("proc_base", config.ProcBasePath))
@@ -731,7 +781,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 			processingStart := time.Now()
 			event := parser.ParseEvent(record.RawSample)
 			if event != nil {
-				eventsParsed++
+				eventsParsed.Add(1)
 				if stackMap != nil && event.StackKey != 0 {
 					var stack stackTraceValue
 					key := event.StackKey
@@ -790,15 +840,14 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 
 				allowed := true
 				cgroupIDs := t.loadCgroupIDs()
-				if filteringDisabled {
+				if filteringDisabled.Load() {
 					// Fallback mode: allow all events
 					allowed = true
 				} else if len(cgroupIDs) > 0 && event.CgroupID != 0 {
 					_, allowed = cgroupIDs[event.CgroupID]
 					if !allowed {
-						eventsFiltered++
 						// Log first few mismatches for debugging, then throttle
-						if eventsFiltered <= 5 || time.Now().Unix()%10 == 0 {
+						if eventsFiltered.Add(1) <= 5 || time.Now().Unix()%10 == 0 {
 							logger.Debug("Event filtered by cgroup ID mismatch",
 								zap.Uint64("event_cgroup_id", event.CgroupID),
 								zap.Int("target_cgroup_id_count", len(cgroupIDs)),
@@ -806,11 +855,10 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 								zap.String("process", event.ProcessName))
 						}
 					}
-				} else if t.useUserspaceCgroupFilter {
+				} else if t.useUserspaceCgroupFilter.Load() {
 					allowed = t.filter.IsPIDInCgroup(event.PID)
 					if !allowed {
-						eventsFiltered++
-						if eventsFiltered <= 5 || time.Now().Unix()%10 == 0 {
+						if eventsFiltered.Add(1) <= 5 || time.Now().Unix()%10 == 0 {
 							logger.Debug("Event filtered by userspace PID cgroup check",
 								zap.Uint32("pid", event.PID),
 								zap.String("process", event.ProcessName),
@@ -818,11 +866,11 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						}
 					}
 				} else {
-					if eventsParsed <= 5 {
+					if eventsParsed.Load() <= 5 {
 						logger.Debug("No cgroup filtering active, allowing all events",
 							zap.Uint64("event_cgroup_id", event.CgroupID),
-							zap.Uint64("target_cgroup_id", t.targetCgroupID),
-							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter))
+							zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
+							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
 					}
 				}
 
@@ -832,8 +880,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						parser.PutEvent(event)
 						return
 					case eventChan <- event:
-						eventsCollected++
-						if eventsCollected <= 5 {
+						if eventsCollected.Add(1) <= 5 {
 							logger.Debug("Event collected",
 								zap.Uint64("cgroup_id", event.CgroupID),
 								zap.Uint32("pid", event.PID),

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -58,6 +58,13 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		{Name: "btf", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/btf"}}},
 		{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 		{Name: "cgroup", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/cgroup"}}},
+		// debugfs/tracefs are required to attach tracepoints (sched_switch,
+		// inet_sock_set_state, ...). Without them every tracepoint silently
+		// failed to attach in session Jobs, so cpu-filtered sessions
+		// collected nothing; the agent DaemonSet has carried these mounts
+		// all along.
+		{Name: "debugfs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/debug"}}},
+		{Name: "tracefs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/kernel/tracing"}}},
 		// Exporter bundle: the CLI reads bundle.yaml to resolve the
 		// exporter endpoint/credentials the session should push to.
 		{
@@ -95,6 +102,8 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
 		{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
 		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+		{Name: "debugfs", MountPath: "/sys/kernel/debug", ReadOnly: true},
+		{Name: "tracefs", MountPath: "/sys/kernel/tracing", ReadOnly: true},
 		{Name: "exporter", MountPath: "/etc/podtrace/exporter", ReadOnly: true},
 		{Name: "exporter-credential", MountPath: "/etc/podtrace/exporter-credential", ReadOnly: true},
 		{Name: "rundir", MountPath: "/var/run/podtrace"},

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -141,9 +141,22 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	if !strings.Contains(args, "--termination-message-path /dev/termination-log") {
 		t.Errorf("missing --termination-message-path: %v", spec.Template.Spec.Containers[0].Args)
 	}
-	// Mount count sanity: bpf, btf, proc, cgroup, exporter, exporter-credential, rundir = 7.
-	if n := len(spec.Template.Spec.Containers[0].VolumeMounts); n != 7 {
-		t.Errorf("main container mounts=%d want 7", n)
+	// Mount count sanity: bpf, btf, proc, cgroup, debugfs, tracefs,
+	// exporter, exporter-credential, rundir = 9.
+	if n := len(spec.Template.Spec.Containers[0].VolumeMounts); n != 9 {
+		t.Errorf("main container mounts=%d want 9", n)
+	}
+	// Tracepoints (sched_switch, inet_sock_set_state, ...) attach via
+	// tracefs; without these mounts every tracepoint silently failed in
+	// session Jobs while the agent DaemonSet carried them.
+	mountPaths := make(map[string]bool)
+	for _, m := range spec.Template.Spec.Containers[0].VolumeMounts {
+		mountPaths[m.MountPath] = true
+	}
+	for _, required := range []string{"/sys/kernel/debug", "/sys/kernel/tracing"} {
+		if !mountPaths[required] {
+			t.Errorf("session Job is missing the %s mount required for tracepoint attach", required)
+		}
 	}
 	// Sidecar must not be present when TracerConfig.Session.SidecarUploader is false.
 	if len(spec.Template.Spec.InitContainers) != 0 {

--- a/scripts/verify-bpf-load.sh
+++ b/scripts/verify-bpf-load.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Load the freshly built BPF object through the real kernel verifier inside a
+# privileged container. Catches verifier rejections (instruction-budget
+# blowups, modified-ctx dereferences, ...) that compilation cannot: container
+# images build from the stub vmlinux.h, where the BTF-only programs compile
+# to no-ops and therefore never face the verifier in CI or in-cluster.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ARCH="$(go env GOARCH)"
+OBJ="internal/ebpf/embedded/podtrace.${ARCH}.bpf.o"
+[[ -f "${OBJ}" ]] || {
+	echo "missing ${OBJ} — run 'make build' first" >&2
+	exit 1
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+cp hack/bpfloadtest/main.go "${WORKDIR}/"
+cp "${OBJ}" "${WORKDIR}/object.bpf.o"
+EBPF_VERSION="$(grep 'github.com/cilium/ebpf' go.mod | awk '{print $2}')"
+(
+	cd "${WORKDIR}"
+	printf 'module bpfloadtest\n\ngo 1.24\n' >go.mod
+	go mod edit -require "github.com/cilium/ebpf@${EBPF_VERSION}"
+	go mod tidy >/dev/null 2>&1
+	CGO_ENABLED=0 go build -o loader .
+)
+
+docker run --rm --privileged -v "${WORKDIR}":/lt debian:bookworm-slim /lt/loader /lt/object.bpf.o


### PR DESCRIPTION
- **TCP state-change events**: `tcp:tcp_set_state` was removed in kernel 4.16; migrated to `sock:inet_sock_set_state` with a `_Static_assert`-pinned layout and an `IPPROTO_TCP` filter.
- **OOM-kill events**: `oom:oom_kill_process` never existed upstream; migrated to `oom:mark_victim` (victim pid on all kernels, comm via a sanity-checked `__data_loc` on 6.10+).
- **Exec events**: the `do_execveat_common` kprobe pair was never registered for attach, is unattachable on modern kernels (isra-mangled symbol), and read a kernel `struct filename *` as a user string; replaced with the stable  `sched:sched_process_exec` tracepoint.
- **Close events**: `__close_fd` was removed in kernel 5.11; migrated to `close_fd` and registered as an optional probe.
- **Connect targets**: the kretprobes read entry arguments from clobbered registers, so `EVENT_CONNECT` targets were essentially never populated. The destination sockaddr (the kernel copy) is now captured at kprobe entry and
  emitted at return, with DNS-name correlation for IPv4 and IPv6.
- **In-kernel cgroup prefiltering**: the filter probed `target_cgroup_ids` for a key-0 sentinel that Go never wrote, so it never ran. A dedicated `cgroup_filter_enabled` flag map activates it, the Go side syncs the ID map
  by diff (no more clear-then-repopulate window), and foreign-context tracepoints (softirq, OOM killer) bypass it so the userspace filter can judge the real subject.
- **Tracepoints in session Jobs**: the Job spec never mounted debugfs/tracefs, so every tracepoint silently failed to attach in sessions (the agent DaemonSet always had the mounts). Surfaced by the new non-empty-failMsg requirement, fixed, and pinned by a regression test.

## Corrected event data

- **sched_switch measured ON-CPU time but reported it as blocked time**, the exact inverse. It now measures real off-CPU intervals, with emission deferred to the task's next switch-out so cgroup/comm/TGID attribution is correct (events previously carried a TID). Verified on kind: a `sleep 1`  loop reports `Max block time: 1001.74ms`.
- **`tcp_retransmit_skb` used a pre-5.10 layout** (ports read from inside `state`, daddr landing on `family`+saddr); rebuilt on the modern layout with pinned offsets and IPv6 support. Ports in TCP tracepoints are host order, the old handlers double-swapped them.
- **Nested probe pairs clobbered each other's state**: `start_times` and its companion maps were keyed by thread only, so an outer uprobe doing I/O (getaddrinfo→UDP, SSL_*→tcp_sendmsg, execve→openat2, pthread_mutex→futex)
  lost its start timestamp and its event was silently dropped. All per-pair state is now keyed by `(pid_tgid, probe_pair)`.
- **`memcached_get` and `PQexec` return pointers, not statuses**, successful calls reported truncated heap pointers as errors and failures reported success. NULL now maps to error, non-NULL to success.
- **FastCGI URI/method carried trailing binary junk** (`\x0fSCRIPT_FILENAME…`); copies are now bounded by the NV-pair valueLen at spec-exact offsets.
- **gRPC inspection ignored `ITER_UBUF`** (plain `send()` on kernels ≥ 6.0), reading a garbage pointer; it now shares the FastCGI `msghdr_user_base()` resolver (moved to `protocols.h`).
- **DNS dotted-quads displayed byte-reversed** (8.8.4.4 → "4.4.8.8"); display strings are now host-order while map keys and raw fields stay network-order.
- **`vfs_rename`/`vfs_unlink` used pre-5.12 signatures** on all kernels; the layout is now selected at load time via
  `bpf_core_type_exists(struct renamedata)`.

## Reliability

- The tracer's monitoring goroutine never ran: its ticker was created in `Start()` with a deferred `Stop()` that fired as soon as `Start()` returned.
  The filter-auto-disable fallback and attachment diagnostics are now live, and the state shared with the event-reader goroutine became atomic.
- Page faults are sampled 1-in-64 per CPU instead of emitting one ringbuf event plus a stack capture per fault (which saturated the ring buffer).
- `dns_inflight`/`dns_resolved`/`dns_resolved6` are LRU maps; unanswered queries no longer leak until the map bricks.
- Every tracepoint now has a non-empty attach-failure message, pinned by `TestTracepointProbes_NoSilentFailures`, silent attach failures are how two dead tracepoints went unnoticed.
- `tcp_sendmsg`/`tcp_recvmsg` no longer delete the `socket_conns` blackboard entry they merely read, which starved the HTTP/Redis consumers of their URL.
- The Makefile BPF prerequisite list covered only 4 of the 13 included C files; incremental builds silently skipped the rest.