### PR TITLE
feat: stitch eBPF kernel spans into the apps OpenTelemetry trace

### DIFF
--- a/bpf/http.c
+++ b/bpf/http.c
@@ -42,6 +42,69 @@ static __always_inline int http_should_trace(void)
 	return 1;
 }
 
+struct tp_scan_ctx {
+	u32 rlen;
+	int pos;
+};
+
+static long tp_scan_cb(u32 i, void *vctx)
+{
+	struct tp_scan_ctx *c = (struct tp_scan_ctx *)vctx;
+	if (i + 16 >= HTTP_SCAN_BUF_SIZE || i >= c->rlen)
+		return 1;
+	u32 zero = 0;
+	char *buf = bpf_map_lookup_elem(&http_scan_buf, &zero);
+	if (!buf)
+		return 1;
+	const char needle[] = "traceparent:";
+	u32 diff = 0;
+	u32 j;
+#pragma unroll
+	for (j = 0; j < 12; j++)
+		diff |= (u32)((u8)buf[(i + j) & (HTTP_SCAN_BUF_SIZE - 1)] ^ (u8)needle[j]);
+	if (diff == 0) {
+		c->pos = (int)i;
+		return 1;
+	}
+	return 0;
+}
+
+static __noinline void http_capture_traceparent(void *base, u64 avail, char *out)
+{
+	out[0] = '\0';
+	if (!base)
+		return;
+	u32 zero = 0;
+	char *buf = bpf_map_lookup_elem(&http_scan_buf, &zero);
+	if (!buf)
+		return;
+	u32 rlen = (avail < HTTP_SCAN_BUF_SIZE) ? (u32)avail : HTTP_SCAN_BUF_SIZE;
+	if (rlen < 32)
+		return;
+	if (bpf_probe_read_user(buf, rlen, base) != 0)
+		return;
+
+	struct tp_scan_ctx sc = {.rlen = rlen, .pos = -1};
+	bpf_loop(HTTP_SCAN_BUF_SIZE, tp_scan_cb, &sc, 0);
+	if (sc.pos < 0)
+		return;
+
+	u32 v = (u32)sc.pos + 12;
+	if (v < HTTP_SCAN_BUF_SIZE && buf[v & (HTTP_SCAN_BUF_SIZE - 1)] == ' ')
+		v++;
+
+	const char prefix[] = "traceparent: ";
+	u32 p;
+#pragma unroll
+	for (p = 0; p < 13; p++)
+		out[p] = prefix[p];
+	u32 k;
+#pragma unroll
+	for (k = 0; k < W3C_TRACEPARENT_LEN; k++)
+		out[13 + k] = buf[(v + k) & (HTTP_SCAN_BUF_SIZE - 1)];
+	out[13 + W3C_TRACEPARENT_LEN] = '\0';
+}
+
 SEC("kprobe/tcp_sendmsg")
 int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
 {
@@ -104,7 +167,7 @@ int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
 		e->bytes = 0;
 		e->tcp_state = 0;
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), endpoint);
-		e->details[0] = '\0';
+		http_capture_traceparent(base, avail, e->details);
 		capture_user_stack(ctx, pid, tid, e);
 		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -389,6 +389,14 @@ struct {
 	__type(value, u64);
 } http_recv_base SEC(".maps");
 
+#define HTTP_SCAN_BUF_SIZE 512
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, char[HTTP_SCAN_BUF_SIZE]);
+} http_scan_buf SEC(".maps");
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 256);

--- a/bpf/protocols.h
+++ b/bpf/protocols.h
@@ -39,6 +39,7 @@
 /* === HTTP/1.x socket-level inspection (bpf/http.c) === */
 #define HTTP_INSPECT_LEN     80
 #define HTTP_MIN_REQUEST_LEN 16
+#define W3C_TRACEPARENT_LEN  55
 
 /* === FastCGI NV Pair Helpers === */
 #define FCGI_NV_LEN_4BYTE    0x80

--- a/internal/agent/sdk_event_exporter.go
+++ b/internal/agent/sdk_event_exporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/logger"
+	"github.com/podtrace/podtrace/internal/tracing/extractor"
 	"github.com/podtrace/podtrace/internal/safeconv"
 	bundlepkg "github.com/podtrace/podtrace/pkg/exporter/bundle"
 	"github.com/podtrace/podtrace/pkg/tracer"
@@ -30,6 +31,7 @@ type sdkEventExporter struct {
 	tp         *sdktrace.TracerProvider
 	thresholds *PolicyThresholds
 	metrics    *Metrics
+	extractor  *extractor.HTTPExtractor
 }
 
 type sdkOption func(*sdkOptions)
@@ -43,7 +45,7 @@ func withMetrics(m *Metrics) sdkOption {
 }
 
 // newSDKEventExporter wires an SDK SpanExporter (the wire-format
-// adapter — OTLP, Zipkin, etc.) into a TracerProvider shaped to the
+// adapter, OTLP, Zipkin, etc.) into a TracerProvider shaped to the
 // bundle's sampling, resource attribution, and batch settings, then
 // returns a tracer.Exporter that emits one span per event.
 func newSDKEventExporter(name string, cr CRKey, b *BundlePayload, spanExporter sdktrace.SpanExporter, opts ...sdkOption) (tracer.Exporter, error) {
@@ -90,10 +92,11 @@ func newSDKEventExporter(name string, cr CRKey, b *BundlePayload, spanExporter s
 	)
 
 	exp := &sdkEventExporter{
-		name:    fmt.Sprintf("%s/%s", name, cr.String()),
-		cr:      cr,
-		tp:      tp,
-		metrics: cfg.metrics,
+		name:      fmt.Sprintf("%s/%s", name, cr.String()),
+		cr:        cr,
+		tp:        tp,
+		metrics:   cfg.metrics,
+		extractor: extractor.NewHTTPExtractor(),
 	}
 	if b != nil && !b.Thresholds.IsZero() {
 		exp.thresholds = policyThresholdsFromBundle(b.Thresholds)
@@ -160,7 +163,11 @@ func (e *sdkEventExporter) Export(ctx context.Context, batch []*events.Event) er
 			endedAt = startedAt
 		}
 
-		_, span := tr.Start(ctx, eventSpanName(ev), trace.WithTimestamp(startedAt))
+		spanCtx := ctx
+		if parent, ok := e.remoteParent(ev); ok {
+			spanCtx = trace.ContextWithSpanContext(ctx, parent)
+		}
+		_, span := tr.Start(spanCtx, eventSpanName(ev), trace.WithTimestamp(startedAt))
 		attrs := []attribute.KeyValue{
 			attribute.String("podtrace.event.type", eventTypeString(ev.Type)),
 			attribute.Int64("podtrace.event.pid", int64(ev.PID)),
@@ -177,6 +184,42 @@ func (e *sdkEventExporter) Export(ctx context.Context, batch []*events.Event) er
 		span.End(trace.WithTimestamp(endedAt))
 	}
 	return nil
+}
+
+// remoteParent derives the application span this event should hang under,
+// from W3C/B3 trace context.
+func (e *sdkEventExporter) remoteParent(ev *events.Event) (trace.SpanContext, bool) {
+	traceIDHex, parentSpanHex := ev.TraceID, ev.ParentSpanID
+	sampled := ev.TraceFlags&0x01 == 1
+	if traceIDHex == "" && (ev.Type == events.EventHTTPReq || ev.Type == events.EventHTTPResp) && ev.Details != "" && e.extractor != nil {
+		tc := e.extractor.ExtractFromRawHeaders(ev.Details)
+		if tc == nil || !tc.IsValid() {
+			return trace.SpanContext{}, false
+		}
+		traceIDHex, parentSpanHex, sampled = tc.TraceID, tc.ParentSpanID, tc.IsSampled()
+	}
+	if traceIDHex == "" || parentSpanHex == "" {
+		return trace.SpanContext{}, false
+	}
+	tid, err := trace.TraceIDFromHex(traceIDHex)
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	sid, err := trace.SpanIDFromHex(parentSpanHex)
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	var flags trace.TraceFlags
+	if sampled {
+		flags = trace.FlagsSampled
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: flags,
+		Remote:     true,
+	})
+	return sc, sc.IsValid()
 }
 
 // appendThresholdAttributes evaluates the bundle's thresholds against

--- a/internal/agent/sdk_span_stitch_test.go
+++ b/internal/agent/sdk_span_stitch_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/tracing/extractor"
+)
+
+// newStitchExporter builds a minimal sdkEventExporter exercising only the
+// trace-context plumbing.
+func newStitchExporter() *sdkEventExporter {
+	return &sdkEventExporter{extractor: extractor.NewHTTPExtractor()}
+}
+
+const (
+	stitchTraceID  = "0af7651916cd43dd8448eb211c80319c"
+	stitchSpanID   = "b7ad6b7169203331"
+	stitchTracePar = "traceparent: 00-" + stitchTraceID + "-" + stitchSpanID + "-01"
+)
+
+// TestRemoteParent_HTTPReqWithTraceparent: an HTTP request event whose Details
+// carries a captured W3C traceparent must yield a remote parent span context
+// under the app's trace, with the app's span as parent.
+func TestRemoteParent_HTTPReqWithTraceparent(t *testing.T) {
+	e := newStitchExporter()
+	ev := &events.Event{Type: events.EventHTTPReq, Target: "GET /api", Details: stitchTracePar}
+
+	sc, ok := e.remoteParent(ev)
+	if !ok {
+		t.Fatal("expected a valid remote parent span context, got none")
+	}
+	if sc.TraceID().String() != stitchTraceID {
+		t.Errorf("TraceID = %s, want %s", sc.TraceID(), stitchTraceID)
+	}
+	if sc.SpanID().String() != stitchSpanID {
+		t.Errorf("parent SpanID = %s, want app span %s", sc.SpanID(), stitchSpanID)
+	}
+	if !sc.IsRemote() {
+		t.Error("parent span context should be marked remote")
+	}
+	if !sc.IsSampled() {
+		t.Error("flags 01 should mark the context sampled")
+	}
+}
+
+// TestRemoteParent_NoContext: events without trace context (no traceparent,
+// non-HTTP types, or a status-only response) stay standalone roots.
+func TestRemoteParent_NoContext(t *testing.T) {
+	e := newStitchExporter()
+	cases := []struct {
+		name string
+		ev   *events.Event
+	}{
+		{"http req, no traceparent", &events.Event{Type: events.EventHTTPReq, Details: ""}},
+		{"http resp, status only", &events.Event{Type: events.EventHTTPResp, Details: "200"}},
+		{"non-http event ignored", &events.Event{Type: events.EventDNS, Details: stitchTracePar}},
+		{"colon detail, not a trace header", &events.Event{Type: events.EventHTTPReq, Details: "1.2.3.4:53"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := e.remoteParent(c.ev); ok {
+				t.Errorf("%s: expected no remote parent", c.name)
+			}
+		})
+	}
+}

--- a/internal/tracing/extractor/http_test.go
+++ b/internal/tracing/extractor/http_test.go
@@ -226,3 +226,27 @@ func TestParseRawHeaders_MaxHeaderCountOverflow(t *testing.T) {
 		t.Errorf("expected at most %d headers, got %d", MaxHeaderCount, len(headers))
 	}
 }
+
+// TestExtractFromRawHeaders_BPFSingleLineContract locks the contract between
+// bpf/http.c (which writes a single bare "traceparent: <value>" line into the
+// event Details — no other headers, no trailing CRLF) and the userspace
+// extractor that must parse it to stitch spans.
+func TestExtractFromRawHeaders_BPFSingleLineContract(t *testing.T) {
+	const traceID = "0af7651916cd43dd8448eb211c80319c"
+	const appSpan = "b7ad6b7169203331"
+	raw := "traceparent: 00-" + traceID + "-" + appSpan + "-01"
+
+	tc := NewHTTPExtractor().ExtractFromRawHeaders(raw)
+	if tc == nil || !tc.IsValid() {
+		t.Fatalf("expected valid trace context from %q, got %+v", raw, tc)
+	}
+	if tc.TraceID != traceID {
+		t.Errorf("TraceID = %s, want %s", tc.TraceID, traceID)
+	}
+	if tc.ParentSpanID != appSpan {
+		t.Errorf("ParentSpanID = %s, want app span %s", tc.ParentSpanID, appSpan)
+	}
+	if tc.SpanID == "" || tc.SpanID == appSpan {
+		t.Errorf("SpanID = %q, want a freshly generated child span id distinct from the parent", tc.SpanID)
+	}
+}


### PR DESCRIPTION
Captures the W3C `traceparent` header off HTTP requests in eBPF and emits podtrace's kernel HTTP span as a **child of the application's distributed trace**, same trace ID, parent = the app's span, fresh child span ID. Works on both export paths: the continuous agent (`PodTrace` CR) and the CLI (`--tracing`).

`bpf/http.c` scans the request header block for `traceparent` and writes it into `event.Details`; the existing userspace extractor already parses that into trace context. The agent's per-event exporter (`sdk_event_exporter.go`) now starts each span under that remote parent when context is present; the CLI's `tracingManager`→trace-tracker→OTLP pipeline already preserved trace/parent IDs, so it stitches once the capture feeds it.