### PR TITLE
fix: export spans once, surface exporter errors, tee event pipeline

### DIFF
--- a/cmd/podtrace/event_tee.go
+++ b/cmd/podtrace/event_tee.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// teeEvents fans every event from source out to one primary channel plus
+// `auxiliary` additional channels. Go channels deliver each value to exactly
+// one receiver, so the report loop, metrics handler, tracing handler, and
+// profiling correlator — which all used to receive from the same channel —
+// each saw only a random disjoint subset of events, and with --filter events
+// randomly bypassed the filter pipeline entirely.
+func teeEvents(ctx context.Context, source <-chan *events.Event, auxiliary int) (chan *events.Event, []chan *events.Event) {
+	primary := make(chan *events.Event, config.EventChannelBufferSize)
+	aux := make([]chan *events.Event, auxiliary)
+	for i := range aux {
+		aux[i] = make(chan *events.Event, config.EventChannelBufferSize)
+	}
+
+	go func() {
+		defer close(primary)
+		for _, c := range aux {
+			defer close(c)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-source:
+				if !ok {
+					return
+				}
+				select {
+				case primary <- ev:
+				case <-ctx.Done():
+					return
+				}
+				for _, c := range aux {
+					select {
+					case c <- ev:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	return primary, aux
+}

--- a/cmd/podtrace/event_tee_test.go
+++ b/cmd/podtrace/event_tee_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestTeeEvents_EveryConsumerSeesEveryEvent is a regression test: the
+// report loop, metrics handler, and tracing handler all used to receive from
+// the SAME channel, so each saw only a random disjoint subset of events.
+func TestTeeEvents_EveryConsumerSeesEveryEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan *events.Event, 16)
+	primary, aux := teeEvents(ctx, source, 2)
+	if len(aux) != 2 {
+		t.Fatalf("aux channels = %d, want 2", len(aux))
+	}
+
+	const total = 10
+	for i := 0; i < total; i++ {
+		source <- &events.Event{PID: uint32(i + 1)}
+	}
+	close(source)
+
+	count := func(name string, ch <-chan *events.Event) {
+		t.Helper()
+		got := 0
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					if got != total {
+						t.Errorf("%s received %d events, want %d", name, got, total)
+					}
+					return
+				}
+				got++
+			case <-deadline:
+				t.Fatalf("%s timed out after %d events", name, got)
+			}
+		}
+	}
+
+	count("primary", primary)
+	count("aux[0]", aux[0])
+	count("aux[1]", aux[1])
+}
+
+// TestTeeEvents_SlowAuxiliaryDoesNotStallPrimary: auxiliary sends are
+// non-blocking, so a consumer that never drains its channel must not stop
+// the report pipeline.
+func TestTeeEvents_SlowAuxiliaryDoesNotStallPrimary(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan *events.Event)
+	primary, _ := teeEvents(ctx, source, 1) // aux never read
+
+	const total = 20000
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < total; i++ {
+			source <- &events.Event{PID: uint32(i + 1)}
+		}
+		close(source)
+	}()
+
+	got := 0
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case _, ok := <-primary:
+			if !ok {
+				if got != total {
+					t.Fatalf("primary received %d events, want %d", got, total)
+				}
+				<-done
+				return
+			}
+			got++
+		case <-deadline:
+			t.Fatalf("primary stalled after %d events (auxiliary backpressure leaked)", got)
+		}
+	}
+}

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -512,7 +512,34 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 
 	eventChan := make(chan *events.Event, config.EventChannelBufferSize)
+
+	// Every consumer below must see EVERY event, so the source channel is
+	// teed: a channel delivers each value to exactly one receiver, and the
+	// previous shared-channel wiring partitioned events randomly between
+	// the report loop, metrics, tracing, and profiling.
+	tracingActive := tracingManager != nil && enableTracing
+	profilingActive := (enableProfiling || config.ProfilingEnabled) &&
+		podInfo != nil && podInfo.PodIP != ""
+	auxiliaryConsumers := 0
+	for _, active := range []bool{enableMetrics, tracingActive, profilingActive} {
+		if active {
+			auxiliaryConsumers++
+		}
+	}
+	reportChan := eventChan
+	var auxiliaryChans []chan *events.Event
+	if auxiliaryConsumers > 0 {
+		reportChan, auxiliaryChans = teeEvents(ctx, eventChan, auxiliaryConsumers)
+	}
+	nextAuxiliary := 0
+	takeAuxiliary := func() chan *events.Event {
+		c := auxiliaryChans[nextAuxiliary]
+		nextAuxiliary++
+		return c
+	}
+
 	if enableMetrics {
+		metricsChan := takeAuxiliary()
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -525,7 +552,7 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 				select {
 				case <-ctx.Done():
 					return
-				case event, ok := <-eventChan:
+				case event, ok := <-metricsChan:
 					if !ok {
 						return
 					}
@@ -545,7 +572,8 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
-	if tracingManager != nil && enableTracing {
+	if tracingActive {
+		tracingChan := takeAuxiliary()
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -558,7 +586,7 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 				select {
 				case <-ctx.Done():
 					return
-				case event, ok := <-eventChan:
+				case event, ok := <-tracingChan:
 					if !ok {
 						return
 					}
@@ -579,9 +607,9 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	if enableProfiling || config.ProfilingEnabled {
 		config.ProfilingEnabled = true // ensures MetricsEnablePprof() returns true
 		ports := parsePprofPorts(config.ProfilingPprofPorts)
-		if podInfo != nil && podInfo.PodIP != "" {
+		if profilingActive {
 			profilingHandler = profiling.NewHandler(podInfo.PodIP, ports)
-			go profilingHandler.Run(ctx, eventChan)
+			go profilingHandler.Run(ctx, takeAuxiliary())
 		} else {
 			logger.Warn("Profiling requested but pod IP is not available; skipping pprof discovery")
 		}
@@ -593,7 +621,7 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	enrichedChan := eventChan
+	enrichedChan := reportChan
 
 	filteredChan := enrichedChan
 	if eventFilter != "" {

--- a/cmd/podtrace/report_uploader.go
+++ b/cmd/podtrace/report_uploader.go
@@ -90,8 +90,19 @@ func runReportUploader(ctx context.Context, opts reportUploaderOptions) error {
 		}
 	}
 
-	return uploadIfPresent(ctx, opts)
+	// With --max-wait 0 the wait above ends BECAUSE ctx was cancelled —
+	// SIGTERM is the designed trigger ("wait until SIGTERM, then upload
+	// what exists"). Running the upload on that cancelled context made it
+	// fail instantly on the exact path it exists for, so detach it and
+	// apply a bounded grace period instead.
+	uploadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), uploadGracePeriod)
+	defer cancel()
+	return uploadIfPresent(uploadCtx, opts)
 }
+
+// uploadGracePeriod bounds the post-shutdown upload so a hung sink cannot
+// keep the sidecar alive past the pod's termination grace period.
+const uploadGracePeriod = 30 * time.Second
 
 func waitForFile(ctx context.Context, path string, interval time.Duration) error {
 	ticker := time.NewTicker(interval)

--- a/cmd/podtrace/session_sink.go
+++ b/cmd/podtrace/session_sink.go
@@ -25,12 +25,22 @@ func finalizeDiagnoseOutputs(ctx context.Context, report string, d *diagnose.Dia
 	if summaryFile == "" && terminationMessagePath == "" && reportTo == "" {
 		return
 	}
+	// On the interrupt path ctx is already cancelled (Ctrl+C, Job deletion,
+	// node drain), and every sink write derives a timeout from it — so the
+	// report was silently lost on exactly the early-termination cases the
+	// sinks exist for. Detach and bound with a grace period instead.
+	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalizeGracePeriod)
+	defer cancel()
 	node := os.Getenv("NODE_NAME")
 	summary := computeSessionSummary(d, node)
-	if err := emitSessionArtifacts(ctx, summary, report); err != nil {
+	if err := emitSessionArtifacts(finalizeCtx, summary, report); err != nil {
 		logger.Warn("emit session artifacts", zap.Error(err))
 	}
 }
+
+// finalizeGracePeriod bounds report/summary delivery after shutdown began so
+// a hung sink cannot exceed the pod's termination grace period.
+const finalizeGracePeriod = 30 * time.Second
 
 // SessionSummary is the compact, machine-readable summary the CLI emits
 // at the end of --diagnose. Matches the CRD's SessionSummary type

--- a/internal/diagnose/tracker/trace_tracker.go
+++ b/internal/diagnose/tracker/trace_tracker.go
@@ -20,6 +20,9 @@ type Trace struct {
 	EndTime   time.Time
 	Services  map[string]*ServiceInfo
 	mu        sync.RWMutex
+
+	exportedSpans int
+	lastUpdate    time.Time
 }
 
 type Span struct {
@@ -74,6 +77,7 @@ func (tt *TraceTracker) ProcessEvent(event *events.Event, k8sContext interface{}
 	trace.mu.Lock()
 	defer trace.mu.Unlock()
 
+	trace.lastUpdate = time.Now()
 	if event.TimestampTime().Before(trace.StartTime) {
 		trace.StartTime = event.TimestampTime()
 	}
@@ -205,6 +209,107 @@ func (tt *TraceTracker) GetAllTraces() []*Trace {
 		traces = append(traces, trace)
 	}
 	return traces
+}
+
+// SnapshotForExport returns deep copies of traces carrying only the spans
+// that have not been handed to an exporter yet, and advances each trace's
+// watermark. This gives every span exactly-once export semantics — the old
+// behavior re-sent EVERY accumulated trace on every export tick, duplicating
+// spans in all backends. Traces updated more recently than settle ago are
+// skipped (unless force, used by shutdown) so a request's spans are not cut
+// off mid-assembly.
+//
+// The returned traces and spans are copies: exporters and the graph builder
+// may sort, mutate, and call UpdateDuration on them without racing
+// ProcessEvent, which keeps appending to the live objects under their locks.
+func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool) []*Trace {
+	tt.mu.RLock()
+	live := make([]*Trace, 0, len(tt.traces))
+	for _, trace := range tt.traces {
+		live = append(live, trace)
+	}
+	tt.mu.RUnlock()
+
+	now := time.Now()
+	out := make([]*Trace, 0, len(live))
+	for _, trace := range live {
+		trace.mu.Lock()
+		if !force && now.Sub(trace.lastUpdate) < settle {
+			trace.mu.Unlock()
+			continue
+		}
+		if trace.exportedSpans >= len(trace.Spans) {
+			trace.mu.Unlock()
+			continue
+		}
+		snapshot := cloneTraceLocked(trace, trace.exportedSpans)
+		trace.exportedSpans = len(trace.Spans)
+		trace.mu.Unlock()
+		out = append(out, snapshot)
+	}
+	return out
+}
+
+// SnapshotAll returns deep copies of every trace (all spans) without touching
+// export watermarks — for read-only consumers like the request-flow graph.
+func (tt *TraceTracker) SnapshotAll() []*Trace {
+	tt.mu.RLock()
+	live := make([]*Trace, 0, len(tt.traces))
+	for _, trace := range tt.traces {
+		live = append(live, trace)
+	}
+	tt.mu.RUnlock()
+
+	out := make([]*Trace, 0, len(live))
+	for _, trace := range live {
+		trace.mu.RLock()
+		out = append(out, cloneTraceLocked(trace, 0))
+		trace.mu.RUnlock()
+	}
+	return out
+}
+
+// cloneTraceLocked deep-copies a trace, including only spans from index
+// fromSpan on. Caller must hold trace.mu. Event pointers are shared — events
+// are not mutated after ProcessEvent — but every slice and map is copied.
+func cloneTraceLocked(trace *Trace, fromSpan int) *Trace {
+	out := &Trace{
+		TraceID:   trace.TraceID,
+		StartTime: trace.StartTime,
+		EndTime:   trace.EndTime,
+		Services:  make(map[string]*ServiceInfo, len(trace.Services)),
+		Spans:     make([]*Span, 0, len(trace.Spans)-fromSpan),
+	}
+	for k, v := range trace.Services {
+		info := *v
+		if v.Labels != nil {
+			info.Labels = make(map[string]string, len(v.Labels))
+			for lk, lv := range v.Labels {
+				info.Labels[lk] = lv
+			}
+		}
+		out.Services[k] = &info
+	}
+	for _, span := range trace.Spans[fromSpan:] {
+		s := &Span{
+			TraceID:      span.TraceID,
+			SpanID:       span.SpanID,
+			ParentSpanID: span.ParentSpanID,
+			Service:      span.Service,
+			Operation:    span.Operation,
+			StartTime:    span.StartTime,
+			Duration:     span.Duration,
+			Error:        span.Error,
+			Events:       make([]*events.Event, len(span.Events)),
+			Attributes:   make(map[string]string, len(span.Attributes)),
+		}
+		copy(s.Events, span.Events)
+		for ak, av := range span.Attributes {
+			s.Attributes[ak] = av
+		}
+		out.Spans = append(out.Spans, s)
+	}
+	return out
 }
 
 func (tt *TraceTracker) CleanupOldTraces(maxAge time.Duration) {

--- a/internal/diagnose/tracker/trace_tracker_snapshot_test.go
+++ b/internal/diagnose/tracker/trace_tracker_snapshot_test.go
@@ -1,0 +1,87 @@
+package tracker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/clock"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func snapshotEvent(traceID, spanID string) *events.Event {
+	return &events.Event{
+		TraceID:   traceID,
+		SpanID:    spanID,
+		Type:      events.EventHTTPReq,
+		Timestamp: clock.WallToBPFTimestamp(time.Now()),
+	}
+}
+
+// TestSnapshotForExport_ExactlyOnce is a regression test for the duplicate
+// re-export bug: every accumulated trace used to be pushed to every exporter
+// on every 5s tick, with nothing marking spans as exported.
+func TestSnapshotForExport_ExactlyOnce(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
+
+	first := tt.SnapshotForExport(time.Hour, true)
+	if len(first) != 1 || len(first[0].Spans) != 1 {
+		t.Fatalf("first snapshot = %d traces, want 1 trace with 1 span", len(first))
+	}
+
+	if second := tt.SnapshotForExport(time.Hour, true); len(second) != 0 {
+		t.Fatalf("second snapshot = %d traces, want 0 (spans must export exactly once)", len(second))
+	}
+
+	tt.ProcessEvent(snapshotEvent("t1", "s2"), nil)
+	third := tt.SnapshotForExport(time.Hour, true)
+	if len(third) != 1 || len(third[0].Spans) != 1 || third[0].Spans[0].SpanID != "s2" {
+		t.Fatalf("third snapshot must carry only the new span s2, got %+v", third)
+	}
+}
+
+// TestSnapshotForExport_SettleWindow: traces still receiving events are
+// skipped until idle for the settle interval, unless force (shutdown flush).
+func TestSnapshotForExport_SettleWindow(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
+
+	if got := tt.SnapshotForExport(time.Hour, false); len(got) != 0 {
+		t.Fatalf("just-updated trace must settle before export, got %d traces", len(got))
+	}
+	if got := tt.SnapshotForExport(time.Hour, true); len(got) != 1 {
+		t.Fatalf("force must flush settling traces, got %d traces", len(got))
+	}
+}
+
+// TestSnapshotAll_DeepCopyAndNoWatermark: graph/report consumers get deep
+// copies (mutating them must not touch live state — exporters used to sort
+// and mutate live spans, racing ProcessEvent) and do not consume the export
+// watermark.
+func TestSnapshotAll_DeepCopyAndNoWatermark(t *testing.T) {
+	tt := NewTraceTracker()
+	ev := snapshotEvent("t1", "s1")
+	ev.Target = "10.0.0.1:443"
+	tt.ProcessEvent(ev, nil)
+
+	snap := tt.SnapshotAll()
+	if len(snap) != 1 || len(snap[0].Spans) != 1 {
+		t.Fatalf("SnapshotAll = %+v, want 1 trace with 1 span", snap)
+	}
+	snap[0].Spans[0].Attributes["target"] = "mutated"
+	snap[0].Spans[0].Events = nil
+
+	live := tt.GetTrace("t1")
+	live.mu.RLock()
+	if live.Spans[0].Attributes["target"] != "10.0.0.1:443" {
+		t.Error("mutating a snapshot leaked into the live trace")
+	}
+	if len(live.Spans[0].Events) != 1 {
+		t.Error("snapshot shares the live Events slice header")
+	}
+	live.mu.RUnlock()
+
+	if got := tt.SnapshotForExport(time.Hour, true); len(got) != 1 {
+		t.Errorf("SnapshotAll must not consume the export watermark, export snapshot = %d traces", len(got))
+	}
+}

--- a/internal/ebpf/tracer/dns_timeout.go
+++ b/internal/ebpf/tracer/dns_timeout.go
@@ -129,6 +129,9 @@ func (t *Tracer) sweepDNSTimeouts(ctx context.Context, eventChan chan<- *events.
 			Details:     "timeout",
 			ProcessName: string(bytes.TrimRight(val.Comm[:], "\x00")),
 		}
+		if t.piiRedactor != nil {
+			t.piiRedactor.Redact(ev)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -38,8 +38,15 @@ func (r *Redactor) Redact(e *events.Event) {
 	if e == nil {
 		return
 	}
-	if r.redactDNSNames && e.Type == events.EventDNS {
-		e.Target = "[redacted]"
+	if r.redactDNSNames {
+		switch e.Type {
+		case events.EventDNS, events.EventDNSQuery:
+			e.Target = "[redacted]"
+		case events.EventConnect:
+			if e.Details != "" {
+				e.Details = "[redacted]"
+			}
+		}
 	}
 	for _, rule := range r.rules {
 		e.Target = rule.Pattern.ReplaceAllString(e.Target, rule.Replace)

--- a/internal/redactor/redactor_test.go
+++ b/internal/redactor/redactor_test.go
@@ -123,3 +123,27 @@ func TestRedact_DNSNames_Toggle(t *testing.T) {
 		t.Errorf("connect target should be untouched, got %q", c.Target)
 	}
 }
+
+// TestRedact_DNSNameBypasses is a regression test for the redaction
+// bypasses: EventDNSQuery (which also carries a query name in Target) and
+// the DNS-correlated hostname in EventConnect.Details were exempt from
+// PODTRACE_REDACT_DNS_NAMES.
+func TestRedact_DNSNameBypasses(t *testing.T) {
+	t.Setenv("PODTRACE_REDACT_DNS_NAMES", "true")
+	r := redactor.Default()
+
+	query := &events.Event{Type: events.EventDNSQuery, Target: "secret-host.internal"}
+	r.Redact(query)
+	if query.Target != "[redacted]" {
+		t.Errorf("EventDNSQuery target = %q, want [redacted]", query.Target)
+	}
+
+	connect := &events.Event{Type: events.EventConnect, Target: "10.0.0.8:00443", Details: "secret-host.internal"}
+	r.Redact(connect)
+	if connect.Details != "[redacted]" {
+		t.Errorf("EventConnect details = %q, want [redacted]", connect.Details)
+	}
+	if connect.Target != "10.0.0.8:00443" {
+		t.Errorf("EventConnect target must keep the ip:port, got %q", connect.Target)
+	}
+}

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -23,17 +24,17 @@ type DataDogExporter struct {
 
 // DataDog v0.4 trace format: outer array = list of traces, inner array = spans of one trace.
 type datadogSpan struct {
-	TraceID  uint64            `json:"trace_id"`
-	SpanID   uint64            `json:"span_id"`
-	ParentID uint64            `json:"parent_id"`
-	Name     string            `json:"name"`
-	Resource string            `json:"resource"`
-	Service  string            `json:"service"`
-	Type     string            `json:"type"`
-	Start    int64             `json:"start"`
-	Duration int64             `json:"duration"`
-	Error    int32             `json:"error"`
-	Meta     map[string]string `json:"meta"`
+	TraceID  uint64             `json:"trace_id"`
+	SpanID   uint64             `json:"span_id"`
+	ParentID uint64             `json:"parent_id"`
+	Name     string             `json:"name"`
+	Resource string             `json:"resource"`
+	Service  string             `json:"service"`
+	Type     string             `json:"type"`
+	Start    int64              `json:"start"`
+	Duration int64              `json:"duration"`
+	Error    int32              `json:"error"`
+	Meta     map[string]string  `json:"meta"`
 	Metrics  map[string]float64 `json:"metrics"`
 }
 
@@ -56,17 +57,18 @@ func (e *DataDogExporter) ExportTraces(traces []*tracker.Trace) error {
 		return nil
 	}
 
+	var errs []error
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
 
 		if err := e.exportTrace(t); err != nil {
-			continue
+			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *DataDogExporter) shouldSample(_ *tracker.Trace) bool {

--- a/internal/tracing/exporter/error_surface_test.go
+++ b/internal/tracing/exporter/error_surface_test.go
@@ -1,0 +1,69 @@
+package exporter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func failingServer(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+}
+
+func errorSurfaceTrace() []*tracker.Trace {
+	return []*tracker.Trace{{
+		TraceID: "0123456789abcdef0123456789abcdef",
+		Spans: []*tracker.Span{{
+			TraceID:    "0123456789abcdef0123456789abcdef",
+			SpanID:     "0123456789abcdef",
+			Operation:  "HTTP",
+			StartTime:  time.Now(),
+			Attributes: map[string]string{},
+			Events:     []*events.Event{{Type: events.EventHTTPReq}},
+		}},
+	}}
+}
+
+// TestExportTraces_SurfacesBackendFailures is a regression test: every
+// exporter used to swallow per-trace errors and return nil, which made the
+// manager's entire exporter-failure alerting layer unreachable dead code.
+func TestExportTraces_SurfacesBackendFailures(t *testing.T) {
+	srv := failingServer(http.StatusInternalServerError)
+	defer srv.Close()
+
+	traces := errorSurfaceTrace()
+
+	jaeger := &JaegerExporter{enabled: true, endpoint: srv.URL, client: srv.Client(), sampleRate: 1.0}
+	if err := jaeger.ExportTraces(traces); err == nil {
+		t.Error("jaeger: expected an error for a 500 backend, got nil")
+	}
+
+	zipkin := &ZipkinExporter{enabled: true, endpoint: srv.URL, client: srv.Client(), sampleRate: 1.0}
+	if err := zipkin.ExportTraces(traces); err == nil {
+		t.Error("zipkin: expected an error for a 500 backend, got nil")
+	}
+
+	datadog := &DataDogExporter{enabled: true, endpoint: srv.URL, client: srv.Client(), sampleRate: 1.0}
+	if err := datadog.ExportTraces(traces); err == nil {
+		t.Error("datadog: expected an error for a 500 backend, got nil")
+	}
+}
+
+// TestSplunkExportTraces_RejectsAuthFailure: Splunk never checked
+// resp.StatusCode, so a 401 from a bad HEC token looked exactly like
+// success.
+func TestSplunkExportTraces_RejectsAuthFailure(t *testing.T) {
+	srv := failingServer(http.StatusUnauthorized)
+	defer srv.Close()
+
+	splunk := &SplunkExporter{enabled: true, endpoint: srv.URL, token: "bad", client: srv.Client(), sampleRate: 1.0}
+	if err := splunk.ExportTraces(errorSurfaceTrace()); err == nil {
+		t.Error("splunk: expected an error for a 401 backend, got nil")
+	}
+}

--- a/internal/tracing/exporter/jaeger.go
+++ b/internal/tracing/exporter/jaeger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -64,17 +65,21 @@ func (e *JaegerExporter) ExportTraces(traces []*tracker.Trace) error {
 		return nil
 	}
 
+	var errs []error
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
 
 		if err := e.exportTrace(t); err != nil {
-			continue
+			// Keep exporting the remaining traces, but surface the failure:
+			// returning nil here made the manager's exporter-failure
+			// alerting unreachable dead code.
+			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *JaegerExporter) shouldSample(_ *tracker.Trace) bool {

--- a/internal/tracing/exporter/jaeger_test.go
+++ b/internal/tracing/exporter/jaeger_test.go
@@ -121,7 +121,7 @@ func TestJaegerExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -135,7 +135,7 @@ func TestJaegerExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("ExportTraces() error (expected for test without server): %v", err)
@@ -147,7 +147,7 @@ func TestJaegerExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -161,7 +161,7 @@ func TestJaegerExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Errorf("ExportTraces() error = %v", err)
@@ -173,23 +173,23 @@ func TestJaegerExporter_exportTrace_WithErrorSpan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
 			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-				Error:     true,
+				TraceID:    "test123",
+				SpanID:     "span123",
+				Operation:  "test-op",
+				Service:    "test-service",
+				StartTime:  time.Now(),
+				Duration:   100 * time.Millisecond,
+				Error:      true,
 				Attributes: map[string]string{"key": "value"},
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
@@ -201,7 +201,7 @@ func TestJaegerExporter_exportTrace_WithEmptyServiceName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -215,7 +215,7 @@ func TestJaegerExporter_exportTrace_WithEmptyServiceName(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
@@ -227,7 +227,7 @@ func TestJaegerExporter_exportTrace_WithEventError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -250,7 +250,7 @@ func TestJaegerExporter_exportTrace_WithEventError(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
@@ -262,7 +262,7 @@ func TestJaegerExporter_exportTrace_WithParentSpanID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -277,7 +277,7 @@ func TestJaegerExporter_exportTrace_WithParentSpanID(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)

--- a/internal/tracing/exporter/otlp.go
+++ b/internal/tracing/exporter/otlp.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -115,6 +116,7 @@ func (e *OTLPExporter) ExportTraces(traces []*tracker.Trace) error {
 	}
 
 	ctx := context.Background()
+	var errs []error
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
@@ -122,12 +124,15 @@ func (e *OTLPExporter) ExportTraces(traces []*tracker.Trace) error {
 
 		for _, span := range t.Spans {
 			if err := e.exportSpan(ctx, span, t); err != nil {
-				continue
+				// Keep exporting, but surface the failure: returning nil
+				// here made the manager's exporter-failure alerting
+				// unreachable dead code.
+				errs = append(errs, fmt.Errorf("trace %s span %s: %w", t.TraceID, span.SpanID, err))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *OTLPExporter) shouldSample(_ *tracker.Trace) bool {

--- a/internal/tracing/exporter/otlp_test.go
+++ b/internal/tracing/exporter/otlp_test.go
@@ -119,7 +119,7 @@ func TestOTLPExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -133,7 +133,7 @@ func TestOTLPExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("ExportTraces() error (expected for test without server): %v", err)
@@ -146,7 +146,7 @@ func TestOTLPExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -160,7 +160,7 @@ func TestOTLPExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Errorf("ExportTraces() error = %v", err)
@@ -173,11 +173,11 @@ func TestOTLPExporter_exportSpan(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 	}
-	
+
 	span := &tracker.Span{
 		TraceID:      "12345678901234567890123456789012",
 		SpanID:       "1234567890123456",
@@ -197,7 +197,7 @@ func TestOTLPExporter_exportSpan(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportSpan(context.Background(), span, trace)
 	if err != nil {
 		t.Logf("exportSpan() error (expected for test without server): %v", err)
@@ -210,11 +210,11 @@ func TestOTLPExporter_exportSpan_InvalidTraceID(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 	}
-	
+
 	span := &tracker.Span{
 		TraceID:   "invalid",
 		SpanID:    "1234567890123456",
@@ -222,7 +222,7 @@ func TestOTLPExporter_exportSpan_InvalidTraceID(t *testing.T) {
 		StartTime: time.Now(),
 		Duration:  100 * time.Millisecond,
 	}
-	
+
 	err = exporter.exportSpan(context.Background(), span, trace)
 	if err == nil {
 		t.Error("exportSpan() should return error for invalid trace ID")
@@ -235,11 +235,11 @@ func TestOTLPExporter_exportSpan_InvalidSpanID(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 	}
-	
+
 	span := &tracker.Span{
 		TraceID:   "12345678901234567890123456789012",
 		SpanID:    "invalid",
@@ -247,7 +247,7 @@ func TestOTLPExporter_exportSpan_InvalidSpanID(t *testing.T) {
 		StartTime: time.Now(),
 		Duration:  100 * time.Millisecond,
 	}
-	
+
 	err = exporter.exportSpan(context.Background(), span, trace)
 	if err == nil {
 		t.Error("exportSpan() should return error for invalid span ID")
@@ -260,11 +260,11 @@ func TestOTLPExporter_exportSpan_NoParentSpanID(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 	}
-	
+
 	span := &tracker.Span{
 		TraceID:      "12345678901234567890123456789012",
 		SpanID:       "1234567890123456",
@@ -275,7 +275,7 @@ func TestOTLPExporter_exportSpan_NoParentSpanID(t *testing.T) {
 		Duration:     100 * time.Millisecond,
 		Attributes:   map[string]string{"key": "value"},
 	}
-	
+
 	err = exporter.exportSpan(context.Background(), span, trace)
 	if err != nil {
 		t.Logf("exportSpan() error (expected for test without server): %v", err)
@@ -288,7 +288,7 @@ func TestOTLPExporter_ExportTraces_WithErrorInExportSpan(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -302,7 +302,7 @@ func TestOTLPExporter_ExportTraces_WithErrorInExportSpan(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("ExportTraces() error (expected for invalid trace ID): %v", err)

--- a/internal/tracing/exporter/splunk.go
+++ b/internal/tracing/exporter/splunk.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -46,17 +48,18 @@ func (e *SplunkExporter) ExportTraces(traces []*tracker.Trace) error {
 		return nil
 	}
 
+	var errs []error
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
 
 		if err := e.exportTrace(t); err != nil {
-			continue
+			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *SplunkExporter) shouldSample(_ *tracker.Trace) bool {
@@ -107,14 +110,17 @@ func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {
 		events = append(events, event)
 	}
 
+	var errs []error
 	for _, event := range events {
 		payload, err := json.Marshal(event)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("marshal event: %w", err))
 			continue
 		}
 
 		req, err := http.NewRequestWithContext(context.Background(), "POST", e.endpoint, bytes.NewReader(payload))
 		if err != nil {
+			errs = append(errs, fmt.Errorf("create request: %w", err))
 			continue
 		}
 
@@ -125,12 +131,18 @@ func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {
 
 		resp, err := e.client.Do(req)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("send request: %w", err))
 			continue
 		}
 		_ = resp.Body.Close()
+		// HEC failures (401 bad token, 400 malformed event) used to be
+		// indistinguishable from success.
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+			errs = append(errs, fmt.Errorf("unexpected status code: %d", resp.StatusCode))
+		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *SplunkExporter) Shutdown(ctx context.Context) error {

--- a/internal/tracing/exporter/splunk_test.go
+++ b/internal/tracing/exporter/splunk_test.go
@@ -123,7 +123,7 @@ func TestSplunkExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSplunkExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -137,7 +137,7 @@ func TestSplunkExporter_ExportTraces_WithSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("ExportTraces() error (expected for test without server): %v", err)
@@ -149,7 +149,7 @@ func TestSplunkExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSplunkExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -163,7 +163,7 @@ func TestSplunkExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Errorf("ExportTraces() error = %v", err)
@@ -175,23 +175,23 @@ func TestSplunkExporter_exportTrace_WithErrorSpan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSplunkExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
 			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-				Error:     true,
+				TraceID:    "test123",
+				SpanID:     "span123",
+				Operation:  "test-op",
+				Service:    "test-service",
+				StartTime:  time.Now(),
+				Duration:   100 * time.Millisecond,
+				Error:      true,
 				Attributes: map[string]string{"key": "value"},
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
@@ -203,7 +203,7 @@ func TestSplunkExporter_exportTrace_WithToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSplunkExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -217,7 +217,7 @@ func TestSplunkExporter_exportTrace_WithToken(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
@@ -229,7 +229,7 @@ func TestSplunkExporter_exportTrace_WithParentSpanID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSplunkExporter() error = %v", err)
 	}
-	
+
 	trace := &tracker.Trace{
 		TraceID: "test123",
 		Spans: []*tracker.Span{
@@ -244,7 +244,7 @@ func TestSplunkExporter_exportTrace_WithParentSpanID(t *testing.T) {
 			},
 		},
 	}
-	
+
 	err = exporter.exportTrace(trace)
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,15 +22,15 @@ type ZipkinExporter struct {
 
 // Zipkin v2 span format.
 type zipkinSpan struct {
-	TraceID       string            `json:"traceId"`
-	ID            string            `json:"id"`
-	ParentID      string            `json:"parentId,omitempty"`
-	Name          string            `json:"name"`
-	Timestamp     int64             `json:"timestamp"`
-	Duration      int64             `json:"duration"`
-	Kind          string            `json:"kind,omitempty"`
-	LocalEndpoint zipkinEndpoint    `json:"localEndpoint"`
-	Tags          map[string]string `json:"tags,omitempty"`
+	TraceID       string             `json:"traceId"`
+	ID            string             `json:"id"`
+	ParentID      string             `json:"parentId,omitempty"`
+	Name          string             `json:"name"`
+	Timestamp     int64              `json:"timestamp"`
+	Duration      int64              `json:"duration"`
+	Kind          string             `json:"kind,omitempty"`
+	LocalEndpoint zipkinEndpoint     `json:"localEndpoint"`
+	Tags          map[string]string  `json:"tags,omitempty"`
 	Annotations   []zipkinAnnotation `json:"annotations,omitempty"`
 }
 
@@ -60,17 +61,18 @@ func (e *ZipkinExporter) ExportTraces(traces []*tracker.Trace) error {
 		return nil
 	}
 
+	var errs []error
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
 
 		if err := e.exportTrace(t); err != nil {
-			continue
+			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (e *ZipkinExporter) shouldSample(_ *tracker.Trace) bool {

--- a/internal/tracing/manager.go
+++ b/internal/tracing/manager.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,7 @@ type Manager struct {
 	exportInterval  time.Duration
 	cleanupInterval time.Duration
 	stopCh          chan struct{}
+	stopOnce        sync.Once
 	wg              sync.WaitGroup
 }
 
@@ -147,7 +149,7 @@ func (m *Manager) exportLoop(ctx context.Context) {
 		case <-m.stopCh:
 			return
 		case <-ticker.C:
-			m.exportTraces()
+			m.exportTraces(false)
 		}
 	}
 }
@@ -170,145 +172,91 @@ func (m *Manager) cleanupLoop(ctx context.Context) {
 	}
 }
 
-func (m *Manager) exportTraces() {
-	traces := m.traceTracker.GetAllTraces()
+// exporterTarget pairs one configured exporter with the metadata its
+// failure alert needs.
+type exporterTarget struct {
+	name            string
+	endpoint        string
+	export          func([]*tracker.Trace) error
+	recommendations []string
+	suppressAlert   bool
+}
+
+func (m *Manager) exporterTargets() []exporterTarget {
+	var out []exporterTarget
+	if m.otlpExporter != nil {
+		out = append(out, exporterTarget{
+			name: "otlp", endpoint: config.OTLPEndpoint, export: m.otlpExporter.ExportTraces,
+			recommendations: []string{"Check OTLP endpoint connectivity", "Verify endpoint configuration", "Check network connectivity"},
+		})
+	}
+	if m.jaegerExporter != nil {
+		out = append(out, exporterTarget{
+			name: "jaeger", endpoint: config.JaegerEndpoint, export: m.jaegerExporter.ExportTraces,
+			recommendations: []string{"Check Jaeger endpoint connectivity", "Verify endpoint configuration", "Check network connectivity"},
+		})
+	}
+	if m.splunkExporter != nil {
+		out = append(out, exporterTarget{
+			name: "splunk", endpoint: config.SplunkEndpoint, export: m.splunkExporter.ExportTraces,
+			recommendations: []string{"Check Splunk endpoint connectivity", "Verify Splunk token", "Check network connectivity"},
+			// Avoid an alert feedback loop when alerts themselves are
+			// delivered through Splunk.
+			suppressAlert: config.AlertSplunkEnabled,
+		})
+	}
+	if m.datadogExporter != nil {
+		out = append(out, exporterTarget{
+			name: "datadog", endpoint: config.DataDogEndpoint, export: m.datadogExporter.ExportTraces,
+			recommendations: []string{"Check DataDog agent endpoint connectivity", "Verify DD-API-KEY if using direct ingest", "Check network connectivity"},
+		})
+	}
+	if m.zipkinExporter != nil {
+		out = append(out, exporterTarget{
+			name: "zipkin", endpoint: config.ZipkinEndpoint, export: m.zipkinExporter.ExportTraces,
+			recommendations: []string{"Check Zipkin endpoint connectivity", "Verify endpoint configuration", "Check network connectivity"},
+		})
+	}
+	return out
+}
+
+// exportTraces hands each span to every exporter exactly once: the tracker
+// snapshot advances a per-trace watermark, so a tick no longer re-sends every
+// accumulated trace (which duplicated spans in all backends on every 5s
+// interval). force (shutdown) flushes spans of traces that are still
+// settling.
+func (m *Manager) exportTraces(force bool) {
+	traces := m.traceTracker.SnapshotForExport(m.exportInterval, force)
 	if len(traces) == 0 {
 		return
 	}
 
-	if m.otlpExporter != nil {
-		if err := m.otlpExporter.ExportTraces(traces); err != nil {
-			logger.Warn("Failed to export traces to OTLP", zap.Error(err))
-			manager := alerting.GetGlobalManager()
-			if manager != nil {
-				alert := &alerting.Alert{
-					Severity:  alerting.SeverityWarning,
-					Title:     "OTLP Exporter Failure",
-					Message:   fmt.Sprintf("Failed to export traces to OTLP: %v", err),
-					Timestamp: time.Now(),
-					Source:    "exporter",
-					Context: map[string]interface{}{
-						"exporter": "otlp",
-						"endpoint": config.OTLPEndpoint,
-						"error":    err.Error(),
-					},
-					Recommendations: []string{
-						"Check OTLP endpoint connectivity",
-						"Verify endpoint configuration",
-						"Check network connectivity",
-					},
-				}
-				manager.SendAlert(alert)
-			}
+	for _, target := range m.exporterTargets() {
+		err := target.export(traces)
+		if err == nil {
+			continue
 		}
-	}
-
-	if m.jaegerExporter != nil {
-		if err := m.jaegerExporter.ExportTraces(traces); err != nil {
-			logger.Warn("Failed to export traces to Jaeger", zap.Error(err))
-			manager := alerting.GetGlobalManager()
-			if manager != nil {
-				alert := &alerting.Alert{
-					Severity:  alerting.SeverityWarning,
-					Title:     "Jaeger Exporter Failure",
-					Message:   fmt.Sprintf("Failed to export traces to Jaeger: %v", err),
-					Timestamp: time.Now(),
-					Source:    "exporter",
-					Context: map[string]interface{}{
-						"exporter": "jaeger",
-						"endpoint": config.JaegerEndpoint,
-						"error":    err.Error(),
-					},
-					Recommendations: []string{
-						"Check Jaeger endpoint connectivity",
-						"Verify endpoint configuration",
-						"Check network connectivity",
-					},
-				}
-				manager.SendAlert(alert)
-			}
+		logger.Warn("Failed to export traces", zap.String("exporter", target.name), zap.Error(err))
+		if target.suppressAlert {
+			continue
 		}
-	}
-
-	if m.splunkExporter != nil {
-		if err := m.splunkExporter.ExportTraces(traces); err != nil {
-			logger.Warn("Failed to export traces to Splunk", zap.Error(err))
-			manager := alerting.GetGlobalManager()
-			if manager != nil && !config.AlertSplunkEnabled {
-				alert := &alerting.Alert{
-					Severity:  alerting.SeverityWarning,
-					Title:     "Splunk Exporter Failure",
-					Message:   fmt.Sprintf("Failed to export traces to Splunk: %v", err),
-					Timestamp: time.Now(),
-					Source:    "exporter",
-					Context: map[string]interface{}{
-						"exporter": "splunk",
-						"endpoint": config.SplunkEndpoint,
-						"error":    err.Error(),
-					},
-					Recommendations: []string{
-						"Check Splunk endpoint connectivity",
-						"Verify Splunk token",
-						"Check network connectivity",
-					},
-				}
-				manager.SendAlert(alert)
-			}
+		manager := alerting.GetGlobalManager()
+		if manager == nil {
+			continue
 		}
-	}
-
-	if m.datadogExporter != nil {
-		if err := m.datadogExporter.ExportTraces(traces); err != nil {
-			logger.Warn("Failed to export traces to DataDog", zap.Error(err))
-			manager := alerting.GetGlobalManager()
-			if manager != nil {
-				alert := &alerting.Alert{
-					Severity:  alerting.SeverityWarning,
-					Title:     "DataDog Exporter Failure",
-					Message:   fmt.Sprintf("Failed to export traces to DataDog: %v", err),
-					Timestamp: time.Now(),
-					Source:    "exporter",
-					Context: map[string]interface{}{
-						"exporter": "datadog",
-						"endpoint": config.DataDogEndpoint,
-						"error":    err.Error(),
-					},
-					Recommendations: []string{
-						"Check DataDog agent endpoint connectivity",
-						"Verify DD-API-KEY if using direct ingest",
-						"Check network connectivity",
-					},
-				}
-				manager.SendAlert(alert)
-			}
-		}
-	}
-
-	if m.zipkinExporter != nil {
-		if err := m.zipkinExporter.ExportTraces(traces); err != nil {
-			logger.Warn("Failed to export traces to Zipkin", zap.Error(err))
-			manager := alerting.GetGlobalManager()
-			if manager != nil {
-				alert := &alerting.Alert{
-					Severity:  alerting.SeverityWarning,
-					Title:     "Zipkin Exporter Failure",
-					Message:   fmt.Sprintf("Failed to export traces to Zipkin: %v", err),
-					Timestamp: time.Now(),
-					Source:    "exporter",
-					Context: map[string]interface{}{
-						"exporter": "zipkin",
-						"endpoint": config.ZipkinEndpoint,
-						"error":    err.Error(),
-					},
-					Recommendations: []string{
-						"Check Zipkin endpoint connectivity",
-						"Verify endpoint configuration",
-						"Check network connectivity",
-					},
-				}
-				manager.SendAlert(alert)
-			}
-		}
+		manager.SendAlert(&alerting.Alert{
+			Severity:  alerting.SeverityWarning,
+			Title:     fmt.Sprintf("%s Exporter Failure", strings.ToUpper(target.name[:1])+target.name[1:]),
+			Message:   fmt.Sprintf("Failed to export traces to %s: %v", target.name, err),
+			Timestamp: time.Now(),
+			Source:    "exporter",
+			Context: map[string]interface{}{
+				"exporter": target.name,
+				"endpoint": target.endpoint,
+				"error":    err.Error(),
+			},
+			Recommendations: target.recommendations,
+		})
 	}
 }
 
@@ -317,7 +265,9 @@ func (m *Manager) GetRequestFlowGraph() *graph.RequestFlowGraph {
 		return nil
 	}
 
-	traces := m.traceTracker.GetAllTraces()
+	// Deep-copied snapshot: the graph builder sorts spans in place, which
+	// raced ProcessEvent on the live objects.
+	traces := m.traceTracker.SnapshotAll()
 	return m.graphBuilder.BuildFromTraces(traces)
 }
 
@@ -333,10 +283,11 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	close(m.stopCh)
+	m.stopOnce.Do(func() { close(m.stopCh) })
 	m.wg.Wait()
 
-	m.exportTraces()
+	// Final flush: force-export spans of traces that are still settling.
+	m.exportTraces(true)
 
 	if m.otlpExporter != nil {
 		if err := m.otlpExporter.Shutdown(ctx); err != nil {

--- a/internal/tracing/manager_exporttraces_test.go
+++ b/internal/tracing/manager_exporttraces_test.go
@@ -68,7 +68,7 @@ func TestManager_ExportTraces_AllFiveExporters_Populated(t *testing.T) {
 	if manager.GetTraceCount() != 0 {
 		t.Fatalf("expected empty tracker, got %d traces", manager.GetTraceCount())
 	}
-	manager.exportTraces()
+	manager.exportTraces(true)
 
 	manager.traceTracker.ProcessEvent(&events.Event{
 		Type:    events.EventHTTPReq,
@@ -80,5 +80,5 @@ func TestManager_ExportTraces_AllFiveExporters_Populated(t *testing.T) {
 		t.Fatalf("expected at least one trace after ProcessEvent")
 	}
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }

--- a/internal/tracing/manager_test.go
+++ b/internal/tracing/manager_test.go
@@ -258,7 +258,7 @@ func TestManager_ExportTraces_Empty(t *testing.T) {
 		traceTracker: tracker.NewTraceTracker(),
 	}
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_WithOTLPExporter(t *testing.T) {
@@ -282,7 +282,7 @@ func TestManager_ExportTraces_WithOTLPExporter(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_WithJaegerExporter(t *testing.T) {
@@ -306,7 +306,7 @@ func TestManager_ExportTraces_WithJaegerExporter(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_WithSplunkExporter(t *testing.T) {
@@ -330,7 +330,7 @@ func TestManager_ExportTraces_WithSplunkExporter(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_AllExporters(t *testing.T) {
@@ -360,7 +360,7 @@ func TestManager_ExportTraces_AllExporters(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_OTLPError(t *testing.T) {
@@ -390,7 +390,7 @@ func TestManager_ExportTraces_OTLPError(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_JaegerError(t *testing.T) {
@@ -420,7 +420,7 @@ func TestManager_ExportTraces_JaegerError(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_SplunkError_AlertingDisabled(t *testing.T) {
@@ -453,7 +453,7 @@ func TestManager_ExportTraces_SplunkError_AlertingDisabled(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_SplunkError_NoAlertManager(t *testing.T) {
@@ -482,7 +482,7 @@ func TestManager_ExportTraces_SplunkError_NoAlertManager(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_OTLPError_NoAlertManager(t *testing.T) {
@@ -508,7 +508,7 @@ func TestManager_ExportTraces_OTLPError_NoAlertManager(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_JaegerError_NoAlertManager(t *testing.T) {
@@ -534,7 +534,7 @@ func TestManager_ExportTraces_JaegerError_NoAlertManager(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_Shutdown_WithExporters(t *testing.T) {
@@ -752,7 +752,7 @@ func TestManager_ExportTraces_SplunkError_AlertingEnabled(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_SuccessfulExport(t *testing.T) {
@@ -776,7 +776,7 @@ func TestManager_ExportTraces_SuccessfulExport(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_Shutdown_WithStartedManager(t *testing.T) {
@@ -881,7 +881,7 @@ func TestManager_ExportTraces_OTLPExporterNil(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_JaegerExporterNil(t *testing.T) {
@@ -897,7 +897,7 @@ func TestManager_ExportTraces_JaegerExporterNil(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }
 
 func TestManager_ExportTraces_SplunkExporterNil(t *testing.T) {
@@ -913,5 +913,5 @@ func TestManager_ExportTraces_SplunkExporterNil(t *testing.T) {
 		SpanID:  "test-span",
 	}, nil)
 
-	manager.exportTraces()
+	manager.exportTraces(true)
 }


### PR DESCRIPTION
## Summary

Fixes a set of correctness issues in the tracing pipeline and the CLI event plumbing. The shared theme is data that looked fine but wasn't: spans duplicated into every backend on every export tick, exporter failures invisible to the alerting layer, redaction silently bypassed for some DNS events, events randomly split between consumers, and reports lost on the exact shutdown path the upload machinery was built for.

## Tracing pipeline

- **Spans are exported exactly once.** `exportTraces()` used to push every accumulated trace to every exporter on each 5s tick, and nothing marked anything as exported, duplicate spans piled up in all backends, with the OTLP path minting a new span ID per re-export so the duplicates were not even deduplicable. The trace tracker now keeps a per-trace export watermark: `SnapshotForExport` returns only spans not yet handed to exporters, traces still receiving events settle for one export interval before being cut (so a request is not exported mid-assembly), and shutdown force-flushes the remainder.
- **Exporters no longer race the tracker.** `GetAllTraces()` returned live `*Trace` pointers; the tracker kept appending under its lock while exporters iterated spans, mutated `StartTime`/`Duration` via `UpdateDuration()`, and the graph builder sorted `trace.Spans` in place, all unsynchronized. The export and graph paths now operate on deep-copied snapshots (spans, attributes, services, slice headers all copied; event pointers shared since events are immutable after processing), so consumers may sort and mutate freely.
- **Exporter failures are surfaced.** All five exporters swallowed every per-trace error and returned nil, which made the manager's entire exporter-failure alerting layer unreachable dead code. `ExportTraces` now keeps exporting the remaining traces but returns `errors.Join` of the failures, and Splunk checks the HEC response status — a 401 from a bad token used to be indistinguishable from success. The five copy-pasted alert blocks in the manager collapsed into one table-driven loop (same behavior, including the Splunk alert-feedback-loop suppression), and calling `Shutdown` twice no longer panics.
- **Redaction bypasses closed.** The DNS-timeout sweeper synthesizes events directly into the event channel, skipping the ring-buffer read loop where the PII redactor runs, with `PODTRACE_REDACT_DNS_NAMES=true`, timed-out query names escaped unredacted. Synthesized events now pass through the redactor, which additionally covers `EventDNSQuery` (query name in Target) and the DNS-correlated hostname in `EventConnect.Details` (the `ip:port` target is preserved).

## CLI

- **Every consumer sees every event.** With `--metrics`/`--tracing`/profiling enabled, up to four goroutines received from the SAME channel, and a channel delivers each value to exactly one receiver, so the report loop, metrics, traces, and profiling each saw a random disjoint subset, and with `--filter` events randomly bypassed the filter pipeline entirely. The source channel is now teed: the report pipeline gets a blocking primary channel (backpressure still reaches the tracer, which drops at the source exactly as before), while each auxiliary consumer gets its own buffered channel with non-blocking sends so a slow consumer drops its own copies instead of stalling the report. With no auxiliary consumers enabled the tee is skipped entirely.
- **Reports survive SIGTERM.** The sidecar uploader's `--max-wait 0` mode waits for SIGTERM and then uploaded with the context that SIGTERM had just cancelled, failing instantly on the exact path it was designed for; `finalizeDiagnoseOutputs` had the same bug on the interrupt path, silently losing session reports on Ctrl+C, Job deletion, and node drain. Both now detach via `context.WithoutCancel` with a 30-second grace period, so the upload runs after shutdown begins but a hung sink cannot outlive the pod's termination grace period.