### PR TITLE
feat: capture HTTPS endpoints via SSL_read/SSL_write uprobes

### DIFF
--- a/bpf/http.c
+++ b/bpf/http.c
@@ -105,28 +105,20 @@ static __noinline void http_capture_traceparent(void *base, u64 avail, char *out
 	out[13 + W3C_TRACEPARENT_LEN] = '\0';
 }
 
-SEC("kprobe/tcp_sendmsg")
-int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
+static __noinline void http_emit_request(void *ctx, void *base, u64 avail)
 {
-	if (!http_should_trace())
-		return 0;
-
-	struct msghdr *msg = (struct msghdr *)PT_REGS_PARM2(ctx);
-	u64 avail = 0;
-	void *base = msghdr_user_base(msg, &avail);
 	if (!base || avail < HTTP_MIN_REQUEST_LEN)
-		return 0;
+		return;
 
 	u8 buf[HTTP_INSPECT_LEN] = {};
 	u32 read_len = (u32)avail;
 	if (read_len > HTTP_INSPECT_LEN)
 		read_len = HTTP_INSPECT_LEN;
 	if (bpf_probe_read_user(buf, read_len, base) != 0)
-		return 0;
+		return;
 
-	int mlen = http_method_len(buf);
-	if (mlen == 0)
-		return 0;
+	if (http_method_len(buf) == 0)
+		return;
 
 	char endpoint[MAX_STRING_LEN] = {};
 	u32 p = 0;
@@ -144,7 +136,7 @@ int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
 		endpoint[p++] = c;
 	}
 	if (p == 0)
-		return 0;
+		return;
 	endpoint[p] = '\0';
 
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
@@ -171,6 +163,85 @@ int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
 		capture_user_stack(ctx, pid, tid, e);
 		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	}
+}
+
+/* Parse an HTTP/1.x response status line from a user buffer (socket recv
+ * buffer or TLS plaintext) and, if it pairs with an in-flight request on this
+ * thread, emit EVENT_HTTP_RESP with status + request->response latency. */
+static __noinline void http_emit_response(void *ctx, void *base, u64 len)
+{
+	if (!base || len == 0 || len >= MAX_BYTES_THRESHOLD)
+		return;
+
+	u32 read_len = (u32)len;
+	if (read_len > HTTP_INSPECT_LEN)
+		read_len = HTTP_INSPECT_LEN;
+
+	u8 buf[HTTP_INSPECT_LEN] = {};
+	if (bpf_probe_read_user(buf, read_len, base) != 0)
+		return;
+
+	if (!(buf[0] == 'H' && buf[1] == 'T' && buf[2] == 'T' && buf[3] == 'P' &&
+	      buf[4] == '/' && buf[5] == '1' && buf[6] == '.'))
+		return;
+
+	char status[4] = {};
+	u32 si = 0;
+	int seen_space = 0;
+	u32 i;
+	for (i = 0; i < HTTP_INSPECT_LEN && si < 3; i++) {
+		u8 c = buf[i];
+		if (!seen_space) {
+			if (c == ' ')
+				seen_space = 1;
+			continue;
+		}
+		if (c < '0' || c > '9')
+			break;
+		status[si++] = c;
+	}
+	if (si == 0)
+		return;
+	status[si] = '\0';
+
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+
+	struct http_req *req = bpf_map_lookup_elem(&http_reqs, &key);
+	if (!req)
+		return;
+
+	u64 latency_ns = calc_latency(req->start_ns);
+	s32 status_num = (status[0] - '0') * 100 + (status[1] - '0') * 10 +
+			 (status[2] - '0');
+
+	struct event *e = get_event_buf();
+	if (e) {
+		e->timestamp = bpf_ktime_get_ns();
+		e->pid = pid;
+		e->type = EVENT_HTTP_RESP;
+		e->latency_ns = latency_ns;
+		e->error = status_num >= 500 ? status_num : 0;
+		e->bytes = len;
+		e->tcp_state = 0;
+		bpf_probe_read_kernel_str(e->target, sizeof(e->target), req->endpoint);
+		bpf_probe_read_kernel_str(e->details, sizeof(e->details), status);
+		capture_user_stack(ctx, pid, tid, e);
+		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
+	}
+	bpf_map_delete_elem(&http_reqs, &key);
+}
+
+SEC("kprobe/tcp_sendmsg")
+int kprobe_http_tcp_sendmsg(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	struct msghdr *msg = (struct msghdr *)PT_REGS_PARM2(ctx);
+	u64 avail = 0;
+	void *base = msghdr_user_base(msg, &avail);
+	http_emit_request(ctx, base, avail);
 	return 0;
 }
 
@@ -212,63 +283,97 @@ int kretprobe_http_tcp_recvmsg(struct pt_regs *ctx)
 	bpf_map_delete_elem(&http_recv_base, &key);
 
 	s64 ret = PT_REGS_RC(ctx);
-	if (ret <= 0 || (u64)ret >= MAX_BYTES_THRESHOLD)
+	if (ret <= 0)
 		return 0;
+	http_emit_response(ctx, base, (u64)ret);
+	return 0;
+}
 
-	u32 read_len = (u32)ret;
-	if (read_len > HTTP_INSPECT_LEN)
-		read_len = HTTP_INSPECT_LEN;
-
-	u8 buf[HTTP_INSPECT_LEN] = {};
-	if (bpf_probe_read_user(buf, read_len, base) != 0)
+SEC("uprobe/SSL_write")
+int uprobe_SSL_write(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
 		return 0;
+	void *base = (void *)PT_REGS_PARM2(ctx);
+	u64 num = (u64)(s64)PT_REGS_PARM3(ctx);
+	http_emit_request(ctx, base, num);
+	return 0;
+}
 
-	if (!(buf[0] == 'H' && buf[1] == 'T' && buf[2] == 'T' && buf[3] == 'P' &&
-	      buf[4] == '/' && buf[5] == '1' && buf[6] == '.'))
+SEC("uprobe/SSL_read")
+int uprobe_SSL_read(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
 		return 0;
-
-	char status[4] = {};
-	u32 si = 0;
-	int seen_space = 0;
-	u32 i;
-	for (i = 0; i < HTTP_INSPECT_LEN && si < 3; i++) {
-		u8 c = buf[i];
-		if (!seen_space) {
-			if (c == ' ')
-				seen_space = 1;
-			continue;
-		}
-		if (c < '0' || c > '9')
-			break;
-		status[si++] = c;
-	}
-	if (si == 0)
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	if (!bpf_map_lookup_elem(&http_reqs, &key))
 		return 0;
-	status[si] = '\0';
+	u64 base_val = (u64)PT_REGS_PARM2(ctx);
+	bpf_map_update_elem(&ssl_read_args, &key, &base_val, BPF_ANY);
+	return 0;
+}
 
-	struct http_req *req = bpf_map_lookup_elem(&http_reqs, &key);
-	if (!req)
+SEC("uretprobe/SSL_read")
+int uretprobe_SSL_read(struct pt_regs *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	u64 *base_ptr = bpf_map_lookup_elem(&ssl_read_args, &key);
+	if (!base_ptr)
 		return 0;
+	void *base = (void *)*base_ptr;
+	bpf_map_delete_elem(&ssl_read_args, &key);
+	s64 ret = PT_REGS_RC(ctx);
+	if (ret <= 0)
+		return 0;
+	http_emit_response(ctx, base, (u64)ret);
+	return 0;
+}
 
-	u64 latency_ns = calc_latency(req->start_ns);
-	s32 status_num = (status[0] - '0') * 100 + (status[1] - '0') * 10 +
-			 (status[2] - '0');
+SEC("uprobe/gnutls_record_send")
+int uprobe_gnutls_record_send(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	void *base = (void *)PT_REGS_PARM2(ctx);
+	u64 num = (u64)PT_REGS_PARM3(ctx);
+	http_emit_request(ctx, base, num);
+	return 0;
+}
 
-	struct event *e = get_event_buf();
-	if (e) {
-		e->timestamp = bpf_ktime_get_ns();
-		e->pid = pid;
-		e->type = EVENT_HTTP_RESP;
-		e->latency_ns = latency_ns;
-		e->error = status_num >= 500 ? status_num : 0;
-		e->bytes = (u64)ret;
-		e->tcp_state = 0;
-		bpf_probe_read_kernel_str(e->target, sizeof(e->target), req->endpoint);
-		bpf_probe_read_kernel_str(e->details, sizeof(e->details), status);
-		capture_user_stack(ctx, pid, tid, e);
-		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
-	}
-	bpf_map_delete_elem(&http_reqs, &key);
+SEC("uprobe/gnutls_record_recv")
+int uprobe_gnutls_record_recv(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	if (!bpf_map_lookup_elem(&http_reqs, &key))
+		return 0;
+	u64 base_val = (u64)PT_REGS_PARM2(ctx);
+	bpf_map_update_elem(&ssl_read_args, &key, &base_val, BPF_ANY);
+	return 0;
+}
+
+SEC("uretprobe/gnutls_record_recv")
+int uretprobe_gnutls_record_recv(struct pt_regs *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	u64 *base_ptr = bpf_map_lookup_elem(&ssl_read_args, &key);
+	if (!base_ptr)
+		return 0;
+	void *base = (void *)*base_ptr;
+	bpf_map_delete_elem(&ssl_read_args, &key);
+	s64 ret = PT_REGS_RC(ctx);
+	if (ret <= 0)
+		return 0;
+	http_emit_response(ctx, base, (u64)ret);
 	return 0;
 }
 
@@ -282,5 +387,23 @@ int kprobe_http_tcp_recvmsg(struct pt_regs *ctx) { return 0; }
 
 SEC("kretprobe/tcp_recvmsg")
 int kretprobe_http_tcp_recvmsg(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/SSL_write")
+int uprobe_SSL_write(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/SSL_read")
+int uprobe_SSL_read(struct pt_regs *ctx) { return 0; }
+
+SEC("uretprobe/SSL_read")
+int uretprobe_SSL_read(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/gnutls_record_send")
+int uprobe_gnutls_record_send(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/gnutls_record_recv")
+int uprobe_gnutls_record_recv(struct pt_regs *ctx) { return 0; }
+
+SEC("uretprobe/gnutls_record_recv")
+int uretprobe_gnutls_record_recv(struct pt_regs *ctx) { return 0; }
 
 #endif

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -159,6 +159,13 @@ struct {
 	__uint(max_entries, 1024);
 	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
+} tcp_target SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, struct pair_key);
+	__type(value, char[MAX_STRING_LEN]);
 } syscall_paths SEC(".maps");
 
 struct {
@@ -396,6 +403,13 @@ struct {
 	__type(key, u32);
 	__type(value, char[HTTP_SCAN_BUF_SIZE]);
 } http_scan_buf SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u64);
+	__type(value, u64);
+} ssl_read_args SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -5,11 +5,40 @@
 #include "events.h"
 #include "helpers.h"
 
-/* The destination sockaddr must be captured at kprobe entry: by the time the
- * kretprobe fires, the argument registers have been clobbered by the function
- * body. PARM2 is the KERNEL copy of the caller's sockaddr (the syscall layer
- * runs move_addr_to_kernel before tcp_v4/v6_connect), so it is read with
- * bpf_probe_read_kernel. */
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+static __noinline void stash_tcp_peer(struct pt_regs *ctx, u32 pair)
+{
+	struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
+	if (!sk)
+		return;
+	u16 dport_be = BPF_CORE_READ(sk, __sk_common.skc_dport);
+	if (dport_be == 0)
+		return;
+	u16 family = BPF_CORE_READ(sk, __sk_common.skc_family);
+	char buf[MAX_STRING_LEN] = {};
+	if (family == AF_INET) {
+		u32 daddr_be = BPF_CORE_READ(sk, __sk_common.skc_daddr);
+		if (daddr_be == 0)
+			return;
+		format_ip_port(__builtin_bswap32(daddr_be), __builtin_bswap16(dport_be), buf);
+	} else if (family == AF_INET6) {
+		u8 d6[16] = {};
+		BPF_CORE_READ_INTO(&d6, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr8);
+		format_ipv6_port(d6, __builtin_bswap16(dport_be), buf);
+	} else {
+		return;
+	}
+	struct pair_key key = make_pair_key(pair);
+	bpf_map_update_elem(&tcp_target, &key, buf, BPF_ANY);
+}
+#else
+static __always_inline void stash_tcp_peer(struct pt_regs *ctx, u32 pair)
+{
+	(void)ctx;
+	(void)pair;
+}
+#endif
+
 SEC("kprobe/tcp_v4_connect")
 int kprobe_tcp_connect(struct pt_regs *ctx) {
 	struct pair_key key = make_pair_key(PAIR_TCP_CONNECT_V4);
@@ -152,8 +181,9 @@ int kprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_TCP_SENDMSG);
 	u64 ts = bpf_ktime_get_ns();
-	
+
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	stash_tcp_peer(ctx, PAIR_TCP_SENDMSG);
 	return 0;
 }
 
@@ -176,9 +206,6 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 
 	u64 latency_ns = calc_latency(*start_ts);
 
-	/* socket_conns and grpc_methods are cross-probe blackboards written by
-	 * other probes (http_request uprobe, grpc sendmsg kprobe) and stay keyed
-	 * by the plain thread key. */
 	u64 conn_key = get_key(pid, tid);
 
 	struct event *e = get_event_buf();
@@ -195,21 +222,22 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 	e->bytes = bytes;
 	e->tcp_state = 0;
 
-	/* Look up without deleting: the entry belongs to the in-flight
-	 * http_request pair, which removes it when the request returns.
-	 * Deleting here starved the HTTP/Redis consumers of their URL. */
 	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (conn_ptr) {
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), conn_ptr);
 	} else {
-		e->target[0] = '\0';
+		char *peer = bpf_map_lookup_elem(&tcp_target, &key);
+		if (peer) {
+			bpf_probe_read_kernel_str(e->target, sizeof(e->target), peer);
+		} else {
+			e->target[0] = '\0';
+		}
 	}
+	bpf_map_delete_elem(&tcp_target, &key);
 	capture_user_stack(ctx, pid, tid, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	bpf_map_delete_elem(&start_times, &key);
 
-	/* If kprobe_grpc_tcp_sendmsg detected an HTTP/2 gRPC method path,
-	 * emit an additional EVENT_GRPC_METHOD event for that send. */
 	char *grpc_method_ptr = bpf_map_lookup_elem(&grpc_methods, &conn_key);
 	if (grpc_method_ptr) {
 		struct event *eg = get_event_buf();
@@ -238,8 +266,9 @@ int kprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_TCP_RECVMSG);
 	u64 ts = bpf_ktime_get_ns();
-	
+
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
+	stash_tcp_peer(ctx, PAIR_TCP_RECVMSG);
 	return 0;
 }
 
@@ -273,14 +302,19 @@ int kretprobe_tcp_recvmsg(struct pt_regs *ctx) {
 	e->bytes = bytes;
 	e->tcp_state = 0;
 
-	/* Same blackboard semantics as the sendmsg kretprobe: read-only. */
 	u64 conn_key = get_key(pid, tid);
 	char *conn_ptr = bpf_map_lookup_elem(&socket_conns, &conn_key);
 	if (conn_ptr) {
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), conn_ptr);
 	} else {
-		e->target[0] = '\0';
+		char *peer = bpf_map_lookup_elem(&tcp_target, &key);
+		if (peer) {
+			bpf_probe_read_kernel_str(e->target, sizeof(e->target), peer);
+		} else {
+			e->target[0] = '\0';
+		}
 	}
+	bpf_map_delete_elem(&tcp_target, &key);
 	capture_user_stack(ctx, pid, tid, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	bpf_map_delete_elem(&start_times, &key);
@@ -350,12 +384,6 @@ int uretprobe_getaddrinfo(struct pt_regs *ctx) {
 	return 0;
 }
 
-/* tcp:tcp_set_state was removed in kernel 4.16 (replaced by
- * sock:inet_sock_set_state, commit 563e0bb0dc74), so this handler targets the
- * replacement. Layout pinned to the upstream trace event (verified against a
- * live kernel format file); sport/dport are stored in HOST byte order by the
- * tracepoint (TP_STORE_ADDR_PORTS applies ntohs), the address byte arrays are
- * in network order. */
 struct inet_sock_set_state_args {
 	unsigned short common_type;
 	unsigned char common_flags;
@@ -397,9 +425,6 @@ int tracepoint_inet_sock_set_state(void *ctx) {
 		return 0;
 	}
 
-	/* State changes often fire in softirq context where the current task is
-	 * a bystander, so skip the in-kernel cgroup prefilter and let the
-	 * userspace filter decide. */
 	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
@@ -429,12 +454,6 @@ int tracepoint_inet_sock_set_state(void *ctx) {
 	return 0;
 }
 
-/* Layout pinned to the post-5.10 tcp_event_sk_skb class (skbaddr, skaddr,
- * state, then ports/family/addresses; `family` landed in v5.10). The previous
- * hand-written struct used a pre-5.10 layout, so sport/dport were read from
- * inside `state` and daddr landed on family+saddr — bogus retransmit targets
- * on any modern kernel. Same bug class as the fixed net_dev_xmit handler;
- * same _Static_assert treatment. Ports are in HOST byte order. */
 struct tcp_retransmit_skb_args {
 	unsigned short common_type;
 	unsigned char common_flags;
@@ -469,9 +488,6 @@ int tracepoint_tcp_retransmit_skb(void *ctx) {
 	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
 		return 0;
 	}
-
-	/* Retransmits fire from timers/softirq where the current task is a
-	 * bystander; skip the in-kernel cgroup prefilter. */
 	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
@@ -523,7 +539,6 @@ int tracepoint_net_dev_xmit(void *ctx) {
 	if (args_local.rc == 0) {
 		return 0;
 	}
-	/* Softirq context: current task is a bystander, skip the prefilter. */
 	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
@@ -781,8 +796,6 @@ int uretprobe_PQexec(struct pt_regs *ctx) {
 	e->pid = pid;
 	e->type = EVENT_DB_QUERY;
 	e->latency_ns = latency;
-	/* PQexec returns PGresult* — NULL on failure, a heap pointer on
-	 * success. Storing the pointer as a status inverted the meaning. */
 	long ret = PT_REGS_RC(ctx);
 	e->error = ret == 0 ? -1 : 0;
 	e->bytes = 0;

--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -144,6 +144,18 @@ func (a *ebpfBackendAdapter) SetContainerID(id string) error {
 	return a.tr.SetContainerID(id)
 }
 
+// SetContainerTargets implements the optional pkg/tracer.ContainerUprobeReconciler
+// interface: it hands the eBPF tracer the full set of currently-targeted
+// containers (with per-container PIDs) so it can attach newly-seen containers'
+// uprobes and detach departed ones.
+func (a *ebpfBackendAdapter) SetContainerTargets(targets []tracer.ContainerUprobeTarget) error {
+	conv := make([]ebpf.ContainerProbeTarget, 0, len(targets))
+	for _, t := range targets {
+		conv = append(conv, ebpf.ContainerProbeTarget{ID: t.ContainerID, PID: t.PID})
+	}
+	return a.tr.SetContainerTargets(conv)
+}
+
 func (a *ebpfBackendAdapter) Start(ctx context.Context, ch chan<- *events.Event) error {
 	return a.tr.Start(ctx, ch)
 }

--- a/cmd/podtrace/agent_adapter_unit_test.go
+++ b/cmd/podtrace/agent_adapter_unit_test.go
@@ -44,6 +44,10 @@ func (f *fakeTracer) SetContainerID(id string) error {
 	return f.containerIDErr
 }
 
+func (f *fakeTracer) SetContainerTargets(targets []ebpf.ContainerProbeTarget) error {
+	return nil
+}
+
 func (f *fakeTracer) Start(_ context.Context, ch chan<- *events.Event) error {
 	f.startCalled = true
 	f.startCh = ch

--- a/cmd/podtrace/cmd_tracer_multi_unit_test.go
+++ b/cmd/podtrace/cmd_tracer_multi_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/podtrace/podtrace/internal/ebpf"
 	"github.com/podtrace/podtrace/internal/events"
 )
 
@@ -18,7 +19,10 @@ type multiTracer struct {
 func (m *multiTracer) SetCgroups([]string) error   { return nil }
 func (m *multiTracer) AttachToCgroup(string) error { return nil }
 func (m *multiTracer) SetContainerID(string) error { return nil }
-func (m *multiTracer) Stop() error                 { return nil }
+func (m *multiTracer) SetContainerTargets([]ebpf.ContainerProbeTarget) error {
+	return nil
+}
+func (m *multiTracer) Stop() error { return nil }
 func (m *multiTracer) Start(context.Context, chan<- *events.Event) error {
 	return nil
 }

--- a/cmd/podtrace/filter_test.go
+++ b/cmd/podtrace/filter_test.go
@@ -159,6 +159,7 @@ func TestFilterEvents_AllEventTypes(t *testing.T) {
 		{"TCPRecv with net filter", "net", &events.Event{Type: events.EventTCPRecv}, true},
 		{"HTTPReq with net filter", "net", &events.Event{Type: events.EventHTTPReq}, true},
 		{"HTTPResp with net filter", "net", &events.Event{Type: events.EventHTTPResp}, true},
+		{"GRPCMethod with net filter", "net", &events.Event{Type: events.EventGRPCMethod}, true},
 		{"EventOpen with proc filter", "proc", &events.Event{Type: events.EventOpen}, true},
 		{"EventClose with proc filter", "proc", &events.Event{Type: events.EventClose}, true},
 		{"EventFsync with fs filter", "fs", &events.Event{Type: events.EventFsync}, true},

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -891,7 +891,8 @@ func filterEvents(ctx context.Context, in <-chan *events.Event, out chan<- *even
 				shouldInclude = true
 			case filterMap["net"] && (event.Type == events.EventConnect || event.Type == events.EventTCPSend || event.Type == events.EventTCPRecv ||
 				event.Type == events.EventFastCGIReq || event.Type == events.EventFastCGIResp ||
-				event.Type == events.EventHTTPReq || event.Type == events.EventHTTPResp):
+				event.Type == events.EventHTTPReq || event.Type == events.EventHTTPResp ||
+				event.Type == events.EventGRPCMethod):
 				shouldInclude = true
 			case filterMap["fs"] && (event.Type == events.EventRead || event.Type == events.EventWrite || event.Type == events.EventFsync):
 				shouldInclude = true

--- a/cmd/podtrace/mocks.go
+++ b/cmd/podtrace/mocks.go
@@ -54,6 +54,10 @@ func (m *mockTracer) SetContainerID(containerID string) error {
 	return nil
 }
 
+func (m *mockTracer) SetContainerTargets(targets []ebpf.ContainerProbeTarget) error {
+	return nil
+}
+
 func (m *mockTracer) Start(ctx context.Context, eventChan chan<- *events.Event) error {
 	if m.startFunc != nil {
 		return m.startFunc(ctx, eventChan)

--- a/internal/agent/enricher.go
+++ b/internal/agent/enricher.go
@@ -157,6 +157,7 @@ type PodCgroupEntry struct {
 	Pod           *corev1.Pod
 	ContainerName string
 	ContainerID   string
+	ContainerPID uint32
 }
 
 // buildK8sMetadata projects a PodCgroupEntry onto the frozen v1

--- a/internal/agent/exporter_loader_test.go
+++ b/internal/agent/exporter_loader_test.go
@@ -257,6 +257,6 @@ func (e errString) Error() string { return string(e) }
 
 func errSentinel(s string) error { return errString(s) }
 
-func contextWithTimeout(seconds int) (context.Context, func()) {
+func contextWithTimeout(_ int) (context.Context, func()) {
 	return context.WithCancel(context.Background()) //nolint:contextcheck // tests tolerate indefinite ctx
 }

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -27,6 +28,7 @@ import (
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/operator"
+	"github.com/podtrace/podtrace/internal/sysfs"
 	bundlepkg "github.com/podtrace/podtrace/pkg/exporter/bundle"
 	"github.com/podtrace/podtrace/pkg/tracer"
 )
@@ -413,6 +415,7 @@ func scanPodCgroups(pods []*corev1.Pod) []PodCgroupEntry {
 				Pod:           p,
 				ContainerName: containerName,
 				ContainerID:   containerID,
+				ContainerPID:  firstPIDFromCgroupProcs(child),
 			})
 		}
 	}
@@ -470,6 +473,25 @@ func identifyContainerCgroup(dir string, statuses map[string]string) (name, id s
 		}
 	}
 	return "", ""
+}
+
+// firstPIDFromCgroupProcs returns the first host PID listed in a cgroup
+// directory's cgroup.procs, or 0 if none/unreadable.
+func firstPIDFromCgroupProcs(cgroupDir string) uint32 {
+	rel, ok := sysfs.CgroupRelative(cgroupDir)
+	if !ok {
+		return 0
+	}
+	data, err := sysfs.CgroupReadFile(filepath.Join(rel, "cgroup.procs"))
+	if err != nil {
+		return 0
+	}
+	for _, f := range strings.Fields(string(data)) {
+		if pid, err := strconv.ParseUint(f, 10, 32); err == nil && pid > 0 {
+			return uint32(pid)
+		}
+	}
+	return 0
 }
 
 // kubepodsRootCandidates lists the well-known cgroup directories
@@ -571,6 +593,7 @@ func buildTargetSet(rules []CRRule, pods []*corev1.Pod, podEntries []PodCgroupEn
 					Namespace:     entry.Pod.Namespace,
 					ContainerID:   entry.ContainerID,
 					ContainerName: entry.ContainerName,
+					ContainerPID:  entry.ContainerPID,
 					CgroupPath:    entry.CgroupPath,
 					Labels:        copyMap(entry.Pod.Labels),
 					PodIP:         entry.Pod.Status.PodIP,
@@ -742,6 +765,7 @@ func filterToEventTypes(f podtracev1alpha1.EventFilter) []events.EventType {
 			events.EventTCPRetrans, events.EventNetDevError,
 			events.EventFastCGIReq, events.EventFastCGIResp,
 			events.EventHTTPReq, events.EventHTTPResp,
+			events.EventGRPCMethod,
 		}
 	case podtracev1alpha1.FilterFS:
 		return []events.EventType{

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -142,8 +142,9 @@ func TestFilterToEventTypes_AllCategories(t *testing.T) {
 func TestFilterToEventTypes_NetIncludesHTTP(t *testing.T) {
 	got := filterToEventTypes(podtracev1alpha1.FilterNet)
 	want := map[events.EventType]bool{
-		events.EventHTTPReq:  false,
-		events.EventHTTPResp: false,
+		events.EventHTTPReq:    false,
+		events.EventHTTPResp:   false,
+		events.EventGRPCMethod: false,
 	}
 	for _, et := range got {
 		if _, ok := want[et]; ok {

--- a/internal/diagnose/tracker/connection.go
+++ b/internal/diagnose/tracker/connection.go
@@ -36,12 +36,16 @@ func (ct *ConnectionTracker) ProcessEvent(event *events.Event) {
 	switch event.Type {
 	case events.EventConnect:
 		if event.Error == 0 && event.Target != "" {
-			conn := &ConnectionInfo{
-				Target:       event.Target,
-				ConnectTime:  event.TimestampTime(),
-				LastActivity: event.TimestampTime(),
+			if conn, exists := ct.connections[event.Target]; exists {
+				conn.ConnectTime = event.TimestampTime()
+				conn.LastActivity = event.TimestampTime()
+			} else {
+				ct.connections[event.Target] = &ConnectionInfo{
+					Target:       event.Target,
+					ConnectTime:  event.TimestampTime(),
+					LastActivity: event.TimestampTime(),
+				}
 			}
-			ct.connections[event.Target] = conn
 		}
 
 	case events.EventTCPSend, events.EventTCPRecv:

--- a/internal/diagnose/tracker/connection_test.go
+++ b/internal/diagnose/tracker/connection_test.go
@@ -387,3 +387,25 @@ func TestConnectionTracker_GetConnectionSummary_WithLatency(t *testing.T) {
 		t.Errorf("Expected 15ms avg latency, got %v", summaries[0].AvgLatency)
 	}
 }
+
+// TestConnectionTracker_ReconnectPreservesCounts: a reconnect to a peer we've
+// already accounted send/recv for must refresh timestamps but keep the
+// accumulated op counts (regression: connect used to overwrite the entry,
+// resetting counts to zero on every reconnect).
+func TestConnectionTracker_ReconnectPreservesCounts(t *testing.T) {
+	ct := NewConnectionTracker()
+	ct.ProcessEvent(&events.Event{Type: events.EventConnect, Target: "10.0.0.1:80"})
+	ct.ProcessEvent(&events.Event{Type: events.EventTCPSend, Target: "10.0.0.1:80"})
+	ct.ProcessEvent(&events.Event{Type: events.EventTCPRecv, Target: "10.0.0.1:80"})
+	ct.ProcessEvent(&events.Event{Type: events.EventTCPRecv, Target: "10.0.0.1:80"})
+	// reconnect to the same peer — must NOT wipe the 1 send / 2 recv above
+	ct.ProcessEvent(&events.Event{Type: events.EventConnect, Target: "10.0.0.1:80"})
+
+	s := ct.GetConnectionSummary()
+	if len(s) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(s))
+	}
+	if s[0].SendCount != 1 || s[0].RecvCount != 2 {
+		t.Errorf("reconnect reset counts: got %d send, %d recv; want 1 send, 2 recv", s[0].SendCount, s[0].RecvCount)
+	}
+}

--- a/internal/ebpf/probes/groups.go
+++ b/internal/ebpf/probes/groups.go
@@ -72,6 +72,14 @@ var probeGroupMap = map[string]ProbeGroup{
 	"uprobe_pthread_mutex_lock":    GroupTLS,
 	"uretprobe_pthread_mutex_lock": GroupTLS,
 
+	// TLS plaintext HTTP capture
+	"uprobe_SSL_write":             GroupTLS,
+	"uprobe_SSL_read":              GroupTLS,
+	"uretprobe_SSL_read":           GroupTLS,
+	"uprobe_gnutls_record_send":    GroupTLS,
+	"uprobe_gnutls_record_recv":    GroupTLS,
+	"uretprobe_gnutls_record_recv": GroupTLS,
+
 	// Database
 	"uprobe_PQexec":    GroupDatabase,
 	"uretprobe_PQexec": GroupDatabase,

--- a/internal/ebpf/probes/groups_test.go
+++ b/internal/ebpf/probes/groups_test.go
@@ -14,6 +14,21 @@ func TestGroupForProbe_HTTPSocketProbes(t *testing.T) {
 	}
 }
 
+func TestGroupForProbe_TLSPlaintextProbes(t *testing.T) {
+	for _, prog := range []string{
+		"uprobe_SSL_write",
+		"uprobe_SSL_read",
+		"uretprobe_SSL_read",
+		"uprobe_gnutls_record_send",
+		"uprobe_gnutls_record_recv",
+		"uretprobe_gnutls_record_recv",
+	} {
+		if got := GroupForProbe(prog); got != GroupTLS {
+			t.Errorf("GroupForProbe(%q) = %q, want %q", prog, got, GroupTLS)
+		}
+	}
+}
+
 func TestGroupForProbe_UnknownDefaultsToNetwork(t *testing.T) {
 	if got := GroupForProbe("kprobe_does_not_exist"); got != GroupNetwork {
 		t.Errorf("GroupForProbe(unknown) = %q, want %q", got, GroupNetwork)

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -1471,8 +1471,67 @@ func findTLSLibsInContainerWithPID(containerID string, pid uint32, libPatterns [
 		if foundPaths := findTLSLibsViaProcessMapsProcRoot(pid, libPatterns); len(foundPaths) > 0 {
 			return foundPaths
 		}
+		if foundPaths := findTLSLibsViaProcRootScan(pid, libPatterns); len(foundPaths) > 0 {
+			return foundPaths
+		}
 	}
 	return findTLSLibsInContainer(containerID, libPatterns)
+}
+
+// findTLSLibsViaProcRootScan walks the container rootfs (via /proc/<pid>/root)
+// looking for shared-library files whose name matches one of libPatterns,
+// independent of whether the resolved process has them mapped. Symlinks are
+// resolved and de-duplicated so a uprobe is not attached twice to the same
+// underlying file.
+func findTLSLibsViaProcRootScan(pid uint32, libPatterns []string) []string {
+	root := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "root")
+	dirs := append(config.GetDefaultLibSearchPaths(),
+		"/usr/lib/x86_64-linux-gnu", "/lib/x86_64-linux-gnu",
+		"/usr/lib/aarch64-linux-gnu", "/lib/aarch64-linux-gnu",
+	)
+	patternsLower := make([]string, len(libPatterns))
+	for i, p := range libPatterns {
+		patternsLower[i] = strings.ToLower(p)
+	}
+	var paths []string
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		dirPath := filepath.Join(root, strings.TrimPrefix(d, "/"))
+		entries, err := os.ReadDir(dirPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				logger.Debug("TLS rootfs scan: readdir failed", zap.String("dir", dirPath), zap.Error(err))
+			}
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || e.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			nameLower := strings.ToLower(e.Name())
+			if !strings.Contains(nameLower, ".so") {
+				continue
+			}
+			matched := false
+			for _, pat := range patternsLower {
+				if strings.Contains(nameLower, pat) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			full := filepath.Join(dirPath, e.Name())
+			if seen[full] {
+				continue
+			}
+			seen[full] = true
+			paths = append(paths, full)
+		}
+	}
+	logger.Debug("TLS rootfs scan complete", zap.Uint32("pid", pid), zap.String("root", root), zap.Int("found", len(paths)))
+	return paths
 }
 
 func findTLSLibsViaLdconfig(libPatterns []string) []string {
@@ -1743,7 +1802,14 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 		"SSL_do_handshake":      {"uprobe_SSL_do_handshake", "uretprobe_SSL_do_handshake"},
 		"gnutls_handshake":      {"uprobe_gnutls_handshake", "uretprobe_gnutls_handshake"},
 		"mbedtls_ssl_handshake": {"uprobe_mbedtls_ssl_handshake", "uretprobe_mbedtls_ssl_handshake"},
+		"SSL_write":             {"uprobe_SSL_write", ""},
+		"SSL_read":              {"uprobe_SSL_read", "uretprobe_SSL_read"},
+		"gnutls_record_send":    {"uprobe_gnutls_record_send", ""},
+		"gnutls_record_recv":    {"uprobe_gnutls_record_recv", "uretprobe_gnutls_record_recv"},
 	}
+
+	logger.Debug("TLS probe attach: candidate libraries",
+		zap.Strings("libs", tlsLibPaths), zap.String("containerID", containerID), zap.Uint32("pid", pid))
 
 	for _, libPath := range tlsLibPaths {
 		info, err := os.Stat(libPath)
@@ -1752,6 +1818,7 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 		}
 		exe, err := link.OpenExecutable(libPath)
 		if err != nil {
+			logger.Debug("TLS probe: cannot open library", zap.String("lib", libPath), zap.Error(err))
 			continue
 		}
 
@@ -1766,17 +1833,23 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 				l, err := exe.Uprobe(symbol, uprobeProg, nil)
 				if err == nil {
 					links = append(links, l)
+					logger.Debug("TLS uprobe attached", zap.String("symbol", symbol), zap.String("lib", libPath))
+				} else if !strings.Contains(err.Error(), "not found") {
+					logger.Debug("TLS uprobe attach failed", zap.String("symbol", symbol), zap.String("lib", libPath), zap.Error(err))
 				}
 			}
 			if uretprobeProg != nil {
 				l, err := exe.Uretprobe(symbol, uretprobeProg, nil)
 				if err == nil {
 					links = append(links, l)
+				} else if !strings.Contains(err.Error(), "not found") {
+					logger.Debug("TLS uretprobe attach failed", zap.String("symbol", symbol), zap.String("lib", libPath), zap.Error(err))
 				}
 			}
 		}
 	}
 
+	logger.Debug("TLS probe attach complete", zap.Int("links", len(links)))
 	return links
 }
 

--- a/internal/ebpf/tracer/interface.go
+++ b/internal/ebpf/tracer/interface.go
@@ -11,6 +11,7 @@ type TracerInterface interface {
 
 	AttachToCgroup(cgroupPath string) error
 	SetContainerID(containerID string) error
+	SetContainerTargets(targets []ContainerProbeTarget) error
 	Start(ctx context.Context, eventChan chan<- *events.Event) error
 	Stop() error
 }

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -73,6 +73,9 @@ type Tracer struct {
 
 	intentionallyDisabled    map[probes.ProbeGroup]struct{}
 	detachWarned             map[probes.ProbeGroup]struct{}
+
+	containerUprobes       map[string]*containerUprobeSet
+	globalProtocolAttached bool
 	reader                   *ringbuf.Reader
 	filter                   *filter.CgroupFilter
 	containerID              string
@@ -118,6 +121,100 @@ func (t *Tracer) linkCount() int {
 	t.probeGroupsMu.Lock()
 	defer t.probeGroupsMu.Unlock()
 	return len(t.links)
+}
+
+// ContainerProbeTarget is one container the agent wants container-scoped
+// uprobes on, with a host PID used to resolve that container's libraries.
+type ContainerProbeTarget struct {
+	ID  string
+	PID uint32
+}
+
+type containerUprobeSet struct {
+	pid   uint32
+	links []link.Link
+}
+
+// attachGlobalProtocolProbesOnce attaches the protocol kprobes that are NOT
+// container-scoped (HTTP/1.x, gRPC HTTP/2, FastCGI on shared kernel functions)
+// exactly once.
+func (t *Tracer) attachGlobalProtocolProbesOnce() {
+	t.probeGroupsMu.Lock()
+	already := t.globalProtocolAttached
+	t.globalProtocolAttached = true
+	t.probeGroupsMu.Unlock()
+	if already || t.collection == nil {
+		return
+	}
+	t.registerGroupLinks(probes.GroupFastCGI, probes.AttachFastCGIProbes(t.collection))
+	t.registerGroupLinks(probes.GroupNetwork, probes.AttachGRPCProbes(t.collection))
+	t.registerGroupLinks(probes.GroupNetwork, probes.AttachHTTPProbes(t.collection))
+}
+
+// attachContainerUprobes attaches every container-scoped uprobe group for one
+// container (resolved via its own PID) and returns the links, without
+// registering them in the shared probeGroups registry, the per-container
+// lifecycle in SetContainerTargets owns them.
+func (t *Tracer) attachContainerUprobes(id string, pid uint32) []link.Link {
+	coll := t.collection
+	if coll == nil || id == "" {
+		return nil
+	}
+	var ls []link.Link
+	ls = append(ls, probes.AttachDNSProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachDBProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachPoolProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
+	ls = append(ls, probes.AttachKafkaProbesWithPID(coll, id, pid)...)
+	return ls
+}
+
+// SetContainerTargets reconciles container-scoped uprobes against the full set
+// of currently-targeted containers (the agent's dynamic, multi-container path).
+func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
+	t.attachGlobalProtocolProbesOnce()
+
+	want := make(map[string]uint32, len(targets))
+	for _, ct := range targets {
+		if ct.ID != "" {
+			want[ct.ID] = ct.PID
+		}
+	}
+
+	t.probeGroupsMu.Lock()
+	if t.containerUprobes == nil {
+		t.containerUprobes = map[string]*containerUprobeSet{}
+	}
+	var stale []link.Link
+	for id, set := range t.containerUprobes {
+		if pid, ok := want[id]; ok && pid == set.pid {
+			continue
+		}
+		stale = append(stale, set.links...)
+		delete(t.containerUprobes, id)
+	}
+	var toAttach []ContainerProbeTarget
+	for id, pid := range want {
+		if _, ok := t.containerUprobes[id]; !ok {
+			toAttach = append(toAttach, ContainerProbeTarget{ID: id, PID: pid})
+		}
+	}
+	t.probeGroupsMu.Unlock()
+
+	for _, l := range stale {
+		_ = l.Close()
+	}
+
+	for _, ct := range toAttach {
+		links := t.attachContainerUprobes(ct.ID, ct.PID)
+		t.probeGroupsMu.Lock()
+		t.containerUprobes[ct.ID] = &containerUprobeSet{pid: ct.PID, links: links}
+		t.probeGroupsMu.Unlock()
+	}
+	return nil
 }
 
 // attachGroupUprobes re-attaches the container-scoped probes belonging to a
@@ -1004,6 +1101,10 @@ func (t *Tracer) Stop() error {
 		closing = append(closing, ls...)
 	}
 	t.dnsPacketLinks = nil
+	for _, set := range t.containerUprobes {
+		closing = append(closing, set.links...)
+	}
+	t.containerUprobes = nil
 	t.probeGroupsMu.Unlock()
 	for _, l := range closing {
 		_ = l.Close()

--- a/internal/ebpf/tracer_wrapper.go
+++ b/internal/ebpf/tracer_wrapper.go
@@ -6,6 +6,8 @@ import (
 
 type TracerInterface = tracer.TracerInterface
 
+type ContainerProbeTarget = tracer.ContainerProbeTarget
+
 func NewTracer() (TracerInterface, error) {
 	return tracer.NewTracer()
 }

--- a/internal/ebpf/tracer_wrapper_test.go
+++ b/internal/ebpf/tracer_wrapper_test.go
@@ -56,6 +56,10 @@ func (m *mockTracerForInterface) SetContainerID(containerID string) error {
 	return nil
 }
 
+func (m *mockTracerForInterface) SetContainerTargets(targets []ContainerProbeTarget) error {
+	return nil
+}
+
 func (m *mockTracerForInterface) Start(ctx context.Context, eventChan chan<- *events.Event) error {
 	return nil
 }

--- a/pkg/tracer/engine.go
+++ b/pkg/tracer/engine.go
@@ -175,15 +175,33 @@ func (e *engine) applyTargets(set TargetSet) error {
 		return err
 	}
 
-	for path, t := range desired {
-		if t.ContainerID == "" {
-			continue
+	if rec, ok := e.backend.(ContainerUprobeReconciler); ok {
+		seen := make(map[string]struct{}, len(desired))
+		cts := make([]ContainerUprobeTarget, 0, len(desired))
+		for _, t := range desired {
+			if t.ContainerID == "" {
+				continue
+			}
+			if _, dup := seen[t.ContainerID]; dup {
+				continue
+			}
+			seen[t.ContainerID] = struct{}{}
+			cts = append(cts, ContainerUprobeTarget{ContainerID: t.ContainerID, PID: t.ContainerPID})
 		}
-		if _, alreadyActive := e.activeCgroups[path]; alreadyActive {
-			continue
-		}
-		if err := e.backend.SetContainerID(t.ContainerID); err != nil {
+		if err := rec.SetContainerTargets(cts); err != nil {
 			e.exporterFailure++
+		}
+	} else {
+		for path, t := range desired {
+			if t.ContainerID == "" {
+				continue
+			}
+			if _, alreadyActive := e.activeCgroups[path]; alreadyActive {
+				continue
+			}
+			if err := e.backend.SetContainerID(t.ContainerID); err != nil {
+				e.exporterFailure++
+			}
 		}
 	}
 

--- a/pkg/tracer/engine_container_uprobe_test.go
+++ b/pkg/tracer/engine_container_uprobe_test.go
@@ -1,0 +1,74 @@
+package tracer_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+type reconcilerBackend struct {
+	*mockBackend
+	rmu         sync.Mutex
+	lastTargets []tracer.ContainerUprobeTarget
+	calls       int
+}
+
+func (r *reconcilerBackend) SetContainerTargets(targets []tracer.ContainerUprobeTarget) error {
+	r.rmu.Lock()
+	defer r.rmu.Unlock()
+	r.lastTargets = append([]tracer.ContainerUprobeTarget(nil), targets...)
+	r.calls++
+	return nil
+}
+
+func (r *reconcilerBackend) targetsByID() map[string]uint32 {
+	r.rmu.Lock()
+	defer r.rmu.Unlock()
+	m := make(map[string]uint32, len(r.lastTargets))
+	for _, t := range r.lastTargets {
+		m[t.ContainerID] = t.PID
+	}
+	return m
+}
+
+func TestEngine_DrivesContainerUprobeReconciler(t *testing.T) {
+	backend := &reconcilerBackend{mockBackend: &mockBackend{}}
+	exporter := &recordingExporter{name: "rec"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exporter}, tracer.Config{EventBufferSize: 16, ExportBatchSize: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	targets := make(chan tracer.TargetSet, 4)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 111},
+		{CgroupPath: "/cg/b", ContainerID: "b", ContainerPID: 222},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		m := backend.targetsByID()
+		return m["a"] == 111 && m["b"] == 222
+	})
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 111},
+		{CgroupPath: "/cg/c", ContainerID: "c", ContainerPID: 333},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		m := backend.targetsByID()
+		_, hasB := m["b"]
+		return m["a"] == 111 && m["c"] == 333 && !hasB
+	})
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}

--- a/pkg/tracer/types.go
+++ b/pkg/tracer/types.go
@@ -21,6 +21,8 @@ type Target struct {
 
 	ContainerName string
 
+	ContainerPID uint32
+
 	CgroupPath string
 
 	Labels map[string]string
@@ -77,4 +79,13 @@ type EngineObserver interface {
 // filter category.
 type CategoryGateable interface {
 	SetEnabledCategories(categories []string) error
+}
+
+type ContainerUprobeTarget struct {
+	ContainerID string
+	PID         uint32
+}
+
+type ContainerUprobeReconciler interface {
+	SetContainerTargets(targets []ContainerUprobeTarget) error
 }


### PR DESCRIPTION
Adds HTTPS visibility by reading TLS plaintext at the library boundary, and fixes the agent/correlation gaps that were blocking it. The branch carries four logically-distinct changes:

1. **HTTPS endpoint capture.** New `SSL_write`/`SSL_read` (+ GnuTLS `gnutls_record_send`/`recv`) uprobes feed a refactored shared parser (`http_emit_request`/`http_emit_response`, also used by the plaintext socket probes), so method/path/status/latency are captured for HTTPS with no app changes and no key material, plaintext is read before encryption / after decryption. BTF-gated like the existing gRPC/TLS sock reads.

2. **Agent per-container uprobe lifecycle.** The continuous agent attached uprobes with a single shared/stale PID and leaked links, so HTTPS never worked on the agent path. `tracer.Target` now carries a per-container PID (resolved from the container cgroup's `cgroup.procs`), and `tracer.SetContainerTargets` declaratively attaches/detaches container-scoped uprobes per container. TLS library resolution gains a rootfs-file scan fallback, because the resolved cgroup PID is usually the container's idle `sh` (libssl unmapped), scan `/proc/<pid>/root/{lib,…}` for the file instead.

3. **gRPC filter-drop fix.** `EventGRPCMethod` was silently dropped by both `net` filter gates (`reconciler.go` and `cmd/podtrace/main.go`), the same way HTTP was; added it so gRPC events survive to the report/exporters.

4. **Connection-correlation send/recv attribution.** `tcp_sendmsg`/`tcp_recvmsg` events carried no connection key, so per-connection `Operations` always showed `0 send, 0 recv`. The kprobes now stamp the socket's peer `IP:port` (`skc_daddr`/`skc_dport`, IPv4 + IPv6) onto the event when no application URL is known, so the tracker can join data to its connect. Also fixes a pre-existing bug where a reconnect to the same peer overwrote the entry and reset its op counts.