### PR TITLE
fix: wire systemNamespace override, OTLP headers, exporter close order

### DIFF
--- a/internal/agent/exporter_loader.go
+++ b/internal/agent/exporter_loader.go
@@ -46,6 +46,14 @@ func LoadBundle(ctx context.Context, c client.Client, systemNamespace string, po
 	var sec corev1.Secret
 	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: systemNamespace}, &sec); err == nil {
 		payload.Credential = sec.Data[bundle.CredentialKey]
+		for k, v := range sec.Data {
+			if rest, ok := strings.CutPrefix(k, bundle.SecretHeaderKeyPrefix); ok && rest != "" {
+				if payload.SecretHeaders == nil {
+					payload.SecretHeaders = map[string]string{}
+				}
+				payload.SecretHeaders[rest] = string(v)
+			}
+		}
 	} else if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("get bundle Secret: %w", err)
 	}

--- a/internal/agent/otlp_event_exporter.go
+++ b/internal/agent/otlp_event_exporter.go
@@ -42,9 +42,12 @@ func newOTLPSpanExporter(b *BundlePayload) (*otlptrace.Exporter, error) {
 	if b.Insecure {
 		opts = append(opts, otlptracehttp.WithInsecure())
 	}
-	if len(b.Headers) > 0 || b.HeaderName != "" {
+	if len(b.Headers) > 0 || len(b.SecretHeaders) > 0 || b.HeaderName != "" {
 		headers := map[string]string{}
 		for k, v := range b.Headers {
+			headers[k] = v
+		}
+		for k, v := range b.SecretHeaders {
 			headers[k] = v
 		}
 		if b.HeaderName != "" && len(b.Credential) > 0 {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,7 +53,13 @@ type AgentReconciler struct {
 
 	exporterCacheMu sync.Mutex
 	exporterCache   map[CRKey]cachedExporter
+	// pendingClose accumulates exporters displaced during a reconcile.
+	pendingClose []tracer.Exporter
 }
+
+// exporterCloseTimeout bounds the asynchronous flush+shutdown of displaced
+// exporters so an unreachable collector cannot pin goroutines forever.
+const exporterCloseTimeout = 15 * time.Second
 
 type cachedExporter struct {
 	bundleRV string
@@ -212,6 +219,13 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	r.Router.Publish(rules)
 
+	// Publish holds the router's write lock, and Export holds the read lock
+	// for its whole duration — so once Publish returns, no in-flight Export
+	// references a displaced exporter and they can be flushed and closed.
+	// Done asynchronously: Close blocks on ForceFlush/Shutdown against the
+	// collector, and this reconciler is single-threaded.
+	r.closeDisplacedExporters()
+
 	if r.CategoryGate != nil {
 		categories := unionCategoriesFromRules(rules)
 		if err := r.CategoryGate(categories); err != nil {
@@ -282,7 +296,7 @@ func (r *AgentReconciler) obtainExporter(key CRKey, bundle *BundlePayload) (trac
 			return entry.exporter, nil
 		}
 		if entry.exporter != nil {
-			_ = entry.exporter.Close(context.Background())
+			r.pendingClose = append(r.pendingClose, entry.exporter)
 		}
 	}
 	exporter, err := r.ExporterBuilder(bundle, key)
@@ -299,12 +313,31 @@ func (r *AgentReconciler) obtainExporter(key CRKey, bundle *BundlePayload) (trac
 // releaseExporter closes and removes the cached exporter for key.
 func (r *AgentReconciler) releaseExporter(key CRKey) {
 	r.exporterCacheMu.Lock()
+	defer r.exporterCacheMu.Unlock()
 	entry, ok := r.exporterCache[key]
 	delete(r.exporterCache, key)
-	r.exporterCacheMu.Unlock()
 	if ok && entry.exporter != nil {
-		_ = entry.exporter.Close(context.Background())
+		r.pendingClose = append(r.pendingClose, entry.exporter)
 	}
+}
+
+// closeDisplacedExporters drains the pendingClose accumulator and closes
+// each exporter on a background goroutine with a bounded context.
+func (r *AgentReconciler) closeDisplacedExporters() {
+	r.exporterCacheMu.Lock()
+	displaced := r.pendingClose
+	r.pendingClose = nil
+	r.exporterCacheMu.Unlock()
+	if len(displaced) == 0 {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), exporterCloseTimeout)
+		defer cancel()
+		for _, e := range displaced {
+			_ = e.Close(ctx)
+		}
+	}()
 }
 
 // reapStaleExporters closes exporters whose CR keys did not appear in

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,14 +30,33 @@ type fakeExporter struct {
 	closed  int
 }
 
-func (e *fakeExporter) Name() string                                          { return e.name }
-func (e *fakeExporter) Export(_ context.Context, batch []*events.Event) error { e.exports++; return nil }
+func (e *fakeExporter) Name() string { return e.name }
+func (e *fakeExporter) Export(_ context.Context, batch []*events.Event) error {
+	e.exports++
+	return nil
+}
 func (e *fakeExporter) Close(_ context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.closed++
 	return nil
 }
+
+// waitForCloses polls until the exporter's Close count reaches want.
+// Displaced exporters are closed asynchronously after Router.Publish (so a
+// hung collector cannot stall the reconcile loop), hence the wait.
+func waitForCloses(t *testing.T, e *fakeExporter, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if e.Closes() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("exporter %s Close count = %d, want %d", e.name, e.Closes(), want)
+}
+
 func (e *fakeExporter) Closes() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -313,9 +333,7 @@ func TestReconcile_BundleRotationRebuildsExporter(t *testing.T) {
 	if calls != 2 {
 		t.Errorf("ExporterBuilder calls = %d, want 2 (rotation should rebuild)", calls)
 	}
-	if old.Closes() != 1 {
-		t.Errorf("old exporter Close count = %d, want 1", old.Closes())
-	}
+	waitForCloses(t, old, 1)
 	if new1.Closes() != 0 {
 		t.Errorf("new exporter Close count = %d, want 0", new1.Closes())
 	}
@@ -398,9 +416,7 @@ func TestReconcile_NoMatchedPodsReleasesExporter(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if exp.Closes() != 1 {
-		t.Errorf("stale exporter Close count = %d, want 1", exp.Closes())
-	}
+	waitForCloses(t, exp, 1)
 	if _, ok := r.exporterCache[CRKey{Namespace: ns, Name: "pt"}]; ok {
 		t.Error("exporter cache should be empty after release")
 	}
@@ -687,9 +703,7 @@ func TestReconcile_ReapsExportersForDeletedCRs(t *testing.T) {
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
 		t.Fatal(err)
 	}
-	if stale.Closes() != 1 {
-		t.Errorf("stale exporter Close count = %d, want 1", stale.Closes())
-	}
+	waitForCloses(t, stale, 1)
 }
 
 func TestReconcile_TargetsChannelKeepLatest(t *testing.T) {
@@ -815,17 +829,21 @@ func TestObtainAndReleaseExporter(t *testing.T) {
 	if calls != 2 {
 		t.Errorf("calls = %d, want 2", calls)
 	}
-	if exp1.(*fakeExporter).Closes() != 1 {
-		t.Errorf("old exporter Close count = %d, want 1", exp1.(*fakeExporter).Closes())
+	// Displaced exporters accumulate in pendingClose and are only closed by
+	// the post-Publish drain — never inline, where in-flight Export calls
+	// could still route into them.
+	if exp1.(*fakeExporter).Closes() != 0 {
+		t.Errorf("old exporter closed before drain, count = %d", exp1.(*fakeExporter).Closes())
 	}
+	r.closeDisplacedExporters()
+	waitForCloses(t, exp1.(*fakeExporter), 1)
 
 	r.releaseExporter(key)
 	if _, ok := r.exporterCache[key]; ok {
 		t.Error("releaseExporter did not remove the entry")
 	}
-	if exp3.(*fakeExporter).Closes() != 1 {
-		t.Errorf("released exporter Close count = %d, want 1", exp3.(*fakeExporter).Closes())
-	}
+	r.closeDisplacedExporters()
+	waitForCloses(t, exp3.(*fakeExporter), 1)
 	r.releaseExporter(key)
 }
 
@@ -856,12 +874,11 @@ func TestReapStaleExporters(t *testing.T) {
 	}
 	active := map[CRKey]struct{}{{Namespace: "ns", Name: "a"}: {}}
 	r.reapStaleExporters(active)
+	r.closeDisplacedExporters()
 	if a.Closes() != 0 {
 		t.Errorf("active exporter must not be closed, got %d", a.Closes())
 	}
-	if b.Closes() != 1 {
-		t.Errorf("stale exporter close count = %d, want 1", b.Closes())
-	}
+	waitForCloses(t, b, 1)
 	if _, ok := r.exporterCache[CRKey{Namespace: "ns", Name: "b"}]; ok {
 		t.Error("stale entry not removed")
 	}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -114,9 +114,9 @@ func (r *Router) Name() string { return "cr-router" }
 
 func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	r.mu.RLock()
+	defer r.mu.RUnlock()
 	rules := r.rules
 	enricher := r.enricher
-	r.mu.RUnlock()
 
 	if len(rules) == 0 || len(batch) == 0 {
 		return nil

--- a/internal/kubernetes/nodespawn/container_selection_test.go
+++ b/internal/kubernetes/nodespawn/container_selection_test.go
@@ -1,0 +1,78 @@
+package nodespawn
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	pkgkube "github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func multiContainerPod() *corev1.Pod {
+	running := corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "node-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar", ContainerID: "containerd://aaa", State: running},
+				{Name: "app", ContainerID: "containerd://bbb", State: running},
+			},
+		},
+	}
+}
+
+// TestResolveTargetNodes_HonorsContainerName is a regression test: the
+// node-spawn path used to ignore --container entirely and embed the FIRST
+// running container's ID into --preresolved-pod, so multi-container pods got
+// the sidecar traced while argv showed the requested name.
+func TestResolveTargetNodes_HonorsContainerName(t *testing.T) {
+	cs := fake.NewSimpleClientset(multiContainerPod())
+
+	got, err := ResolveTargetNodes(context.Background(), cs, pkgkube.TargetSelection{
+		DefaultNamespace: "default",
+		Pods:             []string{"web"},
+		ContainerName:    "app",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTargetNodes: %v", err)
+	}
+	refs := got.ByNode["node-1"]
+	if len(refs) != 1 {
+		t.Fatalf("refs on node-1 = %d, want 1", len(refs))
+	}
+	if refs[0].ContainerName != "app" || refs[0].ContainerID != "bbb" {
+		t.Errorf("resolved container = %s/%s, want app/bbb", refs[0].ContainerName, refs[0].ContainerID)
+	}
+}
+
+func TestResolveTargetNodes_MissingContainerNameFails(t *testing.T) {
+	cs := fake.NewSimpleClientset(multiContainerPod())
+
+	_, err := ResolveTargetNodes(context.Background(), cs, pkgkube.TargetSelection{
+		DefaultNamespace: "default",
+		Pods:             []string{"web"},
+		ContainerName:    "no-such-container",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no-such-container") {
+		t.Fatalf("expected a missing-container error, got %v", err)
+	}
+}
+
+func TestPickRunningContainer_ByName(t *testing.T) {
+	pod := multiContainerPod()
+	if cs := pickRunningContainer(pod, "app"); cs == nil || cs.Name != "app" {
+		t.Errorf("pickRunningContainer(pod, app) = %+v, want the app container", cs)
+	}
+	if cs := pickRunningContainer(pod, ""); cs == nil || cs.Name != "sidecar" {
+		t.Errorf("pickRunningContainer(pod, \"\") = %+v, want first running (sidecar)", cs)
+	}
+	if cs := pickRunningContainer(pod, "ghost"); cs != nil {
+		t.Errorf("pickRunningContainer(pod, ghost) = %+v, want nil", cs)
+	}
+}

--- a/internal/kubernetes/nodespawn/target_nodes.go
+++ b/internal/kubernetes/nodespawn/target_nodes.go
@@ -55,6 +55,7 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 	tolByNode := map[string][]corev1.Toleration{}
 	tolSeen := map[string]map[string]struct{}{}
 	unscheduled := []PodRef{}
+	missingContainer := []PodRef{}
 
 	add := func(pod *corev1.Pod) {
 		ref := PodRef{Namespace: pod.Namespace, Name: pod.Name}
@@ -62,7 +63,12 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 			unscheduled = append(unscheduled, ref)
 			return
 		}
-		if cs := pickRunningContainer(pod); cs != nil {
+		cs := pickRunningContainer(pod, sel.ContainerName)
+		if sel.ContainerName != "" && cs == nil {
+			missingContainer = append(missingContainer, ref)
+			return
+		}
+		if cs != nil {
 			ref.ContainerName = cs.Name
 			if idx := indexAfterScheme(cs.ContainerID); idx >= 0 {
 				ref.ContainerID = cs.ContainerID[idx:]
@@ -110,6 +116,10 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 		}
 	}
 
+	if len(missingContainer) > 0 && len(byNode) == 0 {
+		return NodeTargets{}, fmt.Errorf("nodespawn: no matched pod has a running container named %q: %s",
+			sel.ContainerName, joinRefs(missingContainer))
+	}
 	if len(unscheduled) > 0 && len(byNode) == 0 {
 		return NodeTargets{}, fmt.Errorf("nodespawn: %d target pod(s) are not yet scheduled to a node: %s",
 			len(unscheduled), joinRefs(unscheduled))
@@ -132,17 +142,21 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 	return out, nil
 }
 
-// pickRunningContainer returns the first container in the pod whose State is
-// Running.
-func pickRunningContainer(pod *corev1.Pod) *corev1.ContainerStatus {
+// pickRunningContainer returns the running container matching name, or the
+// first running container when name is empty.
+func pickRunningContainer(pod *corev1.Pod, name string) *corev1.ContainerStatus {
 	if pod == nil {
 		return nil
 	}
 	for i := range pod.Status.ContainerStatuses {
 		cs := &pod.Status.ContainerStatuses[i]
-		if cs.State.Running != nil && cs.ContainerID != "" {
-			return cs
+		if cs.State.Running == nil || cs.ContainerID == "" {
+			continue
 		}
+		if name != "" && cs.Name != name {
+			continue
+		}
+		return cs
 	}
 	return nil
 }

--- a/internal/kubernetes/nodespawn/target_nodes_test.go
+++ b/internal/kubernetes/nodespawn/target_nodes_test.go
@@ -186,7 +186,7 @@ func TestPickRunningContainer_PrefersRunning(t *testing.T) {
 			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
 		}},
 	}}}
-	cs := pickRunningContainer(p)
+	cs := pickRunningContainer(p, "")
 	if cs == nil || cs.Name != "b" {
 		t.Fatalf("expected to pick the Running container, got %+v", cs)
 	}
@@ -202,7 +202,7 @@ func TestPickRunningContainer_RejectsAllNonRunning(t *testing.T) {
 			p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
 				{Name: "x", ContainerID: "containerd://xxx", State: st},
 			}}}
-			if cs := pickRunningContainer(p); cs != nil {
+			if cs := pickRunningContainer(p, ""); cs != nil {
 				t.Errorf("must not pick a %s container, got %+v", name, cs)
 			}
 		})
@@ -217,7 +217,7 @@ func TestPickRunningContainer_RejectsRunningWithEmptyID(t *testing.T) {
 			Running: &corev1.ContainerStateRunning{},
 		}},
 	}}}
-	if cs := pickRunningContainer(p); cs != nil {
+	if cs := pickRunningContainer(p, ""); cs != nil {
 		t.Errorf("Running container with empty ID must be rejected, got %+v", cs)
 	}
 }

--- a/internal/operator/exporter_bundle.go
+++ b/internal/operator/exporter_bundle.go
@@ -1,10 +1,15 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 	"github.com/podtrace/podtrace/pkg/exporter/bundle"
@@ -46,7 +51,7 @@ import (
 // (filters, thresholds, generation) are written. Production callers
 // (continuous PodTrace + bounded PodTraceSession) always pass a
 // populated bundlePolicyInputs.
-func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) (map[string]string, *podtracev1alpha1.SecretKeySelector, error) {
+func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) (map[string]string, *podtracev1alpha1.SecretKeySelector, *podtracev1alpha1.LocalObjectReference, error) {
 	data := map[string]string{
 		"version": bundle.CurrentVersion,
 		"type":    string(ec.Spec.Type),
@@ -65,7 +70,7 @@ func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.Export
 	switch ec.Spec.Type {
 	case podtracev1alpha1.ExporterTypeOTLP:
 		if ec.Spec.OTLP == nil {
-			return nil, nil, fmt.Errorf("spec.otlp is required when type=otlp")
+			return nil, nil, nil, fmt.Errorf("spec.otlp is required when type=otlp")
 		}
 		data["endpoint"] = ec.Spec.OTLP.Endpoint
 		if ec.Spec.OTLP.Protocol != "" {
@@ -74,42 +79,55 @@ func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.Export
 			data["protocol"] = string(podtracev1alpha1.OTLPProtocolHTTP)
 		}
 		data["insecure"] = boolString(ec.Spec.OTLP.Insecure)
+		// The loop must visit every header: an early return on the first
+		// ValueFrom header used to drop all literal headers declared after
+		// it (and silently ignore further ValueFrom headers) while the
+		// readiness evaluator still reported the configuration healthy.
+		var credRef *podtracev1alpha1.SecretKeySelector
 		for _, h := range ec.Spec.OTLP.Headers {
 			if h.ValueFrom != nil {
-				sk := h.ValueFrom.DeepCopy()
+				if credRef != nil {
+					return nil, nil, nil, fmt.Errorf(
+						"at most one headers[].valueFrom is supported (the bundle carries a single credential); move additional secret-backed headers into headersFromSecret")
+				}
 				data["header_secret_name"] = h.Name
-				return data, sk, nil
+				credRef = h.ValueFrom.DeepCopy()
+				continue
 			}
 			data["headers."+h.Name] = h.Value
 		}
-		return data, nil, nil
+		var headersFrom *podtracev1alpha1.LocalObjectReference
+		if ec.Spec.OTLP.HeadersFromSecret != nil && ec.Spec.OTLP.HeadersFromSecret.Name != "" {
+			headersFrom = ec.Spec.OTLP.HeadersFromSecret.DeepCopy()
+		}
+		return data, credRef, headersFrom, nil
 
 	case podtracev1alpha1.ExporterTypeJaeger:
 		if ec.Spec.Jaeger == nil {
-			return nil, nil, fmt.Errorf("spec.jaeger is required when type=jaeger")
+			return nil, nil, nil, fmt.Errorf("spec.jaeger is required when type=jaeger")
 		}
 		data["endpoint"] = ec.Spec.Jaeger.Endpoint
-		return data, nil, nil
+		return data, nil, nil, nil
 
 	case podtracev1alpha1.ExporterTypeZipkin:
 		if ec.Spec.Zipkin == nil {
-			return nil, nil, fmt.Errorf("spec.zipkin is required when type=zipkin")
+			return nil, nil, nil, fmt.Errorf("spec.zipkin is required when type=zipkin")
 		}
 		data["endpoint"] = ec.Spec.Zipkin.Endpoint
-		return data, nil, nil
+		return data, nil, nil, nil
 
 	case podtracev1alpha1.ExporterTypeSplunk:
 		if ec.Spec.Splunk == nil {
-			return nil, nil, fmt.Errorf("spec.splunk is required when type=splunk")
+			return nil, nil, nil, fmt.Errorf("spec.splunk is required when type=splunk")
 		}
 		data["endpoint"] = ec.Spec.Splunk.Endpoint
 		data["header_secret_name"] = "X-SF-TOKEN"
 		ref := ec.Spec.Splunk.TokenSecretRef
-		return data, &ref, nil
+		return data, &ref, nil, nil
 
 	case podtracev1alpha1.ExporterTypeDataDog:
 		if ec.Spec.DataDog == nil {
-			return nil, nil, fmt.Errorf("spec.datadog is required when type=datadog")
+			return nil, nil, nil, fmt.Errorf("spec.datadog is required when type=datadog")
 		}
 		site := ec.Spec.DataDog.Site
 		if site == "" {
@@ -123,11 +141,45 @@ func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.Export
 		}
 		data["header_secret_name"] = "DD-API-KEY"
 		ref := ec.Spec.DataDog.APIKeySecretRef
-		return data, &ref, nil
+		return data, &ref, nil, nil
 
 	default:
-		return nil, nil, fmt.Errorf("unsupported exporter type %q", ec.Spec.Type)
+		return nil, nil, nil, fmt.Errorf("unsupported exporter type %q", ec.Spec.Type)
 	}
+}
+
+// buildBundleSecretData materializes the bundle Secret contents: the single
+// credential (bundle.CredentialKey) when credRef is set, plus one
+// "header.<name>" entry per key of the headersFromSecret Secret. The latter
+// used to be checked for existence by the readiness evaluator but never
+// rendered anywhere, so OTLP auth supplied exclusively via headersFromSecret
+// reported Ready=True while agents exported with no headers at all.
+func buildBundleSecretData(ctx context.Context, c client.Client, ecNamespace string, credRef *podtracev1alpha1.SecretKeySelector, headersFrom *podtracev1alpha1.LocalObjectReference) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	if credRef != nil {
+		var src corev1.Secret
+		if err := c.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: credRef.Name}, &src); err != nil {
+			return nil, fmt.Errorf("get credential Secret %s/%s: %w", ecNamespace, credRef.Name, err)
+		}
+		val, ok := src.Data[credRef.Key]
+		if !ok {
+			return nil, fmt.Errorf("secret %s/%s has no key %q", ecNamespace, credRef.Name, credRef.Key)
+		}
+		out[bundle.CredentialKey] = val
+	}
+	if headersFrom != nil {
+		var src corev1.Secret
+		if err := c.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: headersFrom.Name}, &src); err != nil {
+			return nil, fmt.Errorf("get headersFromSecret Secret %s/%s: %w", ecNamespace, headersFrom.Name, err)
+		}
+		for k, v := range src.Data {
+			out[bundle.SecretHeaderKeyPrefix+k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }
 
 // bundlePolicyInputs is the operator-side view of the policy a CR

--- a/internal/operator/exporter_bundle_branches_test.go
+++ b/internal/operator/exporter_bundle_branches_test.go
@@ -18,7 +18,7 @@ func TestRenderBundlePayload_MissingVariantErrors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := renderBundlePayload(nil, ec("missing-"+tc.name, podtracev1alpha1.ExporterConfigSpec{
+			_, _, _, err := renderBundlePayload(nil, ec("missing-"+tc.name, podtracev1alpha1.ExporterConfigSpec{
 				Type: tc.typ,
 			}), nil)
 			if err == nil {
@@ -29,7 +29,7 @@ func TestRenderBundlePayload_MissingVariantErrors(t *testing.T) {
 }
 
 func TestRenderBundlePayload_DataDogExplicitEndpoint(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("dd-ep", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("dd-ep", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeDataDog,
 		DataDog: &podtracev1alpha1.DataDogExporter{
 			Site:            "datadoghq.eu",
@@ -52,7 +52,7 @@ func TestRenderBundlePayload_DataDogExplicitEndpoint(t *testing.T) {
 }
 
 func TestRenderBundlePayload_TargetNamespacesSorted(t *testing.T) {
-	data, _, err := renderBundlePayload(nil, ec("ns", podtracev1alpha1.ExporterConfigSpec{
+	data, _, _, err := renderBundlePayload(nil, ec("ns", podtracev1alpha1.ExporterConfigSpec{
 		Type:   podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
 	}), []string{"team-c", "team-a", "team-b"})

--- a/internal/operator/exporter_bundle_headers_test.go
+++ b/internal/operator/exporter_bundle_headers_test.go
@@ -1,0 +1,118 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/pkg/exporter/bundle"
+)
+
+func otlpSpec(otlp *podtracev1alpha1.OTLPExporter) podtracev1alpha1.ExporterConfigSpec {
+	return podtracev1alpha1.ExporterConfigSpec{
+		Type: podtracev1alpha1.ExporterTypeOTLP,
+		OTLP: otlp,
+	}
+}
+
+// TestRenderBundlePayload_LiteralHeadersAfterValueFrom is a regression test:
+// the header loop used to return on the first ValueFrom header, silently
+// dropping every literal header declared after it.
+func TestRenderBundlePayload_LiteralHeadersAfterValueFrom(t *testing.T) {
+	data, credRef, _, err := renderBundlePayload(nil, ec("otlp-mixed", otlpSpec(&podtracev1alpha1.OTLPExporter{
+		Endpoint: "collector:4318",
+		Headers: []podtracev1alpha1.OTLPHeader{
+			{Name: "X-Tenant", Value: "team-a"},
+			{Name: "Authorization", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"}},
+			{Name: "X-Env", Value: "prod"},
+		},
+	})), nil)
+	if err != nil {
+		t.Fatalf("renderBundlePayload: %v", err)
+	}
+	if credRef == nil || credRef.Name != "auth" || credRef.Key != "token" {
+		t.Errorf("credRef = %+v, want auth/token", credRef)
+	}
+	if data["header_secret_name"] != "Authorization" {
+		t.Errorf("header_secret_name = %q, want Authorization", data["header_secret_name"])
+	}
+	for key, want := range map[string]string{
+		"headers.X-Tenant": "team-a",
+		"headers.X-Env":    "prod",
+	} {
+		if data[key] != want {
+			t.Errorf("data[%q] = %q, want %q (literal headers after a ValueFrom header must not be dropped)", key, data[key], want)
+		}
+	}
+}
+
+// TestRenderBundlePayload_MultipleValueFromRejected: the bundle wire format
+// carries a single credential, so a second ValueFrom header must be a loud
+// error instead of being silently ignored while readiness reports healthy.
+func TestRenderBundlePayload_MultipleValueFromRejected(t *testing.T) {
+	_, _, _, err := renderBundlePayload(nil, ec("otlp-two-creds", otlpSpec(&podtracev1alpha1.OTLPExporter{
+		Endpoint: "collector:4318",
+		Headers: []podtracev1alpha1.OTLPHeader{
+			{Name: "Authorization", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "a", Key: "k"}},
+			{Name: "X-Other", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "b", Key: "k"}},
+		},
+	})), nil)
+	if err == nil {
+		t.Fatal("expected an error for two ValueFrom headers, got nil")
+	}
+}
+
+// TestBuildBundleSecretData_HeadersFromSecret is a regression test:
+// headersFromSecret was checked by the readiness evaluator but never
+// rendered into the bundle, so agents exported with no headers while the
+// ExporterConfig reported Ready=True.
+func TestBuildBundleSecretData_HeadersFromSecret(t *testing.T) {
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "extra-headers", Namespace: "user-ns"},
+		Data: map[string][]byte{
+			"X-Scope-OrgID": []byte("tenant-1"),
+			"X-Api-Key":     []byte("s3cr3t"),
+		},
+	}
+	cred := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "user-ns"},
+		Data:       map[string][]byte{"token": []byte("Bearer xyz")},
+	}
+	c := fake.NewClientBuilder().WithObjects(src, cred).Build()
+
+	got, err := buildBundleSecretData(context.Background(), c, "user-ns",
+		&podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"},
+		&podtracev1alpha1.LocalObjectReference{Name: "extra-headers"})
+	if err != nil {
+		t.Fatalf("buildBundleSecretData: %v", err)
+	}
+	for key, want := range map[string]string{
+		bundle.CredentialKey:                           "Bearer xyz",
+		bundle.SecretHeaderKeyPrefix + "X-Scope-OrgID": "tenant-1",
+		bundle.SecretHeaderKeyPrefix + "X-Api-Key":     "s3cr3t",
+	} {
+		if string(got[key]) != want {
+			t.Errorf("secret data[%q] = %q, want %q", key, got[key], want)
+		}
+	}
+}
+
+func TestCandidateSystemNamespaces(t *testing.T) {
+	cases := []struct {
+		effective, fallback string
+		want                int
+	}{
+		{"podtrace-system", "podtrace-system", 1},
+		{"", "podtrace-system", 1},
+		{"custom-ns", "podtrace-system", 2},
+	}
+	for _, tc := range cases {
+		if got := candidateSystemNamespaces(tc.effective, tc.fallback); len(got) != tc.want {
+			t.Errorf("candidateSystemNamespaces(%q, %q) = %v, want %d entries", tc.effective, tc.fallback, got, tc.want)
+		}
+	}
+}

--- a/internal/operator/exporter_bundle_test.go
+++ b/internal/operator/exporter_bundle_test.go
@@ -18,7 +18,7 @@ func ec(name string, spec podtracev1alpha1.ExporterConfigSpec) *podtracev1alpha1
 }
 
 func TestRenderBundlePayload_OTLP_LiteralHeaders(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("otlp-lit", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("otlp-lit", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeOTLP,
 		OTLP: &podtracev1alpha1.OTLPExporter{
 			Endpoint: "otel:4318",
@@ -51,7 +51,7 @@ func TestRenderBundlePayload_OTLP_LiteralHeaders(t *testing.T) {
 }
 
 func TestRenderBundlePayload_OTLP_SecretBackedHeader(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("otlp-sec", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("otlp-sec", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeOTLP,
 		OTLP: &podtracev1alpha1.OTLPExporter{
 			Endpoint: "otel:4318",
@@ -77,7 +77,7 @@ func TestRenderBundlePayload_OTLP_SecretBackedHeader(t *testing.T) {
 }
 
 func TestRenderBundlePayload_Jaeger_NoCredentials(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("j", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("j", podtracev1alpha1.ExporterConfigSpec{
 		Type:   podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "http://jaeger:14268"},
 	}), nil)
@@ -93,7 +93,7 @@ func TestRenderBundlePayload_Jaeger_NoCredentials(t *testing.T) {
 }
 
 func TestRenderBundlePayload_Zipkin(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("z", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("z", podtracev1alpha1.ExporterConfigSpec{
 		Type:   podtracev1alpha1.ExporterTypeZipkin,
 		Zipkin: &podtracev1alpha1.ZipkinExporter{Endpoint: "http://zipkin:9411/api/v2/spans"},
 	}), nil)
@@ -103,7 +103,7 @@ func TestRenderBundlePayload_Zipkin(t *testing.T) {
 }
 
 func TestRenderBundlePayload_Splunk_RequiresTokenSecret(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("s", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("s", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeSplunk,
 		Splunk: &podtracev1alpha1.SplunkExporter{
 			Endpoint:       "https://splunk:8088",
@@ -122,7 +122,7 @@ func TestRenderBundlePayload_Splunk_RequiresTokenSecret(t *testing.T) {
 }
 
 func TestRenderBundlePayload_DataDog_DefaultSite(t *testing.T) {
-	data, secret, err := renderBundlePayload(nil, ec("d", podtracev1alpha1.ExporterConfigSpec{
+	data, secret, _, err := renderBundlePayload(nil, ec("d", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeDataDog,
 		DataDog: &podtracev1alpha1.DataDogExporter{
 			APIKeySecretRef: podtracev1alpha1.SecretKeySelector{Name: "dd", Key: "api"},
@@ -140,7 +140,7 @@ func TestRenderBundlePayload_DataDog_DefaultSite(t *testing.T) {
 }
 
 func TestRenderBundlePayload_ErrorOnMissingVariant(t *testing.T) {
-	_, _, err := renderBundlePayload(nil, ec("broken", podtracev1alpha1.ExporterConfigSpec{
+	_, _, _, err := renderBundlePayload(nil, ec("broken", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterTypeOTLP,
 		// no OTLP block populated
 	}), nil)
@@ -150,7 +150,7 @@ func TestRenderBundlePayload_ErrorOnMissingVariant(t *testing.T) {
 }
 
 func TestRenderBundlePayload_UnknownType(t *testing.T) {
-	_, _, err := renderBundlePayload(nil, ec("xxx", podtracev1alpha1.ExporterConfigSpec{
+	_, _, _, err := renderBundlePayload(nil, ec("xxx", podtracev1alpha1.ExporterConfigSpec{
 		Type: podtracev1alpha1.ExporterType("made-up"),
 	}), nil)
 	if err == nil {
@@ -160,7 +160,7 @@ func TestRenderBundlePayload_UnknownType(t *testing.T) {
 
 func TestRenderBundlePayload_SamplePercent(t *testing.T) {
 	pct := int32(25)
-	data, _, err := renderBundlePayload(nil, ec("s", podtracev1alpha1.ExporterConfigSpec{
+	data, _, _, err := renderBundlePayload(nil, ec("s", podtracev1alpha1.ExporterConfigSpec{
 		Type:          podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger:        &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
 		SamplePercent: &pct,
@@ -207,7 +207,7 @@ func TestRenderBundlePayload_FullPolicyPropagation(t *testing.T) {
 		SamplePercent: &ecPct,
 	})
 
-	data, _, err := renderBundlePayload(policyFromPodTrace(pt), ecObj, nil)
+	data, _, _, err := renderBundlePayload(policyFromPodTrace(pt), ecObj, nil)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestRenderBundlePayload_NoPolicyOmitsKeys(t *testing.T) {
 		Type:   podtracev1alpha1.ExporterTypeJaeger,
 		Jaeger: &podtracev1alpha1.JaegerExporter{Endpoint: "j:14268"},
 	})
-	data, _, err := renderBundlePayload(policyFromPodTrace(pt), ecObj, nil)
+	data, _, _, err := renderBundlePayload(policyFromPodTrace(pt), ecObj, nil)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestRenderBundlePayload_AlwaysStampsVersion(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			data, _, err := renderBundlePayload(nil, ec("v-"+tc.name, tc.spec), nil)
+			data, _, _, err := renderBundlePayload(nil, ec("v-"+tc.name, tc.spec), nil)
 			if err != nil {
 				t.Fatalf("render: %v", err)
 			}

--- a/internal/operator/finalizer.go
+++ b/internal/operator/finalizer.go
@@ -58,6 +58,17 @@ func cleanupPodTraceChildren(ctx context.Context, c client.Client, pt *podtracev
 	return nil
 }
 
+// candidateSystemNamespaces returns the deduplicated set of namespaces a
+// CR's children may live in: the currently effective system namespace plus
+// the operator default (they differ when TracerConfig.spec.systemNamespace
+// is set, and the effective one may have changed between create and delete).
+func candidateSystemNamespaces(effective, fallback string) []string {
+	if effective == "" || effective == fallback {
+		return []string{fallback}
+	}
+	return []string{effective, fallback}
+}
+
 // cleanupPodTraceSessionChildren deletes all resources this PodTraceSession
 // owns across namespaces:
 //

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -53,8 +53,10 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if !pt.DeletionTimestamp.IsZero() {
-		if err := cleanupPodTraceChildren(ctx, r.Client, &pt, r.SystemNamespace); err != nil {
-			return ctrl.Result{}, err
+		for _, ns := range candidateSystemNamespaces(r.effectiveSystemNamespace(ctx), r.SystemNamespace) {
+			if err := cleanupPodTraceChildren(ctx, r.Client, &pt, ns); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 		if removeFinalizer(&pt) {
 			if err := r.Update(ctx, &pt); err != nil {
@@ -207,10 +209,15 @@ func (r *PodTraceReconciler) exporterConfigToPodTraces(ctx context.Context, obj 
 }
 
 func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) error {
-	systemNS := r.SystemNamespace
+	// The bundle must live where agents read it. Agents are launched with
+	// --system-namespace set to the TracerConfig's systemNamespace override
+	// (tracerconfig_daemonset.go), so writing to the operator default here
+	// made continuous tracing silently export nothing whenever the override
+	// was set: agents looked in a namespace the operator never wrote.
+	systemNS := r.effectiveSystemNamespace(ctx)
 	name := ExporterBundleName(pt.UID)
 
-	payload, credSecretRef, err := renderBundlePayload(policyFromPodTrace(pt), ec, targetNamespaces)
+	payload, credSecretRef, headersFrom, err := renderBundlePayload(policyFromPodTrace(pt), ec, targetNamespaces)
 	if err != nil {
 		return err
 	}
@@ -239,8 +246,8 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 		return fmt.Errorf("bundle ConfigMap: %w", err)
 	}
 
-	if credSecretRef != nil {
-		credData, err := r.loadCredentialSecret(ctx, ec.Namespace, *credSecretRef)
+	if credSecretRef != nil || headersFrom != nil {
+		credData, err := buildBundleSecretData(ctx, r.Client, ec.Namespace, credSecretRef, headersFrom)
 		if err != nil {
 			return fmt.Errorf("load credential Secret: %w", err)
 		}
@@ -270,6 +277,19 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 		}
 	}
 	return nil
+}
+
+// effectiveSystemNamespace returns the namespace agents read bundles from:
+// the default TracerConfig's spec.systemNamespace override when set,
+// otherwise the operator default. Bundles must be written (and cleaned up)
+// there, mirroring the --system-namespace the rendered DaemonSet passes to
+// agents.
+func (r *PodTraceReconciler) effectiveSystemNamespace(ctx context.Context) string {
+	var tc podtracev1alpha1.TracerConfig
+	if err := r.Get(ctx, types.NamespacedName{Name: "default"}, &tc); err == nil && tc.Spec.SystemNamespace != "" {
+		return tc.Spec.SystemNamespace
+	}
+	return r.SystemNamespace
 }
 
 // loadCredentialSecret reads a SecretKeySelector from the ExporterConfig's

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -59,8 +59,11 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Deletion path: clean up cross-namespace Jobs, then release the finalizer.
 	if !session.DeletionTimestamp.IsZero() {
-		if err := cleanupPodTraceSessionChildren(ctx, r.Client, &session, r.SystemNamespace); err != nil {
-			return ctrl.Result{}, err
+		sessionNS := systemNamespaceForSession(r.resolveTracerConfig(ctx), r.SystemNamespace)
+		for _, ns := range candidateSystemNamespaces(sessionNS, r.SystemNamespace) {
+			if err := cleanupPodTraceSessionChildren(ctx, r.Client, &session, ns); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 		forgetReportObservations(session.Namespace, session.Name)
 		if removeFinalizer(&session) {

--- a/internal/operator/session_bundle.go
+++ b/internal/operator/session_bundle.go
@@ -47,7 +47,7 @@ func SessionBundleName(sessionUID types.UID) string {
 func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string) error {
 	name := SessionBundleName(s.UID)
 
-	payload, credSecretRef, err := renderBundlePayload(policyFromSession(s), ec, nil)
+	payload, credSecretRef, headersFrom, err := renderBundlePayload(policyFromSession(s), ec, nil)
 	if err != nil {
 		return fmt.Errorf("render session bundle payload: %w", err)
 	}
@@ -82,8 +82,8 @@ func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtra
 		return fmt.Errorf("session bundle ConfigMap: %w", err)
 	}
 
-	if credSecretRef != nil {
-		credData, err := loadCredentialSecret(ctx, c, ec.Namespace, *credSecretRef)
+	if credSecretRef != nil || headersFrom != nil {
+		credData, err := buildBundleSecretData(ctx, c, ec.Namespace, credSecretRef, headersFrom)
 		if err != nil {
 			return fmt.Errorf("load session credential Secret: %w", err)
 		}

--- a/internal/operator/tracerconfig_controller.go
+++ b/internal/operator/tracerconfig_controller.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -103,19 +104,24 @@ func (r *TracerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // so controller-runtime requeues the TracerConfig whenever an owned
 // resource's status changes.
 func (r *TracerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// The generation/label predicate must apply to the TracerConfig watch
+	// ONLY. A builder-level WithEventFilter also filtered every Owns()
+	// watch — and DaemonSet status updates do not bump metadata.generation
+	// (RBAC objects have no generation semantics at all), so readyAgents/
+	// desiredAgents and the Ready condition went permanently stale and
+	// manual drift in owned RBAC was never repaired.
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("tracerconfig").
-		For(&podtracev1alpha1.TracerConfig{}).
+		For(&podtracev1alpha1.TracerConfig{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.LabelChangedPredicate{},
+		))).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		WithEventFilter(predicate.Or(
-			predicate.GenerationChangedPredicate{},
-			predicate.LabelChangedPredicate{},
-		)).
 		WithOptions(defaultControllerOptions()).
 		Complete(r)
 }

--- a/pkg/exporter/bundle/bundle.go
+++ b/pkg/exporter/bundle/bundle.go
@@ -25,6 +25,12 @@ import (
 // resolved credential material in the companion Secret.
 const CredentialKey = "credential"
 
+// SecretHeaderKeyPrefix prefixes bundle-Secret keys that carry one
+// Secret-backed header each (OTLP headersFromSecret): "header.<name>" maps
+// to header <name>. Kept in the Secret — never the ConfigMap — because the
+// values are credential material.
+const SecretHeaderKeyPrefix = "header."
+
 const CurrentVersion = "v2"
 
 type Type string
@@ -101,6 +107,11 @@ type Payload struct {
 	PolicyGeneration int64 `yaml:"policyGeneration,omitempty"`
 
 	Credential []byte `yaml:"-"`
+
+	// SecretHeaders carries the OTLP headersFromSecret entries, loaded from
+	// the bundle Secret's SecretHeaderKeyPrefix keys. Never serialized:
+	// the values are credential material.
+	SecretHeaders map[string]string `yaml:"-"`
 
 	ResourceVer string `yaml:"-"`
 }


### PR DESCRIPTION
## Summary

Fixes a set of correctness issues across the operator, the agent, and the node-spawn path. The common thread is silent failure: stale status that looked healthy, resources orphaned with no signal, auth headers dropped while readiness reported `Ready=True`, and spans lost while the exported-events counter kept counting.

## Operator

- **TracerConfig status tracked nothing.** The builder-level `WithEventFilter(GenerationChanged ∨ LabelChanged)` also filtered every `Owns()` watch, and DaemonSet **status** updates do not bump `metadata.generation` (RBAC objects have no generation semantics at all). `status.readyAgents`/`desiredAgents` and the Ready condition were computed once and then went permanently stale, and manual drift in owned RBAC was never repaired. The predicate now applies to the TracerConfig watch only (`For(..., builder.WithPredicates(...))`); owned-resource watches keep default predicates. Verified live on kind: deleting an agent pod flips `status.readyAgents` to 2/3 within seconds and back on recovery.
- **`spec.systemNamespace` override is now fully wired.** Bundles are written to the namespace agents actually read from (`effectiveSystemNamespace`, mirroring the `--system-namespace` the rendered DaemonSet passes) instead of the operator default — with an override set, continuous tracing silently exported nothing because agents looked in a namespace the operator never wrote. Deletion paths for both PodTrace and PodTraceSession now clean `candidateSystemNamespaces()` — the override namespace **and** the operator default (the override may have changed between create and delete; deletes are NotFound-idempotent) — instead of orphaning session Jobs, bundle ConfigMaps/Secrets, and copied object-store credential Secrets forever.
- **OTLP header rendering visits every header.** The loop used to `return` on the first `ValueFrom` header, dropping all literal headers declared after it and silently ignoring further `ValueFrom` headers — while the readiness evaluator reported the configuration healthy. A second `ValueFrom` header is now a loud render error (the bundle wire format carries a single credential; use `headersFromSecret` for more).
- **`headersFromSecret` is rendered for the first time.** It was checked for existence by the readiness evaluator but never rendered anywhere, so OTLP auth supplied exclusively through it reported `Ready=True` while agents exported with no headers. Each key of the referenced Secret is now materialized into the bundle Secret as a `header.<name>` entry (new `bundle.SecretHeaderKeyPrefix`); the agent loader exposes them as `Payload.SecretHeaders` and the OTLP exporter merges them into the request headers. Values live only in the Secret, never the ConfigMap.

## Agent

- **No more silent span loss on bundle rotation, CR deletion, or scale-to-zero.** Exporters were closed *before* `Router.Publish` swapped them out of the rule set, so the dispatch goroutine kept routing events into exporters whose shutdown was in progress — spans were discarded while `events_exported_total` counted them as exported. Two coordinated changes: `Router.Export` holds the read lock for its whole duration, making `Publish` (write lock) a drain barrier for in-flight exports; displaced exporters accumulate in `pendingClose` and are flushed and closed only after `Publish`, asynchronously with a 15s bound — which also stops an unreachable collector from stalling the single-threaded reconcile loop.

## Node-spawn

- **`--container` is honored.** The pre-resolution path embedded the *first* running container's ID into `--preresolved-pod`, so multi-container pods got the sidecar traced while argv showed the requested name. The requested container is now resolved by name; if no matched pod has a running container by that name, the command fails with a clear error instead of silently tracing the wrong container.

- `headersFromSecret` reaches the **agent** (continuous PodTrace) path. The session CLI (`--exporter-from-file`) has no OTLP header support of any kind today — pre-existing gap, tracked separately.
- The multiple-`ValueFrom` error surfaces at bundle render time (the CR goes Degraded); schema-level CEL enforcement would be a follow-up.