### PR TITLE
fix: harden agent routing, k8s resolution, and nodespawn lifecycle

### DIFF
--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -139,9 +139,10 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 			logger.Error(err, "load bundle", "cr", key)
 			rules = append(rules, CRRule{
-				Key:     key,
-				Filters: filtersToSet(pt.Spec.Filters),
-				Err:     fmt.Errorf("load bundle: %w", err),
+				Key:        key,
+				Filters:    filtersToSet(pt.Spec.Filters),
+				Categories: filterCategories(pt.Spec.Filters),
+				Err:        fmt.Errorf("load bundle: %w", err),
 			})
 			activeKeys[key] = struct{}{}
 			continue
@@ -151,8 +152,9 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if err != nil {
 			logger.Error(err, "match pods", "cr", key)
 			rules = append(rules, CRRule{
-				Key: key,
-				Err: fmt.Errorf("match pods: %w", err),
+				Key:        key,
+				Categories: filterCategories(pt.Spec.Filters),
+				Err:        fmt.Errorf("match pods: %w", err),
 			})
 			activeKeys[key] = struct{}{}
 			continue
@@ -170,6 +172,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			rules = append(rules, CRRule{
 				Key:         key,
 				Filters:     filtersToSet(pt.Spec.Filters),
+				Categories:  filterCategories(pt.Spec.Filters),
 				Policy:      policy,
 				MatchedPods: lenToInt32(len(matched)),
 				Err:         fmt.Errorf("resolve cgroup IDs: %w", err),
@@ -186,6 +189,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				Key:            key,
 				CgroupIDs:      cgroupIDs,
 				Filters:        filtersToSet(pt.Spec.Filters),
+				Categories:     filterCategories(pt.Spec.Filters),
 				Policy:         policy,
 				BundleRevision: bundle.ResourceVer,
 				MatchedPods:    lenToInt32(len(matched)),
@@ -199,6 +203,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			Key:            key,
 			CgroupIDs:      cgroupIDs,
 			Filters:        filtersToSet(pt.Spec.Filters),
+			Categories:     filterCategories(pt.Spec.Filters),
 			Policy:         policy,
 			Exporter:       exporter,
 			BundleRevision: bundle.ResourceVer,
@@ -669,13 +674,13 @@ func unionCategoriesFromRules(rules []CRRule) []string {
 		if r.Err != nil {
 			continue
 		}
-		if len(r.Policy.Filters) == 0 {
+		if len(r.Categories) == 0 {
 			for _, c := range knownFilterCategories() {
 				seen[c] = struct{}{}
 			}
 			break
 		}
-		for _, c := range r.Policy.Filters {
+		for _, c := range r.Categories {
 			seen[c] = struct{}{}
 		}
 	}
@@ -684,6 +689,19 @@ func unionCategoriesFromRules(rules []CRRule) []string {
 		out = append(out, c)
 	}
 	sort.Strings(out)
+	return out
+}
+
+// filterCategories renders the CR's spec.filters as plain category
+// strings, preserving order.
+func filterCategories(in []podtracev1alpha1.EventFilter) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, f := range in {
+		out = append(out, string(f))
+	}
 	return out
 }
 
@@ -716,7 +734,7 @@ func filtersToSet(in []podtracev1alpha1.EventFilter) map[events.EventType]struct
 func filterToEventTypes(f podtracev1alpha1.EventFilter) []events.EventType {
 	switch f {
 	case podtracev1alpha1.FilterDNS:
-		return []events.EventType{events.EventDNS}
+		return []events.EventType{events.EventDNS, events.EventDNSQuery}
 	case podtracev1alpha1.FilterNet:
 		return []events.EventType{
 			events.EventConnect, events.EventTCPSend, events.EventTCPRecv,
@@ -728,6 +746,7 @@ func filterToEventTypes(f podtracev1alpha1.EventFilter) []events.EventType {
 		return []events.EventType{
 			events.EventOpen, events.EventClose, events.EventRead,
 			events.EventWrite, events.EventFsync,
+			events.EventUnlink, events.EventRename,
 		}
 	case podtracev1alpha1.FilterCPU:
 		return []events.EventType{events.EventSchedSwitch, events.EventLockContention}
@@ -751,8 +770,10 @@ func copyMap(in map[string]string) map[string]string {
 }
 
 // podChangePredicates filters Pod watches down to events that actually
-// affect matching: label changes (selector matching), state changes
-// (Running-ness), and deletions.
+// affect matching or cgroup attribution: label changes (selector
+// matching), phase changes (Running-ness), PodIP assignment (event
+// enrichment), container restarts (each restart creates a new cgroup
+// inode that must be re-resolved), and deletions.
 func podChangePredicates() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
@@ -770,9 +791,34 @@ func podChangePredicates() predicate.Predicate {
 			if !labelsEqual(oldP.Labels, newP.Labels) {
 				return true
 			}
+			if oldP.Status.PodIP != newP.Status.PodIP {
+				return true
+			}
+			if !containerIdentitiesEqual(oldP, newP) {
+				return true
+			}
 			return false
 		},
 	}
+}
+
+// containerIdentitiesEqual reports whether every container in the pod
+// kept its container ID and restart count across the update.
+func containerIdentitiesEqual(oldP, newP *corev1.Pod) bool {
+	digest := func(p *corev1.Pod) map[string]string {
+		out := make(map[string]string,
+			len(p.Status.ContainerStatuses)+len(p.Status.InitContainerStatuses)+len(p.Status.EphemeralContainerStatuses))
+		add := func(statuses []corev1.ContainerStatus) {
+			for _, cs := range statuses {
+				out[cs.Name] = fmt.Sprintf("%s/%d", cs.ContainerID, cs.RestartCount)
+			}
+		}
+		add(p.Status.ContainerStatuses)
+		add(p.Status.InitContainerStatuses)
+		add(p.Status.EphemeralContainerStatuses)
+		return out
+	}
+	return labelsEqual(digest(oldP), digest(newP))
 }
 
 func labelsEqual(a, b map[string]string) bool {

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -98,8 +98,10 @@ func TestFiltersToSet_DedupesAcrossCategories(t *testing.T) {
 	}
 	got := filtersToSet(in)
 	want := []events.EventType{
-		events.EventDNS, events.EventOpen, events.EventClose,
+		events.EventDNS, events.EventDNSQuery,
+		events.EventOpen, events.EventClose,
 		events.EventRead, events.EventWrite, events.EventFsync,
+		events.EventUnlink, events.EventRename,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d entries, want %d (%v)", len(got), len(want), got)
@@ -981,8 +983,8 @@ func TestPolicySnapshotFromBundle_FullRoundTrip(t *testing.T) {
 
 func TestUnionCategoriesFromRules_NoFilterWidensToAll(t *testing.T) {
 	rules := []CRRule{
-		{Key: CRKey{Namespace: "ns", Name: "a"}, Policy: PolicySnapshot{Filters: []string{"dns"}}},
-		{Key: CRKey{Namespace: "ns", Name: "b"}, Policy: PolicySnapshot{}},
+		{Key: CRKey{Namespace: "ns", Name: "a"}, Categories: []string{"dns"}},
+		{Key: CRKey{Namespace: "ns", Name: "b"}},
 	}
 	got := unionCategoriesFromRules(rules)
 	want := []string{"cpu", "dns", "fs", "net", "proc"}
@@ -993,9 +995,9 @@ func TestUnionCategoriesFromRules_NoFilterWidensToAll(t *testing.T) {
 
 func TestUnionCategoriesFromRules_SortedDeduped(t *testing.T) {
 	rules := []CRRule{
-		{Key: CRKey{Namespace: "ns", Name: "a"}, Policy: PolicySnapshot{Filters: []string{"net", "fs"}}},
-		{Key: CRKey{Namespace: "ns", Name: "b"}, Policy: PolicySnapshot{Filters: []string{"fs", "dns"}}},
-		{Key: CRKey{Namespace: "ns", Name: "c"}, Policy: PolicySnapshot{Filters: []string{"net"}}},
+		{Key: CRKey{Namespace: "ns", Name: "a"}, Categories: []string{"net", "fs"}},
+		{Key: CRKey{Namespace: "ns", Name: "b"}, Categories: []string{"fs", "dns"}},
+		{Key: CRKey{Namespace: "ns", Name: "c"}, Categories: []string{"net"}},
 	}
 	got := unionCategoriesFromRules(rules)
 	want := []string{"dns", "fs", "net"}
@@ -1006,11 +1008,11 @@ func TestUnionCategoriesFromRules_SortedDeduped(t *testing.T) {
 
 func TestUnionCategoriesFromRules_SkipsErroredRules(t *testing.T) {
 	rules := []CRRule{
-		{Key: CRKey{Namespace: "ns", Name: "ok"}, Policy: PolicySnapshot{Filters: []string{"dns"}}},
+		{Key: CRKey{Namespace: "ns", Name: "ok"}, Categories: []string{"dns"}},
 		{
-			Key:    CRKey{Namespace: "ns", Name: "bad"},
-			Policy: PolicySnapshot{Filters: []string{"net", "fs"}},
-			Err:    errors.New("bundle load failed"),
+			Key:        CRKey{Namespace: "ns", Name: "bad"},
+			Categories: []string{"net", "fs"},
+			Err:        errors.New("bundle load failed"),
 		},
 	}
 	got := unionCategoriesFromRules(rules)

--- a/internal/agent/robustness_regression_test.go
+++ b/internal/agent/robustness_regression_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+// TestPodChangePredicates_ContainerRestartTriggers: a container restart
+// keeps phase and labels identical but produces a new container ID (and a
+// new cgroup inode). The old predicate filtered such updates out, so on a
+// quiet node the restarted container's events stayed unroutable forever.
+func TestPodChangePredicates_ContainerRestartTriggers(t *testing.T) {
+	p := podChangePredicates()
+
+	old := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "x"}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", ContainerID: "containerd://aaa", RestartCount: 0},
+			},
+		},
+	}
+	restarted := old.DeepCopy()
+	restarted.Status.ContainerStatuses[0].ContainerID = "containerd://bbb"
+	restarted.Status.ContainerStatuses[0].RestartCount = 1
+
+	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: restarted}) {
+		t.Error("container restart (new container ID) must trigger a reconcile")
+	}
+}
+
+// TestPodChangePredicates_PodIPAssignmentTriggers: PodIP often lands after
+// the pod is already Running; matching and enrichment need it.
+func TestPodChangePredicates_PodIPAssignmentTriggers(t *testing.T) {
+	p := podChangePredicates()
+
+	old := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+	withIP := old.DeepCopy()
+	withIP.Status.PodIP = "10.0.0.7"
+
+	if !p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: withIP}) {
+		t.Error("PodIP assignment must trigger a reconcile")
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: withIP, ObjectNew: withIP.DeepCopy()}) {
+		t.Error("identical update must still be filtered out")
+	}
+}
+
+// TestStatusWriter_RetractsStaleNodeRows: when a CR stops having a rule on
+// this node, the agent must apply an empty status under its field owner so
+// the SSA map-list drops the row — previously the last written row (often
+// Ready=true) lingered on the CR forever.
+func TestStatusWriter_RetractsStaleNodeRows(t *testing.T) {
+	const ns = "default"
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: ns, UID: "uid-1"},
+	}
+	rp := &recordingPatcher{}
+	c := newRecordingClient(t, rp, pt)
+
+	router := NewRouter(nil)
+	key := CRKey{Namespace: ns, Name: "pt"}
+	router.Publish([]CRRule{{Key: key, CgroupIDs: map[uint64]struct{}{1: {}}}})
+
+	w := &StatusWriter{Client: c, NodeName: "node-1", Router: router, Ready: func() bool { return true }}
+	if err := w.emitOnce(context.Background()); err != nil {
+		t.Fatalf("first emit: %v", err)
+	}
+
+	router.Publish(nil)
+	if err := w.emitOnce(context.Background()); err != nil {
+		t.Fatalf("second emit: %v", err)
+	}
+
+	calls := rp.snapshot()
+	if len(calls) < 2 {
+		t.Fatalf("expected a status row apply followed by a retraction, got %d applies", len(calls))
+	}
+	last := calls[len(calls)-1]
+	if last.key.Name != "pt" || last.key.Namespace != ns {
+		t.Fatalf("retraction targeted %v, want %s/pt", last.key, ns)
+	}
+	if len(last.pt.Status.NodeStatus) != 0 {
+		t.Errorf("retraction must apply an empty nodeStatus, got %+v", last.pt.Status.NodeStatus)
+	}
+
+	before := len(rp.snapshot())
+	if err := w.emitOnce(context.Background()); err != nil {
+		t.Fatalf("third emit: %v", err)
+	}
+	if after := len(rp.snapshot()); after != before {
+		t.Errorf("idle emit issued %d extra applies, want 0", after-before)
+	}
+}

--- a/internal/agent/status_writer.go
+++ b/internal/agent/status_writer.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -26,6 +27,8 @@ type StatusWriter struct {
 	Heartbeat func()
 
 	BackendErr error
+
+	reportedKeys map[CRKey]struct{}
 }
 
 func (w *StatusWriter) Run(ctx context.Context) error {
@@ -63,12 +66,24 @@ func (w *StatusWriter) emitOnce(ctx context.Context) error {
 	}
 
 	var firstErr error
+	current := make(map[CRKey]struct{}, len(rules))
 	for _, rule := range rules {
 		entry := buildNodeStatusEntry(w.NodeName, &rule, stats[rule.Key], agentReady, w.BackendErr, time.Now())
 		if err := w.patchCRStatus(ctx, rule.Key, entry); err != nil && firstErr == nil {
 			firstErr = err
 		}
+		current[rule.Key] = struct{}{}
 	}
+
+	for key := range w.reportedKeys {
+		if _, stillActive := current[key]; stillActive {
+			continue
+		}
+		if err := w.retractCRStatus(ctx, key); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.reportedKeys = current
 	return firstErr
 }
 
@@ -139,6 +154,21 @@ func (w *StatusWriter) patchCRStatus(ctx context.Context, key CRKey, entry podtr
 		client.FieldOwner("podtrace-agent-"+w.NodeName),
 		client.ForceOwnership,
 	)
+}
+
+// retractCRStatus applies an empty status under this agent's field owner,
+// removing the nodeStatus row it previously owned on the CR.
+func (w *StatusWriter) retractCRStatus(ctx context.Context, key CRKey) error {
+	applyConfig := podtraceac.PodTrace(key.Name, key.Namespace).
+		WithStatus(podtraceac.PodTraceStatus())
+	err := w.Client.Status().Apply(ctx, applyConfig,
+		client.FieldOwner("podtrace-agent-"+w.NodeName),
+		client.ForceOwnership,
+	)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func ComputeNodeReport(nodeName string, router *Router, ready bool) NodeReport {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -25,14 +25,14 @@ type CRKey struct {
 func (k CRKey) String() string { return k.Namespace + "/" + k.Name }
 
 type CRRule struct {
-	Key       CRKey
-	CgroupIDs map[uint64]struct{} // kernel cgroup inode numbers the tracer will see on events
-	Filters   map[events.EventType]struct{}
-	Exporter  tracer.Exporter
+	Key        CRKey
+	CgroupIDs  map[uint64]struct{}
+	Filters    map[events.EventType]struct{}
+	Categories []string
+	Exporter   tracer.Exporter
 
 	BundleRevision string
 
-	// Policy is the resolved effective policy as read from the bundle.
 	Policy PolicySnapshot
 
 	MatchedPods int32
@@ -65,13 +65,13 @@ type PolicyThresholds struct {
 // NodeReport aggregates the counters the status writer reports on one
 // tick.
 type NodeReport struct {
-	Node           string
-	Ready          bool
-	ActiveCgroups  int32
-	EventsTotal    int64
-	DroppedEvents  int64
-	LastHeartbeat  time.Time
-	Message        string
+	Node          string
+	Ready         bool
+	ActiveCgroups int32
+	EventsTotal   int64
+	DroppedEvents int64
+	LastHeartbeat time.Time
+	Message       string
 }
 
 // perCRStats tracks per-CR event counts for status reporting. Keyed by

--- a/internal/cri/resolver.go
+++ b/internal/cri/resolver.go
@@ -236,11 +236,42 @@ func (r *Resolver) ResolveContainer(ctx context.Context, containerID string) (*C
 		}
 	}
 
+	if info.CgroupsPath != "" {
+		info.CgroupsPath = expandSystemdColonPath(info.CgroupsPath)
+	}
 	if info.CgroupsPath != "" && !strings.HasPrefix(info.CgroupsPath, "/") {
 		info.CgroupsPath = "/" + info.CgroupsPath
 	}
 
 	return info, nil
+}
+
+// expandSystemdColonPath converts the systemd-driver colon form the CRI
+// reports ("kubepods-burstable-pod<uid>.slice:cri-containerd:<id>") into
+// the real filesystem layout
+// ("kubepods.slice/kubepods-burstable.slice/.../cri-containerd-<id>.scope").
+func expandSystemdColonPath(cg string) string {
+	parts := strings.Split(cg, ":")
+	if len(parts) != 3 {
+		return cg
+	}
+	slice, runtimePrefix, id := strings.TrimPrefix(parts[0], "/"), parts[1], parts[2]
+	if !strings.HasSuffix(slice, ".slice") || runtimePrefix == "" || id == "" {
+		return cg
+	}
+	return expandSystemdSlice(slice) + "/" + runtimePrefix + "-" + id + ".scope"
+}
+
+// expandSystemdSlice unfolds a systemd slice name into its nested
+// directory path: "a-b-c.slice" → "a.slice/a-b.slice/a-b-c.slice".
+func expandSystemdSlice(slice string) string {
+	name := strings.TrimSuffix(slice, ".slice")
+	segments := strings.Split(name, "-")
+	parts := make([]string, 0, len(segments))
+	for i := range segments {
+		parts = append(parts, strings.Join(segments[:i+1], "-")+".slice")
+	}
+	return strings.Join(parts, "/")
 }
 
 func extractLooseCgroupsPath(s string) string {

--- a/internal/cri/systemd_colon_test.go
+++ b/internal/cri/systemd_colon_test.go
@@ -1,0 +1,57 @@
+package cri
+
+import "testing"
+
+// TestExpandSystemdColonPath: the CRI reports the systemd cgroup driver's
+// colon form on GKE/EKS/kubeadm defaults; without expansion the path never
+// matched the filesystem and CRI resolution silently failed for every pod.
+func TestExpandSystemdColonPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "containerd colon form",
+			in:   "kubepods-burstable-pod2c48a299_e1f2.slice:cri-containerd:0123abc",
+			want: "kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48a299_e1f2.slice/cri-containerd-0123abc.scope",
+		},
+		{
+			name: "crio colon form",
+			in:   "kubepods-besteffort-podabc.slice:crio:fff",
+			want: "kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podabc.slice/crio-fff.scope",
+		},
+		{
+			name: "plain path untouched",
+			in:   "/kubepods/burstable/pod123/abc",
+			want: "/kubepods/burstable/pod123/abc",
+		},
+		{
+			name: "non-slice colon form untouched",
+			in:   "notaslice:cri-containerd:abc",
+			want: "notaslice:cri-containerd:abc",
+		},
+		{
+			name: "missing id untouched",
+			in:   "kubepods.slice:cri-containerd:",
+			want: "kubepods.slice:cri-containerd:",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expandSystemdColonPath(c.in); got != c.want {
+				t.Errorf("expandSystemdColonPath(%q) =\n  %q, want\n  %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExpandSystemdSlice(t *testing.T) {
+	if got := expandSystemdSlice("kubepods.slice"); got != "kubepods.slice" {
+		t.Errorf("single segment = %q", got)
+	}
+	want := "a.slice/a-b.slice/a-b-c.slice"
+	if got := expandSystemdSlice("a-b-c.slice"); got != want {
+		t.Errorf("nested = %q, want %q", got, want)
+	}
+}

--- a/internal/kubernetes/enricher.go
+++ b/internal/kubernetes/enricher.go
@@ -212,10 +212,15 @@ func parseTarget(target string) (string, int) {
 		idx := strings.Index(target, "]")
 		if idx > 0 {
 			ip := target[1:idx]
-			portStr := target[idx+2:]
-			var port int
-			_, _ = fmt.Sscanf(portStr, "%d", &port)
-			return ip, port
+			// "[::1]:8080" carries a port after the bracket; a bare
+			// "[::1]" does not, indexing past the bracket without this
+			// check panicked on every portless bracketed address.
+			if idx+1 < len(target) && target[idx+1] == ':' {
+				var port int
+				_, _ = fmt.Sscanf(target[idx+2:], "%d", &port)
+				return ip, port
+			}
+			return ip, 0
 		}
 	}
 

--- a/internal/kubernetes/events_correlator.go
+++ b/internal/kubernetes/events_correlator.go
@@ -20,14 +20,22 @@ type K8sEvent struct {
 	Count     int32
 }
 
+// rewatchBackoff is how long the correlator waits before re-establishing
+// a watch the API server closed.
+var rewatchBackoff = 2 * time.Second
+
 type EventsCorrelator struct {
-	clientset    kubernetes.Interface
-	podName      string
-	namespace    string
-	events       []*K8sEvent
-	mu           sync.RWMutex
+	clientset kubernetes.Interface
+	podName   string
+	namespace string
+	events    []*K8sEvent
+	mu        sync.RWMutex
+
 	eventWatcher watch.Interface
-	stopCh       chan struct{}
+	lastRV       string
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 func NewEventsCorrelator(clientset kubernetes.Interface, podName, namespace string) *EventsCorrelator {
@@ -49,41 +57,99 @@ func (ec *EventsCorrelator) Start(ctx context.Context) error {
 		return nil
 	}
 
-	watcher, err := ec.clientset.CoreV1().Events(ec.namespace).Watch(ctx, metav1.ListOptions{
-		FieldSelector: "involvedObject.name=" + ec.podName,
-	})
+	watcher, err := ec.watch(ctx, "")
 	if err != nil {
 		return err
 	}
-
-	ec.eventWatcher = watcher
+	ec.setWatcher(watcher)
 
 	go ec.watchEvents(ctx)
 	return nil
 }
 
+func (ec *EventsCorrelator) watch(ctx context.Context, resourceVersion string) (watch.Interface, error) {
+	return ec.clientset.CoreV1().Events(ec.namespace).Watch(ctx, metav1.ListOptions{
+		FieldSelector:   "involvedObject.name=" + ec.podName,
+		ResourceVersion: resourceVersion,
+	})
+}
+
+func (ec *EventsCorrelator) setWatcher(w watch.Interface) {
+	ec.mu.Lock()
+	ec.eventWatcher = w
+	ec.mu.Unlock()
+}
+
+func (ec *EventsCorrelator) currentWatcher() watch.Interface {
+	ec.mu.RLock()
+	defer ec.mu.RUnlock()
+	return ec.eventWatcher
+}
+
+// watchEvents consumes the watch channel and re-establishes the watch
+// whenever the server closes it, resuming from the last seen
+// resourceVersion.
 func (ec *EventsCorrelator) watchEvents(ctx context.Context) {
 	defer func() {
-		if ec.eventWatcher != nil {
-			ec.eventWatcher.Stop()
+		if w := ec.currentWatcher(); w != nil {
+			w.Stop()
 		}
 	}()
 
 	for {
+		w := ec.currentWatcher()
+		if w == nil {
+			return
+		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-ec.stopCh:
 			return
-		case event, ok := <-ec.eventWatcher.ResultChan():
+		case event, ok := <-w.ResultChan():
 			if !ok {
-				return
+				if !ec.rewatch(ctx) {
+					return
+				}
+				continue
 			}
 
 			if k8sEvent, ok := event.Object.(*corev1.Event); ok {
+				ec.mu.Lock()
+				ec.lastRV = k8sEvent.ResourceVersion
+				ec.mu.Unlock()
 				ec.addEvent(k8sEvent)
 			}
 		}
+	}
+}
+
+// rewatch replaces the closed watcher, retrying with backoff until it
+// succeeds or the correlator is stopped. A "resource version too old"
+// rejection falls back to a fresh watch.
+func (ec *EventsCorrelator) rewatch(ctx context.Context) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ec.stopCh:
+			return false
+		case <-time.After(rewatchBackoff):
+		}
+
+		ec.mu.RLock()
+		rv := ec.lastRV
+		ec.mu.RUnlock()
+
+		w, err := ec.watch(ctx, rv)
+		if err != nil && rv != "" && apierrors.IsResourceExpired(err) {
+			w, err = ec.watch(ctx, "")
+		}
+		if err != nil {
+			continue
+		}
+		ec.setWatcher(w)
+		return true
 	}
 }
 
@@ -120,11 +186,15 @@ func (ec *EventsCorrelator) GetEvents() []*K8sEvent {
 	return result
 }
 
+// Stop is idempotent: a second call is a no-op instead of a panic on the
+// already-closed channel.
 func (ec *EventsCorrelator) Stop() {
-	close(ec.stopCh)
-	if ec.eventWatcher != nil {
-		ec.eventWatcher.Stop()
-	}
+	ec.stopOnce.Do(func() {
+		close(ec.stopCh)
+		if w := ec.currentWatcher(); w != nil {
+			w.Stop()
+		}
+	})
 }
 
 func (ec *EventsCorrelator) CorrelateWithAppEvents(appEventTime time.Time, window time.Duration) []*K8sEvent {

--- a/internal/kubernetes/informers_cache.go
+++ b/internal/kubernetes/informers_cache.go
@@ -15,6 +15,9 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/podtrace/podtrace/internal/logger"
+	"go.uber.org/zap"
 )
 
 const (
@@ -139,8 +142,10 @@ func (ic *InformerCache) Start(ctx context.Context) {
 	syncCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
-	synced := cache.WaitForCacheSync(syncCtx.Done(), podInf.HasSynced, esInf.HasSynced)
-	_ = synced
+	if !cache.WaitForCacheSync(syncCtx.Done(), podInf.HasSynced, esInf.HasSynced) {
+		logger.Warn("Kubernetes informer cache did not sync within timeout; enrichment lookups may be incomplete until sync finishes",
+			zap.Int("timeout_seconds", timeoutSec))
+	}
 }
 
 func (ic *InformerCache) Stop() {

--- a/internal/kubernetes/nodespawn/cleanup.go
+++ b/internal/kubernetes/nodespawn/cleanup.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +16,16 @@ import (
 
 	"github.com/podtrace/podtrace/internal/logger"
 )
+
+// MachineBootID returns this machine's kernel boot ID, or "" when it
+// cannot be read (non-Linux workstations). Overridable for tests.
+var MachineBootID = func() string {
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
 
 // DeletePod best-effort deletes the spawn pod; NotFound is swallowed so retries
 // and parallel reapers don't error out.
@@ -50,40 +62,77 @@ func reapStaleWithLiveness(
 		return 0, fmt.Errorf("nodespawn: list stale pods: %w", err)
 	}
 
+	localBootID := MachineBootID()
 	reaped := 0
 	for i := range list.Items {
 		p := &list.Items[i]
 
-		pidStr := p.Labels[LabelOwnerPID]
-		if pidStr == "" {
-			logger.Debug("Spawn pod has no owner-pid label; not reaping (anomaly — surface but don't touch)",
-				zap.String("namespace", p.Namespace),
-				zap.String("name", p.Name))
-			continue
-		}
-		pid, perr := strconv.Atoi(pidStr)
-		if perr != nil || pid <= 0 {
-			logger.Debug("Spawn pod has malformed owner-pid label; not reaping",
-				zap.String("namespace", p.Namespace),
-				zap.String("name", p.Name),
-				zap.String("owner-pid", pidStr))
-			continue
-		}
-		if alive(pid) {
-			// owning CLI is still running — leave its pod alone.
-			continue
+		expired := podOlderThan(p.Labels[LabelCreatedAt], reapAgeBound(p.Spec.ActiveDeadlineSeconds))
+
+		if !expired && localBootID != "" {
+			if podBootID := p.Labels[LabelOwnerBootID]; podBootID != "" && podBootID != sanitizeLabelValue(localBootID) {
+				continue
+			}
 		}
 
-		// dead owner → orphan → reap
+		if !expired {
+			pidStr := p.Labels[LabelOwnerPID]
+			if pidStr == "" {
+				logger.Debug("Spawn pod has no owner-pid label; not reaping (anomaly — surface but don't touch)",
+					zap.String("namespace", p.Namespace),
+					zap.String("name", p.Name))
+				continue
+			}
+			pid, perr := strconv.Atoi(pidStr)
+			if perr != nil || pid <= 0 {
+				logger.Debug("Spawn pod has malformed owner-pid label; not reaping",
+					zap.String("namespace", p.Namespace),
+					zap.String("name", p.Name),
+					zap.String("owner-pid", pidStr))
+				continue
+			}
+			if alive(pid) {
+				continue
+			}
+		}
+
 		if derr := DeletePod(ctx, clientset, p.Namespace, p.Name); derr == nil {
 			reaped++
 			logger.Debug("Reaped orphan spawn pod",
 				zap.String("namespace", p.Namespace),
 				zap.String("name", p.Name),
-				zap.Int("owner_pid", pid))
+				zap.Bool("expired", expired))
 		}
 	}
 	return reaped, nil
+}
+
+// reapAgeBound returns the age past which a spawn pod is reaped
+// unconditionally: ReaperMaxAge, or for traces spawned with a longer
+// explicit deadline, that deadline plus a grace period.
+func reapAgeBound(activeDeadlineSeconds *int64) time.Duration {
+	bound := ReaperMaxAge
+	if activeDeadlineSeconds != nil && *activeDeadlineSeconds > 0 {
+		withGrace := time.Duration(*activeDeadlineSeconds)*time.Second + 10*time.Minute
+		if withGrace > bound {
+			bound = withGrace
+		}
+	}
+	return bound
+}
+
+// podOlderThan parses the created-at label (unix seconds) and reports
+// whether the pod is older than maxAge. Missing or malformed labels
+// report false — age-based reaping requires positive evidence.
+func podOlderThan(createdAt string, maxAge time.Duration) bool {
+	if createdAt == "" {
+		return false
+	}
+	sec, err := strconv.ParseInt(createdAt, 10, 64)
+	if err != nil || sec <= 0 {
+		return false
+	}
+	return time.Since(time.Unix(sec, 0)) > maxAge
 }
 
 func processAlive(pid int) bool {

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -15,14 +15,15 @@ import (
 // Labels stamped on every spawned pod. Used by the reaper to find pods left
 // behind by a crashed CLI.
 const (
-	LabelManagedBy = "app.kubernetes.io/managed-by"
-	LabelComponent = "app.kubernetes.io/component"
-	LabelNode      = "podtrace.io/node"
-	LabelOwnerHost = "podtrace.io/owner-host"
-	LabelOwnerPID  = "podtrace.io/owner-pid"
-	LabelCreatedAt = "podtrace.io/created-at"
-	ManagedByValue = "podtrace-cli"
-	ComponentValue = "cli-spawn"
+	LabelManagedBy   = "app.kubernetes.io/managed-by"
+	LabelComponent   = "app.kubernetes.io/component"
+	LabelNode        = "podtrace.io/node"
+	LabelOwnerHost   = "podtrace.io/owner-host"
+	LabelOwnerPID    = "podtrace.io/owner-pid"
+	LabelOwnerBootID = "podtrace.io/owner-boot-id"
+	LabelCreatedAt   = "podtrace.io/created-at"
+	ManagedByValue   = "podtrace-cli"
+	ComponentValue   = "cli-spawn"
 
 	EnvNodeLocalSentinel = "PODTRACE_NODE_LOCAL"
 
@@ -112,14 +113,14 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 	}
 
 	container := corev1.Container{
-		Name:            "podtrace",
-		Image:           opts.Image,
-		ImagePullPolicy: opts.ImagePullPolicy,
-		Args:            append([]string(nil), opts.Args...),
-		Env:             env,
-		Stdin:           true,
-		StdinOnce:       true,
-		TTY:             false,
+		Name:                     "podtrace",
+		Image:                    opts.Image,
+		ImagePullPolicy:          opts.ImagePullPolicy,
+		Args:                     append([]string(nil), opts.Args...),
+		Env:                      env,
+		Stdin:                    true,
+		StdinOnce:                true,
+		TTY:                      false,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &priv,
@@ -142,6 +143,9 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 	}
 	if opts.OwnerPID > 0 {
 		labels[LabelOwnerPID] = fmt.Sprintf("%d", opts.OwnerPID)
+	}
+	if bootID := MachineBootID(); bootID != "" {
+		labels[LabelOwnerBootID] = sanitizeLabelValue(bootID)
 	}
 
 	spec := corev1.PodSpec{

--- a/internal/kubernetes/nodespawn/robustness_regression_test.go
+++ b/internal/kubernetes/nodespawn/robustness_regression_test.go
@@ -1,0 +1,170 @@
+package nodespawn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestWaitForExitCode_RetriesTransientErrors: a single transient Get error
+// used to report exit -1, which the caller treats as failure and tears the
+// spawn pod down.
+func TestWaitForExitCode_RetriesTransientErrors(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "spawn", Namespace: "ns1"},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "main", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 3}}},
+		}},
+	}
+	clientset := fake.NewSimpleClientset(pod)
+	var mu sync.Mutex
+	failures := 2
+	clientset.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if failures > 0 {
+			failures--
+			return true, nil, errors.New("transient apiserver hiccup")
+		}
+		return false, nil, nil
+	})
+
+	if exit := WaitForExitCode(context.Background(), clientset, "ns1", "spawn"); exit != 3 {
+		t.Errorf("exit = %d, want 3 (transient errors must be retried)", exit)
+	}
+}
+
+// TestWaitForExitCode_OutlastsLongTraces: the old 30s wall-clock cap
+// reported -1 for any container still running past it, tearing down
+// healthy long traces in the log-follow fallback. The wait must keep
+// polling until the container actually terminates.
+func TestWaitForExitCode_OutlastsLongTraces(t *testing.T) {
+	running := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "spawn", Namespace: "ns1"},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "main", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		}},
+	}
+	clientset := fake.NewSimpleClientset(running)
+	var mu sync.Mutex
+	polls := 0
+	clientset.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		polls++
+		if polls < 4 {
+			return false, nil, nil // still running
+		}
+		done := running.DeepCopy()
+		done.Status.ContainerStatuses[0].State = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+		}
+		return true, done, nil
+	})
+
+	if exit := WaitForExitCode(context.Background(), clientset, "ns1", "spawn"); exit != 0 {
+		t.Errorf("exit = %d, want 0 once the container terminates", exit)
+	}
+}
+
+func TestWaitForExitCode_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	clientset := fake.NewSimpleClientset()
+	if exit := WaitForExitCode(ctx, clientset, "ns1", "gone"); exit != -1 {
+		t.Errorf("exit = %d, want -1 on cancelled context", exit)
+	}
+}
+
+// reapPodFull builds a spawn pod with the labels the reaper inspects.
+func reapPodFull(name string, pid int, bootID string, age time.Duration, deadline *int64) *corev1.Pod {
+	labels := map[string]string{
+		LabelManagedBy: ManagedByValue,
+		LabelOwnerPID:  fmt.Sprintf("%d", pid),
+		LabelCreatedAt: fmt.Sprintf("%d", time.Now().Add(-age).Unix()),
+	}
+	if bootID != "" {
+		labels[LabelOwnerBootID] = bootID
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns1", Labels: labels},
+		Spec:       corev1.PodSpec{ActiveDeadlineSeconds: deadline},
+	}
+}
+
+// TestReaper_ForeignBootIDNotReaped: kill(pid, 0) only means something on
+// the machine that spawned the pod. Two hosts whose names collide after
+// label sanitization used to reap each other's LIVE spawn pods.
+func TestReaper_ForeignBootIDNotReaped(t *testing.T) {
+	savedBootID := MachineBootID
+	MachineBootID = func() string { return "local-boot-id" }
+	defer func() { MachineBootID = savedBootID }()
+
+	foreign := reapPodFull("foreign", 4242, "other-boot-id", 10*time.Minute, nil)
+	local := reapPodFull("local", 4242, "local-boot-id", 10*time.Minute, nil)
+	clientset := fake.NewSimpleClientset(foreign, local)
+
+	reaped, err := reapStaleWithLiveness(context.Background(), clientset, "ns1", "", func(int) bool { return false })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reaped != 1 {
+		t.Fatalf("reaped %d pods, want exactly the local one", reaped)
+	}
+	if _, err := clientset.CoreV1().Pods("ns1").Get(context.Background(), "foreign", metav1.GetOptions{}); err != nil {
+		t.Error("foreign machine's pod must not be reaped on a local liveness verdict")
+	}
+	if _, err := clientset.CoreV1().Pods("ns1").Get(context.Background(), "local", metav1.GetOptions{}); err == nil {
+		t.Error("local orphan must be reaped")
+	}
+}
+
+// TestReaper_ExpiredPodReapedRegardlessOfOwner: pods older than the hard
+// age bound are orphans no matter which machine owns them — ReaperMaxAge
+// was defined but never enforced.
+func TestReaper_ExpiredPodReapedRegardlessOfOwner(t *testing.T) {
+	savedBootID := MachineBootID
+	MachineBootID = func() string { return "local-boot-id" }
+	defer func() { MachineBootID = savedBootID }()
+
+	expired := reapPodFull("expired", 4242, "other-boot-id", ReaperMaxAge+time.Hour, nil)
+	clientset := fake.NewSimpleClientset(expired)
+
+	reaped, err := reapStaleWithLiveness(context.Background(), clientset, "ns1", "", func(int) bool { return true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reaped != 1 {
+		t.Errorf("reaped %d, want 1 (expired pod)", reaped)
+	}
+}
+
+// TestReaper_LongDeadlineExtendsAgeBound: a trace spawned with an explicit
+// deadline beyond ReaperMaxAge is not an orphan until that deadline (plus
+// grace) passes.
+func TestReaper_LongDeadlineExtendsAgeBound(t *testing.T) {
+	savedBootID := MachineBootID
+	MachineBootID = func() string { return "local-boot-id" }
+	defer func() { MachineBootID = savedBootID }()
+
+	deadline := int64((4 * time.Hour).Seconds())
+	longTrace := reapPodFull("long-trace", 4242, "other-boot-id", 3*time.Hour, &deadline)
+	clientset := fake.NewSimpleClientset(longTrace)
+
+	reaped, err := reapStaleWithLiveness(context.Background(), clientset, "ns1", "", func(int) bool { return true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reaped != 0 {
+		t.Errorf("reaped %d, want 0: 3h-old pod with a 4h deadline is not an orphan", reaped)
+	}
+}

--- a/internal/kubernetes/nodespawn/stream.go
+++ b/internal/kubernetes/nodespawn/stream.go
@@ -118,7 +118,7 @@ func containerStartFailureReason(p *corev1.Pod) string {
 var stuckPodEventReason = func(ctx context.Context, clientset kubernetes.Interface, p *corev1.Pod) string {
 	fatal := map[string]struct{}{
 		"FailedMount":            {},
-		"FailedAttachVolume":    {},
+		"FailedAttachVolume":     {},
 		"FailedCreatePodSandBox": {},
 		"FailedMapVolume":        {},
 	}
@@ -225,25 +225,37 @@ func streamLogs(ctx context.Context, clientset kubernetes.Interface, pod *corev1
 // exit code.
 func WaitForExitCode(ctx context.Context, clientset kubernetes.Interface, namespace, name string) int32 {
 	const pollEvery = 500 * time.Millisecond
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	const maxConsecutiveErrors = 10
+	consecutiveErrors := 0
+	for {
 		select {
 		case <-ctx.Done():
 			return -1
 		default:
 		}
 		p, err := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
 			return -1
-		}
-		for _, cs := range p.Status.ContainerStatuses {
-			if t := cs.State.Terminated; t != nil {
-				return t.ExitCode
+		case err != nil:
+			consecutiveErrors++
+			if consecutiveErrors >= maxConsecutiveErrors {
+				return -1
+			}
+		default:
+			consecutiveErrors = 0
+			for _, cs := range p.Status.ContainerStatuses {
+				if t := cs.State.Terminated; t != nil {
+					return t.ExitCode
+				}
 			}
 		}
-		time.Sleep(pollEvery)
+		select {
+		case <-ctx.Done():
+			return -1
+		case <-time.After(pollEvery):
+		}
 	}
-	return -1
 }
 
 // IsNotFound is exported so cleanup callers can swallow "already-gone" errors.

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -118,28 +118,13 @@ func (r *PodResolver) ResolvePod(ctx context.Context, podName, namespace, contai
 		return nil, NewNoContainersError()
 	}
 
-	var containerStatus *corev1.ContainerStatus
-	var containerSpec *corev1.Container
-
-	if containerName != "" {
-		for i, status := range pod.Status.ContainerStatuses {
-			if status.Name == containerName {
-				containerStatus = &pod.Status.ContainerStatuses[i]
-				for j, spec := range pod.Spec.Containers {
-					if spec.Name == containerName {
-						containerSpec = &pod.Spec.Containers[j]
-						break
-					}
-				}
-				break
-			}
+	containerStatus, containerSpec := pickContainer(pod, containerName)
+	if containerStatus == nil {
+		name := containerName
+		if name == "" && len(pod.Spec.Containers) > 0 {
+			name = pod.Spec.Containers[0].Name
 		}
-		if containerStatus == nil {
-			return nil, NewContainerNotFoundError(containerName)
-		}
-	} else {
-		containerStatus = &pod.Status.ContainerStatuses[0]
-		containerSpec = &pod.Spec.Containers[0]
+		return nil, NewContainerNotFoundError(name)
 	}
 
 	containerID := containerStatus.ContainerID
@@ -397,6 +382,29 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 	return "", errors.New("podtrace: CRI cgroup path not found on filesystem")
 }
 
+// pickContainer selects the container to trace: the named one, or the
+// pod's first spec container when no name is given.
+func pickContainer(pod *corev1.Pod, containerName string) (*corev1.ContainerStatus, *corev1.Container) {
+	name := containerName
+	if name == "" && len(pod.Spec.Containers) > 0 {
+		name = pod.Spec.Containers[0].Name
+	}
+
+	var spec *corev1.Container
+	for j := range pod.Spec.Containers {
+		if pod.Spec.Containers[j].Name == name {
+			spec = &pod.Spec.Containers[j]
+			break
+		}
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == name {
+			return &pod.Status.ContainerStatuses[i], spec
+		}
+	}
+	return nil, spec
+}
+
 type PodInfo struct {
 	PodName       string
 	Namespace     string
@@ -493,6 +501,13 @@ func findCgroupPathV1(containerID string) (string, error) {
 			filepath.Join(root, "kubepods.slice"),
 			filepath.Join(root, "system.slice"),
 			filepath.Join(root, "user.slice"),
+			filepath.Join(root, "kubepods"),
+		)
+	}
+	for _, controllerRoot := range cgroupV1ControllerRoots() {
+		paths = append(paths,
+			filepath.Join(controllerRoot, "kubepods"),
+			filepath.Join(controllerRoot, "kubepods.slice"),
 		)
 	}
 
@@ -527,6 +542,39 @@ func findCgroupPathV1(containerID string) (string, error) {
 	}
 
 	return "", NewCgroupNotFoundError(containerID)
+}
+
+// cgroupV1ControllerRoots lists the first-level controller hierarchies
+// mounted under the cgroup base.
+func cgroupV1ControllerRoots() []string {
+	if v2, _ := isCgroupV2(config.CgroupBasePath); v2 {
+		return nil
+	}
+	entries, err := os.ReadDir(config.CgroupBasePath)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		out = append(out, filepath.Join(config.CgroupBasePath, e.Name()))
+	}
+	return out
+}
+
+// cgroupV1Controllers parses the controller field of a /proc/<pid>/cgroup
+// v1 line ("cpu,cpuacct", "name=systemd") into mount directory names.
+func cgroupV1Controllers(field string) []string {
+	var out []string
+	for _, c := range strings.Split(field, ",") {
+		c = strings.TrimSpace(strings.TrimPrefix(c, "name="))
+		if c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func findCgroupPathFromProc(containerID string) (string, error) {
@@ -589,15 +637,25 @@ func findCgroupPathFromProc(containerID string) (string, error) {
 					}
 				}
 			} else {
-				parts := strings.Split(line, ":")
-				if len(parts) >= 3 {
+				parts := strings.SplitN(line, ":", 3)
+				if len(parts) == 3 {
 					cgroupPath := parts[2]
 					if cgroupPath != "" && cgroupPath != "/" {
-						for _, root := range cgroupRootCandidates() {
-							fullPath := filepath.Join(root, strings.TrimPrefix(cgroupPath, "/"))
+						trimmed := strings.TrimPrefix(cgroupPath, "/")
+						for _, ctrl := range cgroupV1Controllers(parts[1]) {
+							fullPath := filepath.Join(config.CgroupBasePath, ctrl, trimmed)
 							if statCgroupDir(fullPath) {
 								foundPath = fullPath
 								break
+							}
+						}
+						if foundPath == "" {
+							for _, root := range cgroupRootCandidates() {
+								fullPath := filepath.Join(root, trimmed)
+								if statCgroupDir(fullPath) {
+									foundPath = fullPath
+									break
+								}
 							}
 						}
 					}

--- a/internal/kubernetes/robustness_regression_test.go
+++ b/internal/kubernetes/robustness_regression_test.go
@@ -1,0 +1,276 @@
+package kubernetes
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestParseTarget_BracketedIPv6WithoutPort: "[::1]" used to panic with a
+// slice out-of-range in the event hot path.
+func TestParseTarget_BracketedIPv6WithoutPort(t *testing.T) {
+	cases := []struct {
+		in   string
+		ip   string
+		port int
+	}{
+		{"[::1]", "::1", 0},
+		{"[::1]:8080", "::1", 8080},
+		{"[2001:db8::2]", "2001:db8::2", 0},
+		{"10.0.0.1:443", "10.0.0.1", 443},
+		{"10.0.0.1", "10.0.0.1", 0},
+		{"", "", 0},
+	}
+	for _, c := range cases {
+		ip, port := parseTarget(c.in)
+		if ip != c.ip || port != c.port {
+			t.Errorf("parseTarget(%q) = (%q, %d), want (%q, %d)", c.in, ip, port, c.ip, c.port)
+		}
+	}
+}
+
+// TestPickContainer_StatusOrderIndependent: ContainerStatuses is not
+// guaranteed to share Spec.Containers' order; positional pairing returned
+// the wrong container's ID and cgroup.
+func TestPickContainer_StatusOrderIndependent(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "app"}, {Name: "sidecar"},
+		}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "sidecar", ContainerID: "containerd://side"},
+			{Name: "app", ContainerID: "containerd://app1"},
+		}},
+	}
+
+	status, spec := pickContainer(pod, "")
+	if status == nil || spec == nil {
+		t.Fatal("expected the first spec container to resolve")
+	}
+	if status.Name != "app" || status.ContainerID != "containerd://app1" || spec.Name != "app" {
+		t.Errorf("default pick = status %q/%s spec %q, want the app container", status.Name, status.ContainerID, spec.Name)
+	}
+
+	status, spec = pickContainer(pod, "sidecar")
+	if status == nil || status.ContainerID != "containerd://side" || spec == nil || spec.Name != "sidecar" {
+		t.Errorf("named pick mismatched: status %+v spec %+v", status, spec)
+	}
+
+	if status, _ := pickContainer(pod, "missing"); status != nil {
+		t.Errorf("unknown container name must return nil status, got %+v", status)
+	}
+}
+
+// TestCgroupV1Controllers parses the controller field of v1
+// /proc/<pid>/cgroup lines, including the name= prefix form.
+func TestCgroupV1Controllers(t *testing.T) {
+	if got := cgroupV1Controllers("cpu,cpuacct"); len(got) != 2 || got[0] != "cpu" || got[1] != "cpuacct" {
+		t.Errorf("cpu,cpuacct = %v", got)
+	}
+	if got := cgroupV1Controllers("name=systemd"); len(got) != 1 || got[0] != "systemd" {
+		t.Errorf("name=systemd = %v", got)
+	}
+}
+
+// TestServiceResolver_NegativeCacheSuppressesRelisting: a miss used to
+// trigger a cluster-wide Endpoints list on EVERY lookup; the negative
+// cache must absorb repeats.
+func TestServiceResolver_NegativeCacheSuppressesRelisting(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	var mu sync.Mutex
+	lists := 0
+	clientset.PrependReactor("list", "endpoints", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		lists++
+		mu.Unlock()
+		return false, nil, nil
+	})
+
+	sr := NewServiceResolver(clientset)
+	for i := 0; i < 5; i++ {
+		if svc := sr.ResolveService(context.Background(), "10.9.9.9", 80); svc != nil {
+			t.Fatalf("unexpected service for unbacked endpoint: %+v", svc)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if lists != 1 {
+		t.Errorf("Endpoints listed %d times for 5 identical misses, want 1 (negative cache)", lists)
+	}
+}
+
+// TestServiceResolver_BulkPopulatesFromSingleList: one list call must
+// satisfy later lookups of OTHER endpoints from cache.
+func TestServiceResolver_BulkPopulatesFromSingleList(t *testing.T) {
+	mkEndpoints := func(name, ip string, port int32) *corev1.Endpoints { //nolint:staticcheck // Endpoints API still widely used
+		return &corev1.Endpoints{ //nolint:staticcheck // Endpoints API still widely used
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck // Endpoints API still widely used
+				Addresses: []corev1.EndpointAddress{{IP: ip}},
+				Ports:     []corev1.EndpointPort{{Port: port}},
+			}},
+		}
+	}
+	clientset := fake.NewSimpleClientset(
+		mkEndpoints("svc-a", "10.0.0.1", 80),
+		mkEndpoints("svc-b", "10.0.0.2", 443),
+	)
+	var mu sync.Mutex
+	lists := 0
+	clientset.PrependReactor("list", "endpoints", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		lists++
+		mu.Unlock()
+		return false, nil, nil
+	})
+
+	sr := NewServiceResolver(clientset)
+	if svc := sr.ResolveService(context.Background(), "10.0.0.1", 80); svc == nil || svc.Name != "svc-a" {
+		t.Fatalf("svc-a lookup = %+v", svc)
+	}
+	if svc := sr.ResolveService(context.Background(), "10.0.0.2", 443); svc == nil || svc.Name != "svc-b" {
+		t.Fatalf("svc-b lookup = %+v", svc)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if lists != 1 {
+		t.Errorf("Endpoints listed %d times, want 1 (second lookup served from bulk-populated cache)", lists)
+	}
+}
+
+// TestChannelTargetSource_PublishCloseRace: Publish racing Close used to
+// send on a closed channel and panic. Run under -race.
+func TestChannelTargetSource_PublishCloseRace(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		s := NewChannelTargetSource()
+		_ = s.Start(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				s.Publish([]*PodInfo{{PodName: "p"}})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			s.Close()
+		}()
+		wg.Wait()
+		s.Close()
+		s.Publish(nil)
+	}
+}
+
+// TestEventsCorrelator_RewatchAfterServerClose: API servers close watches
+// after a few minutes; the correlator must re-establish the watch instead
+// of silently collecting nothing for the rest of the trace.
+func TestEventsCorrelator_RewatchAfterServerClose(t *testing.T) {
+	saved := rewatchBackoff
+	rewatchBackoff = 10 * time.Millisecond
+	defer func() { rewatchBackoff = saved }()
+
+	clientset := fake.NewSimpleClientset()
+	var mu sync.Mutex
+	var watchers []*watch.FakeWatcher
+	clientset.PrependWatchReactor("events", func(k8stesting.Action) (bool, watch.Interface, error) {
+		w := watch.NewFake()
+		mu.Lock()
+		watchers = append(watchers, w)
+		mu.Unlock()
+		return true, w, nil
+	})
+
+	ec := NewEventsCorrelator(clientset, "pod-x", "default")
+	if err := ec.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer ec.Stop()
+
+	mu.Lock()
+	first := watchers[0]
+	mu.Unlock()
+	first.Stop()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		n := len(watchers)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("watch was never re-established after server-side close")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	mu.Lock()
+	second := watchers[1]
+	mu.Unlock()
+	second.Add(&corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "ev1", Namespace: "default"},
+		InvolvedObject: corev1.ObjectReference{Name: "pod-x"},
+		Reason:         "AfterRewatch",
+	})
+	deadline = time.After(5 * time.Second)
+	for {
+		evs := ec.GetEvents()
+		if len(evs) == 1 && evs[0].Reason == "AfterRewatch" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("event after re-watch never collected, have %d", len(evs))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// TestEventsCorrelator_StopIdempotent: a second Stop used to panic on the
+// already-closed channel.
+func TestEventsCorrelator_StopIdempotent(t *testing.T) {
+	ec := NewEventsCorrelator(fake.NewSimpleClientset(), "p", "default")
+	if err := ec.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ec.Stop()
+	ec.Stop()
+}
+
+// TestTargetRegistry_DropsStaleTargetOnRestart: when a pod's container
+// restarts, resolution of the new container can fail transiently, but the
+// cached entry points at the OLD container's dead cgroup and must be
+// dropped, not served indefinitely.
+func TestTargetRegistry_DropsStaleTargetOnRestart(t *testing.T) {
+	t.Setenv("PODTRACE_CRI_RESOLVE", "false")
+	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
+	uid := types.UID("u1")
+	tr.targets[uid] = &PodInfo{PodName: "p", ContainerID: "oldcontainer1234"}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: uid, Name: "p", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "main", ContainerID: "containerd://deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+		}},
+	}
+	tr.handlePodUpsert(context.Background(), pod)
+
+	if _, ok := tr.targets[uid]; ok {
+		t.Error("stale target (old container ID) must be dropped when the pod no longer runs that container")
+	}
+}

--- a/internal/kubernetes/service_resolver.go
+++ b/internal/kubernetes/service_resolver.go
@@ -20,11 +20,18 @@ type ServiceResolver struct {
 	clientset     kubernetes.Interface
 	endpointCache *sync.Map
 	cacheTTL      time.Duration
+	negativeTTL   time.Duration
 	informerCache *InformerCache
+
+	fetchMu sync.Mutex
 }
 
+// endpointCacheEntry is a positive or negative cache row: a negative row
+// (notFound=true, shorter TTL) suppresses repeat cluster-wide lists for
+// endpoints that simply are not backed by a Service.
 type endpointCacheEntry struct {
 	serviceInfo ServiceInfo
+	notFound    bool
 	expiresAt   time.Time
 }
 
@@ -34,10 +41,15 @@ func NewServiceResolver(clientset kubernetes.Interface) *ServiceResolver {
 
 func NewServiceResolverWithCache(clientset kubernetes.Interface, ic *InformerCache) *ServiceResolver {
 	ttl := time.Duration(getIntEnvOrDefault("PODTRACE_K8S_CACHE_TTL", 300)) * time.Second
+	negativeTTL := 30 * time.Second
+	if negativeTTL > ttl {
+		negativeTTL = ttl
+	}
 	return &ServiceResolver{
 		clientset:     clientset,
 		endpointCache: &sync.Map{},
 		cacheTTL:      ttl,
+		negativeTTL:   negativeTTL,
 		informerCache: ic,
 	}
 }
@@ -57,48 +69,78 @@ func (sr *ServiceResolver) ResolveService(ctx context.Context, ip string, port i
 	}
 
 	cacheKey := fmt.Sprintf("%s:%d", ip, port)
-	if cached, ok := sr.endpointCache.Load(cacheKey); ok {
-		entry := cached.(*endpointCacheEntry)
-		if time.Now().Before(entry.expiresAt) {
-			return &entry.serviceInfo
-		}
-		sr.endpointCache.Delete(cacheKey)
+	if info, ok := sr.lookupCache(cacheKey); ok {
+		return info
+	}
+
+	sr.fetchMu.Lock()
+	defer sr.fetchMu.Unlock()
+	if info, ok := sr.lookupCache(cacheKey); ok {
+		return info
 	}
 
 	serviceInfo := sr.fetchServiceByEndpoint(ctx, ip, port)
-	if serviceInfo != nil {
+	if serviceInfo == nil {
 		sr.endpointCache.Store(cacheKey, &endpointCacheEntry{
-			serviceInfo: *serviceInfo,
-			expiresAt:   time.Now().Add(sr.cacheTTL),
+			notFound:  true,
+			expiresAt: time.Now().Add(sr.negativeTTL),
 		})
 	}
-
 	return serviceInfo
 }
 
+// lookupCache returns (info, true) on a live positive hit, (nil, true) on
+// a live negative hit, and (nil, false) when the resolver must fetch.
+func (sr *ServiceResolver) lookupCache(cacheKey string) (*ServiceInfo, bool) {
+	cached, ok := sr.endpointCache.Load(cacheKey)
+	if !ok {
+		return nil, false
+	}
+	entry := cached.(*endpointCacheEntry)
+	if time.Now().Before(entry.expiresAt) {
+		if entry.notFound {
+			return nil, true
+		}
+		info := entry.serviceInfo
+		return &info, true
+	}
+	sr.endpointCache.Delete(cacheKey)
+	return nil, false
+}
+
+// fetchServiceByEndpoint lists Endpoints once and populates the positive
+// cache for EVERY endpoint in the response, so one cluster-wide list
+// amortizes across all subsequent lookups instead of being repeated per
+// cache miss.
 func (sr *ServiceResolver) fetchServiceByEndpoint(ctx context.Context, ip string, port int) *ServiceInfo {
 	endpointsList, err := sr.clientset.CoreV1().Endpoints(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil
 	}
 
+	var match *ServiceInfo
+	expiry := time.Now().Add(sr.cacheTTL)
 	for _, endpoint := range endpointsList.Items {
 		for _, subset := range endpoint.Subsets {
 			for _, addr := range subset.Addresses {
-				if addr.IP == ip {
-					for _, epPort := range subset.Ports {
-						if int(epPort.Port) == port {
-							return &ServiceInfo{
-								Name:      endpoint.Name,
-								Namespace: endpoint.Namespace,
-								Port:      port,
-							}
-						}
+				for _, epPort := range subset.Ports {
+					info := ServiceInfo{
+						Name:      endpoint.Name,
+						Namespace: endpoint.Namespace,
+						Port:      int(epPort.Port),
+					}
+					sr.endpointCache.Store(
+						fmt.Sprintf("%s:%d", addr.IP, epPort.Port),
+						&endpointCacheEntry{serviceInfo: info, expiresAt: expiry},
+					)
+					if addr.IP == ip && int(epPort.Port) == port && match == nil {
+						m := info
+						match = &m
 					}
 				}
 			}
 		}
 	}
 
-	return nil
+	return match
 }

--- a/internal/kubernetes/target_registry.go
+++ b/internal/kubernetes/target_registry.go
@@ -73,6 +73,10 @@ type TargetRegistry struct {
 
 	mu      sync.RWMutex
 	targets map[types.UID]*PodInfo
+
+	pendingMu sync.Mutex
+	pending   map[types.UID]*corev1.Pod
+	pendingCh chan struct{}
 }
 
 func NewTargetRegistry(clientset kubernetes.Interface, selection TargetSelection) *TargetRegistry {
@@ -83,6 +87,8 @@ func NewTargetRegistry(clientset kubernetes.Interface, selection TargetSelection
 		updates:     make(chan []*PodInfo, 8),
 		targets:     make(map[types.UID]*PodInfo),
 		podNameRefs: selection.PodRefSet(),
+		pending:     make(map[types.UID]*corev1.Pod),
+		pendingCh:   make(chan struct{}, 1),
 	}
 }
 
@@ -114,10 +120,10 @@ func (tr *TargetRegistry) Start(ctx context.Context) error {
 	podInf := factory.Core().V1().Pods().Informer()
 	_, _ = podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			tr.handlePodUpsert(obj)
+			tr.enqueueUpsert(obj)
 		},
 		UpdateFunc: func(_, newObj interface{}) {
-			tr.handlePodUpsert(newObj)
+			tr.enqueueUpsert(newObj)
 		},
 		DeleteFunc: func(obj interface{}) {
 			tr.handlePodDelete(obj)
@@ -131,9 +137,57 @@ func (tr *TargetRegistry) Start(ctx context.Context) error {
 		return fmt.Errorf("timed out waiting for pod target registry cache sync")
 	}
 
-	tr.rebuildFromStore()
+	tr.rebuildFromStore(ctx)
 	tr.emitSnapshot()
+	go tr.resolveWorker(ctx)
 	return nil
+}
+
+// enqueueUpsert records the pod for the resolution worker. It runs on the
+// informer's delivery goroutine, so it must not block or perform I/O.
+func (tr *TargetRegistry) enqueueUpsert(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil {
+		return
+	}
+	tr.pendingMu.Lock()
+	tr.pending[pod.UID] = pod
+	tr.pendingMu.Unlock()
+	select {
+	case tr.pendingCh <- struct{}{}:
+	default:
+	}
+}
+
+// resolveWorker drains pending pods and resolves them off the informer
+// goroutine. Cgroup resolution can take seconds per pod (CRI socket,
+// filesystem walks); doing it inline in the event handler stalled every
+// other informer callback.
+func (tr *TargetRegistry) resolveWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tr.pendingCh:
+		}
+		for {
+			tr.pendingMu.Lock()
+			var pod *corev1.Pod
+			var uid types.UID
+			for u, p := range tr.pending {
+				uid, pod = u, p
+				break
+			}
+			if pod != nil {
+				delete(tr.pending, uid)
+			}
+			tr.pendingMu.Unlock()
+			if pod == nil {
+				break
+			}
+			tr.handlePodUpsert(ctx, pod)
+		}
+	}
 }
 
 func (tr *TargetRegistry) Updates() <-chan []*PodInfo { return tr.updates }
@@ -144,21 +198,19 @@ func (tr *TargetRegistry) Snapshot() []*PodInfo {
 	return clonePodInfos(tr.targets)
 }
 
-func (tr *TargetRegistry) rebuildFromStore() {
+func (tr *TargetRegistry) rebuildFromStore(ctx context.Context) {
 	if tr.podInf == nil {
 		return
 	}
 	items := tr.podInf.GetStore().List()
 	for _, obj := range items {
-		tr.handlePodUpsert(obj)
+		if pod, ok := obj.(*corev1.Pod); ok && pod != nil {
+			tr.handlePodUpsert(ctx, pod)
+		}
 	}
 }
 
-func (tr *TargetRegistry) handlePodUpsert(obj interface{}) {
-	pod, ok := obj.(*corev1.Pod)
-	if !ok || pod == nil {
-		return
-	}
+func (tr *TargetRegistry) handlePodUpsert(ctx context.Context, pod *corev1.Pod) {
 	if !tr.matchesSelection(pod) {
 		tr.mu.Lock()
 		delete(tr.targets, pod.UID)
@@ -167,8 +219,27 @@ func (tr *TargetRegistry) handlePodUpsert(obj interface{}) {
 		return
 	}
 
-	info, err := resolvePodInfoFromObject(context.Background(), pod, tr.selection.ContainerName)
+	info, err := resolvePodInfoFromObject(ctx, pod, tr.selection.ContainerName)
 	if err != nil {
+		logger.Debug("Target pod resolution failed",
+			zap.String("namespace", pod.Namespace),
+			zap.String("pod", pod.Name),
+			zap.Error(err))
+		tr.mu.Lock()
+		stale := tr.targets[pod.UID]
+		dropped := false
+		if stale != nil && !podHasContainerID(pod, stale.ContainerID) {
+			delete(tr.targets, pod.UID)
+			dropped = true
+		}
+		tr.mu.Unlock()
+		if dropped {
+			logger.Debug("Dropped stale target after container restart",
+				zap.String("namespace", pod.Namespace),
+				zap.String("pod", pod.Name),
+				zap.String("stale_container_id", stale.ContainerID))
+			tr.emitSnapshot()
+		}
 		return
 	}
 
@@ -183,6 +254,24 @@ func (tr *TargetRegistry) handlePodUpsert(obj interface{}) {
 	tr.targets[pod.UID] = info
 	tr.mu.Unlock()
 	tr.emitSnapshot()
+}
+
+// podHasContainerID reports whether any of the pod's current container
+// statuses carries the given (runtime-prefix-stripped) container ID.
+func podHasContainerID(pod *corev1.Pod, shortID string) bool {
+	if shortID == "" {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		id := cs.ContainerID
+		if i := strings.Index(id, "://"); i >= 0 {
+			id = id[i+3:]
+		}
+		if id == shortID {
+			return true
+		}
+	}
+	return false
 }
 
 func (tr *TargetRegistry) handlePodDelete(obj interface{}) {
@@ -256,27 +345,9 @@ func resolvePodInfoFromObject(ctx context.Context, pod *corev1.Pod, containerNam
 		return nil, fmt.Errorf("pod %s/%s has no container statuses", pod.Namespace, pod.Name)
 	}
 
-	var containerStatus *corev1.ContainerStatus
-	var containerSpec *corev1.Container
-	if containerName != "" {
-		for i, status := range pod.Status.ContainerStatuses {
-			if status.Name == containerName {
-				containerStatus = &pod.Status.ContainerStatuses[i]
-				for j, spec := range pod.Spec.Containers {
-					if spec.Name == containerName {
-						containerSpec = &pod.Spec.Containers[j]
-						break
-					}
-				}
-				break
-			}
-		}
-		if containerStatus == nil {
-			return nil, fmt.Errorf("container %s not found in pod %s/%s", containerName, pod.Namespace, pod.Name)
-		}
-	} else {
-		containerStatus = &pod.Status.ContainerStatuses[0]
-		containerSpec = &pod.Spec.Containers[0]
+	containerStatus, containerSpec := pickContainer(pod, containerName)
+	if containerStatus == nil {
+		return nil, fmt.Errorf("container %q has no status yet in pod %s/%s", containerName, pod.Namespace, pod.Name)
 	}
 
 	containerID := containerStatus.ContainerID

--- a/internal/kubernetes/target_registry_test.go
+++ b/internal/kubernetes/target_registry_test.go
@@ -42,15 +42,15 @@ func TestTargetSelection_PodRefSet(t *testing.T) {
 			"plain",
 			"  ",
 			"ns1/qual",
-			"ns1/qual",  // dedup within ns
+			"ns1/qual", // dedup within ns
 			"ns2/other",
 		},
 	}
 	got := sel.PodRefSet()
 	want := map[string]map[string]struct{}{
-		"def":  {"plain": {}},
-		"ns1":  {"qual": {}},
-		"ns2":  {"other": {}},
+		"def": {"plain": {}},
+		"ns1": {"qual": {}},
+		"ns2": {"other": {}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v want %#v", got, want)
@@ -297,7 +297,7 @@ func TestTargetRegistry_HandlePodUpsert_NonMatchingDeletes(t *testing.T) {
 	tr.targets[uid] = &PodInfo{PodName: "stale"}
 
 	// Upsert with a pod outside the watched namespace must remove it.
-	tr.handlePodUpsert(&corev1.Pod{
+	tr.handlePodUpsert(context.Background(), &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{UID: uid, Name: "stale", Namespace: "dev"},
 	})
 	if _, ok := tr.targets[uid]; ok {
@@ -305,12 +305,12 @@ func TestTargetRegistry_HandlePodUpsert_NonMatchingDeletes(t *testing.T) {
 	}
 }
 
-func TestTargetRegistry_HandlePodUpsert_IgnoresNonPod(t *testing.T) {
+func TestTargetRegistry_EnqueueUpsert_IgnoresNonPod(t *testing.T) {
 	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
-	tr.handlePodUpsert("not a pod") // must be a no-op
-	tr.handlePodUpsert(nil)         // nil pod
-	if len(tr.targets) != 0 {
-		t.Fatal("upsert of non-pod must not insert anything")
+	tr.enqueueUpsert("not a pod") // must be a no-op
+	tr.enqueueUpsert(nil)         // nil pod
+	if len(tr.pending) != 0 || len(tr.targets) != 0 {
+		t.Fatal("upsert of non-pod must not enqueue or insert anything")
 	}
 }
 
@@ -322,7 +322,7 @@ func TestTargetRegistry_HandlePodUpsert_ResolveErrorIsSwallowed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{UID: "no-status", Name: "p", Namespace: "ns"},
 		// Status.ContainerStatuses intentionally empty.
 	}
-	tr.handlePodUpsert(pod)
+	tr.handlePodUpsert(context.Background(), pod)
 	if _, ok := tr.targets[pod.UID]; ok {
 		t.Fatal("pod with no container statuses must not be inserted")
 	}

--- a/internal/kubernetes/target_registry_unit_test.go
+++ b/internal/kubernetes/target_registry_unit_test.go
@@ -174,7 +174,7 @@ func TestHandlePodUpsert_InsertsMatchingPod(t *testing.T) {
 	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{Namespaces: []string{"prod"}})
 	pod := runningPod("uid-ins", "prod", "api-0", "app", cid)
 
-	tr.handlePodUpsert(pod)
+	tr.handlePodUpsert(context.Background(), pod)
 
 	tr.mu.RLock()
 	got, ok := tr.targets[pod.UID]
@@ -201,7 +201,7 @@ func TestHandlePodUpsert_RespectsMaxTargets(t *testing.T) {
 	tr.targets[types.UID("existing")] = &PodInfo{PodName: "existing"}
 
 	pod := runningPod("uid-overflow", "ns", "newpod", "app", cid)
-	tr.handlePodUpsert(pod)
+	tr.handlePodUpsert(context.Background(), pod)
 
 	tr.mu.RLock()
 	_, inserted := tr.targets[pod.UID]
@@ -225,7 +225,7 @@ func TestHandlePodUpsert_UpdatesExistingAtMaxTargets(t *testing.T) {
 	pod := runningPod("uid-upd", "ns", "p", "app", cid)
 	tr.targets[pod.UID] = &PodInfo{PodName: "stale"}
 
-	tr.handlePodUpsert(pod)
+	tr.handlePodUpsert(context.Background(), pod)
 
 	tr.mu.RLock()
 	got := tr.targets[pod.UID]
@@ -253,7 +253,7 @@ func TestRebuildFromStore_PopulatesFromInformerStore(t *testing.T) {
 		t.Fatalf("store add non-matching: %v", err)
 	}
 
-	tr.rebuildFromStore()
+	tr.rebuildFromStore(context.Background())
 
 	tr.mu.RLock()
 	_, hasMatch := tr.targets[matching.UID]
@@ -274,7 +274,7 @@ func TestRebuildFromStore_PopulatesFromInformerStore(t *testing.T) {
 
 func TestRebuildFromStore_NoInformerIsNoop(t *testing.T) {
 	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{})
-	tr.rebuildFromStore()
+	tr.rebuildFromStore(context.Background())
 	if len(tr.targets) != 0 {
 		t.Fatalf("expected no targets, got %d", len(tr.targets))
 	}

--- a/internal/kubernetes/target_source.go
+++ b/internal/kubernetes/target_source.go
@@ -43,6 +43,7 @@ type ChannelTargetSource struct {
 	mu      sync.RWMutex
 	latest  []*PodInfo
 	started bool
+	closed  bool
 }
 
 // NewChannelTargetSource constructs an idle source. Publish is a no-op
@@ -78,32 +79,52 @@ func (s *ChannelTargetSource) Snapshot() []*PodInfo {
 }
 
 // Publish replaces the current snapshot and emits it. Safe for concurrent
-// use. If no consumer is reading, the oldest pending snapshot is dropped
-// to make room for the newest (latest-wins semantics).
+// use, including concurrently with Close: a Publish that loses the race is
+// a no-op rather than a send on a closed channel.
 func (s *ChannelTargetSource) Publish(snapshot []*PodInfo) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
 	// Take a defensive copy so the producer can reuse its own slice.
 	cp := make([]*PodInfo, len(snapshot))
 	copy(cp, snapshot)
 	s.latest = cp
-	started := s.started
-	s.mu.Unlock()
-
-	if !started {
+	if !s.started {
 		return
 	}
-	s.emit(cp)
+	s.emitLocked(cp)
 }
 
-// Close releases the internal channel. Publish calls after Close panic.
+// Close releases the internal channel. Idempotent, and safe to call
+// concurrently with Publish; later Publish calls become no-ops.
 func (s *ChannelTargetSource) Close() {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
 	s.started = false
-	s.mu.Unlock()
 	close(s.updates)
 }
 
 func (s *ChannelTargetSource) emit(snap []*PodInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.emitLocked(snap)
+}
+
+// emitLocked performs the non-blocking latest-wins send. Callers must
+// hold s.mu, which serializes sends against Close — every send path
+// checks s.closed under the same lock, so a send on a closed channel
+// cannot happen. The send itself never blocks, so holding the lock here
+// is cheap.
+func (s *ChannelTargetSource) emitLocked(snap []*PodInfo) {
 	select {
 	case s.updates <- snap:
 	default:


### PR DESCRIPTION
## Summary

This PR fixes a set of robustness issues across the agent's event routing, the Kubernetes resolution layer, CRI cgroup-path handling, and the nodespawn CLI lifecycle.

**Event routing.** The `fs` filter category now expands to unlink and rename events, and the `dns` category includes DNS query events, both were silently dropped for CRs that restricted their filters, even though the tracer produced them. The kernel-side probe category gate is now computed from the CR's `spec.filters`, the same source the router matches events against, instead of the bundle's policy copy, which is rendered by the operator and can lag the spec by a sync round; during that window events the router would have passed were never generated.

**Pod watching.** The agent's pod watch predicates now trigger a reconcile on container restarts and PodIP assignment. A restarted container gets a new container ID and a new cgroup inode, so without a reconcile its events stayed unroutable indefinitely on an otherwise quiet node.

**Node status.** The agent retracts its `nodeStatus` row from PodTrace status when the CR stops matching anything on the node, by applying an empty status under its server-side-apply field owner. Previously the last written row — often `Ready: true` with a frozen heartbeat, lingered on the CR forever.

**Container and cgroup resolution.** Container status and spec are now paired by name; pairing `containerStatuses[0]` with `spec.containers[0]` positionally returned the wrong container's ID when the API server ordered the lists differently. The CRI-reported systemd colon form (`kubepods-…-pod<uid>.slice:cri-containerd:<id>`), the default on GKE, EKS, and kubeadm clusters — is expanded into the real nested `.scope` filesystem path, so CRI resolution works there instead of silently failing into a full `/sys/fs/cgroup` walk on every pod event. Cgroup v1 with the cgroupfs driver is now supported: the filesystem scan covers plain `kubepods` directories and per-controller hierarchies, and the `/proc` fallback joins v1 cgroup lines onto their own controller mount instead of the unified base.

**Event enrichment.** A bracketed IPv6 address without a port (`[::1]`) no longer panics with a slice out-of-range in the event hot path. The service resolver negative-caches lookups that found no Service (30 seconds) and populates its cache for every endpoint returned by a single cluster-wide list, instead of issuing one full list per cache miss; concurrent misses now share one fetch. The Kubernetes events correlator re-establishes its watch when the API server closes it, previously event collection silently stopped after a few minutes, resumes from the last seen resourceVersion, and its `Stop` is idempotent instead of panicking on a second call.

**Target registry.** Cgroup resolution moved off the informer's event delivery goroutine onto a dedicated worker, resolution failures are logged instead of swallowed, and a cached target whose container the pod no longer runs is dropped instead of being served with a dead cgroup until the next successful resolve.

**Nodespawn CLI.** `WaitForExitCode` no longer reports exit −1 after a 30-second wall-clock cap, the attach or log stream can end well before a long trace's container does, and the cap tore those traces down as failures. It now waits for actual termination, retries transient API errors, and gives up only on pod deletion, sustained errors, or context cancellation. Spawn pods carry a new `podtrace.io/owner-boot-id` label: the reaper's `kill(pid, 0)` liveness probe is only meaningful on the machine that spawned the pod, and sanitized-hostname collisions could previously reap another machine's live spawn pods. Pods from a different boot are left alone until they pass a hard age bound, `ReaperMaxAge`, extended by the pod's own `activeDeadlineSeconds` plus grace, which was defined but never enforced.

Concurrency fixes: `ChannelTargetSource` can no longer send on a closed channel when `Publish` races `Close`, and both are now idempotent and safe to call concurrently.