### PR TITLE
fix: rate-based utilization, metric caps, probe lifecycle, GCS abort

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,8 @@ var (
 	ShutdownTimeout           = getDurationEnvOrDefault("PODTRACE_SHUTDOWN_TIMEOUT", DefaultShutdownTimeout)
 	EventBatchSize            = getIntEnvOrDefault("PODTRACE_EVENT_BATCH_SIZE", DefaultEventBatchSize)
 	ResourceMonitorInterval   = getDurationEnvOrDefault("PODTRACE_RESOURCE_MONITOR_INTERVAL", DefaultResourceMonitorInterval)
+	MetricsLabelLimit         = getIntEnvOrDefault("PODTRACE_METRICS_LABEL_LIMIT", 200)
+	MetricsPodLabelLimit      = getIntEnvOrDefault("PODTRACE_METRICS_POD_LABEL_LIMIT", 500)
 	ProcessCacheEvictionRatio = getFloatEnvOrDefault("PODTRACE_PROCESS_CACHE_EVICTION_RATIO", DefaultProcessCacheEvictionRatio)
 	PIDCacheEvictionRatio     = getFloatEnvOrDefault("PODTRACE_PID_CACHE_EVICTION_RATIO", DefaultPIDCacheEvictionRatio)
 	CacheEvictionThreshold    = getFloatEnvOrDefault("PODTRACE_CACHE_EVICTION_THRESHOLD", DefaultCacheEvictionThreshold)

--- a/internal/ebpf/filter/filter.go
+++ b/internal/ebpf/filter/filter.go
@@ -18,6 +18,7 @@ type CgroupFilter struct {
 	cgroupPaths map[string]struct{}
 	pidCache    map[uint32]bool
 	pidCacheMu  sync.RWMutex
+	pathsMu     sync.RWMutex
 }
 
 func NewCgroupFilter() *CgroupFilter {
@@ -28,17 +29,20 @@ func NewCgroupFilter() *CgroupFilter {
 }
 
 func (f *CgroupFilter) SetCgroupPath(path string) {
+	f.pathsMu.Lock()
 	f.cgroupPath = path
 	f.cgroupPaths = make(map[string]struct{})
 	if path != "" {
 		f.cgroupPaths[path] = struct{}{}
 	}
+	f.pathsMu.Unlock()
 	f.pidCacheMu.Lock()
 	f.pidCache = make(map[uint32]bool)
 	f.pidCacheMu.Unlock()
 }
 
 func (f *CgroupFilter) SetCgroupPaths(paths []string) {
+	f.pathsMu.Lock()
 	f.cgroupPath = ""
 	f.cgroupPaths = make(map[string]struct{}, len(paths))
 	for _, path := range paths {
@@ -47,13 +51,34 @@ func (f *CgroupFilter) SetCgroupPaths(paths []string) {
 		}
 		f.cgroupPaths[path] = struct{}{}
 	}
+	f.pathsMu.Unlock()
 	f.pidCacheMu.Lock()
 	f.pidCache = make(map[uint32]bool)
 	f.pidCacheMu.Unlock()
 }
 
+// snapshotTargets copies the configured target paths under pathsMu. The
+// agent calls SetCgroupPaths on every reconcile while IsPIDInCgroup runs on
+// the event hot path; only pidCache used to be locked, so the map swap raced
+// the iteration below.
+func (f *CgroupFilter) snapshotTargets() []string {
+	f.pathsMu.RLock()
+	defer f.pathsMu.RUnlock()
+	targets := make([]string, 0, len(f.cgroupPaths)+1)
+	if f.cgroupPath != "" {
+		targets = append(targets, f.cgroupPath)
+	}
+	for p := range f.cgroupPaths {
+		if p != "" {
+			targets = append(targets, p)
+		}
+	}
+	return targets
+}
+
 func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
-	if f.cgroupPath == "" && len(f.cgroupPaths) == 0 {
+	configuredTargets := f.snapshotTargets()
+	if len(configuredTargets) == 0 {
 		return true
 	}
 
@@ -118,18 +143,9 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	}
 
 	normalizedPID := NormalizeCgroupPath(pidCgroupPath)
-	targets := make([]string, 0, len(f.cgroupPaths)+1)
-	if f.cgroupPath != "" {
-		targets = append(targets, f.cgroupPath)
-	}
-	for p := range f.cgroupPaths {
-		if p != "" {
-			targets = append(targets, p)
-		}
-	}
 
 	result := false
-	for _, target := range targets {
+	for _, target := range configuredTargets {
 		normalizedTarget := NormalizeCgroupPath(target)
 		// If the configured target normalizes to empty (e.g. "/" or the cgroup base),
 		// treat it as invalid to avoid accidentally matching everything.

--- a/internal/ebpf/filter/filter_race_test.go
+++ b/internal/ebpf/filter/filter_race_test.go
@@ -1,0 +1,40 @@
+package filter
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestCgroupFilter_ConcurrentSetAndCheck is a regression test for the data
+// race between SetCgroupPaths (called on every agent reconcile) and
+// IsPIDInCgroup (the event hot path): only pidCache used to be locked while
+// the path map was swapped and iterated concurrently. Run under -race.
+func TestCgroupFilter_ConcurrentSetAndCheck(t *testing.T) {
+	f := NewCgroupFilter()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		paths := [][]string{
+			{"/sys/fs/cgroup/kubepods/pod-a"},
+			{"/sys/fs/cgroup/kubepods/pod-a", "/sys/fs/cgroup/kubepods/pod-b"},
+			nil,
+		}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			f.SetCgroupPaths(paths[i%len(paths)])
+		}
+	}()
+
+	for i := 0; i < 5000; i++ {
+		f.IsPIDInCgroup(uint32(i%200 + 1))
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/internal/ebpf/tracer/links_lifecycle_test.go
+++ b/internal/ebpf/tracer/links_lifecycle_test.go
@@ -1,0 +1,83 @@
+package tracer
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/ebpf/link"
+
+	"github.com/podtrace/podtrace/internal/ebpf/probes"
+)
+
+// fakeLink counts Close calls so the tests can assert single-close
+// semantics.
+type fakeLink struct {
+	link.Link
+	closes atomic.Int32
+}
+
+func (f *fakeLink) Close() error {
+	f.closes.Add(1)
+	return nil
+}
+
+// TestDisableProbeGroup_RemovesLinksFromFlatRegistry is a regression test:
+// DisableProbeGroup closed a group's links but left them in t.links, so
+// Stop() double-closed them and repeated disable/enable cycles grew t.links
+// with dead handles indefinitely.
+func TestDisableProbeGroup_RemovesLinksFromFlatRegistry(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+
+	grouped := &fakeLink{}
+	ungrouped := &fakeLink{}
+	tr.registerGroupLinks(probes.GroupFastCGI, []link.Link{grouped})
+	tr.addLinks([]link.Link{ungrouped})
+
+	if tr.linkCount() != 2 {
+		t.Fatalf("linkCount = %d, want 2", tr.linkCount())
+	}
+
+	if err := tr.DisableProbeGroup(probes.GroupFastCGI); err != nil {
+		t.Fatalf("DisableProbeGroup: %v", err)
+	}
+	if grouped.closes.Load() != 1 {
+		t.Errorf("grouped link closes = %d, want 1", grouped.closes.Load())
+	}
+	if tr.linkCount() != 1 {
+		t.Errorf("linkCount after disable = %d, want 1 (closed links must leave the registry)", tr.linkCount())
+	}
+
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if grouped.closes.Load() != 1 {
+		t.Errorf("grouped link closes after Stop = %d, want 1 (no double-close)", grouped.closes.Load())
+	}
+	if ungrouped.closes.Load() != 1 {
+		t.Errorf("ungrouped link closes after Stop = %d, want 1", ungrouped.closes.Load())
+	}
+}
+
+// TestRegisterGroupLinks_GroupGating: container-scoped uprobe batches must be
+// registered under their probe group so SetEnabledCategories and the
+// management endpoints can actually detach them — they used to land only in
+// the flat registry, making the FastCGI/TLS gating a silent no-op.
+func TestRegisterGroupLinks_GroupGating(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+	l := &fakeLink{}
+	tr.registerGroupLinks(probes.GroupTLS, []link.Link{l})
+
+	tr.probeGroupsMu.Lock()
+	registered := len(tr.probeGroups[probes.GroupTLS])
+	tr.probeGroupsMu.Unlock()
+	if registered != 1 {
+		t.Fatalf("GroupTLS registry has %d links, want 1", registered)
+	}
+
+	if err := tr.DisableProbeGroup(probes.GroupTLS); err != nil {
+		t.Fatalf("DisableProbeGroup: %v", err)
+	}
+	if l.closes.Load() != 1 {
+		t.Errorf("TLS uprobe link closes = %d, want 1 (gating must detach it)", l.closes.Load())
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -66,10 +66,11 @@ type ProfilingControllerSetter interface {
 }
 
 type Tracer struct {
-	collection    *ebpf.Collection
-	links         []link.Link
-	probeGroupsMu sync.Mutex
-	probeGroups   map[probes.ProbeGroup][]link.Link
+	collection     *ebpf.Collection
+	links          []link.Link
+	probeGroupsMu  sync.Mutex
+	probeGroups    map[probes.ProbeGroup][]link.Link
+	dnsPacketLinks map[string][]link.Link
 
 	intentionallyDisabled    map[probes.ProbeGroup]struct{}
 	detachWarned             map[probes.ProbeGroup]struct{}
@@ -89,6 +90,125 @@ type Tracer struct {
 	cpAnalyzer               *criticalpath.Analyzer
 	piiRedactor              *redactor.Redactor
 	profilingCtrl            ProfilingController
+}
+
+// registerGroupLinks records freshly attached links under their probe group
+// (so Disable/EnableProbeGroup can manage them) and in the flat registry
+// Stop() closes.
+func (t *Tracer) registerGroupLinks(g probes.ProbeGroup, ls []link.Link) {
+	if len(ls) == 0 {
+		return
+	}
+	t.probeGroupsMu.Lock()
+	defer t.probeGroupsMu.Unlock()
+	t.probeGroups[g] = append(t.probeGroups[g], ls...)
+	t.links = append(t.links, ls...)
+}
+
+func (t *Tracer) addLinks(ls []link.Link) {
+	if len(ls) == 0 {
+		return
+	}
+	t.probeGroupsMu.Lock()
+	defer t.probeGroupsMu.Unlock()
+	t.links = append(t.links, ls...)
+}
+
+func (t *Tracer) linkCount() int {
+	t.probeGroupsMu.Lock()
+	defer t.probeGroupsMu.Unlock()
+	return len(t.links)
+}
+
+// attachGroupUprobes re-attaches the container-scoped probes belonging to a
+// group, using the most recent SetContainerIDs target.
+func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
+	coll := t.collection
+	if coll == nil {
+		return nil
+	}
+	id, pid := t.containerID, t.containerPID
+	switch g {
+	case probes.GroupTLS:
+		if id == "" {
+			return nil
+		}
+		var ls []link.Link
+		ls = append(ls, probes.AttachDNSProbesWithPID(coll, id, pid)...)
+		ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid)...)
+		ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
+		return ls
+	case probes.GroupDatabase:
+		if id == "" {
+			return nil
+		}
+		return probes.AttachDBProbesWithPID(coll, id, pid)
+	case probes.GroupPool:
+		if id == "" {
+			return nil
+		}
+		return probes.AttachPoolProbesWithPID(coll, id, pid)
+	case probes.GroupCache:
+		if id == "" {
+			return nil
+		}
+		var ls []link.Link
+		ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
+		ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
+		return ls
+	case probes.GroupMessaging:
+		if id == "" {
+			return nil
+		}
+		return probes.AttachKafkaProbesWithPID(coll, id, pid)
+	case probes.GroupFastCGI:
+		return probes.AttachFastCGIProbes(coll)
+	case probes.GroupNetwork:
+		return probes.AttachGRPCProbes(coll)
+	}
+	return nil
+}
+
+// syncDNSPacketProbes reconciles the per-cgroup dns_egress/dns_ingress
+// attachments with the current target set.
+func (t *Tracer) syncDNSPacketProbes(paths []string) {
+	if t.collection == nil {
+		return
+	}
+	want := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		if p != "" {
+			want[p] = struct{}{}
+		}
+	}
+
+	t.probeGroupsMu.Lock()
+	if t.dnsPacketLinks == nil {
+		t.dnsPacketLinks = map[string][]link.Link{}
+	}
+	for p, ls := range t.dnsPacketLinks {
+		if _, ok := want[p]; ok {
+			continue
+		}
+		for _, l := range ls {
+			_ = l.Close()
+		}
+		delete(t.dnsPacketLinks, p)
+	}
+	var missing []string
+	for p := range want {
+		if _, ok := t.dnsPacketLinks[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	t.probeGroupsMu.Unlock()
+
+	for _, p := range missing {
+		ls := probes.AttachDNSPacketProbes(t.collection, []string{p})
+		t.probeGroupsMu.Lock()
+		t.dnsPacketLinks[p] = ls
+		t.probeGroupsMu.Unlock()
+	}
 }
 
 // SetProfilingController wires an optional profiling controller into the
@@ -278,6 +398,7 @@ func (t *Tracer) SetCgroups(cgroupPaths []string) error {
 			logger.Warn("Failed to clear target_cgroup_ids map", zap.Error(err))
 		}
 		t.cgroupWriteMu.Unlock()
+		t.syncDNSPacketProbes(nil)
 		logger.Debug("Detached all cgroups")
 		return nil
 	}
@@ -406,6 +527,11 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		t.storeCgroupIDs(newIDs)
 		logger.Debug("Cgroup v2 not detected, using userspace filtering only", zap.String("cgroup_base", config.CgroupBasePath))
 	}
+	// attachCgroups holds cgroupWriteMu for its whole body (deferred
+	// unlock), so read the final path set directly.
+	currentPaths := append([]string(nil), t.cgroupPaths...)
+	t.syncDNSPacketProbes(currentPaths)
+
 	logger.Debug("Attached to cgroups",
 		zap.Int("cgroup_count", len(t.cgroupPaths)),
 		zap.Uint32("container_pid", t.containerPID),
@@ -553,31 +679,18 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 	}
 
 	t.containerID = primary
-	dnsLinks := probes.AttachDNSProbesWithPID(t.collection, primary, t.containerPID)
-	if len(dnsLinks) > 0 {
-		t.links = append(t.links, dnsLinks...)
-	}
-	syncLinks := probes.AttachSyncProbesWithPID(t.collection, primary, t.containerPID)
-	if len(syncLinks) > 0 {
-		t.links = append(t.links, syncLinks...)
-	}
-	dbLinks := probes.AttachDBProbesWithPID(t.collection, primary, t.containerPID)
-	if len(dbLinks) > 0 {
-		t.links = append(t.links, dbLinks...)
-	}
-	poolLinks := probes.AttachPoolProbesWithPID(t.collection, primary, t.containerPID)
-	if len(poolLinks) > 0 {
-		t.links = append(t.links, poolLinks...)
-	}
-	tlsLinks := probes.AttachTLSProbesWithPID(t.collection, primary, t.containerPID)
-	if len(tlsLinks) > 0 {
-		t.links = append(t.links, tlsLinks...)
-	}
-	t.links = append(t.links, probes.AttachRedisProbesWithPID(t.collection, primary, t.containerPID)...)
-	t.links = append(t.links, probes.AttachMemcachedProbesWithPID(t.collection, primary, t.containerPID)...)
-	t.links = append(t.links, probes.AttachKafkaProbesWithPID(t.collection, primary, t.containerPID)...)
-	t.links = append(t.links, probes.AttachFastCGIProbes(t.collection)...)
-	t.links = append(t.links, probes.AttachGRPCProbes(t.collection)...)
+	// Each batch is registered under its probe group so the category gate
+	// and the management endpoints can detach and re-attach it.
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachDNSProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachSyncProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupDatabase, probes.AttachDBProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupPool, probes.AttachPoolProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachTLSProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupCache, probes.AttachRedisProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupCache, probes.AttachMemcachedProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupMessaging, probes.AttachKafkaProbesWithPID(t.collection, primary, t.containerPID))
+	t.registerGroupLinks(probes.GroupFastCGI, probes.AttachFastCGIProbes(t.collection))
+	t.registerGroupLinks(probes.GroupNetwork, probes.AttachGRPCProbes(t.collection))
 	return nil
 }
 
@@ -590,9 +703,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 	t.cgroupWriteMu.Lock()
 	dnsCgroups := append([]string(nil), t.cgroupPaths...)
 	t.cgroupWriteMu.Unlock()
-	if dnsLinks := probes.AttachDNSPacketProbes(t.collection, dnsCgroups); len(dnsLinks) > 0 {
-		t.links = append(t.links, dnsLinks...)
-	}
+	t.syncDNSPacketProbes(dnsCgroups)
 
 	if t.cgroupPath != "" {
 		limitsMap := t.collection.Maps["cgroup_limits"]
@@ -697,7 +808,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						zap.Uint64("target_cgroup_id", t.targetCgroupID.Load()),
 						zap.String("cgroup_path", t.cgroupPath),
 						zap.Duration("elapsed", elapsed),
-						zap.Int("links_attached", len(t.links)))
+						zap.Int("links_attached", t.linkCount()))
 					logger.Warn("If running in a container (e.g. DaemonSet), ensure host /sys/fs/cgroup and /proc are mounted and PODTRACE_CGROUP_BASE / PODTRACE_PROC_BASE point at them; see installation doc 'Running as a DaemonSet'")
 				} else if eventsCollected.Load() == 0 && eventsParsed.Load() > 0 && elapsed > 10*time.Second {
 					logger.Warn("Events parsed but none collected - filtering may be too strict",
@@ -907,7 +1018,16 @@ func (t *Tracer) Stop() error {
 		_ = t.reader.Close()
 	}
 
-	for _, l := range t.links {
+	t.probeGroupsMu.Lock()
+	closing := t.links
+	t.links = nil
+	t.probeGroups = map[probes.ProbeGroup][]link.Link{}
+	for _, ls := range t.dnsPacketLinks {
+		closing = append(closing, ls...)
+	}
+	t.dnsPacketLinks = nil
+	t.probeGroupsMu.Unlock()
+	for _, l := range closing {
 		_ = l.Close()
 	}
 
@@ -1133,6 +1253,10 @@ func (t *Tracer) EnableProbeGroup(g probes.ProbeGroup) error {
 	if err != nil {
 		return err
 	}
+	// Groups with container-scoped uprobes (TLS, cache, FastCGI, ...) have
+	// nothing in the kprobe/tracepoint tables AttachProbeGroup walks; they
+	// are re-attached from the most recent SetContainerIDs target.
+	newLinks = append(newLinks, t.attachGroupUprobes(g)...)
 
 	t.probeGroupsMu.Lock()
 	t.probeGroups[g] = append(t.probeGroups[g], newLinks...)
@@ -1183,7 +1307,7 @@ var groupCategoryNeeds = map[probes.ProbeGroup][]string{
 	probes.GroupCPU:        {"cpu", "proc"},
 	probes.GroupMemory:     {"proc"},
 	probes.GroupFastCGI:    {"net"},
-	probes.GroupTLS:        {"dns", "cpu"},
+	probes.GroupTLS:        {"dns", "cpu", "net"},
 }
 
 // DisableProbeGroup closes all links associated with the given group.
@@ -1194,9 +1318,21 @@ func (t *Tracer) DisableProbeGroup(g probes.ProbeGroup) error {
 	if !ok || len(ls) == 0 {
 		return nil
 	}
+	closed := make(map[link.Link]struct{}, len(ls))
 	for _, l := range ls {
 		_ = l.Close()
+		closed[l] = struct{}{}
 	}
+	// Drop the closed links from the flat registry too: leaving them in
+	// meant Stop() double-closed them and repeated disable/enable cycles
+	// grew t.links with dead handles indefinitely.
+	kept := t.links[:0]
+	for _, l := range t.links {
+		if _, isClosed := closed[l]; !isClosed {
+			kept = append(kept, l)
+		}
+	}
+	t.links = kept
 	delete(t.probeGroups, g)
 	logger.Info("Probe group disabled", zap.String("group", string(g)))
 	return nil

--- a/internal/metricsexporter/cardinality_test.go
+++ b/internal/metricsexporter/cardinality_test.go
@@ -1,0 +1,31 @@
+package metricsexporter
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestLabelCardinalityLimiter is a regression test for unbounded label
+// cardinality: traffic-derived labels (commands, methods, topics) and
+// pod-churn labels used to mint one Prometheus series per distinct observed
+// value forever.
+func TestLabelCardinalityLimiter(t *testing.T) {
+	l := newLabelCardinalityLimiter(3)
+
+	for _, v := range []string{"a", "b", "c"} {
+		if got := l.bound(v); got != v {
+			t.Errorf("bound(%q) = %q, want passthrough under the cap", v, got)
+		}
+	}
+	if got := l.bound("b"); got != "b" {
+		t.Errorf("bound(b) = %q, want b (already admitted)", got)
+	}
+	for i := 0; i < 100; i++ {
+		if got := l.bound(fmt.Sprintf("new-%d", i)); got != "other" {
+			t.Fatalf("bound(new-%d) = %q, want \"other\" beyond the cap", i, got)
+		}
+	}
+	if got := l.bound(""); got != "" {
+		t.Errorf("bound(\"\") = %q, want empty", got)
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	pprofhttp "net/http/pprof"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -428,18 +429,19 @@ func init() {
 
 // RecordProfilingGoroutines records goroutine counts from the last pprof fetch.
 func RecordProfilingGoroutines(podIP string, total, blocked int) {
+	podIP = podIPCardinality.bound(podIP)
 	profilingGoroutinesGauge.WithLabelValues(podIP, "total").Set(float64(total))
 	profilingGoroutinesGauge.WithLabelValues(podIP, "blocked").Set(float64(blocked))
 }
 
 // RecordProfilingAutoTrigger increments the auto-trigger counter.
 func RecordProfilingAutoTrigger(podIP string) {
-	profilingAutoTriggersTotal.WithLabelValues(podIP).Inc()
+	profilingAutoTriggersTotal.WithLabelValues(podIPCardinality.bound(podIP)).Inc()
 }
 
 // RecordProfilingFetchError increments the fetch error counter.
 func RecordProfilingFetchError(podIP, profileType string) {
-	profilingFetchErrorsTotal.WithLabelValues(podIP, profileType).Inc()
+	profilingFetchErrorsTotal.WithLabelValues(podIPCardinality.bound(podIP), profileType).Inc()
 }
 
 func HandleEvents(ch <-chan *events.Event) {
@@ -462,13 +464,59 @@ func HandleEvent(e *events.Event) {
 	HandleEventWithContext(e, nil)
 }
 
+// labelCardinalityLimiter caps the number of distinct values a
+// traffic-derived label can mint. Labels like command/method/topic come
+// straight off the traced wire (arbitrary URL paths, Redis command words,
+// Kafka topics) and target_pod/pod_ip churn with the cluster — and Prometheus
+// keeps one series (x 20 histogram buckets) per distinct value forever, since
+// nothing here ever calls DeleteLabelValues. Without a cap a long-lived agent
+// is a textbook exporter memory explosion. Values beyond the cap collapse
+// into "other"; bounded staleness in exchange for bounded memory.
+type labelCardinalityLimiter struct {
+	mu    sync.Mutex
+	seen  map[string]struct{}
+	limit int
+}
+
+func newLabelCardinalityLimiter(limit int) *labelCardinalityLimiter {
+	return &labelCardinalityLimiter{seen: make(map[string]struct{}), limit: limit}
+}
+
+func (l *labelCardinalityLimiter) bound(value string) string {
+	if value == "" {
+		return value
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.seen[value]; ok {
+		return value
+	}
+	if len(l.seen) >= l.limit {
+		return "other"
+	}
+	l.seen[value] = struct{}{}
+	return value
+}
+
+var (
+	// Wire-derived labels: one limiter per label so a noisy gRPC service
+	// cannot evict Redis commands and vice versa.
+	commandCardinality = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	methodCardinality  = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	topicCardinality   = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	// Pod-churn labels.
+	podCardinality     = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+	serviceCardinality = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+	podIPCardinality   = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+)
+
 func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) {
 	if e == nil {
 		return
 	}
 	namespace := getLabel(k8sContext, "namespace", "")
-	targetPod := getLabel(k8sContext, "target_pod", "")
-	targetService := getLabel(k8sContext, "target_service", "")
+	targetPod := podCardinality.bound(getLabel(k8sContext, "target_pod", ""))
+	targetService := serviceCardinality.bound(getLabel(k8sContext, "target_service", ""))
 
 	switch e.Type {
 	case events.EventConnect:
@@ -522,7 +570,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventRedisCmd:
 		latSec := float64(e.LatencyNS) / 1e9
-		cmd := e.Details
+		cmd := commandCardinality.bound(e.Details)
 		if cmd == "" {
 			cmd = "unknown"
 		}
@@ -530,7 +578,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventMemcachedCmd:
 		latSec := float64(e.LatencyNS) / 1e9
-		op := e.Details
+		op := commandCardinality.bound(e.Details)
 		if op == "" {
 			op = "unknown"
 		}
@@ -538,7 +586,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventFastCGIResp:
 		latSec := float64(e.LatencyNS) / 1e9
-		method := e.Details
+		method := methodCardinality.bound(e.Details)
 		if method == "" {
 			method = "unknown"
 		}
@@ -546,7 +594,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventGRPCMethod:
 		latSec := float64(e.LatencyNS) / 1e9
-		method := e.Target
+		method := methodCardinality.bound(e.Target)
 		if method == "" {
 			method = "unknown"
 		}
@@ -554,7 +602,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventKafkaProduce:
 		latSec := float64(e.LatencyNS) / 1e9
-		topic := e.Details
+		topic := topicCardinality.bound(e.Details)
 		if topic == "" {
 			topic = "unknown"
 		}
@@ -565,7 +613,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 
 	case events.EventKafkaFetch:
 		latSec := float64(e.LatencyNS) / 1e9
-		topic := e.Details
+		topic := topicCardinality.bound(e.Details)
 		if topic == "" {
 			topic = "unknown"
 		}

--- a/internal/profiling/profiler.go
+++ b/internal/profiling/profiler.go
@@ -180,7 +180,13 @@ func (p *PodProfiler) FetchCPUProfile(ctx context.Context, duration time.Duratio
 	if err != nil {
 		return &ProfileResult{Type: ProfileCPU, Available: false, Error: err.Error()}
 	}
-	resp, err := p.httpClient.Do(req)
+	// p.httpClient carries a 5s global timeout for discovery and the quick
+	// profile endpoints, but /debug/pprof/profile?seconds=N blocks for the
+	// FULL N seconds before responding — the shared client timed out every
+	// CPU profile longer than ~5s (the default is 30s). Use a dedicated
+	// client bounded only by fetchCtx.
+	cpuClient := &http.Client{Transport: p.httpClient.Transport}
+	resp, err := cpuClient.Do(req)
 	if err != nil {
 		return &ProfileResult{Type: ProfileCPU, Available: false, Error: err.Error()}
 	}

--- a/internal/reportsink/objectstore/gcs.go
+++ b/internal/reportsink/objectstore/gcs.go
@@ -84,10 +84,17 @@ func (g *gcsSink) Upload(ctx context.Context, keyHint, contentType string, body 
 	if key == "" {
 		return "", fmt.Errorf("gcs: resolved object key is empty (URI must include a key or prefix)")
 	}
-	w := g.client.Bucket(g.dest.bucket).Object(key).NewWriter(ctx)
+	// Aborting a GCS upload requires cancelling the writer's context:
+	// Close() FINALIZES the object with whatever bytes were buffered, so
+	// closing after a mid-stream copy failure committed a silently
+	// truncated report (which a prefix-keyed retry would not overwrite).
+	writeCtx, cancelWrite := context.WithCancel(ctx)
+	defer cancelWrite()
+	w := g.client.Bucket(g.dest.bucket).Object(key).NewWriter(writeCtx)
 	w.ContentType = contentType
 	if _, err := io.Copy(w, body); err != nil {
-		_ = w.Close()
+		cancelWrite()
+		_ = w.Close() // releases resources; the object is NOT committed
 		return "", fmt.Errorf("gcs: stream to %s/%s: %w", g.dest.bucket, key, err)
 	}
 	if err := w.Close(); err != nil {

--- a/internal/resource/monitor.go
+++ b/internal/resource/monitor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/logger"
 	"github.com/podtrace/podtrace/internal/metricsexporter"
+	"github.com/podtrace/podtrace/internal/safeconv"
 	"github.com/podtrace/podtrace/internal/sysfs"
 )
 
@@ -57,6 +58,13 @@ type limitMapValue struct {
 	_            [4]byte
 }
 
+// resourceSample is one (cumulative usage, wall clock) observation, kept so
+// CPU and IO utilization can be computed as RATES between ticks.
+type resourceSample struct {
+	usage  uint64
+	wallNS uint64
+}
+
 type ResourceMonitor struct {
 	cgroupPath    string
 	cgroupInode   uint64
@@ -69,6 +77,10 @@ type ResourceMonitor struct {
 	stopCh        chan struct{}
 	wg            sync.WaitGroup
 	namespace     string
+
+	cpuQuotaMicros  uint64
+	cpuPeriodMicros uint64
+	previousSamples map[uint32]resourceSample
 }
 
 func NewResourceMonitor(cgroupPath string, limitsMap, alertsMap *ebpf.Map, eventChan chan<- *events.Event, namespace string) (*ResourceMonitor, error) {
@@ -78,13 +90,14 @@ func NewResourceMonitor(cgroupPath string, limitsMap, alertsMap *ebpf.Map, event
 	}
 
 	rm := &ResourceMonitor{
-		cgroupPath:    cgroupPath,
-		cgroupInode:   inode,
-		eventChan:     eventChan,
-		limits:        make(map[uint32]*ResourceLimit),
-		checkInterval: config.ResourceMonitorInterval,
-		stopCh:        make(chan struct{}),
-		namespace:     namespace,
+		cgroupPath:      cgroupPath,
+		cgroupInode:     inode,
+		eventChan:       eventChan,
+		limits:          make(map[uint32]*ResourceLimit),
+		previousSamples: make(map[uint32]resourceSample),
+		checkInterval:   config.ResourceMonitorInterval,
+		stopCh:          make(chan struct{}),
+		namespace:       namespace,
 	}
 	if limitsMap != nil {
 		rm.limitsMap = limitsMap
@@ -157,11 +170,12 @@ func (rm *ResourceMonitor) readLimitsV2() error {
 	cpuMax, err := readCgroupFile(cpuMaxPath)
 	if err == nil {
 		quota, period, unlimited := parseCPUMax(cpuMax)
-		if !unlimited && quota > 0 {
+		if !unlimited && quota > 0 && period > 0 {
+			rm.cpuQuotaMicros = quota
+			rm.cpuPeriodMicros = period
 			rm.limits[ResourceCPU] = &ResourceLimit{
 				LimitBytes:   quota,
 				ResourceType: ResourceCPU,
-				LastUpdateNS: period,
 			}
 			logger.Debug("CPU limit read", zap.Uint64("quota", quota), zap.Uint64("period", period))
 		} else {
@@ -211,10 +225,11 @@ func (rm *ResourceMonitor) readLimitsV1() error {
 		quota, _ := strconv.ParseUint(strings.TrimSpace(cpuQuota), 10, 64)
 		period, _ := strconv.ParseUint(strings.TrimSpace(cpuPeriod), 10, 64)
 		if quota > 0 && period > 0 {
+			rm.cpuQuotaMicros = quota
+			rm.cpuPeriodMicros = period
 			rm.limits[ResourceCPU] = &ResourceLimit{
 				LimitBytes:   quota,
 				ResourceType: ResourceCPU,
-				LastUpdateNS: uint64(time.Now().UnixNano()),
 			}
 		}
 	}
@@ -248,6 +263,11 @@ func (rm *ResourceMonitor) readLimitsV1() error {
 
 func (rm *ResourceMonitor) updateResourceUsage() error {
 	rm.mu.Lock()
+	for _, resourceType := range []uint32{ResourceCPU, ResourceIO} {
+		if limit, ok := rm.limits[resourceType]; ok && limit.LastUpdateNS != 0 {
+			rm.previousSamples[resourceType] = resourceSample{usage: limit.UsageBytes, wallNS: limit.LastUpdateNS}
+		}
+	}
 	defer rm.mu.Unlock()
 
 	isV2, err := isCgroupV2(rm.cgroupPath)
@@ -352,6 +372,61 @@ func isBenignMapDeleteError(err error) bool {
 	return errors.Is(err, ebpf.ErrKeyNotExist)
 }
 
+// utilizationPercent returns the 0-100 utilization for one resource.
+//
+// Memory compares current bytes against the byte limit directly. CPU and IO
+// usage counters are CUMULATIVE (cpu.stat usage_usec, io.stat rbytes+wbytes),
+// while their limits are RATES (quota per period, bytes per second) — the
+// previous code divided one by the other, so after ~0.1 CPU-seconds of total
+// runtime "utilization" saturated at 100% and fired AlertEmergency every tick
+// forever. Both are now computed as the consumption rate between the last two
+// samples relative to the allowed rate; the first tick (no previous sample)
+// and counter resets (container restart) report no data.
+func (rm *ResourceMonitor) utilizationPercent(resourceType uint32, limit *ResourceLimit) (uint64, bool) {
+	clamp := func(v float64) (uint64, bool) {
+		if v < 0 {
+			return 0, false
+		}
+		if v > 100 {
+			return 100, true
+		}
+		return uint64(v), true
+	}
+
+	switch resourceType {
+	case ResourceMemory:
+		return clamp(float64(limit.UsageBytes) * 100 / float64(limit.LimitBytes))
+
+	case ResourceCPU:
+		if rm.cpuQuotaMicros == 0 || rm.cpuPeriodMicros == 0 {
+			return 0, false
+		}
+		previous, ok := rm.previousSamples[ResourceCPU]
+		if !ok || limit.LastUpdateNS <= previous.wallNS || limit.UsageBytes < previous.usage {
+			return 0, false
+		}
+		usedMicros := float64(limit.UsageBytes - previous.usage)
+		wallMicros := float64(limit.LastUpdateNS-previous.wallNS) / 1000
+		if wallMicros <= 0 {
+			return 0, false
+		}
+		allowedCPUs := float64(rm.cpuQuotaMicros) / float64(rm.cpuPeriodMicros)
+		return clamp(usedMicros / wallMicros / allowedCPUs * 100)
+
+	case ResourceIO:
+		previous, ok := rm.previousSamples[ResourceIO]
+		if !ok || limit.LastUpdateNS <= previous.wallNS || limit.UsageBytes < previous.usage {
+			return 0, false
+		}
+		bytesPerSecond := float64(limit.UsageBytes-previous.usage) /
+			(float64(limit.LastUpdateNS-previous.wallNS) / 1e9)
+		return clamp(bytesPerSecond / float64(limit.LimitBytes) * 100)
+
+	default:
+		return clamp(float64(limit.UsageBytes) * 100 / float64(limit.LimitBytes))
+	}
+}
+
 func (rm *ResourceMonitor) checkAlerts() {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
@@ -371,11 +446,11 @@ func (rm *ResourceMonitor) checkAlerts() {
 			continue
 		}
 
-		utilization := (limit.UsageBytes * 100) / limit.LimitBytes
-		if utilization > 100 {
-			utilization = 100
+		utilization, ok := rm.utilizationPercent(resourceType, limit)
+		if !ok {
+			continue
 		}
-		utilizationUint32 := uint32(utilization)
+		utilizationUint32 := safeconv.Uint64ToUint32(utilization)
 
 		var alertLevel uint32
 		if utilizationUint32 >= 95 {
@@ -454,7 +529,7 @@ func (rm *ResourceMonitor) checkAlerts() {
 					PID:         0,
 					ProcessName: "cgroup",
 					LatencyNS:   limit.LimitBytes,
-					Error:       int32(utilizationUint32),
+					Error:       safeconv.Uint64ToInt32(utilization),
 					Bytes:       limit.UsageBytes,
 					TCPState:    resourceType,
 					Target:      rm.cgroupPath,

--- a/internal/resource/monitor_utilization_test.go
+++ b/internal/resource/monitor_utilization_test.go
@@ -1,0 +1,92 @@
+package resource
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUtilizationPercent_CPURateNotCumulative is a regression test: CPU
+// "utilization" used to divide the CUMULATIVE usage counter (cpu.stat
+// usage_usec) by the per-period quota, so after ~0.1 CPU-seconds of total
+// runtime it saturated at 100% and fired AlertEmergency on every tick
+// forever. Utilization must reflect the consumption RATE between samples.
+func TestUtilizationPercent_CPURateNotCumulative(t *testing.T) {
+	rm := &ResourceMonitor{
+		cpuQuotaMicros:  100000, // 1 full CPU:
+		cpuPeriodMicros: 100000, // 100ms per 100ms
+		previousSamples: map[uint32]resourceSample{},
+	}
+	now := uint64(time.Now().UnixNano())
+
+	const hourMicros = 3_600_000_000
+	rm.previousSamples[ResourceCPU] = resourceSample{usage: hourMicros, wallNS: now - 5*uint64(time.Second)}
+	limit := &ResourceLimit{
+		LimitBytes:   rm.cpuQuotaMicros,
+		UsageBytes:   hourMicros + 100_000, // +100ms CPU in 5s wall
+		LastUpdateNS: now,
+		ResourceType: ResourceCPU,
+	}
+
+	utilization, ok := rm.utilizationPercent(ResourceCPU, limit)
+	if !ok {
+		t.Fatal("expected a utilization value with two samples available")
+	}
+	if utilization > 5 {
+		t.Errorf("utilization = %d%%, want ~2%% (cumulative counter must not saturate the rate)", utilization)
+	}
+
+	limit.UsageBytes = hourMicros + 5_000_000 // 5s CPU in 5s wall at 1-CPU quota
+	utilization, ok = rm.utilizationPercent(ResourceCPU, limit)
+	if !ok || utilization < 95 {
+		t.Errorf("utilization = %d%% (ok=%v), want ~100%% for a saturated quota", utilization, ok)
+	}
+}
+
+// TestUtilizationPercent_FirstSampleReportsNoData: rate-based types need two
+// samples; the first tick must not alert.
+func TestUtilizationPercent_FirstSampleReportsNoData(t *testing.T) {
+	rm := &ResourceMonitor{
+		cpuQuotaMicros:  100000,
+		cpuPeriodMicros: 100000,
+		previousSamples: map[uint32]resourceSample{},
+	}
+	limit := &ResourceLimit{
+		LimitBytes:   100000,
+		UsageBytes:   999_999_999,
+		LastUpdateNS: uint64(time.Now().UnixNano()),
+		ResourceType: ResourceCPU,
+	}
+	if _, ok := rm.utilizationPercent(ResourceCPU, limit); ok {
+		t.Error("first sample must report no data, not a (saturated) utilization")
+	}
+}
+
+// TestUtilizationPercent_IORate: IO limits are bytes/second; usage is a
+// cumulative byte counter — same rate treatment as CPU.
+func TestUtilizationPercent_IORate(t *testing.T) {
+	rm := &ResourceMonitor{previousSamples: map[uint32]resourceSample{}}
+	now := uint64(time.Now().UnixNano())
+
+	rm.previousSamples[ResourceIO] = resourceSample{usage: 10_000_000_000, wallNS: now - uint64(time.Second)}
+	limit := &ResourceLimit{
+		LimitBytes:   1_000_000, // 1 MB/s throttle
+		UsageBytes:   10_000_000_000 + 500_000,
+		LastUpdateNS: now,
+		ResourceType: ResourceIO,
+	}
+	utilization, ok := rm.utilizationPercent(ResourceIO, limit)
+	if !ok || utilization < 45 || utilization > 55 {
+		t.Errorf("utilization = %d%% (ok=%v), want ~50%% for 0.5 MB/s against a 1 MB/s limit", utilization, ok)
+	}
+}
+
+// TestUtilizationPercent_MemoryStaysDirect: memory compares current bytes
+// against the byte limit, no rate involved.
+func TestUtilizationPercent_MemoryStaysDirect(t *testing.T) {
+	rm := &ResourceMonitor{previousSamples: map[uint32]resourceSample{}}
+	limit := &ResourceLimit{LimitBytes: 1000, UsageBytes: 960, ResourceType: ResourceMemory}
+	utilization, ok := rm.utilizationPercent(ResourceMemory, limit)
+	if !ok || utilization != 96 {
+		t.Errorf("utilization = %d%% (ok=%v), want 96%%", utilization, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a set of correctness and resource-lifecycle issues across the report sinks, the Prometheus exporter, the resource monitor, profiling, and the eBPF tracer's probe management. The recurring themes: data that lied (truncated uploads that looked committed, utilization math that screamed emergency on healthy pods), unbounded growth (metric series, dead link handles), and lifecycle paths that silently did nothing (probe-group gating, dynamic DNS capture).

## Report sinks

- **GCS no longer commits truncated objects.** Aborting a GCS upload requires cancelling the writer's context, `Close()` finalizes the object with whatever bytes were buffered, so closing after a mid-stream copy failure committed a silently truncated report while the caller saw an error (and a prefix-keyed retry would not overwrite it). The writer now runs on a cancellable child context that is cancelled before `Close()` on the failure path, so the failed object is never created.

## Metrics exporter

- **Label cardinality is bounded.** Labels like Redis command, FastCGI/gRPC method, and Kafka topic come straight off the traced wire (arbitrary URL paths and command words), and `target_pod`/`target_service`/`pod_ip` churn with the cluster, and Prometheus keeps one series (× 20 histogram buckets) per distinct value forever, since nothing ever called `DeleteLabelValues`. A new per-label cardinality limiter admits the first N distinct values and collapses the rest into `"other"`: wire-derived labels cap at `PODTRACE_METRICS_LABEL_LIMIT` (default 200), pod-churn labels at `PODTRACE_METRICS_POD_LABEL_LIMIT` (default 500). Bounded staleness in exchange for bounded memory.

## Resource monitor

- **CPU/IO utilization is computed as a rate, not a cumulative ratio.** Usage counters are cumulative (`cpu.stat usage_usec`, `io.stat rbytes+wbytes`) while the limits are rates (quota per period, bytes per second), dividing one by the other meant utilization saturated at 100% after ~0.1 CPU-seconds of total runtime and fired `AlertEmergency` every 5 seconds forever on any CPU-limited pod. Utilization is now the consumption rate between the last two samples relative to the allowed rate; the first tick and counter resets (container restart) report no data instead of a false alarm. The CPU period is kept in its own field, it was previously smuggled through `LastUpdateNS` and clobbered by the first usage update (cgroup v1 parsed it and threw it away entirely). Memory keeps the direct byte comparison; unknown resource types fall back to the generic ratio. Verified on kind: a session against a pod with a 100m CPU limit produced zero resource alerts.

## Profiling

- **CPU profiles work for durations ≥ 5s (including the 30s default).** `/debug/pprof/profile?seconds=N` blocks for the full N seconds before responding, but the fetch went through the shared HTTP client with a global 5-second timeout, every CPU profile longer than ~5s timed out. The CPU fetch now uses a dedicated client bounded only by its `duration+5s` context; discovery and the quick endpoints keep the short timeout.

## eBPF tracer

- **Probe-group gating now covers the container-scoped uprobes.** The TLS/DNS/database/pool/cache/messaging/FastCGI uprobe batches attached by `SetContainerIDs` landed only in the flat link list, never under their probe group, so `SetEnabledCategories` and the management endpoints could never detach them, and `EnableProbeGroup` re-attached nothing while logging success. Batches are now registered under their groups, and `EnableProbeGroup` re-attaches uprobe-based groups from the most recent container target.
- **Packet-based DNS capture follows dynamic targets.** The per-cgroup `dns_egress`/`dns_ingress` programs were attached exactly once in `Start()` with the then-current cgroup snapshot, so pods targeted after startup, the agent's normal `SetCgroups` flow, silently never got DNS capture. A reconciler now attaches new target cgroups and releases removed ones on every cgroup update. Verified on kind: scaling the traced workload mid-trace attached capture for the new pod.
- **Link lifecycle has one owner.** `t.links` was appended from three call sites with no consistent locking, `Stop()` iterated it lock-free, and `DisableProbeGroup` closed a group's links but left them in the flat list, double-closed by `Stop()` and growing with dead handles on every disable/enable cycle. The probe-group mutex now owns the registry; disable removes what it closes; `Stop()` snapshots under the lock.
- **Cgroup filter race closed.** The agent calls `SetCgroupPaths` on every reconcile while `IsPIDInCgroup` runs on the event hot path; only the PID cache was locked, so the path-map swap raced the iteration. The path state is now guarded and snapshotted, pinned by a concurrent `-race` test.