### PR TITLE
feat: harden Go crypto/tls tracing (stripped binaries, arm64)

### DIFF
--- a/bpf/gotls.c
+++ b/bpf/gotls.c
@@ -6,8 +6,21 @@
 #include "helpers.h"
 #include "protocols.h"
 
-#if defined(PODTRACE_VMLINUX_FROM_BTF) && \
-	(defined(__TARGET_ARCH_x86) || defined(__x86_64__))
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+
+#if defined(__TARGET_ARCH_x86) || defined(__x86_64__)
+#define GO_ARG_PTR(ctx) ((void *)(ctx)->bx)
+#define GO_ARG_LEN(ctx) ((u64)(ctx)->cx)
+#define GO_TLS_SUPPORTED 1
+#elif defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
+#define GO_ARG_PTR(ctx) ((void *)PT_REGS_PARM2(ctx))
+#define GO_ARG_LEN(ctx) ((u64)PT_REGS_PARM3(ctx))
+#define GO_TLS_SUPPORTED 1
+#endif
+
+#endif
+
+#ifdef GO_TLS_SUPPORTED
 
 #define GO_PEEK_LEN 16
 
@@ -17,8 +30,8 @@ int uprobe_go_tls_write(struct pt_regs *ctx)
 	if (!http_should_trace())
 		return 0;
 
-	void *base = (void *)ctx->bx;
-	u64 avail = (u64)ctx->cx;
+	void *base = GO_ARG_PTR(ctx);
+	u64 avail = GO_ARG_LEN(ctx);
 	if (!base || avail < HTTP2_FRAME_HDR)
 		return 0;
 

--- a/internal/ebpf/probes/gosym.go
+++ b/internal/ebpf/probes/gosym.go
@@ -1,0 +1,50 @@
+package probes
+
+import (
+	"debug/elf"
+	"debug/gosym"
+)
+
+// goSymbolFileOffset resolves the executable file offset of a Go function
+// (e.g. "crypto/tls.(*Conn).Write") from the binary's .gopclntab.
+func goSymbolFileOffset(exePath, symbol string) (offset uint64, ok bool) {
+	f, err := elf.Open(exePath)
+	if err != nil {
+		return 0, false
+	}
+	defer func() { _ = f.Close() }()
+
+	pcln := f.Section(".gopclntab")
+	text := f.Section(".text")
+	if pcln == nil || text == nil {
+		return 0, false
+	}
+	pclnData, err := pcln.Data()
+	if err != nil {
+		return 0, false
+	}
+
+	var symtabData []byte
+	if s := f.Section(".gosymtab"); s != nil {
+		symtabData, _ = s.Data()
+	}
+
+	tbl, err := gosym.NewTable(symtabData, gosym.NewLineTable(pclnData, text.Addr))
+	if err != nil {
+		return 0, false
+	}
+	fn := tbl.LookupFunc(symbol)
+	if fn == nil {
+		return 0, false
+	}
+
+	for _, prog := range f.Progs {
+		if prog.Type != elf.PT_LOAD {
+			continue
+		}
+		if fn.Entry >= prog.Vaddr && fn.Entry < prog.Vaddr+prog.Memsz {
+			return fn.Entry - prog.Vaddr + prog.Off, true
+		}
+	}
+	return 0, false
+}

--- a/internal/ebpf/probes/gosym_test.go
+++ b/internal/ebpf/probes/gosym_test.go
@@ -1,0 +1,32 @@
+package probes
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestGoSymbolFileOffset resolves a function from the test binary's own
+// .gopclntab (the test binary is itself a Go ELF), validating the pclntab
+// parse + vaddr→file-offset conversion without building a fixture.
+func TestGoSymbolFileOffset(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("ELF/.gopclntab parsing is Linux-only here")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot find test executable: %v", err)
+	}
+
+	off, ok := goSymbolFileOffset(exe, "runtime.main")
+	if !ok {
+		t.Fatal("expected to resolve runtime.main from .gopclntab")
+	}
+	if off == 0 {
+		t.Errorf("resolved offset is 0, want a real file offset")
+	}
+
+	if _, ok := goSymbolFileOffset(exe, "definitely.NotAReal.Func"); ok {
+		t.Error("expected not-found for a nonexistent symbol")
+	}
+}

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -1855,10 +1855,8 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 
 // AttachGoTLSProbes attaches an entry uprobe on crypto/tls.(*Conn).Write in a
 // statically-linked Go binary (resolved via /proc/<pid>/exe), capturing HTTPS
-// request endpoints — HTTP/1.x or h2 — from the plaintext buffer before
-// encryption. Go does not use libssl, so the OpenSSL/GnuTLS uprobes never fire
-// for it. BTF + x86-64 only; requires the Go binary to retain its symbol table
-// (a stripped binary, or a non-Go process, simply yields no attachment).
+// request endpoints, HTTP/1.x or h2, from the plaintext buffer before
+// encryption.
 func AttachGoTLSProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 	var links []link.Link
 	prog := coll.Programs["uprobe_go_tls_write"]
@@ -1875,7 +1873,15 @@ func AttachGoTLSProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 	const sym = "crypto/tls.(*Conn).Write"
 	l, err := exe.Uprobe(sym, prog, nil)
 	if err != nil {
-		// Expected for stripped binaries and non-Go processes.
+		if off, ok := goSymbolFileOffset(exePath, sym); ok {
+			l, err = exe.Uprobe("", prog, &link.UprobeOptions{Address: off})
+			if err == nil {
+				logger.Debug("Go TLS uprobe attached via gopclntab",
+					zap.Uint32("pid", pid), zap.Uint64("offset", off))
+			}
+		}
+	}
+	if err != nil {
 		logger.Debug("Go TLS uprobe not attached",
 			zap.String("symbol", sym), zap.Uint32("pid", pid), zap.Error(err))
 		return links


### PR DESCRIPTION
- **Stripped Go binaries**: production Go images are built with `-ldflags="-s -w"`, which removes `.symtab`, so the `crypto/tls.(*Conn).Write` uprobe could not attach by symbol. We now fall back to resolving the function
  offset from `.gopclntab`, which the Go runtime retains even when stripped (it needs it for stack unwinding). New `goSymbolFileOffset` parses the pclntab, looks up the function, and converts its virtual address to a file offset for   `link.UprobeOptions.Address`. `AttachGoTLSProbes` tries the symbol first and falls back to this when the symbol table is absent.
- **arm64**: `gotls.c` gains the arm64 register path. Go's arm64 ABIInternal passes the first args in X0..X7, the same registers as the arm64 C ABI, so `PT_REGS_PARM2/PARM3` give b.ptr / b.len (on amd64 Go uses RBX/RCX, distinct
  from the C ABI, hence the separate path).
