### PR TITLE
fix: harden exporters, alerting, metrics, and resource monitoring

### DIFF
--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -179,17 +179,26 @@ struct resource_limit {
 	u32 resource_type;
 };
 
+/* Keyed by (cgroup, resource type): a plain cgroup-id key made CPU,
+ * memory, and IO entries clobber each other, leaving whichever resource
+ * happened to be written last (Go map iteration order). */
+struct resource_key {
+	u64 cgroup_id;
+	u32 resource_type;
+	u32 _pad;
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct resource_key);
 	__type(value, struct resource_limit);
 } cgroup_limits SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);
-	__type(key, u64);
+	__type(key, struct resource_key);
 	__type(value, u32);
 } cgroup_alerts SEC(".maps");
 

--- a/bpf/resources.c
+++ b/bpf/resources.c
@@ -93,9 +93,13 @@ static inline void emit_resource_alert(u64 cgroup_id, u32 resource_type, u32 uti
     bpf_ringbuf_output(&events, e, sizeof(*e), 0);
     
     u32 alert_level = check_alert_threshold(utilization);
+    struct resource_key alert_key = {
+        .cgroup_id = cgroup_id,
+        .resource_type = resource_type,
+    };
     if (alert_level > 0) {
-        bpf_map_update_elem(&cgroup_alerts, &cgroup_id, &alert_level, BPF_ANY);
+        bpf_map_update_elem(&cgroup_alerts, &alert_key, &alert_level, BPF_ANY);
     } else {
-        bpf_map_delete_elem(&cgroup_alerts, &cgroup_id);
+        bpf_map_delete_elem(&cgroup_alerts, &alert_key);
     }
 }

--- a/internal/alerting/alert.go
+++ b/internal/alerting/alert.go
@@ -44,6 +44,26 @@ func (a *Alert) Key() string {
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
+// Clone returns a deep copy. Each delivery goroutine works on its own
+// copy because senders mutate the alert (Sanitize truncates fields) while
+// siblings are marshaling it.
+func (a *Alert) Clone() *Alert {
+	if a == nil {
+		return nil
+	}
+	cp := *a
+	if a.Context != nil {
+		cp.Context = make(map[string]interface{}, len(a.Context))
+		for k, v := range a.Context {
+			cp.Context[k] = v
+		}
+	}
+	if a.Recommendations != nil {
+		cp.Recommendations = append([]string(nil), a.Recommendations...)
+	}
+	return &cp
+}
+
 func (a *Alert) Validate() error {
 	if a == nil {
 		return fmt.Errorf("alert is nil")
@@ -148,4 +168,3 @@ func ShouldSendAlert(severity AlertSeverity) bool {
 	minSeverity := ParseSeverity(config.GetAlertMinSeverity())
 	return SeverityLevel(severity) >= SeverityLevel(minSeverity)
 }
-

--- a/internal/alerting/deduplicator.go
+++ b/internal/alerting/deduplicator.go
@@ -34,6 +34,19 @@ func (d *AlertDeduplicator) ShouldSend(alert *Alert) bool {
 	return true
 }
 
+// Forget removes the alert's dedup record so the next occurrence is sent
+// again. Called when every sender failed: ShouldSend records the alert at
+// decision time (so concurrent duplicates do not stampede), but a total
+// delivery failure must not silence the alert for the whole window.
+func (d *AlertDeduplicator) Forget(alert *Alert) {
+	if alert == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.seenAlerts, alert.Key())
+}
+
 func (d *AlertDeduplicator) Cleanup(olderThan time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -50,5 +63,3 @@ func (d *AlertDeduplicator) Reset() {
 	defer d.mu.Unlock()
 	d.seenAlerts = make(map[string]time.Time)
 }
-
-

--- a/internal/alerting/delivery_regression_test.go
+++ b/internal/alerting/delivery_regression_test.go
@@ -1,0 +1,190 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func enableAlerting(t *testing.T) {
+	t.Helper()
+	orig := config.AlertingEnabled
+	config.AlertingEnabled = true
+	t.Cleanup(func() { config.AlertingEnabled = orig })
+}
+
+func deliveryTestAlert() *Alert {
+	return &Alert{
+		Severity:  SeverityCritical,
+		Title:     "title",
+		Message:   "message",
+		Timestamp: time.Now(),
+		Source:    "test",
+		Context:   map[string]interface{}{"k": "v"},
+	}
+}
+
+func deliveryTestManager(senders ...Sender) *Manager {
+	return &Manager{
+		senders:      senders,
+		deduplicator: NewAlertDeduplicator(time.Hour),
+		rateLimiter:  NewRateLimiter(1000),
+		enabled:      true,
+		stopCh:       make(chan struct{}),
+	}
+}
+
+// marshalingSender JSON-marshals the alert on every send — combined with a
+// sibling sender mutating the same alert (Sanitize), this is the exact
+// data race the per-sender clone fixes. Run under -race.
+type marshalingSender struct {
+	sends atomic.Int64
+	err   error
+}
+
+func (m *marshalingSender) Send(_ context.Context, alert *Alert) error {
+	alert.Sanitize()
+	if _, err := json.Marshal(alert); err != nil {
+		return err
+	}
+	m.sends.Add(1)
+	return m.err
+}
+func (m *marshalingSender) Name() string { return "marshaling" }
+
+// TestSendAlert_ConcurrentSendersDoNotShareTheAlert: N sender goroutines
+// used to share one *Alert; each Send sanitized (mutated) it while siblings
+// marshaled — a guaranteed race with two or more senders.
+func TestSendAlert_ConcurrentSendersDoNotShareTheAlert(t *testing.T) {
+	enableAlerting(t)
+	s1, s2, s3 := &marshalingSender{}, &marshalingSender{}, &marshalingSender{}
+	m := deliveryTestManager(s1, s2, s3)
+
+	for i := 0; i < 20; i++ {
+		alert := deliveryTestAlert()
+		alert.Title = alert.Title + string(rune('a'+i)) // distinct dedup keys
+		m.SendAlert(alert)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := m.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if s1.sends.Load() != 20 || s2.sends.Load() != 20 || s3.sends.Load() != 20 {
+		t.Errorf("sends = %d/%d/%d, want 20 each", s1.sends.Load(), s2.sends.Load(), s3.sends.Load())
+	}
+}
+
+// TestSendAlert_TotalFailureForgetsDedup: the dedup record was written at
+// decision time, so when every sender failed the alert stayed silenced for
+// the whole window. A total failure must allow the next occurrence through.
+func TestSendAlert_TotalFailureForgetsDedup(t *testing.T) {
+	enableAlerting(t)
+	failing := &marshalingSender{err: errors.New("backend down")}
+	m := deliveryTestManager(failing)
+
+	m.SendAlert(deliveryTestAlert())
+	waitForDeliveries(t, m)
+
+	m.SendAlert(deliveryTestAlert())
+	waitForDeliveries(t, m)
+
+	if got := failing.sends.Load(); got != 2 {
+		t.Errorf("sends = %d, want 2 (total failure must not silence the dedup window)", got)
+	}
+
+	ok := &marshalingSender{}
+	m2 := deliveryTestManager(ok)
+	m2.SendAlert(deliveryTestAlert())
+	waitForDeliveries(t, m2)
+	m2.SendAlert(deliveryTestAlert())
+	waitForDeliveries(t, m2)
+	if got := ok.sends.Load(); got != 1 {
+		t.Errorf("sends = %d, want 1 (successful delivery dedups the window)", got)
+	}
+}
+
+func waitForDeliveries(t *testing.T, m *Manager) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("deliveries never finished")
+	}
+}
+
+// TestDeliveryBudget_CoversRetrySchedule: the 2×HTTP-timeout deadline
+// expired mid-retry-schedule, making PODTRACE_ALERT_MAX_RETRIES mostly
+// dead config. The budget must cover every attempt plus every backoff.
+func TestDeliveryBudget_CoversRetrySchedule(t *testing.T) {
+	var schedule time.Duration
+	schedule += time.Duration(config.AlertMaxRetries+1) * config.AlertHTTPTimeout
+	for attempt := 1; attempt <= config.AlertMaxRetries; attempt++ {
+		backoff := config.DefaultAlertRetryBackoffBase * time.Duration(1<<uint(attempt-1))
+		if backoff > 30*time.Second {
+			backoff = 30 * time.Second
+		}
+		schedule += backoff
+	}
+	if got := deliveryBudget(); got < schedule {
+		t.Errorf("deliveryBudget() = %v, want at least the full retry schedule %v", got, schedule)
+	}
+}
+
+// TestShutdown_WaitsForInFlightAndIsIdempotent: delivery goroutines were
+// not tracked by the WaitGroup (Shutdown dropped in-flight alerts), and a
+// second Shutdown panicked closing the closed stop channel.
+func TestShutdown_WaitsForInFlightAndIsIdempotent(t *testing.T) {
+	enableAlerting(t)
+	release := make(chan struct{})
+	var delivered atomic.Bool
+	slow := &testMockSender{name: "slow", sendFunc: func(ctx context.Context, _ *Alert) error {
+		<-release
+		delivered.Store(true)
+		return nil
+	}}
+	m := deliveryTestManager(slow)
+	m.SendAlert(deliveryTestAlert())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	shutdownDone := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		shutdownDone <- m.Shutdown(ctx)
+	}()
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned while a delivery was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	wg.Wait()
+	if err := <-shutdownDone; err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if !delivered.Load() {
+		t.Error("in-flight delivery was dropped by Shutdown")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := m.Shutdown(ctx); err != nil {
+		t.Errorf("second Shutdown: %v", err)
+	}
+}

--- a/internal/alerting/manager.go
+++ b/internal/alerting/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -31,7 +32,27 @@ type Manager struct {
 	mu            sync.RWMutex
 	cleanupTicker *time.Ticker
 	stopCh        chan struct{}
+	stopOnce      sync.Once
+	shuttingDown  bool
 	wg            sync.WaitGroup
+}
+
+// deliveryBudget is the per-alert deadline handed to each sender. It must
+// cover the sender's full retry schedule — maxRetries+1 attempts, each up
+// to the HTTP timeout, plus the exponential backoff sleeps between them —
+// or the deadline expires mid-schedule and the configured retries are
+// dead config. (The previous 2×HTTP-timeout budget allowed roughly one
+// retry of the default schedule.)
+func deliveryBudget() time.Duration {
+	budget := time.Duration(config.AlertMaxRetries+1) * config.AlertHTTPTimeout
+	for attempt := 1; attempt <= config.AlertMaxRetries; attempt++ {
+		backoff := config.DefaultAlertRetryBackoffBase * time.Duration(1<<uint(attempt-1))
+		if backoff > 30*time.Second {
+			backoff = 30 * time.Second
+		}
+		budget += backoff
+	}
+	return budget + 5*time.Second
 }
 
 // redactURLForLog returns a URL safe to log (query and fragment stripped).
@@ -116,16 +137,49 @@ func (m *Manager) SendAlert(alert *Alert) {
 		return
 	}
 	m.mu.RLock()
+	if m.shuttingDown {
+		m.mu.RUnlock()
+		return
+	}
 	senders := make([]Sender, len(m.senders))
 	copy(senders, m.senders)
+	// wg.Add must happen before RUnlock so Shutdown cannot observe a zero
+	// counter between the shutting-down check and the goroutine spawn.
+	m.wg.Add(len(senders) + 1)
 	m.mu.RUnlock()
+
+	// Fan out one goroutine per sender, each with its OWN copy of the
+	// alert: senders mutate it (Sanitize truncates fields), and a shared
+	// pointer raced sibling goroutines marshaling it concurrently.
+	var successes atomic.Int64
+	var deliveries sync.WaitGroup
 	for _, sender := range senders {
-		go func(s Sender) {
-			ctx, cancel := context.WithTimeout(context.Background(), config.AlertHTTPTimeout*2)
+		deliveries.Add(1)
+		go func(s Sender, a *Alert) {
+			defer m.wg.Done()
+			defer deliveries.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), deliveryBudget())
 			defer cancel()
-			_ = s.Send(ctx, alert)
-		}(sender)
+			if err := s.Send(ctx, a); err != nil {
+				alertLog.Warn("Alert delivery failed",
+					zap.String("sender", s.Name()),
+					zap.String("alert", a.Title),
+					zap.Error(err))
+			} else {
+				successes.Add(1)
+			}
+		}(sender, alert.Clone())
 	}
+	go func() {
+		defer m.wg.Done()
+		deliveries.Wait()
+		if successes.Load() == 0 {
+			// Every sender failed: forget the dedup record so the next
+			// occurrence is attempted again instead of being silenced for
+			// the rest of the window.
+			m.deduplicator.Forget(alert)
+		}
+	}()
 }
 
 func (m *Manager) cleanupLoop() {
@@ -140,11 +194,18 @@ func (m *Manager) cleanupLoop() {
 	}
 }
 
+// Shutdown waits for in-flight alert deliveries (bounded by ctx) and is
+// idempotent — a second call no longer panics on the closed stop channel.
 func (m *Manager) Shutdown(ctx context.Context) error {
 	if !m.enabled {
 		return nil
 	}
-	close(m.stopCh)
+	m.mu.Lock()
+	m.shuttingDown = true
+	m.mu.Unlock()
+	m.stopOnce.Do(func() {
+		close(m.stopCh)
+	})
 	if m.cleanupTicker != nil {
 		m.cleanupTicker.Stop()
 	}
@@ -173,4 +234,3 @@ func (m *Manager) AddSender(sender Sender) {
 func (m *Manager) IsEnabled() bool {
 	return m.enabled
 }
-

--- a/internal/analysis/criticalpath/criticalpath.go
+++ b/internal/analysis/criticalpath/criticalpath.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/safeconv"
 )
 
 // Segment is one contribution to a request's total latency.
@@ -54,12 +55,14 @@ func isBoundary(t events.EventType) bool {
 }
 
 // Feed processes one event. It is safe to call from multiple goroutines.
+// The emit callback runs after the analyzer's lock is released, so a slow
+// (or re-entrant) callback can neither stall the event hot path nor
+// deadlock the analyzer.
 func (a *Analyzer) Feed(e *events.Event) {
 	if e == nil || e.LatencyNS == 0 {
 		return
 	}
 	a.mu.Lock()
-	defer a.mu.Unlock()
 
 	pid := e.PID
 	w, ok := a.windows[pid]
@@ -69,41 +72,69 @@ func (a *Analyzer) Feed(e *events.Event) {
 	}
 	w.lastSeen = time.Now()
 
-	label := e.TypeString()
-	if e.Details != "" {
-		label = e.Details
-	}
-	w.segments = append(w.segments, Segment{Label: label, LatencyNS: e.LatencyNS})
-
+	var path CriticalPath
+	finalized := false
 	if isBoundary(e.Type) {
-		a.finalize(pid, w)
+		if len(w.segments) == 0 {
+			label := e.TypeString()
+			if e.Details != "" {
+				label = e.Details
+			}
+			w.segments = append(w.segments, Segment{Label: label, LatencyNS: e.LatencyNS})
+		}
+		path, finalized = a.buildPath(pid, w, e.LatencyNS)
 		delete(a.windows, pid)
+	} else {
+		label := e.TypeString()
+		if e.Details != "" {
+			label = e.Details
+		}
+		w.segments = append(w.segments, Segment{Label: label, LatencyNS: e.LatencyNS})
+	}
+	a.mu.Unlock()
+
+	if finalized && a.emit != nil {
+		a.emit(path)
 	}
 }
 
 // Evict removes windows older than the timeout and finalizes them.
-// Call periodically to prevent unbounded memory growth.
+// Call periodically to prevent unbounded memory growth. Like Feed, emit
+// callbacks run after the lock is released.
 func (a *Analyzer) Evict() {
 	now := time.Now()
 	a.mu.Lock()
-	defer a.mu.Unlock()
+	var finalized []CriticalPath
 	for pid, w := range a.windows {
 		if now.Sub(w.lastSeen) > a.timeout {
-			if len(w.segments) > 0 {
-				a.finalize(pid, w)
+			if path, ok := a.buildPath(pid, w, 0); ok {
+				finalized = append(finalized, path)
 			}
 			delete(a.windows, pid)
 		}
 	}
+	a.mu.Unlock()
+
+	if a.emit != nil {
+		for _, path := range finalized {
+			a.emit(path)
+		}
+	}
 }
 
-func (a *Analyzer) finalize(pid uint32, w *requestWindow) {
-	if len(w.segments) == 0 || a.emit == nil {
-		return
+// buildPath assembles the CriticalPath for a window. boundaryLatencyNS is
+// the request-spanning latency of the boundary event (0 for timeout
+// evictions, where the segment sum is the best available total). Callers
+// must hold a.mu.
+func (a *Analyzer) buildPath(pid uint32, w *requestWindow, boundaryLatencyNS uint64) (CriticalPath, bool) {
+	if len(w.segments) == 0 {
+		return CriticalPath{}, false
 	}
-	var total uint64
-	for _, s := range w.segments {
-		total += s.LatencyNS
+	total := boundaryLatencyNS
+	if total == 0 {
+		for _, s := range w.segments {
+			total += s.LatencyNS
+		}
 	}
 	segs := make([]Segment, len(w.segments))
 	copy(segs, w.segments)
@@ -112,9 +143,9 @@ func (a *Analyzer) finalize(pid uint32, w *requestWindow) {
 			segs[i].Fraction = float64(segs[i].LatencyNS) / float64(total)
 		}
 	}
-	a.emit(CriticalPath{
+	return CriticalPath{
 		PID:          pid,
-		TotalLatency: time.Duration(total),
+		TotalLatency: time.Duration(safeconv.Uint64ToInt64(total)),
 		Segments:     segs,
-	})
+	}, true
 }

--- a/internal/analysis/criticalpath/criticalpath_test.go
+++ b/internal/analysis/criticalpath/criticalpath_test.go
@@ -34,20 +34,23 @@ func TestFeed_EmitsOnBoundary(t *testing.T) {
 	if cp.PID != 42 {
 		t.Errorf("PID: want 42, got %d", cp.PID)
 	}
-	if len(cp.Segments) != 3 {
-		t.Fatalf("expected 3 segments, got %d", len(cp.Segments))
+	// The boundary response (10ms) spans the whole request, so it IS the
+	// total; the DB and Redis segments are parts of it. The old behavior
+	// summed the boundary on top of its parts (16ms "total" for a 10ms
+	// request) — fractions were diluted by the double count.
+	if len(cp.Segments) != 2 {
+		t.Fatalf("expected 2 segments (boundary excluded), got %d", len(cp.Segments))
 	}
 	totalNS := uint64(cp.TotalLatency)
-	if totalNS != 16_000_000 {
-		t.Errorf("TotalLatency: want 16ms, got %d ns", totalNS)
+	if totalNS != 10_000_000 {
+		t.Errorf("TotalLatency: want the boundary's 10ms, got %d ns", totalNS)
 	}
-	// Fractions should sum to ~1.0
 	var sum float64
 	for _, s := range cp.Segments {
 		sum += s.Fraction
 	}
-	if sum < 0.999 || sum > 1.001 {
-		t.Errorf("fractions should sum to 1.0, got %f", sum)
+	if sum < 0.599 || sum > 0.601 {
+		t.Errorf("fractions: want 0.6 of the request attributed (5ms+1ms of 10ms), got %f", sum)
 	}
 }
 

--- a/internal/analysis/criticalpath/reentrancy_regression_test.go
+++ b/internal/analysis/criticalpath/reentrancy_regression_test.go
@@ -1,0 +1,37 @@
+package criticalpath_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/analysis/criticalpath"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestEmit_ReentrantCallbackDoesNotDeadlock: the emit callback used to run
+// under the analyzer's mutex, so a callback that fed an event back in (or
+// merely blocked) deadlocked the event hot path. It must run lock-free.
+func TestEmit_ReentrantCallbackDoesNotDeadlock(t *testing.T) {
+	var a *criticalpath.Analyzer
+	emitted := 0
+	a = criticalpath.New(time.Second, func(cp criticalpath.CriticalPath) {
+		emitted++
+		if emitted == 1 {
+			a.Feed(&events.Event{Type: events.EventHTTPResp, PID: 999, LatencyNS: 1})
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		a.Feed(&events.Event{Type: events.EventHTTPResp, PID: 1, LatencyNS: 1_000_000})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-entrant emit callback deadlocked the analyzer")
+	}
+	if emitted != 2 {
+		t.Errorf("emitted = %d, want 2 (outer + re-entrant)", emitted)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,9 +52,9 @@ var (
 	EventChannelBufferSize    = getIntEnvOrDefault("PODTRACE_EVENT_BUFFER_SIZE", 10000)
 	CacheMaxSize              = getIntEnvOrDefault("PODTRACE_CACHE_MAX_SIZE", MaxProcessCacheSize)
 	CacheTTLSeconds           = getIntEnvOrDefault("PODTRACE_CACHE_TTL_SECONDS", DefaultCacheTTLSeconds)
-	ErrorBackoffEnabled       = getEnvOrDefault("PODTRACE_ERROR_BACKOFF_ENABLED", "true") == "true"
-	CircuitBreakerEnabled     = getEnvOrDefault("PODTRACE_CIRCUIT_BREAKER_ENABLED", "true") == "true"
-	TracingEnabled            = getEnvOrDefault("PODTRACE_TRACING_ENABLED", "false") == "true"
+	ErrorBackoffEnabled       = getBoolEnvOrDefault("PODTRACE_ERROR_BACKOFF_ENABLED", true)
+	CircuitBreakerEnabled     = getBoolEnvOrDefault("PODTRACE_CIRCUIT_BREAKER_ENABLED", true)
+	TracingEnabled            = getBoolEnvOrDefault("PODTRACE_TRACING_ENABLED", false)
 	TracingSampleRate         = getFloatEnvOrDefault("PODTRACE_TRACING_SAMPLE_RATE", DefaultTracingSampleRate)
 	OTLPEndpoint              = getEnvOrDefault("PODTRACE_OTLP_ENDPOINT", DefaultOTLPEndpoint)
 	JaegerEndpoint            = getEnvOrDefault("PODTRACE_JAEGER_ENDPOINT", DefaultJaegerEndpoint)
@@ -66,11 +66,11 @@ var (
 	MaxTraceIDLength          = 32
 	MaxSpanIDLength           = 16
 	MaxTraceStateLength       = 512
-	AlertingEnabled           = getEnvOrDefault("PODTRACE_ALERTING_ENABLED", "false") == "true"
+	AlertingEnabled           = getBoolEnvOrDefault("PODTRACE_ALERTING_ENABLED", false)
 	AlertWebhookURL           = getEnvOrDefault("PODTRACE_ALERT_WEBHOOK_URL", "")
 	AlertSlackWebhookURL      = getEnvOrDefault("PODTRACE_ALERT_SLACK_WEBHOOK_URL", "")
 	AlertSlackChannel         = getEnvOrDefault("PODTRACE_ALERT_SLACK_CHANNEL", "#alerts")
-	AlertSplunkEnabled        = getEnvOrDefault("PODTRACE_ALERT_SPLUNK_ENABLED", "false") == "true"
+	AlertSplunkEnabled        = getBoolEnvOrDefault("PODTRACE_ALERT_SPLUNK_ENABLED", false)
 	AlertDeduplicationWindow  = getDurationEnvOrDefault("PODTRACE_ALERT_DEDUP_WINDOW", DefaultAlertDedupWindow)
 	AlertRateLimitPerMinute   = getIntEnvOrDefault("PODTRACE_ALERT_RATE_LIMIT", DefaultAlertRateLimitPerMin)
 	AlertHTTPTimeout          = getDurationEnvOrDefault("PODTRACE_ALERT_HTTP_TIMEOUT", DefaultAlertHTTPTimeout)
@@ -118,13 +118,13 @@ var (
 	ManagementPort = getIntEnvOrDefault("PODTRACE_MANAGEMENT_PORT", 0)
 
 	GRPCPort             = getIntEnvOrDefault("PODTRACE_GRPC_PORT", 50051)
-	USDTEnabled          = getEnvOrDefault("PODTRACE_USDT_ENABLED", "false") == "true"
-	RedactPII            = getEnvOrDefault("PODTRACE_REDACT_PII", "false") == "true"
+	USDTEnabled          = getBoolEnvOrDefault("PODTRACE_USDT_ENABLED", false)
+	RedactPII            = getBoolEnvOrDefault("PODTRACE_REDACT_PII", false)
 	RedactCustomRules    = getEnvOrDefault("PODTRACE_REDACT_CUSTOM_RULES", "")
-	CriticalPathEnabled  = getEnvOrDefault("PODTRACE_CRITICAL_PATH", "true") == "true"
+	CriticalPathEnabled  = getBoolEnvOrDefault("PODTRACE_CRITICAL_PATH", true)
 	CriticalPathWindowMS = getIntEnvOrDefault("PODTRACE_CRITICAL_PATH_WINDOW_MS", 500)
 
-	ProfilingEnabled         = getEnvOrDefault("PODTRACE_PROFILING_ENABLED", "false") == "true"
+	ProfilingEnabled         = getBoolEnvOrDefault("PODTRACE_PROFILING_ENABLED", false)
 	ProfilingPprofPorts      = getEnvOrDefault("PODTRACE_PROFILING_PPROF_PORTS", "6060,8080,8081,9090,2345")
 	ProfilingAutoTriggerMS   = getFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
 	ProfilingDefaultDuration = getDurationEnvOrDefault("PODTRACE_PROFILING_DEFAULT_DURATION", DefaultProfilingDuration)
@@ -332,6 +332,32 @@ var (
 	ConnectLatencyThresholdMS  = getFloatEnvOrDefault("PODTRACE_CONNECT_LATENCY_MS", 1.0)
 )
 
+// getBoolEnvOrDefault parses the env var with strconv.ParseBool, so
+// "true", "TRUE", "True", "1", "t" (and their negatives) all work — the
+// previous string comparison silently treated "TRUE" or "1" as false. A
+// set-but-unparsable value is reported instead of silently ignored.
+func getBoolEnvOrDefault(key string, defaultValue bool) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		warnIgnoredEnv(key, value, "not a boolean")
+		return defaultValue
+	}
+	return b
+}
+
+// warnIgnoredEnv surfaces configuration that LOOKS set but is being
+// ignored. It writes directly to stderr because internal/logger imports
+// this package (cycle).
+func warnIgnoredEnv(key, value, reason string) {
+	_, _ = fmt.Fprintf(os.Stderr,
+		`{"level":"warn","component":"config","message":"environment variable ignored","key":%q,"value":%q,"reason":%q}`+"\n",
+		key, value, reason)
+}
+
 func getEnvOrDefault(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
@@ -344,15 +370,21 @@ func getFloatEnvOrDefault(key string, defaultValue float64) float64 {
 		if f, err := strconv.ParseFloat(value, 64); err == nil {
 			return f
 		}
+		warnIgnoredEnv(key, value, "not a number")
 	}
 	return defaultValue
 }
 
+// getIntEnvOrDefault keeps the positive-only constraint (every consumer is
+// a size, port, or count where 0/negative would disable or break the
+// feature), but a set-and-ignored value is now reported instead of
+// silently falling back to the default.
 func getIntEnvOrDefault(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {
 		if i, err := strconv.Atoi(value); err == nil && i > 0 {
 			return i
 		}
+		warnIgnoredEnv(key, value, "must be a positive integer")
 	}
 	return defaultValue
 }
@@ -391,6 +423,7 @@ func getDurationEnvOrDefault(key string, defaultValue time.Duration) time.Durati
 		if d, err := time.ParseDuration(value); err == nil && d > 0 {
 			return d
 		}
+		warnIgnoredEnv(key, value, "must be a positive Go duration")
 	}
 	return defaultValue
 }
@@ -404,7 +437,7 @@ func GetMetricsAddress() string {
 }
 
 func AllowNonLoopbackMetrics() bool {
-	return os.Getenv("PODTRACE_METRICS_INSECURE_ALLOW_ANY_ADDR") == "1"
+	return getBoolEnvOrDefault("PODTRACE_METRICS_INSECURE_ALLOW_ANY_ADDR", false)
 }
 
 func GetAlertMinSeverity() string {
@@ -462,17 +495,17 @@ func GetUserAgent() string {
 }
 
 func OTLPAllowInsecureNonLoopback() bool {
-	return os.Getenv("PODTRACE_OTLP_INSECURE") == "1"
+	return getBoolEnvOrDefault("PODTRACE_OTLP_INSECURE", false)
 }
 
 func MetricsEnablePprof() bool {
-	return os.Getenv("PODTRACE_METRICS_ENABLE_PPROF") == "1" || ProfilingEnabled
+	return getBoolEnvOrDefault("PODTRACE_METRICS_ENABLE_PPROF", false) || ProfilingEnabled
 }
 
 func SplunkAlertAllowHTTP() bool {
-	return os.Getenv("PODTRACE_ALERT_SPLUNK_ALLOW_HTTP") == "1"
+	return getBoolEnvOrDefault("PODTRACE_ALERT_SPLUNK_ALLOW_HTTP", false)
 }
 
 func AllowCgroupFilterAutoDisable() bool {
-	return os.Getenv("PODTRACE_ALLOW_CGROUP_FILTER_DISABLE") == "1"
+	return getBoolEnvOrDefault("PODTRACE_ALLOW_CGROUP_FILTER_DISABLE", false)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,9 +169,10 @@ func TestAllowNonLoopbackMetrics(t *testing.T) {
 		expected bool
 	}{
 		{"enabled", "1", true},
+		{"enabled spelled out", "true", true},
 		{"disabled", "0", false},
 		{"not set", "", false},
-		{"invalid", "true", false},
+		{"garbage fails closed", "yes-please", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/env_helpers_test.go
+++ b/internal/config/env_helpers_test.go
@@ -48,8 +48,12 @@ func TestSplunkAlertAllowHTTP(t *testing.T) {
 		t.Error("env=1 should allow http")
 	}
 	t.Setenv("PODTRACE_ALERT_SPLUNK_ALLOW_HTTP", "true")
+	if !SplunkAlertAllowHTTP() {
+		t.Error("env=true must also allow http; requiring the literal '1' silently ignored explicit intent")
+	}
+	t.Setenv("PODTRACE_ALERT_SPLUNK_ALLOW_HTTP", "garbage")
 	if SplunkAlertAllowHTTP() {
-		t.Error("only literal '1' should allow http (defensive)")
+		t.Error("unparsable value must fail closed")
 	}
 }
 

--- a/internal/config/env_parsing_regression_test.go
+++ b/internal/config/env_parsing_regression_test.go
@@ -1,0 +1,27 @@
+package config
+
+import "testing"
+
+// TestGetBoolEnvOrDefault_AcceptedForms: only lowercase "true" used to
+// count; "TRUE", "True", and "1" silently read as false.
+func TestGetBoolEnvOrDefault_AcceptedForms(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true}, {"TRUE", true}, {"True", true}, {"1", true}, {"t", true},
+		{"false", false}, {"FALSE", false}, {"0", false},
+		{"garbage", true}, // unparsable keeps the default (true here)
+		{" true ", true},  // surrounding whitespace tolerated
+	}
+	for _, c := range cases {
+		t.Setenv("PODTRACE_TEST_BOOL", c.value)
+		if got := getBoolEnvOrDefault("PODTRACE_TEST_BOOL", true); got != c.want {
+			t.Errorf("getBoolEnvOrDefault(%q, true) = %v, want %v", c.value, got, c.want)
+		}
+	}
+	t.Setenv("PODTRACE_TEST_BOOL", "garbage")
+	if got := getBoolEnvOrDefault("PODTRACE_TEST_BOOL", false); got != false {
+		t.Error("unparsable value must keep the default (false)")
+	}
+}

--- a/internal/diagnose/detector/issues.go
+++ b/internal/diagnose/detector/issues.go
@@ -79,20 +79,25 @@ func DetectIssues(allEvents []*events.Event, errorRateThreshold, rttSpikeThresho
 			}
 		}
 	}
-	
+
+	// Same thresholds the monitor and BPF side honor — a hardcoded copy
+	// here silently dropped alerts the monitor had already raised whenever
+	// PODTRACE_ALERT_*_PCT was tuned below the defaults.
 	for resourceName, maxUtil := range resourceAlerts {
 		var severity string
-		if maxUtil >= 95 {
+		switch {
+		case maxUtil >= config.AlertEmergPct:
 			severity = "EMERGENCY"
-		} else if maxUtil >= 90 {
+		case maxUtil >= config.AlertCritPct:
 			severity = "CRITICAL"
-		} else if maxUtil >= 80 {
+		case maxUtil >= config.AlertWarnPct:
 			severity = "WARNING"
 		}
-		
+
 		if severity != "" {
-			issues = append(issues, fmt.Sprintf("Resource limit %s: %s - %d%% utilization (threshold: 80%% warning, 90%% critical, 95%% emergency)", 
-				severity, resourceName, maxUtil))
+			issues = append(issues, fmt.Sprintf("Resource limit %s: %s - %d%% utilization (threshold: %d%% warning, %d%% critical, %d%% emergency)",
+				severity, resourceName, maxUtil,
+				config.AlertWarnPct, config.AlertCritPct, config.AlertEmergPct))
 		}
 	}
 

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -106,7 +106,15 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 			},
 		},
 	}
-	for _, name := range []string{"PODTRACE_BPF_LOG_LEVEL", "PODTRACE_BPF_LOG_SIZE"} {
+	passthrough := []string{
+		"PODTRACE_BPF_LOG_LEVEL",
+		"PODTRACE_BPF_LOG_SIZE",
+		"PODTRACE_OTLP_INSECURE",
+		"PODTRACE_ALERT_WARN_PCT",
+		"PODTRACE_ALERT_CRIT_PCT",
+		"PODTRACE_ALERT_EMERG_PCT",
+	}
+	for _, name := range passthrough {
 		if v := os.Getenv(name); v != "" {
 			env = append(env, corev1.EnvVar{Name: name, Value: v})
 		}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	pprofhttp "net/http/pprof"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -445,19 +446,28 @@ func RecordProfilingFetchError(podIP, profileType string) {
 }
 
 func HandleEvents(ch <-chan *events.Event) {
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("Panic in metrics event handler",
-				zap.Any("panic", r),
-				zap.ByteString("stack", debug.Stack()))
-		}
-	}()
 	for e := range ch {
 		if e == nil {
 			continue
 		}
-		HandleEvent(e)
+		handleEventRecovered(e)
 	}
+}
+
+// handleEventRecovered isolates a panic to the one event that caused it.
+// A function-scope recover around the whole consumer loop meant a single
+// poisoned event killed metrics consumption permanently — the gauges froze
+// and every producer blocked on the full channel.
+func handleEventRecovered(e *events.Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic in metrics event handler; event skipped",
+				zap.Any("panic", r),
+				zap.String("event_type", e.TypeString()),
+				zap.ByteString("stack", debug.Stack()))
+		}
+	}()
+	HandleEvent(e)
 }
 
 func HandleEvent(e *events.Event) {
@@ -777,6 +787,24 @@ func rateLimitMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// addrIsLoopback reports whether the listen address is confined to the
+// loopback interface. The previous guard only fired when the host parsed
+// as a non-loopback IP — ":9090" (empty host = ALL interfaces), hostnames,
+// and unparsable addresses all skipped it and bound publicly.
+func addrIsLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "" {
+		return false // empty host means listen on every interface
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return strings.EqualFold(host, "localhost")
+}
+
 type Server struct {
 	server *http.Server
 }
@@ -785,24 +813,26 @@ func StartServer() *Server {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", securityHeadersMiddleware(rateLimitMiddleware(promhttp.Handler())))
 	if config.MetricsEnablePprof() {
-		mux.HandleFunc("/debug/pprof/", pprofhttp.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprofhttp.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprofhttp.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprofhttp.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprofhttp.Trace)
+		// pprof goes through the same security/rate-limit middleware as
+		// /metrics: a 30-second CPU profile request is a cheap DoS against
+		// a privileged pod when the handlers are exposed raw.
+		wrap := func(h http.HandlerFunc) http.Handler {
+			return securityHeadersMiddleware(rateLimitMiddleware(h))
+		}
+		mux.Handle("/debug/pprof/", wrap(pprofhttp.Index))
+		mux.Handle("/debug/pprof/cmdline", wrap(pprofhttp.Cmdline))
+		mux.Handle("/debug/pprof/profile", wrap(pprofhttp.Profile))
+		mux.Handle("/debug/pprof/symbol", wrap(pprofhttp.Symbol))
+		mux.Handle("/debug/pprof/trace", wrap(pprofhttp.Trace))
 	}
 
 	addr := config.GetMetricsAddress()
 
-	if host, _, err := net.SplitHostPort(addr); err == nil {
-		if ip := net.ParseIP(host); ip != nil && !ip.IsLoopback() {
-			if !config.AllowNonLoopbackMetrics() {
-				logger.Warn("Rejecting non-loopback metrics address, falling back to default",
-					zap.String("requested_addr", addr),
-					zap.String("fallback", fmt.Sprintf("%s:%d", config.DefaultMetricsHost, config.DefaultMetricsPort)))
-				addr = config.DefaultMetricsHost + ":" + fmt.Sprintf("%d", config.DefaultMetricsPort)
-			}
-		}
+	if !addrIsLoopback(addr) && !config.AllowNonLoopbackMetrics() {
+		logger.Warn("Rejecting non-loopback metrics address, falling back to default",
+			zap.String("requested_addr", addr),
+			zap.String("fallback", fmt.Sprintf("%s:%d", config.DefaultMetricsHost, config.DefaultMetricsPort)))
+		addr = config.DefaultMetricsHost + ":" + fmt.Sprintf("%d", config.DefaultMetricsPort)
 	}
 
 	server := &http.Server{

--- a/internal/metricsexporter/server_guard_regression_test.go
+++ b/internal/metricsexporter/server_guard_regression_test.go
@@ -1,0 +1,31 @@
+package metricsexporter
+
+import (
+	"testing"
+)
+
+// TestAddrIsLoopback: the old bind guard only fired when the host parsed
+// as a non-loopback IP. ":9090" (empty host = every interface), hostnames,
+// and unparsable addresses all skipped the guard and bound publicly on a
+// privileged pod.
+func TestAddrIsLoopback(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:9090", true},
+		{"[::1]:9090", true},
+		{"localhost:9090", true},
+		{"LOCALHOST:9090", true},
+		{":9090", false},
+		{"0.0.0.0:9090", false},
+		{"10.0.0.5:9090", false},
+		{"metrics.internal:9090", false},
+		{"not-an-addr", false},
+	}
+	for _, c := range cases {
+		if got := addrIsLoopback(c.addr); got != c.want {
+			t.Errorf("addrIsLoopback(%q) = %v, want %v", c.addr, got, c.want)
+		}
+	}
+}

--- a/internal/profiling/doprofile_unit_test.go
+++ b/internal/profiling/doprofile_unit_test.go
@@ -28,7 +28,7 @@ func TestDoProfile_HeapAvailable_MergesResult(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	h := NewHandler(host, []int{port})
-	h.profiler.foundPort = port
+	h.profiler.foundPort.Store(int64(port))
 
 	h.doProfile(context.Background(), ProfileHeap, 0)
 
@@ -62,7 +62,7 @@ runtime.gopark()
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	h := NewHandler(host, []int{port})
-	h.profiler.foundPort = port
+	h.profiler.foundPort.Store(int64(port))
 
 	h.doProfile(context.Background(), ProfileGoroutine, 0)
 
@@ -125,7 +125,7 @@ func TestDoProfile_CPU_SetsMetadataOnly(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	h := NewHandler(host, []int{port})
-	h.profiler.foundPort = port
+	h.profiler.foundPort.Store(int64(port))
 
 	h.doProfile(context.Background(), ProfileCPU, 0)
 

--- a/internal/profiling/handler.go
+++ b/internal/profiling/handler.go
@@ -199,7 +199,7 @@ func (h *Handler) GenerateSection(allEvents []*events.Event, duration time.Durat
 	cr.PodIP = h.podIP
 
 	// Merge pprof availability from profiler discovery.
-	if h.profiler.foundPort != 0 {
+	if h.profiler.foundPort.Load() != 0 {
 		cr.PprofAvailable = true
 	}
 
@@ -255,17 +255,17 @@ func (h *Handler) HTTPStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	h.mu.RLock()
 	hasResult := h.result != nil
-	pprofAvail := h.profiler.foundPort != 0
+	pprofAvail := h.profiler.foundPort.Load() != 0
 	h.mu.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"pprof_available":  pprofAvail,
-		"pprof_port":       h.profiler.foundPort,
-		"has_result":       hasResult,
-		"auto_triggered":   h.triggered.Load(),
+		"pprof_available":      pprofAvail,
+		"pprof_port":           h.profiler.foundPort.Load(),
+		"has_result":           hasResult,
+		"auto_triggered":       h.triggered.Load(),
 		"trigger_threshold_ms": config.ProfilingAutoTriggerMS,
-		"pod_ip":           h.podIP,
+		"pod_ip":               h.podIP,
 	})
 }
 

--- a/internal/profiling/profiler.go
+++ b/internal/profiling/profiler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -61,9 +62,12 @@ type ProfileResult struct {
 // PodProfiler discovers and fetches pprof profiles from a running pod.
 // It is safe for concurrent use after construction.
 type PodProfiler struct {
-	podIP      string
-	ports      []int
-	foundPort  int // 0 = not yet discovered / not available
+	podIP string
+	ports []int
+	// foundPort is 0 until discovery succeeds. Atomic because Discover
+	// runs on the trace goroutine while the HTTP fetchers read it from
+	// handler goroutines concurrently.
+	foundPort  atomic.Int64
 	httpClient *http.Client
 }
 
@@ -82,7 +86,7 @@ func NewPodProfiler(podIP string, ports []int) *PodProfiler {
 // Returns true if one is found and caches the port for subsequent fetches.
 // Uses a short per-port timeout to avoid blocking the caller.
 func (p *PodProfiler) Discover(ctx context.Context) bool {
-	if p.foundPort != 0 {
+	if p.foundPort.Load() != 0 {
 		return true
 	}
 	if p.podIP == "" {
@@ -102,7 +106,7 @@ func (p *PodProfiler) Discover(ctx context.Context) bool {
 		}
 		_ = resp.Body.Close()
 		if resp.StatusCode == http.StatusOK {
-			p.foundPort = port
+			p.foundPort.Store(int64(port))
 			logger.Info("Discovered pprof endpoint on target pod",
 				zap.String("pod_ip", p.podIP),
 				zap.Int("port", port))
@@ -118,10 +122,11 @@ func (p *PodProfiler) Discover(ctx context.Context) bool {
 // FetchHeap fetches the heap profile in text mode (?debug=1) and parses
 // top allocating functions.
 func (p *PodProfiler) FetchHeap(ctx context.Context) *ProfileResult {
-	if p.foundPort == 0 {
+	port := p.foundPort.Load()
+	if port == 0 {
 		return &ProfileResult{Type: ProfileHeap, Available: false, Error: "no pprof endpoint discovered"}
 	}
-	url := fmt.Sprintf("http://%s:%d/debug/pprof/heap?debug=1", p.podIP, p.foundPort)
+	url := fmt.Sprintf("http://%s:%d/debug/pprof/heap?debug=1", p.podIP, port)
 	text, raw, err := p.fetchText(ctx, url)
 	if err != nil {
 		return &ProfileResult{Type: ProfileHeap, Available: false, Error: err.Error()}
@@ -140,10 +145,11 @@ func (p *PodProfiler) FetchHeap(ctx context.Context) *ProfileResult {
 // FetchGoroutine fetches the goroutine profile in full text mode (?debug=2)
 // and counts total and blocked goroutines.
 func (p *PodProfiler) FetchGoroutine(ctx context.Context) *ProfileResult {
-	if p.foundPort == 0 {
+	port := p.foundPort.Load()
+	if port == 0 {
 		return &ProfileResult{Type: ProfileGoroutine, Available: false, Error: "no pprof endpoint discovered"}
 	}
-	url := fmt.Sprintf("http://%s:%d/debug/pprof/goroutine?debug=2", p.podIP, p.foundPort)
+	url := fmt.Sprintf("http://%s:%d/debug/pprof/goroutine?debug=2", p.podIP, port)
 	text, raw, err := p.fetchText(ctx, url)
 	if err != nil {
 		return &ProfileResult{Type: ProfileGoroutine, Available: false, Error: err.Error()}
@@ -164,14 +170,15 @@ func (p *PodProfiler) FetchGoroutine(ctx context.Context) *ProfileResult {
 // raw binary bytes. The binary is not parsed here — it can be written to a file
 // and inspected with `go tool pprof`.
 func (p *PodProfiler) FetchCPUProfile(ctx context.Context, duration time.Duration) *ProfileResult {
-	if p.foundPort == 0 {
+	port := p.foundPort.Load()
+	if port == 0 {
 		return &ProfileResult{Type: ProfileCPU, Available: false, Error: "no pprof endpoint discovered"}
 	}
 	secs := int(duration.Seconds())
 	if secs < 1 {
 		secs = 1
 	}
-	url := fmt.Sprintf("http://%s:%d/debug/pprof/profile?seconds=%d", p.podIP, p.foundPort, secs)
+	url := fmt.Sprintf("http://%s:%d/debug/pprof/profile?seconds=%d", p.podIP, port, secs)
 	// Use a longer timeout for CPU profiles — duration + 5s buffer.
 	fetchCtx, cancel := context.WithTimeout(ctx, duration+5*time.Second)
 	defer cancel()
@@ -321,15 +328,15 @@ func parseHeapText(text string) []FunctionSample {
 // semacquire, IO wait, sleep, syscall, etc.
 func parseGoroutineText(text string) (total, blocked int) {
 	blockedStates := map[string]bool{
-		"chan receive":  true,
-		"chan send":     true,
-		"select":       true,
-		"semacquire":   true,
-		"IO wait":      true,
-		"sleep":        true,
-		"syscall":      true,
-		"sync.Mutex":   true,
-		"sync.RWMutex": true,
+		"chan receive":           true,
+		"chan send":              true,
+		"select":                 true,
+		"semacquire":             true,
+		"IO wait":                true,
+		"sleep":                  true,
+		"syscall":                true,
+		"sync.Mutex":             true,
+		"sync.RWMutex":           true,
 		"timer goroutine (idle)": true,
 	}
 	scanner := bufio.NewScanner(strings.NewReader(text))

--- a/internal/profiling/profiler_race_test.go
+++ b/internal/profiling/profiler_race_test.go
@@ -1,0 +1,30 @@
+package profiling
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestPodProfiler_DiscoverFetchRace: Discover writes foundPort while HTTP
+// handler goroutines read it concurrently — a plain int field raced. Run
+// under -race.
+func TestPodProfiler_DiscoverFetchRace(t *testing.T) {
+	p := NewPodProfiler("127.0.0.1", []int{1}) // closed port: Discover fails fast
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			p.Discover(context.Background())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			_ = p.FetchHeap(context.Background())
+			_ = p.FetchGoroutine(context.Background())
+		}
+	}()
+	wg.Wait()
+}

--- a/internal/profiling/profiling_test.go
+++ b/internal/profiling/profiling_test.go
@@ -36,7 +36,7 @@ func TestDiscover_EmptyPodIP(t *testing.T) {
 
 func TestDiscover_AlreadyDiscovered(t *testing.T) {
 	p := NewPodProfiler("127.0.0.1", []int{6060})
-	p.foundPort = 9999
+	p.foundPort.Store(9999)
 	if !p.Discover(context.Background()) {
 		t.Error("Discover should return true when foundPort already set")
 	}
@@ -64,8 +64,8 @@ func TestDiscover_LiveServer(t *testing.T) {
 	if !p.Discover(context.Background()) {
 		t.Error("Discover should return true for a live server with /debug/pprof/")
 	}
-	if p.foundPort != port {
-		t.Errorf("expected foundPort=%d, got %d", port, p.foundPort)
+	if p.foundPort.Load() != int64(port) {
+		t.Errorf("expected foundPort=%d, got %d", port, p.foundPort.Load())
 	}
 }
 
@@ -120,7 +120,7 @@ func TestFetchHeap_LiveServer(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	p := NewPodProfiler(host, []int{port})
-	p.foundPort = port
+	p.foundPort.Store(int64(port))
 	r := p.FetchHeap(context.Background())
 	if !r.Available {
 		t.Errorf("expected Available=true, error=%q", r.Error)
@@ -151,7 +151,7 @@ runtime.gopark()
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	p := NewPodProfiler(host, []int{port})
-	p.foundPort = port
+	p.foundPort.Store(int64(port))
 	r := p.FetchGoroutine(context.Background())
 	if !r.Available {
 		t.Errorf("expected Available=true, error=%q", r.Error)
@@ -173,7 +173,7 @@ func TestFetchCPUProfile_LiveServer(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	p := NewPodProfiler(host, []int{port})
-	p.foundPort = port
+	p.foundPort.Store(int64(port))
 	r := p.FetchCPUProfile(context.Background(), 1*time.Second)
 	if !r.Available {
 		t.Errorf("expected Available=true, error=%q", r.Error)
@@ -191,7 +191,7 @@ func TestFetchHeap_ServerReturns500(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	p := NewPodProfiler(host, []int{port})
-	p.foundPort = port
+	p.foundPort.Store(int64(port))
 	r := p.FetchHeap(context.Background())
 	if r.Available {
 		t.Error("expected Available=false for 500 response")
@@ -206,7 +206,7 @@ func TestFetchCPUProfile_ServerReturns404(t *testing.T) {
 
 	host, port := mustParseAddr(t, srv.Listener.Addr().String())
 	p := NewPodProfiler(host, []int{port})
-	p.foundPort = port
+	p.foundPort.Store(int64(port))
 	r := p.FetchCPUProfile(context.Background(), 1*time.Second)
 	if r.Available {
 		t.Error("expected Available=false for 404 response")
@@ -381,9 +381,9 @@ func TestCorrelate_OOMAndPageFault(t *testing.T) {
 
 func TestCorrelate_SlowEvents_SortedByLatency(t *testing.T) {
 	evts := []*events.Event{
-		{Type: events.EventTCPSend, LatencyNS: 500_000_000, PID: 1},  // 500ms
+		{Type: events.EventTCPSend, LatencyNS: 500_000_000, PID: 1},   // 500ms
 		{Type: events.EventTCPSend, LatencyNS: 1_000_000_000, PID: 2}, // 1s
-		{Type: events.EventTCPSend, LatencyNS: 100_000_000, PID: 3},  // 100ms
+		{Type: events.EventTCPSend, LatencyNS: 100_000_000, PID: 3},   // 100ms
 	}
 	cr := Correlate(evts, nil, nil, 50.0) // 50ms threshold
 	if len(cr.SlowEvents) == 0 {
@@ -416,7 +416,7 @@ func TestCorrelate_SchedSwitchCorrelation(t *testing.T) {
 		},
 	}
 	cr := Correlate(evts, nil, nil, 100.0) // 100ms threshold
-	_ = cr // result depends on clock alignment; just ensure no panic
+	_ = cr                                 // result depends on clock alignment; just ensure no panic
 }
 
 func TestCorrelate_WithPprofData(t *testing.T) {
@@ -726,8 +726,8 @@ func TestHandler_GenerateSection_WithResult(t *testing.T) {
 	h := NewHandler("10.0.0.1", []int{})
 	h.mu.Lock()
 	h.result = &CorrelatedResult{
-		PprofAvailable: true,
-		PodIP:          "10.0.0.1",
+		PprofAvailable:  true,
+		PodIP:           "10.0.0.1",
 		PageFaultCounts: map[uint32]int{},
 		HeapProfile: &ProfileResult{
 			Available: true,

--- a/internal/redactor/credential_rules_regression_test.go
+++ b/internal/redactor/credential_rules_regression_test.go
@@ -1,0 +1,47 @@
+package redactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestDefaultRules_CredentialForms: the default rule set only caught
+// password= query params and Bearer tokens — token=, api_key=, secret=,
+// Basic auth, and JSON/YAML password bodies all passed through unredacted.
+func TestDefaultRules_CredentialForms(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		leaked   string
+		survives string
+	}{
+		{"token query", "GET /cb?token=sk_live_4242&x=1", "sk_live_4242", "/cb"},
+		{"api_key query", "POST /v1?api_key=AKIAEXAMPLE", "AKIAEXAMPLE", "/v1"},
+		{"apikey query", "GET /v1?apikey=abc123def", "abc123def", "/v1"},
+		{"secret query", "GET /auth?secret=s3cr3t", "s3cr3t", "/auth"},
+		{"access_key query", "PUT /b?access_key=AK99", "AK99", "/b"},
+		{"basic auth", "Authorization: Basic dXNlcjpodW50ZXIy", "dXNlcjpodW50ZXIy", "Authorization"},
+		{"json password", `{"user":"bob","password":"hunter2"}`, "hunter2", "bob"},
+		{"json api_key", `{"api_key": "AKIA123", "region":"eu"}`, "AKIA123", "eu"},
+		{"yaml password", "password: hunter2", "hunter2", "password"},
+		{"yaml token", "token: ghp_abcdef123", "ghp_abcdef123", "token"},
+	}
+
+	r := Default()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := &events.Event{Type: events.EventHTTPReq, Target: c.in, Details: c.in}
+			r.Redact(e)
+			for field, v := range map[string]string{"Target": e.Target, "Details": e.Details} {
+				if strings.Contains(v, c.leaked) {
+					t.Errorf("%s still leaks %q: %q", field, c.leaked, v)
+				}
+				if c.survives != "" && !strings.Contains(v, c.survives) {
+					t.Errorf("%s lost non-secret context %q: %q", field, c.survives, v)
+				}
+			}
+		})
+	}
+}

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -57,14 +57,29 @@ func (r *Redactor) Redact(e *events.Event) {
 func defaultRules() []Rule {
 	return []Rule{
 		{
-			Name:    "password",
-			Pattern: regexp.MustCompile(`(?i)(password|passwd|pwd)=[^\s&]+`),
+			Name:    "credential_kv",
+			Pattern: regexp.MustCompile(`(?i)(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key|auth)=[^\s&]+`),
 			Replace: "${1}=***",
 		},
 		{
 			Name:    "bearer_token",
 			Pattern: regexp.MustCompile(`(?i)Bearer\s+[A-Za-z0-9._~+/\-]+=*`),
 			Replace: "Bearer ***",
+		},
+		{
+			Name:    "basic_auth",
+			Pattern: regexp.MustCompile(`(?i)Basic\s+[A-Za-z0-9+/]+=*`),
+			Replace: "Basic ***",
+		},
+		{
+			Name:    "credential_json",
+			Pattern: regexp.MustCompile(`(?i)"(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key)"\s*:\s*"[^"]*"`),
+			Replace: `"${1}":"***"`,
+		},
+		{
+			Name:    "credential_yaml",
+			Pattern: regexp.MustCompile(`(?i)\b(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key)\s*:\s+[^\s,}]+`),
+			Replace: "${1}: ***",
 		},
 		{
 			Name:    "email",

--- a/internal/reportsink/objectstore/azblob.go
+++ b/internal/reportsink/objectstore/azblob.go
@@ -23,8 +23,8 @@ const (
 	azureSecretKeyTenantID     = "tenant_id"
 	azureSecretKeyClientID     = "client_id"
 	azureSecretKeyClientSecret = "client_secret"
-	azureSecretKeyAccountKey = "account_key"
-	azureSecretKeyEndpoint = "endpoint"
+	azureSecretKeyAccountKey   = "account_key"
+	azureSecretKeyEndpoint     = "endpoint"
 )
 
 type azureSink struct {
@@ -152,7 +152,7 @@ func (p *azureRetryLogPolicy) Do(req *policy.Request) (*http.Response, error) {
 	}
 	_, _ = fmt.Fprintf(os.Stderr,
 		`{"component":"objectstore.retry","backend":%q,"method":%q,"url":%q,"status":%d,"attempt":%d,"took_ms":%d,"error":%q}`+"\n",
-		SchemeAzure, raw.Method, raw.URL.String(), status, attempt, took.Milliseconds(), errStr,
+		SchemeAzure, raw.Method, redactURL(raw.URL), status, attempt, took.Milliseconds(), errStr,
 	)
 	return resp, err
 }

--- a/internal/reportsink/objectstore/gcs.go
+++ b/internal/reportsink/objectstore/gcs.go
@@ -47,6 +47,9 @@ func newGCSSink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 	if endpoint := stringFromCreds(creds, gcsSecretKeyEndpoint); endpoint != "" {
 		opts = append(opts, option.WithEndpoint(endpoint))
 		if saJSON == "" {
+			_, _ = fmt.Fprintf(os.Stderr,
+				`{"component":"objectstore.gcs","level":"warn","message":"custom endpoint without %s: uploading WITHOUT AUTHENTICATION; this mode is for fake-gcs-server/dev only","endpoint":%q}`+"\n",
+				gcsSecretKeyServiceAccountJSON, endpoint)
 			opts = append(opts, option.WithoutAuthentication())
 		}
 	}

--- a/internal/reportsink/objectstore/redact_url_regression_test.go
+++ b/internal/reportsink/objectstore/redact_url_regression_test.go
@@ -1,0 +1,33 @@
+package objectstore
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRedactURL_StripsCredentialQueries: retry log lines carried the full
+// request URL — Azure SAS tokens and S3 presigned credentials live in the
+// query string and were written to stderr on every retried attempt.
+func TestRedactURL_StripsCredentialQueries(t *testing.T) {
+	u, err := url.Parse("https://acct.blob.core.windows.net/c/report.json?sv=2024&sig=SECRETSIG&se=2026")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := redactURL(u)
+	if strings.Contains(got, "SECRETSIG") || strings.Contains(got, "sig=") {
+		t.Errorf("redactURL leaked the SAS signature: %q", got)
+	}
+	if !strings.Contains(got, "acct.blob.core.windows.net/c/report.json") {
+		t.Errorf("redactURL lost host/path context: %q", got)
+	}
+
+	if got := redactURL(nil); got != "" {
+		t.Errorf("redactURL(nil) = %q, want empty", got)
+	}
+
+	plain, _ := url.Parse("https://storage.googleapis.com/bucket/obj")
+	if got := redactURL(plain); got != "https://storage.googleapis.com/bucket/obj" {
+		t.Errorf("query-less URL must pass through unchanged, got %q", got)
+	}
+}

--- a/internal/reportsink/objectstore/retry_log.go
+++ b/internal/reportsink/objectstore/retry_log.go
@@ -3,6 +3,7 @@ package objectstore
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,22 @@ func (defaultRetryLogger) OnAttempt(backend, method, url string, status, attempt
 		`{"component":"objectstore.retry","backend":%q,"method":%q,"url":%q,"status":%d,"attempt":%d,"took_ms":%d,"error":%q}`+"\n",
 		backend, method, url, status, attempt, took.Milliseconds(), errStr,
 	)
+}
+
+// redactURL strips query and fragment before logging: presigned S3 URLs
+// and Azure SAS tokens carry their credentials in the query string, and a
+// retry log line must not leak them to stderr.
+func redactURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	c := *u
+	if c.RawQuery != "" {
+		c.RawQuery = "REDACTED"
+	}
+	c.Fragment = ""
+	c.User = nil
+	return c.String()
 }
 
 // loggingTransport is an http.RoundTripper that wraps an inner
@@ -77,6 +94,6 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if resp != nil {
 		status = resp.StatusCode
 	}
-	t.logger.OnAttempt(t.backend, req.Method, req.URL.String(), status, attempt, took, err)
+	t.logger.OnAttempt(t.backend, req.Method, redactURL(req.URL), status, attempt, took, err)
 	return resp, err
 }

--- a/internal/resource/monitor.go
+++ b/internal/resource/monitor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -54,6 +55,17 @@ type limitMapValue struct {
 	LimitBytes   uint64
 	UsageBytes   uint64
 	LastUpdateNS uint64
+	ResourceType uint32
+	_            [4]byte
+}
+
+// resourceMapKey mirrors struct resource_key in bpf/maps.h. Keying the
+// BPF maps by cgroup inode alone made CPU, memory, and IO entries
+// clobber each other — the surviving entry depended on Go map iteration
+// order, so the kernel-visible limit and alert level flapped between
+// resource types on every sync.
+type resourceMapKey struct {
+	CgroupID     uint64
 	ResourceType uint32
 	_            [4]byte
 }
@@ -247,14 +259,16 @@ func (rm *ResourceMonitor) readLimitsV1() error {
 	}
 
 	ioRead, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.throttle.read_bps_device"))
-	if ioRead != "" {
-		limit := parseIOV1(ioRead)
-		if limit > 0 {
-			rm.limits[ResourceIO] = &ResourceLimit{
-				LimitBytes:   limit,
-				ResourceType: ResourceIO,
-				LastUpdateNS: uint64(time.Now().UnixNano()),
-			}
+	ioWrite, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.throttle.write_bps_device"))
+	limit := parseBlkioThrottleBps(ioRead)
+	if w := parseBlkioThrottleBps(ioWrite); w > limit {
+		limit = w
+	}
+	if limit > 0 {
+		rm.limits[ResourceIO] = &ResourceLimit{
+			LimitBytes:   limit,
+			ResourceType: ResourceIO,
+			LastUpdateNS: uint64(time.Now().UnixNano()),
 		}
 	}
 
@@ -333,7 +347,7 @@ func (rm *ResourceMonitor) updateUsageV1() error {
 
 	ioBytes, err := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.io_service_bytes"))
 	if err == nil {
-		usage := parseIOV1(ioBytes)
+		usage := parseBlkioServiceBytes(ioBytes)
 		if limit, ok := rm.limits[ResourceIO]; ok {
 			limit.UsageBytes = usage
 			limit.LastUpdateNS = uint64(time.Now().UnixNano())
@@ -349,7 +363,7 @@ func (rm *ResourceMonitor) syncToBPF() error {
 	}
 
 	for resourceType, limit := range rm.limits {
-		key := rm.cgroupInode
+		key := resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: resourceType}
 		value := limitMapValue{
 			LimitBytes:   limit.LimitBytes,
 			UsageBytes:   limit.UsageBytes,
@@ -359,7 +373,7 @@ func (rm *ResourceMonitor) syncToBPF() error {
 
 		if err := rm.limitsMap.Put(key, value); err != nil {
 			logger.Warn("Failed to update BPF map",
-				zap.Uint64("cgroup_inode", key),
+				zap.Uint64("cgroup_inode", rm.cgroupInode),
 				zap.Uint32("resource_type", resourceType),
 				zap.Error(err))
 		}
@@ -452,18 +466,22 @@ func (rm *ResourceMonitor) checkAlerts() {
 		}
 		utilizationUint32 := safeconv.Uint64ToUint32(utilization)
 
+		// Same thresholds the BPF side reads from the alert_thresholds
+		// map — hardcoding 95/90/80 here ignored PODTRACE_ALERT_*_PCT
+		// for every userspace-evaluated alert.
 		var alertLevel uint32
-		if utilizationUint32 >= 95 {
+		switch {
+		case utilizationUint32 >= safeconv.IntToUint32(config.AlertEmergPct):
 			alertLevel = AlertEmergency
-		} else if utilizationUint32 >= 90 {
+		case utilizationUint32 >= safeconv.IntToUint32(config.AlertCritPct):
 			alertLevel = AlertCritical
-		} else if utilizationUint32 >= 80 {
+		case utilizationUint32 >= safeconv.IntToUint32(config.AlertWarnPct):
 			alertLevel = AlertWarning
-		} else {
+		default:
 			alertLevel = AlertNone
 		}
 
-		key := rm.cgroupInode
+		key := resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: resourceType}
 		if alertLevel > 0 {
 			if err := rm.alertsMap.Put(key, alertLevel); err != nil {
 				logger.Warn("Failed to update alert map", zap.Error(err))
@@ -609,11 +627,14 @@ func readCgroupFile(path string) (string, error) {
 		}
 	}()
 
-	scanner := bufio.NewScanner(file)
-	if scanner.Scan() {
-		return scanner.Text(), nil
+	// Read the WHOLE file: io.max, io.stat, and the blkio v1 files carry
+	// one line per device, and returning only the first line meant only
+	// the first device was ever counted.
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return "", err
 	}
-	return "", scanner.Err()
+	return string(data), nil
 }
 
 func parseCPUMax(cpuMax string) (quota, period uint64, unlimited bool) {
@@ -662,13 +683,35 @@ func parseIOMax(ioMax string) uint64 {
 	return maxBytes
 }
 
-func parseIOV1(ioData string) uint64 {
+// parseBlkioThrottleBps parses blkio.throttle.{read,write}_bps_device,
+// whose real format is two fields per line ("MAJ:MIN bytes_per_sec").
+// The previous parser required three fields, so a configured v1 IO limit
+// never parsed. The strictest (largest) per-device limit is reported,
+// mirroring parseIOMax's treatment of v2 io.max.
+func parseBlkioThrottleBps(ioData string) uint64 {
+	var maxBps uint64
+	scanner := bufio.NewScanner(strings.NewReader(ioData))
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) == 2 && strings.Contains(parts[0], ":") {
+			if val, err := strconv.ParseUint(parts[1], 10, 64); err == nil && val > maxBps {
+				maxBps = val
+			}
+		}
+	}
+	return maxBps
+}
+
+// parseBlkioServiceBytes sums the Read and Write rows of
+// blkio.io_service_bytes ("MAJ:MIN Read N"). Summing every 3-field row
+// also counted the Sync/Async/Total rows, which already contain the
+// Read/Write bytes — usage was roughly tripled.
+func parseBlkioServiceBytes(ioData string) uint64 {
 	var total uint64
 	scanner := bufio.NewScanner(strings.NewReader(ioData))
 	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Fields(line)
-		if len(parts) >= 3 {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) == 3 && (parts[1] == "Read" || parts[1] == "Write") {
 			if val, err := strconv.ParseUint(parts[2], 10, 64); err == nil {
 				total += val
 			}

--- a/internal/resource/monitor_alerts_unit_test.go
+++ b/internal/resource/monitor_alerts_unit_test.go
@@ -18,17 +18,17 @@ import (
 
 type fakeBPFMap struct {
 	mu      sync.Mutex
-	entries map[uint64]interface{}
+	entries map[resourceMapKey]interface{}
 }
 
 func newFakeBPFMap() *fakeBPFMap {
-	return &fakeBPFMap{entries: make(map[uint64]interface{})}
+	return &fakeBPFMap{entries: make(map[resourceMapKey]interface{})}
 }
 
 func (f *fakeBPFMap) Put(key, value interface{}) error {
-	k, ok := key.(uint64)
+	k, ok := key.(resourceMapKey)
 	if !ok {
-		return fmt.Errorf("fakeBPFMap.Put: key must be uint64, got %T", key)
+		return fmt.Errorf("fakeBPFMap.Put: key must be resourceMapKey, got %T", key)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -37,9 +37,9 @@ func (f *fakeBPFMap) Put(key, value interface{}) error {
 }
 
 func (f *fakeBPFMap) Delete(key interface{}) error {
-	k, ok := key.(uint64)
+	k, ok := key.(resourceMapKey)
 	if !ok {
-		return fmt.Errorf("fakeBPFMap.Delete: key must be uint64, got %T", key)
+		return fmt.Errorf("fakeBPFMap.Delete: key must be resourceMapKey, got %T", key)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -50,7 +50,7 @@ func (f *fakeBPFMap) Delete(key interface{}) error {
 	return nil
 }
 
-func (f *fakeBPFMap) get(key uint64) (interface{}, bool) {
+func (f *fakeBPFMap) get(key resourceMapKey) (interface{}, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	v, ok := f.entries[key]
@@ -177,27 +177,26 @@ func TestSyncToBPF_WritesLimitsToMap(t *testing.T) {
 		t.Fatalf("syncToBPF() error = %v", err)
 	}
 
-	// All resource types share the cgroup-inode key, so the map holds one
-	// entry: whichever type was written last. Assert it matches that type.
-	raw, ok := limitsMap.get(rm.cgroupInode)
-	if !ok {
-		t.Fatalf("expected an entry at cgroup inode %d", rm.cgroupInode)
-	}
-	got, ok := raw.(limitMapValue)
-	if !ok {
-		t.Fatalf("map value has unexpected type %T", raw)
-	}
+	// Regression: the map is keyed (cgroup, resource type), so EVERY
+	// resource gets its own entry. The old cgroup-only key meant CPU and
+	// memory clobbered each other, leaving whichever was written last.
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
-	expected := rm.limits[got.ResourceType]
-	if expected == nil {
-		t.Fatalf("map holds unknown resource type %d", got.ResourceType)
-	}
-	if got.LimitBytes != expected.LimitBytes ||
-		got.UsageBytes != expected.UsageBytes ||
-		got.LastUpdateNS != expected.LastUpdateNS {
-		t.Errorf("map value mismatch: got %+v, expected limit %d usage %d updated %d",
-			got, expected.LimitBytes, expected.UsageBytes, expected.LastUpdateNS)
+	for resourceType, expected := range rm.limits {
+		raw, ok := limitsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: resourceType})
+		if !ok {
+			t.Fatalf("expected an entry for resource type %d at cgroup inode %d", resourceType, rm.cgroupInode)
+		}
+		got, ok := raw.(limitMapValue)
+		if !ok {
+			t.Fatalf("map value has unexpected type %T", raw)
+		}
+		if got.LimitBytes != expected.LimitBytes ||
+			got.UsageBytes != expected.UsageBytes ||
+			got.LastUpdateNS != expected.LastUpdateNS {
+			t.Errorf("type %d value mismatch: got %+v, expected limit %d usage %d updated %d",
+				resourceType, got, expected.LimitBytes, expected.UsageBytes, expected.LastUpdateNS)
+		}
 	}
 }
 
@@ -212,7 +211,7 @@ func TestSyncToBPF_EmptyLimits(t *testing.T) {
 	if err := rm.syncToBPF(); err != nil {
 		t.Fatalf("syncToBPF() error = %v", err)
 	}
-	if _, ok := limitsMap.get(rm.cgroupInode); ok {
+	if _, ok := limitsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceCPU}); ok {
 		t.Errorf("expected no entry in map")
 	}
 }
@@ -255,7 +254,7 @@ func TestCheckAlerts_AlertLevels(t *testing.T) {
 
 			// Seed a prior warning so the "no breach" case exercises the
 			// delete-existing branch.
-			if err := alertsMap.Put(rm.cgroupInode, uint32(AlertWarning)); err != nil {
+			if err := alertsMap.Put(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceMemory}, uint32(AlertWarning)); err != nil {
 				t.Fatalf("seed alertsMap: %v", err)
 			}
 
@@ -271,7 +270,7 @@ func TestCheckAlerts_AlertLevels(t *testing.T) {
 
 			rm.checkAlerts()
 
-			raw, ok := alertsMap.get(rm.cgroupInode)
+			raw, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceMemory})
 			if !tt.wantEntry {
 				if ok {
 					t.Errorf("expected alertsMap entry deleted, but found %v", raw)
@@ -330,7 +329,7 @@ func TestCheckAlerts_BenignDeleteWhenAbsent(t *testing.T) {
 
 	rm.checkAlerts()
 
-	if _, ok := alertsMap.get(rm.cgroupInode); ok {
+	if _, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceMemory}); ok {
 		t.Errorf("expected no alertsMap entry")
 	}
 }
@@ -360,8 +359,10 @@ func TestCheckAlerts_ZeroAndUnlimitedSkipped(t *testing.T) {
 
 	rm.checkAlerts()
 
-	if _, ok := alertsMap.get(rm.cgroupInode); ok {
-		t.Errorf("expected no alertsMap entry")
+	for _, resourceType := range []uint32{ResourceCPU, ResourceMemory} {
+		if _, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: resourceType}); ok {
+			t.Errorf("expected no alertsMap entry for type %d", resourceType)
+		}
 	}
 	select {
 	case ev := <-eventChan:
@@ -385,7 +386,7 @@ func TestCheckAlerts_UnknownResourceTypeLabel(t *testing.T) {
 
 	rm.checkAlerts()
 
-	raw, ok := alertsMap.get(rm.cgroupInode)
+	raw, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: unknownType})
 	if !ok {
 		t.Fatalf("expected alertsMap entry")
 	}
@@ -427,7 +428,7 @@ func TestCheckAlerts_ChannelFullDoesNotBlock(t *testing.T) {
 	}
 
 	// The map write still happened despite the dropped event.
-	raw, ok := alertsMap.get(rm.cgroupInode)
+	raw, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceMemory})
 	if !ok {
 		t.Fatalf("expected alertsMap entry")
 	}

--- a/internal/resource/monitor_findings_regression_test.go
+++ b/internal/resource/monitor_findings_regression_test.go
@@ -1,0 +1,75 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+// TestParseBlkioThrottleBps_RealKernelFormat: the v1 throttle files are
+// two fields per line ("MAJ:MIN bytes_per_sec"); the old parser required
+// three fields, so a configured v1 IO limit never parsed (the fixtures
+// used a fictional format).
+func TestParseBlkioThrottleBps_RealKernelFormat(t *testing.T) {
+	if got := parseBlkioThrottleBps("8:0 2097152"); got != 2097152 {
+		t.Errorf("single device = %d, want 2097152", got)
+	}
+	if got := parseBlkioThrottleBps("8:0 2097152\n8:16 4194304"); got != 4194304 {
+		t.Errorf("multi device = %d, want the strictest (largest) limit 4194304", got)
+	}
+	if got := parseBlkioThrottleBps(""); got != 0 {
+		t.Errorf("empty = %d, want 0", got)
+	}
+	if got := parseBlkioThrottleBps("garbage line"); got != 0 {
+		t.Errorf("garbage = %d, want 0", got)
+	}
+}
+
+// TestParseBlkioServiceBytes_SkipsAggregateRows: io_service_bytes carries
+// Read/Write/Sync/Async/Total rows per device; summing every row counted
+// each byte roughly three times.
+func TestParseBlkioServiceBytes_SkipsAggregateRows(t *testing.T) {
+	data := "8:0 Read 100\n8:0 Write 200\n8:0 Sync 250\n8:0 Async 50\n8:0 Total 300\nTotal 300"
+	if got := parseBlkioServiceBytes(data); got != 300 {
+		t.Errorf("usage = %d, want 300 (Read+Write only, no aggregate rows)", got)
+	}
+}
+
+// TestParseIOMax_MultiDevice: io.max has one line per device; reading only
+// the first line of the file dropped every other device's limit.
+func TestParseIOMax_MultiDevice(t *testing.T) {
+	data := "8:0 rbps=1000 wbps=2000\n8:16 rbps=9000 wbps=500"
+	if got := parseIOMax(data); got != 9000 {
+		t.Errorf("limit = %d, want 9000 from the SECOND device line", got)
+	}
+}
+
+// TestCheckAlerts_HonorsConfiguredThresholds: the Go-side alert evaluation
+// hardcoded 95/90/80 while the BPF side honored PODTRACE_ALERT_*_PCT —
+// the two halves disagreed whenever the operator tuned the thresholds.
+func TestCheckAlerts_HonorsConfiguredThresholds(t *testing.T) {
+	saveWarn, saveCrit, saveEmerg := config.AlertWarnPct, config.AlertCritPct, config.AlertEmergPct
+	config.AlertWarnPct, config.AlertCritPct, config.AlertEmergPct = 50, 60, 70
+	t.Cleanup(func() {
+		config.AlertWarnPct, config.AlertCritPct, config.AlertEmergPct = saveWarn, saveCrit, saveEmerg
+	})
+
+	alertsMap := newFakeBPFMap()
+	rm := newMonitorWithFakeMaps(t, nil, alertsMap, nil)
+
+	rm.mu.Lock()
+	rm.limits = map[uint32]*ResourceLimit{
+		ResourceMemory: {LimitBytes: 100, UsageBytes: 65, ResourceType: ResourceMemory},
+	}
+	rm.mu.Unlock()
+
+	rm.checkAlerts()
+
+	raw, ok := alertsMap.get(resourceMapKey{CgroupID: rm.cgroupInode, ResourceType: ResourceMemory})
+	if !ok {
+		t.Fatal("expected an alert entry: 65% breaches the configured 60% critical threshold")
+	}
+	if level := raw.(uint32); level != AlertCritical {
+		t.Errorf("level = %d, want %d (65%% with crit=60 emerg=70)", level, AlertCritical)
+	}
+}

--- a/internal/resource/monitor_test.go
+++ b/internal/resource/monitor_test.go
@@ -364,7 +364,9 @@ func TestReadCgroupFile(t *testing.T) {
 		t.Fatalf("readCgroupFile() error = %v", err)
 	}
 
-	expected := "test content"
+	// The whole file comes back (multi-device cgroup files need every
+	// line); parsers trim whitespace themselves.
+	expected := "test content\n"
 	if got != expected {
 		t.Errorf("readCgroupFile() = %q, want %q", got, expected)
 	}
@@ -392,14 +394,13 @@ func TestParseIOV1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseIOV1(tt.input)
+			got := parseBlkioServiceBytes(tt.input)
 			if got != tt.want {
-				t.Errorf("parseIOV1() = %v, want %v", got, tt.want)
+				t.Errorf("parseBlkioServiceBytes() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
-
 
 func TestResourceMonitor_ReadLimitsV2(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -412,11 +413,11 @@ func TestResourceMonitor_ReadLimitsV2(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(cgroupPath, "cgroup.controllers"), []byte("cpu memory io"), 0644)
 
 	tests := []struct {
-		name     string
-		setup    func() error
-		wantCPU  bool
-		wantMem  bool
-		wantIO   bool
+		name    string
+		setup   func() error
+		wantCPU bool
+		wantMem bool
+		wantIO  bool
 	}{
 		{
 			name: "all limits",
@@ -505,7 +506,7 @@ func TestResourceMonitor_ReadLimitsV1(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
 	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
 	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("1073741824"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 Read 1048576"), 0644)
+	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 1048576"), 0644)
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -647,7 +648,7 @@ func TestResourceMonitor_CheckAlerts_WithNilAlertsMap(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  96000,
+		UsageBytes:   96000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -734,7 +735,7 @@ func TestResourceMonitor_CheckAlerts_ZeroLimit(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   0,
-		UsageBytes:  100000,
+		UsageBytes:   100000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -1310,7 +1311,7 @@ func TestResourceMonitor_ReadLimitsV1_ZeroIO(t *testing.T) {
 	}
 
 	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 Read 0"), 0644)
+	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 0"), 0644)
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1340,7 +1341,7 @@ func TestResourceMonitor_CheckAlerts_Over100Percent(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  150000,
+		UsageBytes:   150000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -1370,7 +1371,7 @@ func TestResourceMonitor_CheckAlerts_UnknownResourceType(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[99] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  95000,
+		UsageBytes:   95000,
 		ResourceType: 99,
 	}
 	monitor.mu.Unlock()
@@ -1455,9 +1456,9 @@ func TestParseIOV1_MultipleFormats(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseIOV1(tt.input)
+			got := parseBlkioServiceBytes(tt.input)
 			if got != tt.want {
-				t.Errorf("parseIOV1() = %v, want %v", got, tt.want)
+				t.Errorf("parseBlkioServiceBytes() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1589,7 +1590,7 @@ func TestResourceMonitor_CheckAlerts_NoAlerts(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  50000,
+		UsageBytes:   50000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -1619,7 +1620,7 @@ func TestResourceMonitor_CheckAlerts_Unlimited(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   ^uint64(0),
-		UsageBytes:  100000,
+		UsageBytes:   100000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -1649,7 +1650,7 @@ func TestResourceMonitor_CheckAlerts_NoAlertsMap_Nil(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  95000,
+		UsageBytes:   95000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()
@@ -1675,7 +1676,7 @@ func TestResourceMonitor_CheckAlerts_ChannelFull_Blocked(t *testing.T) {
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
 		LimitBytes:   100000,
-		UsageBytes:  95000,
+		UsageBytes:   95000,
 		ResourceType: ResourceCPU,
 	}
 	monitor.mu.Unlock()

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
@@ -71,14 +70,8 @@ func (e *DataDogExporter) ExportTraces(traces []*tracker.Trace) error {
 	return errors.Join(errs...)
 }
 
-func (e *DataDogExporter) shouldSample(_ *tracker.Trace) bool {
-	if e.sampleRate >= 1.0 {
-		return true
-	}
-	if e.sampleRate <= 0.0 {
-		return false
-	}
-	return time.Now().UnixNano()%int64(1.0/e.sampleRate) == 0
+func (e *DataDogExporter) shouldSample(t *tracker.Trace) bool {
+	return sampleTrace(t.TraceID, e.sampleRate)
 }
 
 func (e *DataDogExporter) exportTrace(t *tracker.Trace) error {
@@ -182,7 +175,7 @@ func spanType(span *tracker.Span) string {
 			return "web"
 		case "DB":
 			return "db"
-		case "Redis", "Memcached":
+		case "CACHE":
 			return "cache"
 		case "gRPC":
 			return "rpc"

--- a/internal/tracing/exporter/error_surface_test.go
+++ b/internal/tracing/exporter/error_surface_test.go
@@ -39,9 +39,16 @@ func TestExportTraces_SurfacesBackendFailures(t *testing.T) {
 
 	traces := errorSurfaceTrace()
 
-	jaeger := &JaegerExporter{enabled: true, endpoint: srv.URL, client: srv.Client(), sampleRate: 1.0}
+	// Jaeger now ships OTLP; a permanent 400 fails fast (5xx would be
+	// retried by the OTLP client until its timeout).
+	badReq := failingServer(http.StatusBadRequest)
+	defer badReq.Close()
+	jaeger, err := NewJaegerExporter(badReq.URL, 1.0)
+	if err != nil {
+		t.Fatalf("NewJaegerExporter: %v", err)
+	}
 	if err := jaeger.ExportTraces(traces); err == nil {
-		t.Error("jaeger: expected an error for a 500 backend, got nil")
+		t.Error("jaeger: expected an error for a 400 backend, got nil")
 	}
 
 	zipkin := &ZipkinExporter{enabled: true, endpoint: srv.URL, client: srv.Client(), sampleRate: 1.0}

--- a/internal/tracing/exporter/jaeger.go
+++ b/internal/tracing/exporter/jaeger.go
@@ -1,190 +1,64 @@
 package exporter
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"time"
+	"net/url"
+	"strings"
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
 )
 
+// JaegerExporter ships traces to Jaeger over OTLP/HTTP.
+//
+// The previous implementation POSTed a homegrown JSON shape (modeled on the
+// Jaeger UI's read API) to the collector endpoint. No Jaeger collector
+// release ingests that: the legacy /api/traces endpoint speaks Thrift, and
+// modern Jaeger (1.35+, and all of v2) ingests OTLP natively on :4318.
+// Only the httptest stubs in our own tests ever accepted those payloads.
+// Delegating to the OTLP exporter makes the spans actually land in Jaeger,
+// with their original span IDs and parent/child structure.
 type JaegerExporter struct {
-	endpoint   string
-	client     *http.Client
-	enabled    bool
-	sampleRate float64
-}
-
-type JaegerSpan struct {
-	TraceID       string            `json:"traceID"`
-	SpanID        string            `json:"spanID"`
-	ParentSpanID  string            `json:"parentSpanID,omitempty"`
-	OperationName string            `json:"operationName"`
-	StartTime     int64             `json:"startTime"`
-	Duration      int64             `json:"duration"`
-	Tags          map[string]string `json:"tags"`
-	Logs          []JaegerLog       `json:"logs,omitempty"`
-}
-
-type JaegerLog struct {
-	Timestamp int64             `json:"timestamp"`
-	Fields    map[string]string `json:"fields"`
-}
-
-type JaegerProcess struct {
-	ServiceName string            `json:"serviceName"`
-	Tags        map[string]string `json:"tags,omitempty"`
-}
-
-type JaegerSpanData struct {
-	TraceID   string                   `json:"traceID"`
-	Spans     []JaegerSpan             `json:"spans"`
-	Processes map[string]JaegerProcess `json:"processes"`
+	inner    *OTLPExporter
+	endpoint string
 }
 
 func NewJaegerExporter(endpoint string, sampleRate float64) (*JaegerExporter, error) {
-	if endpoint == "" {
-		endpoint = config.DefaultJaegerEndpoint
+	otlpEndpoint := jaegerToOTLPEndpoint(endpoint)
+	inner, err := NewOTLPExporter(otlpEndpoint, sampleRate)
+	if err != nil {
+		return nil, err
 	}
+	return &JaegerExporter{inner: inner, endpoint: otlpEndpoint}, nil
+}
 
-	return &JaegerExporter{
-		endpoint:   endpoint,
-		client:     &http.Client{Timeout: config.TracingExporterTimeout},
-		enabled:    true,
-		sampleRate: sampleRate,
-	}, nil
+// jaegerToOTLPEndpoint translates a legacy Jaeger collector URL into the
+// collector's OTLP/HTTP endpoint: the "/api/traces" suffix is dropped and
+// the classic Thrift port 14268 becomes the OTLP port 4318. Endpoints that
+// already point at an OTLP listener pass through unchanged.
+func jaegerToOTLPEndpoint(endpoint string) string {
+	raw := strings.TrimSpace(endpoint)
+	if raw == "" {
+		raw = config.DefaultJaegerEndpoint
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		u, err = url.Parse("http://" + raw)
+		if err != nil || u.Host == "" {
+			return raw
+		}
+	}
+	u.Path = strings.TrimSuffix(u.Path, "/api/traces")
+	if u.Port() == "14268" {
+		u.Host = u.Hostname() + ":4318"
+	}
+	return u.String()
 }
 
 func (e *JaegerExporter) ExportTraces(traces []*tracker.Trace) error {
-	if !e.enabled || len(traces) == 0 {
-		return nil
-	}
-
-	var errs []error
-	for _, t := range traces {
-		if !e.shouldSample(t) {
-			continue
-		}
-
-		if err := e.exportTrace(t); err != nil {
-			// Keep exporting the remaining traces, but surface the failure:
-			// returning nil here made the manager's exporter-failure
-			// alerting unreachable dead code.
-			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (e *JaegerExporter) shouldSample(_ *tracker.Trace) bool {
-	if e.sampleRate >= 1.0 {
-		return true
-	}
-	if e.sampleRate <= 0.0 {
-		return false
-	}
-	return time.Now().UnixNano()%int64(1.0/e.sampleRate) == 0
-}
-
-func (e *JaegerExporter) exportTrace(t *tracker.Trace) error {
-	if len(t.Spans) == 0 {
-		return nil
-	}
-
-	jaegerSpans := make([]JaegerSpan, 0, len(t.Spans))
-	processes := make(map[string]JaegerProcess)
-
-	for _, span := range t.Spans {
-		span.UpdateDuration()
-
-		jaegerSpan := JaegerSpan{
-			TraceID:       span.TraceID,
-			SpanID:        span.SpanID,
-			ParentSpanID:  span.ParentSpanID,
-			OperationName: span.Operation,
-			StartTime:     span.StartTime.UnixMicro(),
-			Duration:      span.Duration.Microseconds(),
-			Tags:          make(map[string]string),
-			Logs:          make([]JaegerLog, 0),
-		}
-
-		for k, v := range span.Attributes {
-			jaegerSpan.Tags[k] = v
-		}
-
-		if span.Error {
-			jaegerSpan.Tags["error"] = "true"
-		}
-
-		serviceName := span.Service
-		if serviceName == "" {
-			serviceName = "unknown"
-		}
-
-		if _, exists := processes[serviceName]; !exists {
-			processes[serviceName] = JaegerProcess{
-				ServiceName: serviceName,
-				Tags:        make(map[string]string),
-			}
-		}
-
-		for _, event := range span.Events {
-			log := JaegerLog{
-				Timestamp: event.TimestampTime().UnixMicro(),
-				Fields: map[string]string{
-					"event":   event.TypeString(),
-					"target":  event.Target,
-					"latency": fmt.Sprintf("%d", event.LatencyNS),
-				},
-			}
-			if event.Error != 0 {
-				log.Fields["error"] = fmt.Sprintf("%d", event.Error)
-			}
-			jaegerSpan.Logs = append(jaegerSpan.Logs, log)
-		}
-
-		jaegerSpans = append(jaegerSpans, jaegerSpan)
-	}
-
-	spanData := JaegerSpanData{
-		TraceID:   t.TraceID,
-		Spans:     jaegerSpans,
-		Processes: processes,
-	}
-
-	payload, err := json.Marshal([]JaegerSpanData{spanData})
-	if err != nil {
-		return fmt.Errorf("failed to marshal span data: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(context.Background(), "POST", e.endpoint, bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := e.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	return nil
+	return e.inner.ExportTraces(traces)
 }
 
 func (e *JaegerExporter) Shutdown(ctx context.Context) error {
-	return nil
+	return e.inner.Shutdown(ctx)
 }

--- a/internal/tracing/exporter/jaeger_httptest_test.go
+++ b/internal/tracing/exporter/jaeger_httptest_test.go
@@ -1,8 +1,11 @@
 package exporter
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,11 +14,11 @@ import (
 
 func newTestTrace() *tracker.Trace {
 	return &tracker.Trace{
-		TraceID: "trace-httptest",
+		TraceID: "0123456789abcdef0123456789abcdef",
 		Spans: []*tracker.Span{
 			{
-				TraceID:   "trace-httptest",
-				SpanID:    "span-httptest",
+				TraceID:   "0123456789abcdef0123456789abcdef",
+				SpanID:    "0123456789abcdef",
 				Operation: "test-op",
 				Service:   "test-service",
 				StartTime: time.Now(),
@@ -25,10 +28,20 @@ func newTestTrace() *tracker.Trace {
 	}
 }
 
-// TestJaegerExporter_exportTrace_HTTPSuccess covers the defer+return-nil path
-// (lines 172-174 and 180) when the server returns 200 OK.
-func TestJaegerExporter_exportTrace_HTTPSuccess(t *testing.T) {
+// TestJaegerExporter_ShipsOTLPToCollector is a regression test: the old
+// exporter POSTed a homegrown JSON shape that no Jaeger collector release
+// ingests (the legacy /api/traces endpoint speaks Thrift). The exporter
+// must hit the OTLP path with a protobuf payload — what real Jaeger
+// actually accepts.
+func TestJaegerExporter_ShipsOTLPToCollector(t *testing.T) {
+	var mu sync.Mutex
+	var gotPath, gotContentType string
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotPath, gotContentType, gotBody = r.URL.Path, r.Header.Get("Content-Type"), body
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -37,34 +50,28 @@ func TestJaegerExporter_exportTrace_HTTPSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error: %v", err)
 	}
+	t.Cleanup(func() { _ = exporter.Shutdown(t.Context()) })
 
-	err = exporter.exportTrace(newTestTrace())
-	if err != nil {
-		t.Errorf("exportTrace() unexpected error: %v", err)
+	if err := exporter.ExportTraces([]*tracker.Trace{newTestTrace()}); err != nil {
+		t.Fatalf("ExportTraces() error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPath != "/v1/traces" {
+		t.Errorf("POST path = %q, want the OTLP /v1/traces endpoint", gotPath)
+	}
+	if !strings.Contains(gotContentType, "protobuf") {
+		t.Errorf("Content-Type = %q, want an OTLP protobuf payload", gotContentType)
+	}
+	if len(gotBody) == 0 {
+		t.Error("empty body posted to the collector")
 	}
 }
 
-// TestJaegerExporter_exportTrace_HTTPAccepted covers the 202 Accepted success path.
-func TestJaegerExporter_exportTrace_HTTPAccepted(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	t.Cleanup(srv.Close)
-
-	exporter, err := NewJaegerExporter(srv.URL, 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error: %v", err)
-	}
-
-	err = exporter.exportTrace(newTestTrace())
-	if err != nil {
-		t.Errorf("exportTrace() unexpected error for 202: %v", err)
-	}
-}
-
-// TestJaegerExporter_exportTrace_HTTPError covers the non-200/202 status error path
-// (lines 176-178) when the server returns 400 Bad Request.
-func TestJaegerExporter_exportTrace_HTTPError(t *testing.T) {
+// TestJaegerExporter_SurfacesCollectorRejection: a permanent 4xx from the
+// collector must surface as an error, not be swallowed.
+func TestJaegerExporter_SurfacesCollectorRejection(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -74,28 +81,9 @@ func TestJaegerExporter_exportTrace_HTTPError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error: %v", err)
 	}
+	t.Cleanup(func() { _ = exporter.Shutdown(t.Context()) })
 
-	err = exporter.exportTrace(newTestTrace())
-	if err == nil {
-		t.Error("expected error for 400 Bad Request, got nil")
-	}
-}
-
-// TestJaegerExporter_ExportTraces_WithServer covers ExportTraces with a live
-// server — exercises the full exportTrace success path via ExportTraces.
-func TestJaegerExporter_ExportTraces_WithServer(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-
-	exporter, err := NewJaegerExporter(srv.URL, 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error: %v", err)
-	}
-
-	err = exporter.ExportTraces([]*tracker.Trace{newTestTrace()})
-	if err != nil {
-		t.Errorf("ExportTraces() unexpected error: %v", err)
+	if err := exporter.ExportTraces([]*tracker.Trace{newTestTrace()}); err == nil {
+		t.Error("expected an error for a 400 from the collector, got nil")
 	}
 }

--- a/internal/tracing/exporter/jaeger_live_test.go
+++ b/internal/tracing/exporter/jaeger_live_test.go
@@ -1,0 +1,100 @@
+package exporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+)
+
+// TestJaegerLive_IngestsAndPreservesStructure runs against a REAL Jaeger
+// (not an httptest stub — the old JSON exporter only ever passed against
+// stubs while real Jaeger silently dropped everything). Gated behind
+// PODTRACE_JAEGER_LIVE_E2E, which must point at a Jaeger OTLP endpoint
+// with the query API on port 16686 of the same host.
+func TestJaegerLive_IngestsAndPreservesStructure(t *testing.T) {
+	endpoint := os.Getenv("PODTRACE_JAEGER_LIVE_E2E")
+	if endpoint == "" {
+		t.Skip("set PODTRACE_JAEGER_LIVE_E2E to a live Jaeger OTLP endpoint to run")
+	}
+
+	exporter, err := NewJaegerExporter(endpoint, 1.0)
+	if err != nil {
+		t.Fatalf("NewJaegerExporter: %v", err)
+	}
+	t.Cleanup(func() { _ = exporter.Shutdown(t.Context()) })
+
+	traceID := fmt.Sprintf("%016x%016x", time.Now().UnixNano(), time.Now().UnixNano()>>1)
+	base := time.Now().Add(-2 * time.Second)
+	mkSpan := func(spanID, parentID, op string, offset time.Duration) *tracker.Span {
+		return &tracker.Span{
+			TraceID: traceID, SpanID: spanID, ParentSpanID: parentID,
+			Operation: op, Service: "live-e2e",
+			StartTime: base.Add(offset), Duration: 100 * time.Millisecond,
+		}
+	}
+	live := &tracker.Trace{TraceID: traceID, Spans: []*tracker.Span{
+		mkSpan("aaaaaaaaaaaaaaa1", "", "root", 0),
+		mkSpan("aaaaaaaaaaaaaaa2", "aaaaaaaaaaaaaaa1", "child-a", 10*time.Millisecond),
+		mkSpan("aaaaaaaaaaaaaaa3", "aaaaaaaaaaaaaaa1", "child-b", 20*time.Millisecond),
+	}}
+
+	if err := exporter.ExportTraces([]*tracker.Trace{live}); err != nil {
+		t.Fatalf("ExportTraces: %v", err)
+	}
+
+	queryBase := "http://localhost:16686"
+	var stored struct {
+		Data []struct {
+			Spans []struct {
+				TraceID       string `json:"traceID"`
+				SpanID        string `json:"spanID"`
+				OperationName string `json:"operationName"`
+				References    []struct {
+					RefType string `json:"refType"`
+					SpanID  string `json:"spanID"`
+				} `json:"references"`
+			} `json:"spans"`
+		} `json:"data"`
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		resp, err := http.Get(queryBase + "/api/traces/" + traceID)
+		if err == nil {
+			err = json.NewDecoder(resp.Body).Decode(&stored)
+			_ = resp.Body.Close()
+		}
+		if err == nil && len(stored.Data) > 0 && len(stored.Data[0].Spans) == 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Jaeger never stored the 3 exported spans (got %+v); the trace was not ingested", stored.Data)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	spans := map[string]string{}
+	parents := map[string]string{}
+	for _, s := range stored.Data[0].Spans {
+		spans[s.SpanID] = s.OperationName
+		for _, ref := range s.References {
+			if ref.RefType == "CHILD_OF" {
+				parents[s.SpanID] = ref.SpanID
+			}
+		}
+	}
+	for _, id := range []string{"aaaaaaaaaaaaaaa1", "aaaaaaaaaaaaaaa2", "aaaaaaaaaaaaaaa3"} {
+		if _, ok := spans[id]; !ok {
+			t.Errorf("span %s missing from Jaeger — original span IDs were not preserved (have %v)", id, spans)
+		}
+	}
+	for _, child := range []string{"aaaaaaaaaaaaaaa2", "aaaaaaaaaaaaaaa3"} {
+		if parents[child] != "aaaaaaaaaaaaaaa1" {
+			t.Errorf("child %s parent reference = %q, want the real root aaaaaaaaaaaaaaa1", child, parents[child])
+		}
+	}
+}

--- a/internal/tracing/exporter/jaeger_test.go
+++ b/internal/tracing/exporter/jaeger_test.go
@@ -3,283 +3,71 @@ package exporter
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
-	"github.com/podtrace/podtrace/internal/events"
 )
 
-func TestNewJaegerExporter(t *testing.T) {
+func TestNewJaegerExporter_DefaultEndpointTranslatesToOTLP(t *testing.T) {
 	exporter, err := NewJaegerExporter("", 1.0)
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	if exporter == nil {
-		t.Fatal("NewJaegerExporter() returned nil")
-	}
-	if exporter.endpoint != config.DefaultJaegerEndpoint {
-		t.Errorf("Expected endpoint %s, got %s", config.DefaultJaegerEndpoint, exporter.endpoint)
+	defer func() { _ = exporter.Shutdown(context.Background()) }()
+	// The legacy default (localhost:14268/api/traces) speaks Thrift; the
+	// exporter must target the collector's OTLP listener instead.
+	if exporter.endpoint != "http://localhost:4318" {
+		t.Errorf("endpoint = %q, want the translated OTLP endpoint", exporter.endpoint)
 	}
 }
 
-func TestJaegerExporter_ExportTraces_Disabled(t *testing.T) {
-	exporter := &JaegerExporter{enabled: false}
-	err := exporter.ExportTraces([]*tracker.Trace{})
-	if err != nil {
-		t.Errorf("ExportTraces() error = %v", err)
+func TestJaegerToOTLPEndpoint(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "http://localhost:4318"},
+		{"http://localhost:14268/api/traces", "http://localhost:4318"},
+		{"http://jaeger-collector:14268/api/traces", "http://jaeger-collector:4318"},
+		{"https://jaeger.example.com/api/traces", "https://jaeger.example.com"},
+		{"http://localhost:4318", "http://localhost:4318"},
+		{"https://jaeger.example.com:4318", "https://jaeger.example.com:4318"},
+	}
+	for _, c := range cases {
+		if got := jaegerToOTLPEndpoint(c.in); got != c.want {
+			t.Errorf("jaegerToOTLPEndpoint(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 
 func TestJaegerExporter_ExportTraces_Empty(t *testing.T) {
-	exporter := &JaegerExporter{enabled: true}
-	err := exporter.ExportTraces([]*tracker.Trace{})
+	exporter, err := NewJaegerExporter("", 1.0)
 	if err != nil {
+		t.Fatalf("NewJaegerExporter() error = %v", err)
+	}
+	defer func() { _ = exporter.Shutdown(context.Background()) }()
+	if err := exporter.ExportTraces([]*tracker.Trace{}); err != nil {
 		t.Errorf("ExportTraces() error = %v", err)
 	}
 }
 
-func TestJaegerExporter_shouldSample(t *testing.T) {
-	tests := []struct {
-		name       string
-		sampleRate float64
-	}{
-		{"rate 1.0", 1.0},
-		{"rate 0.0", 0.0},
-		{"rate 0.5", 0.5},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exporter := &JaegerExporter{sampleRate: tt.sampleRate}
-			trace := &tracker.Trace{TraceID: "test"}
-			result := exporter.shouldSample(trace)
-			if tt.sampleRate == 1.0 && !result {
-				t.Error("Sample rate 1.0 should always sample")
-			}
-			if tt.sampleRate == 0.0 && result {
-				t.Error("Sample rate 0.0 should never sample")
-			}
-		})
-	}
-}
-
-func TestJaegerExporter_exportTrace_NoSpans(t *testing.T) {
-	exporter := &JaegerExporter{enabled: true}
-	trace := &tracker.Trace{
-		TraceID: "test",
-		Spans:   []*tracker.Span{},
-	}
-	err := exporter.exportTrace(trace)
-	if err != nil {
-		t.Errorf("exportTrace() error = %v", err)
-	}
-}
-
-func TestJaegerExporter_exportTrace_WithSpans(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
+func TestJaegerExporter_ExportTraces_NotSampled(t *testing.T) {
+	exporter, err := NewJaegerExporter("", 0.0)
 	if err != nil {
 		t.Fatalf("NewJaegerExporter() error = %v", err)
 	}
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-				Events: []*events.Event{
-					{
-						Type:      events.EventHTTPReq,
-						Target:    "http://example.com",
-						Timestamp: uint64(time.Now().UnixNano()),
-					},
-				},
-			},
-		},
-	}
-	exportErr := exporter.exportTrace(trace)
-	if exportErr != nil {
-		t.Logf("exportTrace() error (expected for test without server): %v", exportErr)
+	defer func() { _ = exporter.Shutdown(context.Background()) }()
+	traces := errorSurfaceTrace()
+	if err := exporter.ExportTraces(traces); err != nil {
+		t.Errorf("ExportTraces() with rate 0 must be a no-op, got %v", err)
 	}
 }
 
 func TestJaegerExporter_Shutdown(t *testing.T) {
-	exporter := &JaegerExporter{}
-	ctx := context.Background()
-	err := exporter.Shutdown(ctx)
+	exporter, err := NewJaegerExporter("", 1.0)
 	if err != nil {
+		t.Fatalf("NewJaegerExporter() error = %v", err)
+	}
+	if err := exporter.Shutdown(context.Background()); err != nil {
 		t.Errorf("Shutdown() error = %v", err)
-	}
-}
-
-func TestJaegerExporter_ExportTraces_WithSampledTrace(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-			},
-		},
-	}
-
-	err = exporter.ExportTraces([]*tracker.Trace{trace})
-	if err != nil {
-		t.Logf("ExportTraces() error (expected for test without server): %v", err)
-	}
-}
-
-func TestJaegerExporter_ExportTraces_WithNotSampledTrace(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 0.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-			},
-		},
-	}
-
-	err = exporter.ExportTraces([]*tracker.Trace{trace})
-	if err != nil {
-		t.Errorf("ExportTraces() error = %v", err)
-	}
-}
-
-func TestJaegerExporter_exportTrace_WithErrorSpan(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:    "test123",
-				SpanID:     "span123",
-				Operation:  "test-op",
-				Service:    "test-service",
-				StartTime:  time.Now(),
-				Duration:   100 * time.Millisecond,
-				Error:      true,
-				Attributes: map[string]string{"key": "value"},
-			},
-		},
-	}
-
-	err = exporter.exportTrace(trace)
-	if err != nil {
-		t.Logf("exportTrace() error (expected for test without server): %v", err)
-	}
-}
-
-func TestJaegerExporter_exportTrace_WithEmptyServiceName(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-			},
-		},
-	}
-
-	err = exporter.exportTrace(trace)
-	if err != nil {
-		t.Logf("exportTrace() error (expected for test without server): %v", err)
-	}
-}
-
-func TestJaegerExporter_exportTrace_WithEventError(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:   "test123",
-				SpanID:    "span123",
-				Operation: "test-op",
-				Service:   "test-service",
-				StartTime: time.Now(),
-				Duration:  100 * time.Millisecond,
-				Events: []*events.Event{
-					{
-						Type:      events.EventHTTPReq,
-						Target:    "http://example.com",
-						Timestamp: uint64(time.Now().UnixNano()),
-						Error:     500,
-						LatencyNS: 1000000,
-					},
-				},
-			},
-		},
-	}
-
-	err = exporter.exportTrace(trace)
-	if err != nil {
-		t.Logf("exportTrace() error (expected for test without server): %v", err)
-	}
-}
-
-func TestJaegerExporter_exportTrace_WithParentSpanID(t *testing.T) {
-	exporter, err := NewJaegerExporter("http://localhost:14268/api/traces", 1.0)
-	if err != nil {
-		t.Fatalf("NewJaegerExporter() error = %v", err)
-	}
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-		Spans: []*tracker.Span{
-			{
-				TraceID:      "test123",
-				SpanID:       "span123",
-				ParentSpanID: "parent123",
-				Operation:    "test-op",
-				Service:      "test-service",
-				StartTime:    time.Now(),
-				Duration:     100 * time.Millisecond,
-			},
-		},
-	}
-
-	err = exporter.exportTrace(trace)
-	if err != nil {
-		t.Logf("exportTrace() error (expected for test without server): %v", err)
 	}
 }

--- a/internal/tracing/exporter/otlp.go
+++ b/internal/tracing/exporter/otlp.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -24,8 +25,7 @@ import (
 
 type OTLPExporter struct {
 	exporter   sdktrace.SpanExporter
-	tracer     trace.Tracer
-	tp         *sdktrace.TracerProvider
+	resource   *resource.Resource
 	endpoint   string
 	enabled    bool
 	sampleRate float64
@@ -93,17 +93,9 @@ func NewOTLPExporter(endpoint string, sampleRate float64) (*OTLPExporter, error)
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(otlpExporter),
-		sdktrace.WithResource(res),
-	)
-
-	otel.SetTracerProvider(tp)
-
 	return &OTLPExporter{
 		exporter:   otlpExporter,
-		tp:         tp,
-		tracer:     tp.Tracer("Podtrace"),
+		resource:   res,
 		endpoint:   endpointURL,
 		enabled:    true,
 		sampleRate: sampleRate,
@@ -117,71 +109,91 @@ func (e *OTLPExporter) ExportTraces(traces []*tracker.Trace) error {
 
 	ctx := context.Background()
 	var errs []error
+	var snapshots []sdktrace.ReadOnlySpan
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
 
 		for _, span := range t.Spans {
-			if err := e.exportSpan(ctx, span, t); err != nil {
+			snapshot, err := e.spanSnapshot(span)
+			if err != nil {
 				// Keep exporting, but surface the failure: returning nil
 				// here made the manager's exporter-failure alerting
 				// unreachable dead code.
 				errs = append(errs, fmt.Errorf("trace %s span %s: %w", t.TraceID, span.SpanID, err))
+				continue
 			}
+			snapshots = append(snapshots, snapshot)
+		}
+	}
+
+	if len(snapshots) > 0 {
+		if err := e.exporter.ExportSpans(ctx, snapshots); err != nil {
+			errs = append(errs, fmt.Errorf("export %d spans: %w", len(snapshots), err))
 		}
 	}
 
 	return errors.Join(errs...)
 }
 
-func (e *OTLPExporter) shouldSample(_ *tracker.Trace) bool {
-	if e.sampleRate >= 1.0 {
-		return true
-	}
-	if e.sampleRate <= 0.0 {
-		return false
-	}
-	return time.Now().UnixNano()%int64(1.0/e.sampleRate) == 0
+func (e *OTLPExporter) shouldSample(t *tracker.Trace) bool {
+	return sampleTrace(t.TraceID, e.sampleRate)
 }
 
-func (e *OTLPExporter) exportSpan(ctx context.Context, span *tracker.Span, _ *tracker.Trace) error {
+// spanSnapshot converts a tracker span into a ReadOnlySpan that carries the
+// ORIGINAL trace, span, and parent IDs. The previous implementation replayed
+// spans through the SDK tracer, which mints a fresh span ID for every span
+// and demotes the original ID to its parent — every OTLP backend then showed
+// a broken parent/child structure with phantom intermediate spans.
+func (e *OTLPExporter) spanSnapshot(span *tracker.Span) (sdktrace.ReadOnlySpan, error) {
 	span.UpdateDuration()
 
 	traceID, err := trace.TraceIDFromHex(span.TraceID)
 	if err != nil {
-		return fmt.Errorf("invalid trace ID: %w", err)
+		return nil, fmt.Errorf("invalid trace ID: %w", err)
 	}
 
 	spanID, err := trace.SpanIDFromHex(span.SpanID)
 	if err != nil {
-		return fmt.Errorf("invalid span ID: %w", err)
+		return nil, fmt.Errorf("invalid span ID: %w", err)
 	}
 
-	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    traceID,
-		SpanID:     spanID,
-		Remote:     false,
-		TraceFlags: trace.FlagsSampled,
-	})
+	stub := tracetest.SpanStub{
+		Name: span.Operation,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		}),
+		StartTime: span.StartTime,
+		EndTime:   span.StartTime.Add(span.Duration),
+		Resource:  e.resource,
+		InstrumentationScope: instrumentation.Scope{
+			Name: "Podtrace",
+		},
+	}
 
-	ctx = trace.ContextWithSpanContext(ctx, spanContext)
-
-	_, otelSpan := e.tracer.Start(ctx, span.Operation,
-		trace.WithTimestamp(span.StartTime),
-	)
+	if span.ParentSpanID != "" {
+		parentID, err := trace.SpanIDFromHex(span.ParentSpanID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid parent span ID: %w", err)
+		}
+		stub.Parent = trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     parentID,
+			TraceFlags: trace.FlagsSampled,
+		})
+	}
 
 	attrs := make([]attribute.KeyValue, 0, len(span.Attributes))
 	for k, v := range span.Attributes {
 		attrs = append(attrs, attribute.String(k, v))
 	}
-	if span.ParentSpanID != "" {
-		attrs = append(attrs, attribute.String("parent_span_id", span.ParentSpanID))
-	}
-	otelSpan.SetAttributes(attrs...)
+	stub.Attributes = attrs
 
 	if span.Error {
-		otelSpan.RecordError(fmt.Errorf("span error"))
+		stub.Status = sdktrace.Status{Code: codes.Error}
 	}
 
 	for _, event := range span.Events {
@@ -205,20 +217,19 @@ func (e *OTLPExporter) exportSpan(ctx context.Context, span *tracker.Span, _ *tr
 				attrs = append(attrs, attribute.String("dns.transport", "tcp"))
 			}
 		}
-		otelSpan.AddEvent(event.TypeString(),
-			trace.WithTimestamp(event.TimestampTime()),
-			trace.WithAttributes(attrs...),
-		)
+		stub.Events = append(stub.Events, sdktrace.Event{
+			Name:       event.TypeString(),
+			Time:       event.TimestampTime(),
+			Attributes: attrs,
+		})
 	}
 
-	otelSpan.End(trace.WithTimestamp(span.StartTime.Add(span.Duration)))
-
-	return nil
+	return stub.Snapshot(), nil
 }
 
 func (e *OTLPExporter) Shutdown(ctx context.Context) error {
-	if e.tp != nil {
-		return e.tp.Shutdown(ctx)
+	if e.exporter != nil {
+		return e.exporter.Shutdown(ctx)
 	}
 	return nil
 }

--- a/internal/tracing/exporter/otlp_test.go
+++ b/internal/tracing/exporter/otlp_test.go
@@ -174,10 +174,6 @@ func TestOTLPExporter_exportSpan(t *testing.T) {
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
 
-	trace := &tracker.Trace{
-		TraceID: "test123",
-	}
-
 	span := &tracker.Span{
 		TraceID:      "12345678901234567890123456789012",
 		SpanID:       "1234567890123456",
@@ -198,9 +194,8 @@ func TestOTLPExporter_exportSpan(t *testing.T) {
 		},
 	}
 
-	err = exporter.exportSpan(context.Background(), span, trace)
-	if err != nil {
-		t.Logf("exportSpan() error (expected for test without server): %v", err)
+	if _, err := exporter.spanSnapshot(span); err != nil {
+		t.Errorf("spanSnapshot() unexpected error: %v", err)
 	}
 }
 
@@ -211,10 +206,6 @@ func TestOTLPExporter_exportSpan_InvalidTraceID(t *testing.T) {
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
 
-	trace := &tracker.Trace{
-		TraceID: "test123",
-	}
-
 	span := &tracker.Span{
 		TraceID:   "invalid",
 		SpanID:    "1234567890123456",
@@ -223,9 +214,8 @@ func TestOTLPExporter_exportSpan_InvalidTraceID(t *testing.T) {
 		Duration:  100 * time.Millisecond,
 	}
 
-	err = exporter.exportSpan(context.Background(), span, trace)
-	if err == nil {
-		t.Error("exportSpan() should return error for invalid trace ID")
+	if _, err := exporter.spanSnapshot(span); err == nil {
+		t.Error("spanSnapshot() should return error for invalid trace ID")
 	}
 }
 
@@ -236,10 +226,6 @@ func TestOTLPExporter_exportSpan_InvalidSpanID(t *testing.T) {
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
 
-	trace := &tracker.Trace{
-		TraceID: "test123",
-	}
-
 	span := &tracker.Span{
 		TraceID:   "12345678901234567890123456789012",
 		SpanID:    "invalid",
@@ -248,9 +234,8 @@ func TestOTLPExporter_exportSpan_InvalidSpanID(t *testing.T) {
 		Duration:  100 * time.Millisecond,
 	}
 
-	err = exporter.exportSpan(context.Background(), span, trace)
-	if err == nil {
-		t.Error("exportSpan() should return error for invalid span ID")
+	if _, err := exporter.spanSnapshot(span); err == nil {
+		t.Error("spanSnapshot() should return error for invalid span ID")
 	}
 }
 
@@ -260,10 +245,6 @@ func TestOTLPExporter_exportSpan_NoParentSpanID(t *testing.T) {
 		t.Skipf("Skipping test: failed to create exporter: %v", err)
 	}
 	defer func() { _ = exporter.Shutdown(context.Background()) }()
-
-	trace := &tracker.Trace{
-		TraceID: "test123",
-	}
 
 	span := &tracker.Span{
 		TraceID:      "12345678901234567890123456789012",
@@ -276,9 +257,8 @@ func TestOTLPExporter_exportSpan_NoParentSpanID(t *testing.T) {
 		Attributes:   map[string]string{"key": "value"},
 	}
 
-	err = exporter.exportSpan(context.Background(), span, trace)
-	if err != nil {
-		t.Logf("exportSpan() error (expected for test without server): %v", err)
+	if _, err := exporter.spanSnapshot(span); err != nil {
+		t.Errorf("spanSnapshot() unexpected error: %v", err)
 	}
 }
 

--- a/internal/tracing/exporter/otlp_unit_test.go
+++ b/internal/tracing/exporter/otlp_unit_test.go
@@ -108,8 +108,8 @@ func TestOTLPExporter_exportSpan_DNSEvent(t *testing.T) {
 		},
 	}
 
-	if err := exporter.exportSpan(context.Background(), span, &tracker.Trace{TraceID: "t"}); err != nil {
-		t.Errorf("exportSpan() unexpected error: %v", err)
+	if _, err := exporter.spanSnapshot(span); err != nil {
+		t.Errorf("spanSnapshot() unexpected error: %v", err)
 	}
 }
 
@@ -139,7 +139,7 @@ func TestOTLPExporter_exportSpan_DNSEvent_MinimalFields(t *testing.T) {
 		},
 	}
 
-	if err := exporter.exportSpan(context.Background(), span, &tracker.Trace{TraceID: "t"}); err != nil {
-		t.Errorf("exportSpan() unexpected error: %v", err)
+	if _, err := exporter.spanSnapshot(span); err != nil {
+		t.Errorf("spanSnapshot() unexpected error: %v", err)
 	}
 }

--- a/internal/tracing/exporter/robustness_regression_test.go
+++ b/internal/tracing/exporter/robustness_regression_test.go
@@ -1,0 +1,97 @@
+package exporter
+
+import (
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestSampleTrace_RateIsRespected: the old time.Now()%int64(1/rate) check
+// truncated every rate in (0.5, 1.0) to "always export" and re-rolled the
+// decision on each export tick. The hash-based sampler must export a
+// fraction of trace IDs close to the configured rate.
+func TestSampleTrace_RateIsRespected(t *testing.T) {
+	for _, rate := range []float64{0.1, 0.5, 0.7, 0.9} {
+		sampled := 0
+		const n = 20000
+		for i := 0; i < n; i++ {
+			if sampleTrace(fmt.Sprintf("trace-%d", i), rate) {
+				sampled++
+			}
+		}
+		got := float64(sampled) / n
+		if got < rate-0.02 || got > rate+0.02 {
+			t.Errorf("rate %.1f: sampled fraction %.3f, want within ±0.02", rate, got)
+		}
+	}
+}
+
+// TestSampleTrace_DeterministicPerTrace: one trace gets ONE verdict — the
+// clock-based roll exported every long-lived trace eventually because the
+// decision repeated on each 5s tick.
+func TestSampleTrace_DeterministicPerTrace(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		id := fmt.Sprintf("trace-%d", i)
+		first := sampleTrace(id, 0.5)
+		for roll := 0; roll < 20; roll++ {
+			if sampleTrace(id, 0.5) != first {
+				t.Fatalf("trace %s changed sampling verdict between rolls", id)
+			}
+		}
+	}
+	if sampleTrace("any", 1.0) != true || sampleTrace("any", 0.0) != false {
+		t.Error("boundary rates must be all-or-nothing")
+	}
+}
+
+// TestOTLPSpanSnapshot_PreservesSpanIdentity: replaying spans through the
+// SDK tracer minted fresh span IDs and demoted the original ID to the
+// parent — every OTLP backend showed phantom intermediate spans. The
+// exported snapshot must carry the original IDs verbatim.
+func TestOTLPSpanSnapshot_PreservesSpanIdentity(t *testing.T) {
+	exporter, err := NewOTLPExporter("http://localhost:4318", 1.0)
+	if err != nil {
+		t.Fatalf("NewOTLPExporter: %v", err)
+	}
+	t.Cleanup(func() { _ = exporter.Shutdown(t.Context()) })
+
+	span := errorSurfaceTrace()[0].Spans[0]
+	span.ParentSpanID = "fedcba9876543210"
+
+	snapshot, err := exporter.spanSnapshot(span)
+	if err != nil {
+		t.Fatalf("spanSnapshot: %v", err)
+	}
+
+	wantTrace, _ := trace.TraceIDFromHex(span.TraceID)
+	wantSpan, _ := trace.SpanIDFromHex(span.SpanID)
+	wantParent, _ := trace.SpanIDFromHex(span.ParentSpanID)
+
+	if snapshot.SpanContext().TraceID() != wantTrace {
+		t.Errorf("trace ID = %s, want %s", snapshot.SpanContext().TraceID(), span.TraceID)
+	}
+	if snapshot.SpanContext().SpanID() != wantSpan {
+		t.Errorf("span ID = %s, want the ORIGINAL %s", snapshot.SpanContext().SpanID(), span.SpanID)
+	}
+	if snapshot.Parent().SpanID() != wantParent {
+		t.Errorf("parent span ID = %s, want %s", snapshot.Parent().SpanID(), span.ParentSpanID)
+	}
+}
+
+// TestSpanTypeAndZipkinKind_CacheEvents: TypeString returns "CACHE" for
+// Redis/Memcached events; the comparisons against "Redis"/"Memcached"
+// were dead branches, so cache spans fell through to "custom"/no kind.
+func TestSpanTypeAndZipkinKind_CacheEvents(t *testing.T) {
+	span := &tracker.Span{Events: []*events.Event{{Type: events.EventRedisCmd}}}
+
+	if got := spanType(span); got != "cache" {
+		t.Errorf("spanType = %q, want cache", got)
+	}
+	if got := zipkinKind(span); got != "CLIENT" {
+		t.Errorf("zipkinKind = %q, want CLIENT", got)
+	}
+}

--- a/internal/tracing/exporter/sampling.go
+++ b/internal/tracing/exporter/sampling.go
@@ -1,0 +1,20 @@
+package exporter
+
+import (
+	"hash/fnv"
+	"math"
+)
+
+// sampleTrace decides deterministically whether a trace is exported at the
+// given rate, by hashing the trace ID onto [0, 1).
+func sampleTrace(traceID string, rate float64) bool {
+	if rate >= 1.0 {
+		return true
+	}
+	if rate <= 0.0 {
+		return false
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(traceID))
+	return float64(h.Sum64())/float64(math.MaxUint64) < rate
+}

--- a/internal/tracing/exporter/splunk.go
+++ b/internal/tracing/exporter/splunk.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
@@ -62,14 +61,8 @@ func (e *SplunkExporter) ExportTraces(traces []*tracker.Trace) error {
 	return errors.Join(errs...)
 }
 
-func (e *SplunkExporter) shouldSample(_ *tracker.Trace) bool {
-	if e.sampleRate >= 1.0 {
-		return true
-	}
-	if e.sampleRate <= 0.0 {
-		return false
-	}
-	return time.Now().UnixNano()%int64(1.0/e.sampleRate) == 0
+func (e *SplunkExporter) shouldSample(t *tracker.Trace) bool {
+	return sampleTrace(t.TraceID, e.sampleRate)
 }
 
 func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
@@ -75,14 +74,8 @@ func (e *ZipkinExporter) ExportTraces(traces []*tracker.Trace) error {
 	return errors.Join(errs...)
 }
 
-func (e *ZipkinExporter) shouldSample(_ *tracker.Trace) bool {
-	if e.sampleRate >= 1.0 {
-		return true
-	}
-	if e.sampleRate <= 0.0 {
-		return false
-	}
-	return time.Now().UnixNano()%int64(1.0/e.sampleRate) == 0
+func (e *ZipkinExporter) shouldSample(t *tracker.Trace) bool {
+	return sampleTrace(t.TraceID, e.sampleRate)
 }
 
 func (e *ZipkinExporter) exportTrace(t *tracker.Trace) error {
@@ -168,7 +161,7 @@ func (e *ZipkinExporter) Shutdown(ctx context.Context) error {
 func zipkinKind(span *tracker.Span) string {
 	for _, event := range span.Events {
 		switch event.TypeString() {
-		case "HTTP", "DB", "Redis", "Memcached", "gRPC":
+		case "HTTP", "DB", "CACHE", "gRPC":
 			return "CLIENT"
 		}
 	}

--- a/internal/tracing/graph/fanout_regression_test.go
+++ b/internal/tracing/graph/fanout_regression_test.go
@@ -1,0 +1,52 @@
+package graph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/tracker"
+)
+
+// TestBuildFromTraces_FanOutEdges: edges were only created between spans
+// ADJACENT in start order, so a parent fanning out to several children kept
+// only the edge to its first child — every other parent/child edge was
+// silently dropped from the request-flow graph.
+func TestBuildFromTraces_FanOutEdges(t *testing.T) {
+	base := time.Now()
+	parent := &tracker.Span{
+		TraceID: "t1", SpanID: "root", Service: "frontend",
+		StartTime: base, Duration: 50 * time.Millisecond,
+	}
+	childA := &tracker.Span{
+		TraceID: "t1", SpanID: "a", ParentSpanID: "root", Service: "auth",
+		StartTime: base.Add(1 * time.Millisecond), Duration: 5 * time.Millisecond,
+	}
+	// An unrelated span starts between the two children, breaking adjacency.
+	unrelated := &tracker.Span{
+		TraceID: "t1", SpanID: "x", Service: "cron",
+		StartTime: base.Add(2 * time.Millisecond), Duration: time.Millisecond,
+	}
+	childB := &tracker.Span{
+		TraceID: "t1", SpanID: "b", ParentSpanID: "root", Service: "billing",
+		StartTime: base.Add(3 * time.Millisecond), Duration: 5 * time.Millisecond,
+	}
+
+	g := NewGraphBuilder().BuildFromTraces([]*tracker.Trace{{
+		TraceID: "t1",
+		Spans:   []*tracker.Span{parent, childA, unrelated, childB},
+	}})
+
+	edges := map[string]bool{}
+	for _, e := range g.Edges {
+		edges[e.Source+"->"+e.Target] = true
+	}
+	if !edges["frontend->auth"] {
+		t.Error("missing frontend->auth edge")
+	}
+	if !edges["frontend->billing"] {
+		t.Error("missing frontend->billing edge (fan-out child not adjacent to parent)")
+	}
+	if len(edges) != 2 {
+		t.Errorf("got edges %v, want exactly the two fan-out edges", edges)
+	}
+}

--- a/internal/tracing/graph/graph.go
+++ b/internal/tracing/graph/graph.go
@@ -70,15 +70,19 @@ func (gb *GraphBuilder) processTrace(trace *tracker.Trace) {
 		return trace.Spans[i].StartTime.Before(trace.Spans[j].StartTime)
 	})
 
-	for i, span := range trace.Spans {
+	byID := make(map[string]*tracker.Span, len(trace.Spans))
+	for _, span := range trace.Spans {
+		byID[span.SpanID] = span
+	}
+
+	for _, span := range trace.Spans {
 		span.UpdateDuration()
 
 		sourceID := gb.getNodeID(span.Service, trace.Services)
 		gb.ensureNode(sourceID, span.Service, trace.Services)
 
-		if i > 0 {
-			parentSpan := trace.Spans[i-1]
-			if span.ParentSpanID == parentSpan.SpanID {
+		if span.ParentSpanID != "" {
+			if parentSpan, ok := byID[span.ParentSpanID]; ok {
 				targetID := gb.getNodeID(parentSpan.Service, trace.Services)
 				gb.ensureNode(targetID, parentSpan.Service, trace.Services)
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -171,7 +171,12 @@ func ValidatePath(path string, basePath string) error {
 	}
 	cleanPath := filepath.Clean(path)
 	cleanBase := filepath.Clean(basePath)
-	if !strings.HasPrefix(cleanPath, cleanBase) {
+	// The prefix check must stop at a path-separator boundary: a bare
+	// HasPrefix accepted "/base-evil" as being inside "/base".
+	inside := cleanPath == cleanBase ||
+		cleanBase == string(filepath.Separator) && strings.HasPrefix(cleanPath, cleanBase) ||
+		strings.HasPrefix(cleanPath, cleanBase+string(filepath.Separator))
+	if !inside {
 		return fmt.Errorf("path %s is outside base path %s", cleanPath, cleanBase)
 	}
 	if strings.Contains(cleanPath, "..") {

--- a/internal/validation/validation_boundary_test.go
+++ b/internal/validation/validation_boundary_test.go
@@ -1,0 +1,28 @@
+package validation
+
+import "testing"
+
+// TestValidatePath_SeparatorBoundary: a bare prefix check accepted
+// "/base-evil/secret" as inside "/base" — the boundary must be a path
+// separator.
+func TestValidatePath_SeparatorBoundary(t *testing.T) {
+	cases := []struct {
+		path string
+		base string
+		ok   bool
+	}{
+		{"/base/file", "/base", true},
+		{"/base", "/base", true},
+		{"/base/sub/dir", "/base", true},
+		{"/base-evil/secret", "/base", false},
+		{"/baseline", "/base", false},
+		{"/other", "/base", false},
+		{"/etc/passwd", "/", true},
+	}
+	for _, c := range cases {
+		err := ValidatePath(c.path, c.base)
+		if (err == nil) != c.ok {
+			t.Errorf("ValidatePath(%q, %q) error = %v, want ok=%v", c.path, c.base, err, c.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes correctness and robustness issues across the trace exporters, request-flow graph, critical-path analyzer, PII redactor, alert delivery, metrics endpoint, object-store sinks, resource monitor, pod profiler, and configuration parsing.

**Trace sampling.** All five exporters shared a sampling check based on `time.Now().UnixNano() % int64(1.0/rate)`. Integer truncation turned every rate in (0.5, 1.0) into 100%, and the clock re-rolled the decision on every export tick, so long-lived traces were eventually exported regardless of rate. Sampling is now one stable per-trace decision derived from a hash of the trace ID.

**OTLP span identity.** Spans were replayed through the OpenTelemetry SDK tracer, which mints fresh span IDs and demotes the original ID to the parent, backends showed broken parent/child structures with phantom spans. The exporter now ships read-only span snapshots carrying the original trace, span, and parent IDs verbatim.

**Jaeger.** The exporter POSTed a homegrown JSON shape no Jaeger release ingests (the legacy `/api/traces` endpoint speaks Thrift). It now ships OTLP, which modern Jaeger ingests natively — translating legacy collector URLs (`:14268/api/traces`) to the OTLP listener (`:4318`). Verified against a live Jaeger 1.57: spans are stored with their original IDs and resolvable parent references. Jaeger endpoints are now subject to the same cleartext-HTTP guard as OTLP (`PODTRACE_OTLP_INSECURE=1` for in-cluster plain-HTTP collectors), and that opt-in is propagated to spawned trace pods, where the exporters actually run.

**Request-flow graph.** Edges were only created between spans adjacent in start order, dropping every fan-out edge beyond a parent's first child. Parents are now resolved by span ID.

**Span classification.** The DataDog span-type and Zipkin span-kind mappings compared event types against "Redis"/"Memcached", but cache events stringify as "CACHE", the branches were dead and cache spans fell through to the default classification.

**Critical-path analysis.** The emit callback ran under the analyzer's mutex (slow callbacks stalled the hot path; re-entrant ones deadlocked); it now runs after the lock is released. Total latency no longer double-counts the boundary response event on top of the segments it contains.

**PII redaction.** Added rules for `token=`/`api_key=`/`secret=`/`access_key=` parameters, HTTP Basic auth, and JSON/YAML credential fields.

**Alert delivery.** Each sender goroutine now works on its own copy of the alert (the shared pointer raced sanitization against marshaling). The per-alert deadline covers the full retry schedule, making the configured retry count effective. Deliveries are tracked so shutdown waits for them, shutdown is idempotent, final errors are logged with the sender name, and a total delivery failure releases the deduplication record instead of silencing the alert for the rest of the window.

**Metrics endpoint.** pprof handlers now pass through the security-headers and rate-limit middleware; previously they were exposed raw, making an unauthenticated 30-second CPU profile request a cheap denial-of-service against a privileged pod. The loopback bind guard fails closed for empty hosts (`":9090"` means all interfaces), hostnames, and unparsable addresses, which all bypassed it before. A panic on one event no longer kills the metrics consumer loop permanently.

**Object-store sinks.** Retry logs redact query strings (Azure SAS tokens, presigned credentials were written to stderr on every retried attempt). A GCS sink with a custom endpoint and no service-account key logs an unmissable unauthenticated-mode warning instead of silently uploading without credentials.

**Resource monitor.** The kernel-shared limit and alert maps are now keyed by (cgroup, resource type) on both the BPF and Go sides, a cgroup-only key made CPU, memory, and IO entries clobber each other in map-iteration order. Cgroup files are read in full instead of first-line-only, so multi-device `io.max`/`io.stat`/blkio data is complete. The cgroup v1 IO limit parser now matches the kernel's real two-field `blkio.throttle.*_bps_device` format (the old three-field parser never matched anything, and usage summing also counted the Sync/Async/Total aggregate rows, roughly tripling reported usage). Alert thresholds honor `PODTRACE_ALERT_{WARN,CRIT,EMERG}_PCT` in both places that evaluated them — the monitor and the diagnose report's issue detector each carried their own hardcoded 95/90/80 copy, so tuned thresholds were ignored when raising alerts and the report dropped alerts the monitor had raised. The threshold variables are also forwarded to spawned trace pods, where the monitor actually runs; previously they silently had no effect on spawned traces.

**Pod profiler.** The discovered pprof port is accessed atomically; discovery racing the HTTP fetch handlers was a data race.

**Validation and configuration.** `ValidatePath` enforces a path-separator boundary, so `/base-evil` no longer validates against base `/base`. Boolean environment variables are parsed with `strconv.ParseBool`, `TRUE`, `True`, and `1` all work, including for the security opt-in gates, where requiring the literal `1` silently ignored an explicit `=true`; unparsable values fail closed and are reported. Integer, float, and duration variables that are set but invalid now emit a warning instead of being silently ignored.