### PR TITLE
fix: wire OLM bootstrap image and split quickstart manifests

### DIFF
--- a/.github/workflows/chainsaw.yml
+++ b/.github/workflows/chainsaw.yml
@@ -10,6 +10,8 @@ on:
       - "internal/agent/**"
       - "deploy/charts/podtrace/**"
       - "test/chainsaw/**"
+      - "test/e2e/**"
+      - "deploy/quickstart-sample.yaml"
       - "Makefile"
       - "Dockerfile"
       - ".github/workflows/chainsaw.yml"
@@ -100,3 +102,57 @@ jobs:
           kubectl -n podtrace-system get pods,ds,deploy,cm,secret 2>&1 || true
           kubectl -n podtrace-system describe pods 2>&1 | tail -200 || true
           kubectl -n podtrace-system logs deploy/podtrace-operator --tail=200 || true
+
+  # Guards the released quickstart manifests: quickstart.yaml must apply in a
+  # SINGLE kubectl invocation on a fresh cluster (explicit Namespace, no CRs
+  # racing their CRDs) and the demo manifest must complete end to end. This
+  # script existed but was never wired into CI, which is how a broken
+  # quickstart shipped undetected.
+  quickstart-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kind
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
+        with:
+          cluster_name: podtrace-quickstart
+          config: ./test/chainsaw/kind-config.yaml
+          version: v0.24.0
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+        with:
+          version: v3.16.0
+
+      - name: Install BPF toolchain
+        uses: ./.github/actions/setup-bpf-toolchain
+
+      - name: Build podtrace image
+        run: |
+          make docker-build IMAGE_TAG=ci
+          kind load docker-image ghcr.io/gma1k/podtrace:ci \
+            --name podtrace-quickstart
+
+      - name: Run quickstart smoke
+        env:
+          PODTRACE_IMAGE_REPO: ghcr.io/gma1k/podtrace
+          PODTRACE_IMAGE_TAG: ci
+        run: ./test/e2e/quickstart-smoke.sh
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          kubectl get pods -A || true
+          kubectl -n podtrace-system describe deploy/podtrace-operator || true
+          kubectl -n podtrace-system logs deploy/podtrace-operator --tail=100 || true
+          kubectl -n podtrace-demo get podtracesession -o yaml || true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Replace release notes with attributed generated notes
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -f tag_name="${TAG}" --jq .body > notes.md
+          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,28 +162,37 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - name: Render quickstart manifest
+      - name: Render quickstart manifests
         run: |
           set -euo pipefail
           mkdir -p dist
-          # Operator + CRDs from the chart, namespace-creating defaults.
+          cat > dist/quickstart.yaml <<'NSEOF'
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: podtrace-system
+            labels:
+              app.kubernetes.io/managed-by: podtrace-quickstart
+          NSEOF
+          echo "---" >> dist/quickstart.yaml
           helm template podtrace ${{ env.CHART_PATH }} \
             --namespace podtrace-system \
             --include-crds \
             --set namespace.create=true \
             --set operator.enabled=true \
-            > dist/operator.yaml
-          # Append the demo workload + sample CRs.
-          {
-            echo "---"
-            cat deploy/quickstart-sample.yaml
-          } > dist/sample.yaml
-          cat dist/operator.yaml dist/sample.yaml > dist/quickstart.yaml
-          echo "Rendered $(wc -l < dist/quickstart.yaml) lines"
+            >> dist/quickstart.yaml
+          # The demo workload + sample CRs ship as a SEPARATE manifest:
+          # applying CRs in the same kubectl invocation that installs their
+          # CRDs fails with the discovery-cache "ensure CRDs are installed
+          # first" error, so the documented flow is two applies.
+          cp deploy/quickstart-sample.yaml dist/quickstart-demo.yaml
+          echo "Rendered $(wc -l < dist/quickstart.yaml) + $(wc -l < dist/quickstart-demo.yaml) lines"
 
       - name: Compute checksum
         run: |
-          cd dist && sha256sum quickstart.yaml > quickstart.yaml.sha256
+          cd dist
+          sha256sum quickstart.yaml > quickstart.yaml.sha256
+          sha256sum quickstart-demo.yaml > quickstart-demo.yaml.sha256
 
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
@@ -191,6 +200,8 @@ jobs:
           files: |
             dist/quickstart.yaml
             dist/quickstart.yaml.sha256
+            dist/quickstart-demo.yaml
+            dist/quickstart-demo.yaml.sha256
           fail_on_unmatched_files: true
 
   cli:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -22,8 +22,10 @@ spec:
     at /sys/kernel/btf/vmlinux.
 
     The agent and per-session Jobs run as privileged in-cluster
-    containers with CAP_BPF + CAP_PERFMON + hostPID. The kubectl plugin
-    itself does not need elevated permissions on your workstation.
+    containers with hostPID (capabilities include CAP_BPF,
+    CAP_SYS_ADMIN, CAP_PERFMON, CAP_SYS_RESOURCE, CAP_NET_ADMIN). The
+    kubectl plugin itself does not need elevated permissions on your
+    workstation.
 
     Supported platforms: linux/amd64, linux/arm64, darwin/amd64,
     darwin/arm64. Compatibility matrix:

--- a/cmd/podtrace/operator.go
+++ b/cmd/podtrace/operator.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"github.com/podtrace/podtrace/internal/config"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -91,5 +94,24 @@ func toOperatorOptions(c *operatorOptions) operator.Options {
 		LeaderElectionNamespace: leaderNS,
 		WebhookPort:             c.webhookPort,
 		WebhookCertDir:          c.webhookCertDir,
+		BootstrapFallbackImage:  bootstrapFallbackImage(),
 	}
+}
+
+// releaseVersionPattern matches clean release versions (v0.12.9 / 0.12.9) —
+// dev builds (git describe suffixes, "dev", -dirty) must not produce a
+// fallback image, since that tag does not exist in the registry and the
+// bootstrap TracerConfig would render an unpullable agent DaemonSet.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// bootstrapFallbackImage derives the agent image for the TracerConfig
+// bootstrap from the operator binary's own build identity. It is the second
+// line of defense behind the PODTRACE_BOOTSTRAP_IMAGE env var: distributions
+// that forget the env (the OLM CSV did, leaving installs with no agent
+// DaemonSet) still bootstrap correctly when running a release build.
+func bootstrapFallbackImage() string {
+	if config.Image == "" || !releaseVersionPattern.MatchString(config.Version) {
+		return ""
+	}
+	return config.Image + ":" + strings.TrimPrefix(config.Version, "v")
 }

--- a/cmd/podtrace/operator_bootstrap_image_test.go
+++ b/cmd/podtrace/operator_bootstrap_image_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// TestBootstrapFallbackImage is a regression test for OLM installs coming up
+// with no agent DaemonSet: the CSV forgot PODTRACE_BOOTSTRAP_IMAGE and the
+// operator never set BootstrapFallbackImage, so the TracerConfig bootstrap
+// silently skipped itself.
+func TestBootstrapFallbackImage(t *testing.T) {
+	savedImage, savedVersion := config.Image, config.Version
+	defer func() { config.Image, config.Version = savedImage, savedVersion }()
+
+	cases := []struct {
+		name    string
+		image   string
+		version string
+		want    string
+	}{
+		{"clean release with v prefix", "ghcr.io/gma1k/podtrace", "v0.12.9", "ghcr.io/gma1k/podtrace:0.12.9"},
+		{"clean release without prefix", "ghcr.io/gma1k/podtrace", "0.12.9", "ghcr.io/gma1k/podtrace:0.12.9"},
+		{"dev build", "ghcr.io/gma1k/podtrace", "dev", ""},
+		{"dirty build", "ghcr.io/gma1k/podtrace", "v0.12.9-2-gfdec2a4-dirty", ""},
+		{"no image baked in", "", "v0.12.9", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			config.Image, config.Version = tc.image, tc.version
+			if got := bootstrapFallbackImage(); got != tc.want {
+				t.Errorf("bootstrapFallbackImage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/deploy/olm/csv-template.yaml
+++ b/deploy/olm/csv-template.yaml
@@ -114,9 +114,11 @@ spec:
     Memcached, Kafka, FastCGI/PHP-FPM) — without requiring application
     code changes or sidecars.
 
-    ## Four usage modes
+    ## Five usage modes
 
-    Podtrace ships one operator that supports four workflows:
+    Podtrace ships one operator with six CRDs supporting five
+    workflows. The sixth CRD, `ExporterConfig`, defines the export
+    destination that the other CRs reference via `exporterRef`.
 
     - **`PodTrace` CR** — continuous, realtime tracing of pods matching
       a label selector. Events stream through a per-node agent
@@ -135,6 +137,12 @@ spec:
       `ConcurrencyPolicy` (Allow / Forbid / Replace), with
       history-limit retention and owner-reference cascade deletion.
 
+    - **`ApplicationTrace` CR** — continuous tracing for a whole
+      application: multiple label selectors (optionally across
+      namespaces selected by a `namespaceSelector`) roll up into one
+      managed `PodTrace`, so a frontend + checkout + worker trio is
+      traced and reported as a single unit.
+
     - **`TracerConfig` CR** — cluster-wide tracer configuration that
       governs the agent DaemonSet (event buffer sizes, default filters,
       probe groups, alert thresholds, sample rates).
@@ -142,13 +150,15 @@ spec:
     ## Architecture
 
     On install the operator runs unprivileged in the
-    `podtrace-system` namespace and watches the five CRD kinds
+    `podtrace-system` namespace and watches the six CRD kinds
     cluster-wide. When a `TracerConfig` is created, the operator rolls
-    out a `podtrace-agent` DaemonSet across the cluster with the
-    minimum capabilities eBPF requires: `CAP_BPF`, `CAP_PERFMON`, and
-    `hostPID`. Per-session Jobs use a separate, narrower
-    ServiceAccount with namespaced RBAC scoped to the session's
-    target.
+    out a `podtrace-agent` DaemonSet across the cluster. The agent
+    container runs **privileged** with `hostPID` (capabilities include
+    `CAP_BPF`, `CAP_SYS_ADMIN`, `CAP_PERFMON`, `CAP_SYS_RESOURCE`, and
+    `CAP_NET_ADMIN`) — required for attaching eBPF kprobes/uprobes and
+    walking host cgroup and proc trees. Per-session Jobs use a
+    separate, narrower ServiceAccount with namespaced RBAC scoped to
+    the session's target.
 
     ## Stability
 
@@ -416,6 +426,8 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
+                      - name: PODTRACE_BOOTSTRAP_IMAGE
+                        value: ghcr.io/gma1k/podtrace:__VERSION__
                     ports:
                       - name: metrics
                         containerPort: 8080

--- a/deploy/quickstart-sample.yaml
+++ b/deploy/quickstart-sample.yaml
@@ -1,10 +1,12 @@
 # Quickstart demo workload + diagnose session.
 #
-# Concatenated to the chart-rendered operator manifest by release.yml to
-# produce dist/quickstart.yaml on each tagged release. End users can
-# then apply the combined file in a single command:
+# Published as quickstart-demo.yaml on each tagged release, applied as the
+# SECOND step after quickstart.yaml (operator + CRDs). It is a separate file
+# because kubectl cannot apply custom resources in the same invocation that
+# installs their CRDs (client discovery-cache limitation):
 #
 #   kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
+#   kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart-demo.yaml
 #
 # After the operator becomes Ready, the PodTraceSession runs for 30s
 # against the nginx Deployment and writes a human-readable report to

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,17 +13,18 @@ Four install paths, ordered by friction:
 
 ### Quickstart manifest (one-shot demo)
 
-A pre-rendered manifest including the operator + CRDs + a sample nginx workload + a `PodTraceSession` is attached to every GitHub Release. Apply it with one command:
+Two pre-rendered manifests are attached to every GitHub Release: `quickstart.yaml` (namespace + CRDs + operator) and `quickstart-demo.yaml` (a sample nginx workload + a `PodTraceSession`). They are separate files because kubectl cannot apply custom resources in the same invocation that installs their CRDs. Apply them in order:
 
 ```bash
 kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
+kubectl apply -f https://github.com/gma1k/podtrace/releases/latest/download/quickstart-demo.yaml
 ```
 
 What it deploys, in order:
 
 | Resource | Namespace | Purpose |
 |---|---|---|
-| 4 CRDs (`podtrace.io`) | cluster | Operator's API surface |
+| 6 CRDs (`podtrace.io`) | cluster | Operator's API surface |
 | `podtrace-system` Namespace + RBAC + Deployment | `podtrace-system` | Operator runtime |
 | `default` `TracerConfig` | cluster | Governs the agent DaemonSet |
 | `podtrace-demo` Namespace + nginx Deployment | `podtrace-demo` | Sample workload |
@@ -126,13 +127,15 @@ cosign download attestation ghcr.io/gma1k/podtrace:0.11.0 \
   --predicate-type https://spdx.dev/Document | jq .
 ```
 
-The quickstart manifest ships with a `quickstart.yaml.sha256` for integrity verification:
+Both quickstart manifests ship with `.sha256` companions for integrity verification:
 
 ```bash
 cd $(mktemp -d)
 curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml
 curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/quickstart.yaml.sha256
-sha256sum -c quickstart.yaml.sha256
+curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/quickstart-demo.yaml
+curl -fsSLO https://github.com/gma1k/podtrace/releases/latest/download/quickstart-demo.yaml.sha256
+sha256sum -c quickstart.yaml.sha256 quickstart-demo.yaml.sha256
 ```
 
 ### Install the CLI

--- a/test/e2e/quickstart-smoke.sh
+++ b/test/e2e/quickstart-smoke.sh
@@ -51,23 +51,36 @@ render_quickstart() {
 	local root="$1"
 	local out="$2"
 
+	local image_flags=()
+	if [[ -n "${PODTRACE_IMAGE_REPO:-}" ]]; then
+		image_flags+=(--set "image.repository=${PODTRACE_IMAGE_REPO}")
+	fi
+	if [[ -n "${PODTRACE_IMAGE_TAG:-}" ]]; then
+		image_flags+=(--set "image.tag=${PODTRACE_IMAGE_TAG}")
+	fi
+
+	cat >"${out}" <<'NSEOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: podtrace-system
+  labels:
+    app.kubernetes.io/managed-by: podtrace-quickstart
+NSEOF
+	echo "---" >>"${out}"
 	helm template podtrace "${root}/deploy/charts/podtrace" \
 		--namespace "${SYSTEM_NS}" \
 		--include-crds \
 		--set namespace.create=true \
 		--set operator.enabled=true \
-		>"${out}.operator"
+		"${image_flags[@]}" \
+		>>"${out}"
 
-	{
-		cat "${out}.operator"
-		echo "---"
-		cat "${root}/deploy/quickstart-sample.yaml"
-	} >"${out}"
-	rm -f "${out}.operator"
+	cp "${root}/deploy/quickstart-sample.yaml" "${out}.demo"
 
 	local lines
 	lines=$(wc -l <"${out}")
-	log_info "rendered quickstart at ${out} (${lines} lines)"
+	log_info "rendered quickstart at ${out} (${lines} lines) + demo manifest"
 }
 
 cleanup() {
@@ -75,8 +88,10 @@ cleanup() {
 
 	kubectl delete ns "${DEMO_NS}" "${SYSTEM_NS}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 	kubectl delete crd \
+		applicationtraces.podtrace.io \
 		exporterconfigs.podtrace.io \
 		podtraces.podtrace.io \
+		podtraceschedules.podtrace.io \
 		podtracesessions.podtrace.io \
 		tracerconfigs.podtrace.io \
 		--ignore-not-found --wait=false >/dev/null 2>&1 || true
@@ -168,19 +183,27 @@ main() {
 	local root
 	root="$(repo_root)"
 	RENDERED="$(mktemp -t quickstart.XXXXXX.yaml)"
-	trap 'rm -f "${RENDERED:-}"' EXIT
+	trap 'rm -f "${RENDERED:-}" "${RENDERED:-}.demo"' EXIT
 
-	log_info "rendering quickstart.yaml from chart + sample"
+	log_info "rendering quickstart manifests from chart + sample"
 	render_quickstart "${root}" "${RENDERED}"
 
-	log_info "applying quickstart"
+	# Two applies, exactly as documented: infra first (must succeed in ONE
+	# invocation on a fresh cluster — this is the regression the script
+	# guards), demo CRs second.
+	log_info "applying quickstart (operator + CRDs)"
 	kubectl apply -f "${RENDERED}" >/dev/null
 
 	wait_for "operator Deployment Ready" 120 \
 		"kubectl -n ${SYSTEM_NS} rollout status deploy/podtrace-operator --timeout=60s"
 
-	wait_for "demo PodTraceSession reaches phase=Completed" 180 \
-		"[[ \$(kubectl -n ${DEMO_NS} get podtracesession ${SESSION_NAME} -o jsonpath='{.status.phase}' 2>/dev/null) == 'Completed' ]]"
+	log_info "applying quickstart demo (workload + sample CRs)"
+	kubectl apply -f "${RENDERED}.demo" >/dev/null
+
+	# The CRD's field is .status.state — the script previously polled the
+	# nonexistent .status.phase and could never pass.
+	wait_for "demo PodTraceSession reaches state=Completed" 180 \
+		"[[ \$(kubectl -n ${DEMO_NS} get podtracesession ${SESSION_NAME} -o jsonpath='{.status.state}' 2>/dev/null) == 'Completed' ]]"
 
 	assert_summary_populated
 


### PR DESCRIPTION
## Summary

Fixes the OLM install path coming up without an agent DaemonSet, makes the released quickstart manifest apply first-try on a fresh cluster, wires the quickstart smoke test into CI, refreshes the stale OperatorHub listing text, and switches release notes to GitHub-generated attributed notes.

## OLM bootstrap

- **OLM installs bootstrap a default TracerConfig again.** The CSV never set `PODTRACE_BOOTSTRAP_IMAGE` (the env the Helm chart has always carried) and the operator never populated `BootstrapFallbackImage`, so under OLM the TracerConfig bootstrap silently skipped itself: no default TracerConfig, no agent DaemonSet, contradicting the documented out-of-the-box behavior. The CSV template now sets the env, and the operator additionally derives a fallback from its own build identity, gated to clean release versions only, since a dev or dirty build's image tag does not exist in the registry and would render an unpullable DaemonSet.
- Verified end to end: OLM installed on a kind cluster, the bundle deployed via `operator-sdk run bundle`, CSV reached `Succeeded`, the `default` TracerConfig was created, and the agent DaemonSet went fully Ready. `operator-sdk bundle validate` passes.

## Quickstart manifests

- **`quickstart.yaml` applies in a single `kubectl apply` on a fresh cluster.** Two failures fixed: the chart deliberately renders no Namespace document (a Helm pre-install hook creates it asynchronously), so the rendered operator resources targeted a namespace that did not exist, the release now prepends an explicit Namespace. And custom resources cannot be applied in the same kubectl invocation that installs their CRDs (client discovery-cache limitation), so the demo workload + sample CRs now ship as a separate `quickstart-demo.yaml` applied as a documented second step. Both files get `.sha256` companions; `docs/installation.md` and the sample header describe the two-step flow.
- **The quickstart smoke test runs in CI now.** `test/e2e/quickstart-smoke.sh` existed but was never wired into any workflow, which is how a broken quickstart shipped undetected. It runs as its own kind job in the chainsaw workflow, building the PR's image via new `PODTRACE_IMAGE_REPO`/`PODTRACE_IMAGE_TAG` overrides. While wiring it: the script polled the nonexistent `.status.phase` (the CRD field is `.status.state`) so it could never have passed, and its CRD cleanup list covered four of six CRDs, both fixed. The script's rendering now mirrors the release assembly exactly. Verified live on a kind cluster: single-apply infra, demo second, the demo session reaches `Completed` with its report ConfigMap written.