### PR TITLE
chore(deps): pin helm to v4.2.2 and free runner disk in chainsaw

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "description": "Skip helm v4.2.1 only: a WaitForDelete regression hangs chart installs with before-hook-creation hooks.",
+      "description": "Skip helm v4.2.1 only: an intermittent WaitForDelete race affecting before-hook-creation hooks (upstream helm#32214), reverted in v4.2.2 (commit b05881c). v4.2.2+ is allowed by this range.",
       "matchDepNames": [
         "helm"
       ],

--- a/.github/workflows/chainsaw.yml
+++ b/.github/workflows/chainsaw.yml
@@ -36,6 +36,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL \
+            /usr/local/lib/android /usr/local/share/boost || true
+          sudo docker image prune -af || true
+          df -h /
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -51,7 +58,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: v4.2.0
+          version: v4.2.2
 
       - name: Install chainsaw
         run: |
@@ -115,11 +122,6 @@ jobs:
           kubectl -n podtrace-system describe pods 2>&1 | tail -200 || true
           kubectl -n podtrace-system logs deploy/podtrace-operator --tail=200 || true
 
-  # Guards the released quickstart manifests: quickstart.yaml must apply in a
-  # SINGLE kubectl invocation on a fresh cluster (explicit Namespace, no CRs
-  # racing their CRDs) and the demo manifest must complete end to end. This
-  # script existed but was never wired into CI, which is how a broken
-  # quickstart shipped undetected.
   quickstart-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -144,7 +146,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
         with:
-          version: v4.2.0
+          version: v4.2.2
 
       - name: Install BPF toolchain
         uses: ./.github/actions/setup-bpf-toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ env:
   CHART_PATH: deploy/charts/podtrace
   CHART_REPO: ghcr.io/gma1k/charts
   COSIGN_VERSION: v3.0.6
-  HELM_VERSION: v4.1.4
+  HELM_VERSION: v4.2.2
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:


### PR DESCRIPTION
Pins Helm to v4.2.2 across CI (chainsaw.yml + release.yml's HELM_VERSION), replacing v4.2.0/v4.1.4. v4.2.2 reverts the intermittent WaitForDelete race (upstream helm#32214) that made us skip v4.2.1, so the chart's before-hook-creation hooks install cleanly again. The Renovate skip comment is refreshed to note the fix.

Also adds a "Free up disk space" step to the chainsaw job, fixing the recent `no space left on device` failure during `kind load` of the alpine/k8s hook image on the hosted runner.