### PR TITLE
feat: capture Node.js HTTPS h1 + h2 over TLS, client and server

### DIFF
--- a/bpf/fastcgi.c
+++ b/bpf/fastcgi.c
@@ -1,27 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-/*
- * FastCGI / PHP-FPM tracing via unix domain socket kprobes.
- *
- * Requires PODTRACE_VMLINUX_FROM_BTF for iov_iter access.
- * Without BTF, all probes are no-ops (return 0 immediately).
- *
- * FastCGI protocol overview (per spec):
- *   Record header (8 bytes):
- *     [0] version   (always 1)
- *     [1] type      (1=BEGIN_REQUEST, 3=END_REQUEST, 4=PARAMS, 5=STDIN, 6=STDOUT)
- *     [2-3] requestId (big-endian u16)
- *     [4-5] contentLength (big-endian u16)
- *     [6]   paddingLength
- *     [7]   reserved
- *
- * From the php-fpm worker's perspective:
- *   - kretprobe/unix_stream_recvmsg: php-fpm receives PARAMS from nginx → extract URI/method
- *   - kprobe/unix_stream_sendmsg: php-fpm sends END_REQUEST back → emit response event
- *
- * Field mapping:
- *   EVENT_FASTCGI_REQUEST: target=REQUEST_URI, details=REQUEST_METHOD
- *   EVENT_FASTCGI_RESPONSE: target=REQUEST_URI, error=appStatus, latency_ns=request latency
- */
 
 #include "common.h"
 #include "maps.h"
@@ -31,17 +8,6 @@
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
 
-/* msghdr_user_base / read_msghdr_data now live in protocols.h, shared with
- * the gRPC inspector. */
-
-/* -----------------------------------------------------------------------
- * kprobe/unix_stream_recvmsg — save msghdr* for kretprobe use
- * -----------------------------------------------------------------------
- * Called when a unix socket read is initiated.
- * Signature: int unix_stream_recvmsg(struct socket *sock, struct msghdr *msg,
- *                                     size_t size, int flags)
- * PARM2 = struct msghdr *
- */
 SEC("kprobe/unix_stream_recvmsg")
 int kprobe_unix_stream_recvmsg(struct pt_regs *ctx)
 {
@@ -69,27 +35,6 @@ int kprobe_unix_stream_recvmsg(struct pt_regs *ctx)
 	return 0;
 }
 
-/* -----------------------------------------------------------------------
- * kretprobe/unix_stream_recvmsg -- parse FastCGI PARAMS record
- * -----------------------------------------------------------------------
- * Three layouts, all handled below:
- *
- *   A. PARAMS header + body in one recvmsg buffer.
- *      Detected by hdr[1]=FCGI_PARAMS at buffer[0] AND rc_bytes > 8.
- *      Scan params at offset 8.
- *
- *   B. BEGIN_REQUEST(16) + PARAMS header + body in one recvmsg.
- *      Detected by hdr[1]=FCGI_BEGIN_REQUEST AND hdr[17]=FCGI_PARAMS
- *      AND rc_bytes >= 24+content. Scan params at offset 24.
- *
- *   C. PHP-FPM / libfcgi split reads:
- *        recvmsg #1 = 8 bytes:  PARAMS header alone -- stash state.
- *        recvmsg #2 = N bytes:  PARAMS body -- replay state, scan
- *                               buffer at offset 0, emit, drop state.
- *      Stale state is bounded by the LRU cap on `fastcgi_pending`
- *      (1024 entries) so an aborted request can't pin memory; a
- *      stray non-matching second read just drops the entry.
- */
 SEC("kretprobe/unix_stream_recvmsg")
 int kretprobe_unix_stream_recvmsg(struct pt_regs *ctx)
 {
@@ -168,10 +113,6 @@ emit_params: ;
 	u8 params[FCGI_PARAMS_SCAN_LEN] = {};
 	u32 scan_len = content_len < FCGI_PARAMS_SCAN_LEN ? content_len : FCGI_PARAMS_SCAN_LEN;
 
-	/* params_buf_offset already accounts for whichever layout fired:
-	 *   A (PARAMS at 0)         -> offset = 8
-	 *   B (BEGIN+PARAMS at 16)  -> offset = 24
-	 *   C (body alone)          -> offset = 0  */
 	u8 *params_base = (u8 *)user_ptr + params_buf_offset;
 	if (bpf_probe_read_user(params, scan_len & 0xFF, params_base) != 0)
 		return 0;
@@ -183,15 +124,11 @@ emit_params: ;
 		if (found_uri && found_method)
 			break;
 
-		/* REQUEST_URI (11 bytes) */
 		if (!found_uri && params[i] == 'R' && i + 11 < FCGI_PARAMS_SCAN_LEN) {
 			if (params[i+1] == 'E' && params[i+2] == 'Q' && params[i+3] == 'U' &&
 			    params[i+4] == 'E' && params[i+5] == 'S' && params[i+6] == 'T' &&
 			    params[i+7] == '_' && params[i+8] == 'U' && params[i+9] == 'R' &&
 			    params[i+10] == 'I') {
-				/* Indices are masked to keep every params[] offset provably
-				 * in-bounds for the verifier (the guards already bound them
-				 * logically; 128 is a power of two so the mask is free). */
 				u32 vstart = (i + 11) & (FCGI_PARAMS_SCAN_LEN - 1);
 				if (params[vstart] == '/') {
 					u32 copy = FCGI_PARAMS_SCAN_LEN - vstart;
@@ -210,7 +147,6 @@ emit_params: ;
 			}
 		}
 
-		/* REQUEST_METHOD (14 bytes) */
 		if (!found_method && params[i] == 'R' && i + 14 < FCGI_PARAMS_SCAN_LEN) {
 			if (params[i+1] == 'E' && params[i+2] == 'Q' && params[i+3] == 'U' &&
 			    params[i+4] == 'E' && params[i+5] == 'S' && params[i+6] == 'T' &&
@@ -243,14 +179,12 @@ emit_params: ;
 	if (!found_uri) e->target[0] = '\0';
 	if (!found_method) e->details[0] = '\0';
 
-	/* Store request state for END_REQUEST correlation */
 	struct fastcgi_req req = {};
 	req.start_ns = bpf_ktime_get_ns();
 	bpf_probe_read_kernel_str(req.uri, sizeof(req.uri), e->target);
 	bpf_probe_read_kernel_str(req.method, sizeof(req.method), e->details);
 	bpf_map_update_elem(&fastcgi_reqs, &req_key, &req, BPF_ANY);
 
-	/* Emit EVENT_FASTCGI_REQUEST */
 	e->timestamp  = req.start_ns;
 	e->pid        = pid;
 	e->type       = EVENT_FASTCGI_REQUEST;
@@ -332,9 +266,8 @@ int kprobe_unix_stream_sendmsg(struct pt_regs *ctx)
 	return 0;
 }
 
-#else /* !PODTRACE_VMLINUX_FROM_BTF */
+#else
 
-/* Non-BTF build: FastCGI probes are no-ops */
 SEC("kprobe/unix_stream_recvmsg")
 int kprobe_unix_stream_recvmsg(struct pt_regs *ctx) { return 0; }
 
@@ -344,4 +277,4 @@ int kretprobe_unix_stream_recvmsg(struct pt_regs *ctx) { return 0; }
 SEC("kprobe/unix_stream_sendmsg")
 int kprobe_unix_stream_sendmsg(struct pt_regs *ctx) { return 0; }
 
-#endif /* PODTRACE_VMLINUX_FROM_BTF */
+#endif

--- a/bpf/filesystem.h
+++ b/bpf/filesystem.h
@@ -6,15 +6,6 @@
 #include "common.h"
 #include "maps.h"
 
-/*
- * get_path_str_from_file — extract the filename from a kernel struct file *.
- *
- * When built with full kernel BTF (PODTRACE_VMLINUX_FROM_BTF), uses BPF CO-RE
- * to read file->f_path.dentry->d_name.name — gives at minimum the basename.
- * Full path traversal is not verifier-safe from kprobe context without BTF.
- *
- * Without BTF (minimal vmlinux.h fallback): returns 0 / empty string.
- */
 static inline int get_path_str_from_file(struct file *file, char *out_buf, u32 buf_size)
 {
     if (!file || !out_buf || buf_size < 2) {

--- a/bpf/grpc.c
+++ b/bpf/grpc.c
@@ -6,8 +6,8 @@
 #include "helpers.h"
 #include "protocols.h"
 
-#define GRPC_INSPECT_LEN 50   /* bytes to read from send buffer */
-#define HTTP2_FRAME_HDR  9    /* HTTP/2 frame header size */
+#define GRPC_INSPECT_LEN 50
+#define HTTP2_FRAME_HDR  9
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
 

--- a/bpf/http.c
+++ b/bpf/http.c
@@ -287,14 +287,35 @@ int kretprobe_http_tcp_recvmsg(struct pt_regs *ctx)
 	return 0;
 }
 
+static __always_inline void h2_emit_frames(void *base, u64 avail, u64 conn,
+					   u32 dir, u8 transport);
+
+#define SSL_TLS_PEEK 16
+
 SEC("uprobe/SSL_write")
 int uprobe_SSL_write(struct pt_regs *ctx)
 {
 	if (!http_should_trace())
 		return 0;
+	void *ssl = (void *)PT_REGS_PARM1(ctx);
 	void *base = (void *)PT_REGS_PARM2(ctx);
 	u64 num = (u64)(s64)PT_REGS_PARM3(ctx);
-	http_emit_request(ctx, base, num, HTTP_TRANSPORT_TLS);
+	if (!base || num == 0)
+		return 0;
+
+	u8 peek[SSL_TLS_PEEK] = {};
+	u32 plen = num < sizeof(peek) ? (u32)num : sizeof(peek);
+	if (bpf_probe_read_user(peek, plen, base) != 0)
+		return 0;
+
+	if (http_method_len(peek) > 0)
+		http_emit_request(ctx, base, num, HTTP_TRANSPORT_TLS);
+	else if (peek[0] == 'H' && peek[1] == 'T' && peek[2] == 'T' && peek[3] == 'P' &&
+		 peek[4] == '/' && peek[5] == '1' && peek[6] == '.')
+		http_emit_response(ctx, base, num, HTTP_TRANSPORT_TLS);
+	else
+		h2_emit_frames(base, num, (u64)ssl, H2_DIR_EGRESS,
+			       HTTP_TRANSPORT_H2_TLS);
 	return 0;
 }
 
@@ -306,10 +327,11 @@ int uprobe_SSL_read(struct pt_regs *ctx)
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	u64 key = get_key(pid, tid);
-	if (!bpf_map_lookup_elem(&http_reqs, &key))
-		return 0;
-	u64 base_val = (u64)PT_REGS_PARM2(ctx);
-	bpf_map_update_elem(&ssl_read_args, &key, &base_val, BPF_ANY);
+	struct ssl_read_state st = {
+		.buf = (u64)PT_REGS_PARM2(ctx),
+		.conn = (u64)PT_REGS_PARM1(ctx),
+	};
+	bpf_map_update_elem(&ssl_read_args, &key, &st, BPF_ANY);
 	return 0;
 }
 
@@ -319,15 +341,29 @@ int uretprobe_SSL_read(struct pt_regs *ctx)
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	u64 key = get_key(pid, tid);
-	u64 *base_ptr = bpf_map_lookup_elem(&ssl_read_args, &key);
-	if (!base_ptr)
+	struct ssl_read_state *st = bpf_map_lookup_elem(&ssl_read_args, &key);
+	if (!st)
 		return 0;
-	void *base = (void *)*base_ptr;
+	void *base = (void *)st->buf;
+	u64 conn = st->conn;
 	bpf_map_delete_elem(&ssl_read_args, &key);
 	s64 ret = PT_REGS_RC(ctx);
 	if (ret <= 0)
 		return 0;
-	http_emit_response(ctx, base, (u64)ret, HTTP_TRANSPORT_TLS);
+
+	u8 peek[SSL_TLS_PEEK] = {};
+	u32 plen = (u64)ret < sizeof(peek) ? (u32)ret : sizeof(peek);
+	if (bpf_probe_read_user(peek, plen, base) != 0)
+		return 0;
+
+	if (peek[0] == 'H' && peek[1] == 'T' && peek[2] == 'T' && peek[3] == 'P' &&
+	    peek[4] == '/' && peek[5] == '1' && peek[6] == '.')
+		http_emit_response(ctx, base, (u64)ret, HTTP_TRANSPORT_TLS);
+	else if (http_method_len(peek) > 0)
+		http_emit_request(ctx, base, (u64)ret, HTTP_TRANSPORT_TLS);
+	else
+		h2_emit_frames(base, (u64)ret, conn, H2_DIR_INGRESS,
+			       HTTP_TRANSPORT_H2_TLS);
 	return 0;
 }
 
@@ -352,8 +388,11 @@ int uprobe_gnutls_record_recv(struct pt_regs *ctx)
 	u64 key = get_key(pid, tid);
 	if (!bpf_map_lookup_elem(&http_reqs, &key))
 		return 0;
-	u64 base_val = (u64)PT_REGS_PARM2(ctx);
-	bpf_map_update_elem(&ssl_read_args, &key, &base_val, BPF_ANY);
+	struct ssl_read_state st = {
+		.buf = (u64)PT_REGS_PARM2(ctx),
+		.conn = (u64)PT_REGS_PARM1(ctx),
+	};
+	bpf_map_update_elem(&ssl_read_args, &key, &st, BPF_ANY);
 	return 0;
 }
 
@@ -363,10 +402,10 @@ int uretprobe_gnutls_record_recv(struct pt_regs *ctx)
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u32 tid = (u32)bpf_get_current_pid_tgid();
 	u64 key = get_key(pid, tid);
-	u64 *base_ptr = bpf_map_lookup_elem(&ssl_read_args, &key);
-	if (!base_ptr)
+	struct ssl_read_state *st = bpf_map_lookup_elem(&ssl_read_args, &key);
+	if (!st)
 		return 0;
-	void *base = (void *)*base_ptr;
+	void *base = (void *)st->buf;
 	bpf_map_delete_elem(&ssl_read_args, &key);
 	s64 ret = PT_REGS_RC(ctx);
 	if (ret <= 0)

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -404,11 +404,15 @@ struct {
 	__type(value, char[HTTP_SCAN_BUF_SIZE]);
 } http_scan_buf SEC(".maps");
 
+struct ssl_read_state {
+	u64 buf;
+	u64 conn;
+};
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
-	__type(value, u64);
+	__type(value, struct ssl_read_state);
 } ssl_read_args SEC(".maps");
 
 struct h2_recv_info {

--- a/bpf/memcached.c
+++ b/bpf/memcached.c
@@ -5,7 +5,6 @@
 #include "events.h"
 #include "helpers.h"
 
-/* Prefix constants for op strings */
 #define MC_OP_GET "get "
 #define MC_OP_SET "set "
 #define MC_OP_DEL "del "
@@ -96,7 +95,6 @@ int uretprobe_memcached_get(struct pt_regs *ctx)
 	return mc_emit(ctx, pid, tid, 1);
 }
 
-/* uprobe/memcached_set — PARM2=key, PARM3=klen, PARM4=val, PARM5=vlen */
 SEC("uprobe/memcached_set")
 int uprobe_memcached_set(struct pt_regs *ctx)
 {
@@ -118,7 +116,6 @@ int uretprobe_memcached_set(struct pt_regs *ctx)
 	return mc_emit(ctx, pid, tid, 0);
 }
 
-/* uprobe/memcached_delete — PARM2=key, PARM3=klen */
 SEC("uprobe/memcached_delete")
 int uprobe_memcached_delete(struct pt_regs *ctx)
 {

--- a/bpf/redis.c
+++ b/bpf/redis.c
@@ -1,35 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0
-/*
- * Redis tracing via hiredis library uprobes.
- *
- * Hooks:
- *   uprobe/redisCommand       — int redisCommand(redisContext *c, const char *format, ...)
- *   uretprobe/redisCommand
- *   uprobe/redisCommandArgv   — void *redisCommandArgv(redisContext *c, int argc,
- *                                   const char **argv, const size_t *argvlen)
- *   uretprobe/redisCommandArgv
- *
- * Field mapping (event struct):
- *   target  = server IP:port (from socket_conns if available, else empty)
- *   details = command name (e.g. "SET", "GET", "HGET")
- *   bytes   = 0 (response size not available without reading reply object)
- *   error   = return value (NULL pointer = error in hiredis)
- *   latency_ns = time from entry to return
- */
 
 #include "common.h"
 #include "maps.h"
 #include "events.h"
 #include "helpers.h"
 
-/* Store the command name from the format string PARM2.
- * Truncates at the first space or '%' (format verbs follow the command). */
 static __always_inline void redis_store_cmd(const struct pair_key *key, const char *format_ptr, u64 ts)
 {
 	char buf[MAX_STRING_LEN] = {};
 	bpf_probe_read_user_str(buf, sizeof(buf), format_ptr);
 
-	/* Truncate at first space or '%' — format is "CMD arg1 %s ..." */
 	u32 i;
 	for (i = 0; i < MAX_STRING_LEN; i++) {
 		if (buf[i] == ' ' || buf[i] == '%' || buf[i] == '\0') {
@@ -42,7 +22,6 @@ static __always_inline void redis_store_cmd(const struct pair_key *key, const ch
 	bpf_map_update_elem(&start_times, key, &ts, BPF_ANY);
 }
 
-/* Emit the EVENT_REDIS_CMD event from a uretprobe context. */
 static __always_inline int redis_emit(struct pt_regs *ctx, u32 pair, u32 pid, u32 tid)
 {
 	struct pair_key key = make_pair_key(pair);
@@ -63,7 +42,6 @@ static __always_inline int redis_emit(struct pt_regs *ctx, u32 pair, u32 pid, u3
 	e->pid        = pid;
 	e->type       = EVENT_REDIS_CMD;
 	e->latency_ns = latency;
-	/* NULL return = error (hiredis returns NULL on failure) */
 	e->error      = PT_REGS_RC(ctx) == 0 ? -1 : 0;
 	e->bytes      = 0;
 	e->tcp_state  = 0;
@@ -84,7 +62,6 @@ static __always_inline int redis_emit(struct pt_regs *ctx, u32 pair, u32 pid, u3
 	return 0;
 }
 
-/* uprobe/redisCommand — PARM2 = const char *format */
 SEC("uprobe/redisCommand")
 int uprobe_redisCommand(struct pt_regs *ctx)
 {
@@ -107,7 +84,6 @@ int uretprobe_redisCommand(struct pt_regs *ctx)
 	return redis_emit(ctx, PAIR_REDIS_COMMAND, pid, tid);
 }
 
-/* uprobe/redisCommandArgv — PARM3 = const char **argv, argv[0] = command */
 SEC("uprobe/redisCommandArgv")
 int uprobe_redisCommandArgv(struct pt_regs *ctx)
 {
@@ -116,12 +92,10 @@ int uprobe_redisCommandArgv(struct pt_regs *ctx)
 	struct pair_key key = make_pair_key(PAIR_REDIS_COMMAND_ARGV);
 	u64 ts  = bpf_ktime_get_ns();
 
-	/* PARM3 = const char **argv; argv[0] is the command name */
 	const char **argv = (const char **)PT_REGS_PARM3(ctx);
 	if (!argv)
 		return 0;
 
-	/* First dereference: read the argv[0] pointer from user space */
 	const char *cmd_ptr = NULL;
 	if (bpf_probe_read_user(&cmd_ptr, sizeof(cmd_ptr), argv) != 0 || !cmd_ptr)
 		return 0;

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -5,19 +5,12 @@
 #include "events.h"
 #include "helpers.h"
 
-/* exec events come from the stable sched:sched_process_exec tracepoint.
- * The previous kprobe pair targeted do_execveat_common, which (a) was never
- * registered in the Go attach tables, so the programs were dead weight, and
- * (b) is a static function that compilers routinely emit as
- * do_execveat_common.isra.0, so a plain kprobe cannot attach reliably; it
- * also read PARM2 — a kernel `struct filename *` — with
- * bpf_probe_read_user_str, which always failed, leaving the target empty. */
 struct sched_process_exec_args {
 	unsigned short common_type;
 	unsigned char common_flags;
 	unsigned char common_preempt_count;
 	int common_pid;
-	unsigned int filename_loc; /* __data_loc char[] */
+	unsigned int filename_loc;
 	int pid;
 	int old_pid;
 };
@@ -31,8 +24,6 @@ int tracepoint_sched_process_exec(void *ctx) {
 		return 0;
 	}
 
-	/* Fires in the exec'ing task's own context, so the cgroup prefilter
-	 * applies cleanly. */
 	struct event *e = get_event_buf();
 	if (!e) {
 		return 0;
@@ -85,9 +76,6 @@ int tracepoint_sched_process_fork(void *ctx) {
 	e->error = 0;
 	e->bytes = 0;
 	e->tcp_state = 0;
-	/* e->pid is the child's; get_event_buf() set e->comm to the parent's name
-	 * via bpf_get_current_comm(). Overwrite with the child's comm from the
-	 * tracepoint so the pair refers to the same task. */
 	__builtin_memcpy(e->comm, args_local.child_comm, sizeof(e->comm));
 
 	bpf_probe_read_kernel_str(e->target, sizeof(e->target), args_local.child_comm);
@@ -163,13 +151,6 @@ int kprobe_vfs_unlink(struct pt_regs *ctx) {
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
-	/* 5.12 added a mnt_userns/mnt_idmap first argument, moving the dentry
-	 * from PARM2 to PARM3. struct renamedata (also introduced in 5.12) is
-	 * the CO-RE probe for which side of that boundary the running kernel
-	 * is on. */
-	/* Read both candidate registers up front: selecting the register first
-	 * and dereferencing afterwards makes clang emit ctx+variable_offset,
-	 * which the verifier rejects ("dereference of modified ctx ptr"). */
 	struct dentry *de_parm2 = (struct dentry *)PT_REGS_PARM2(ctx);
 	barrier_var(de_parm2);
 	struct dentry *de_parm3 = (struct dentry *)PT_REGS_PARM3(ctx);
@@ -226,13 +207,6 @@ int kretprobe_vfs_unlink(struct pt_regs *ctx) {
 	return 0;
 }
 
-/*
- * vfs_rename kprobe: signature varies across kernel versions.
- * Pre-5.12: vfs_rename(old_dir, old_dentry, new_dir, new_dentry, ...) — PARM2 and PARM4.
- * 5.12+:    vfs_rename(struct renamedata *) — single struct pointer (PARM1).
- * (The boundary is 5.12, commit 9fe61450972d, not 6.3 as previously noted.)
- * bpf_core_type_exists(struct renamedata) selects the layout at load time.
- */
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
@@ -242,12 +216,6 @@ int kprobe_vfs_rename(struct pt_regs *ctx) {
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
 
 #ifdef PODTRACE_VMLINUX_FROM_BTF
-	/* Works with both old and new BTF-generated layouts via CO-RE.
-	 * Use fixed compile-time offsets so the BPF verifier can bound stack
-	 * writes — variable-offset writes (buf[idx]) are often rejected on 6.x.
-	 * Layout: [0 .. HALF-2] old name, [HALF-1] '>', [HALF .. END] new name. */
-	/* Same modified-ctx-pointer consideration as vfs_unlink: pull all
-	 * candidate registers out of ctx first, then select. */
 	struct renamedata *rd = (struct renamedata *)PT_REGS_PARM1(ctx);
 	barrier_var(rd);
 	struct dentry *old_parm2 = (struct dentry *)PT_REGS_PARM2(ctx);
@@ -317,10 +285,6 @@ int kretprobe_vfs_rename(struct pt_regs *ctx) {
 	return 0;
 }
 
-/* __close_fd(files, fd) was removed in kernel 5.11 and replaced by
- * close_fd(fd) — the fd moves from PARM2 to PARM1. The old probe targeted
- * the removed symbol (and was never registered for attach), so EVENT_CLOSE
- * never fired. */
 SEC("kprobe/close_fd")
 int kprobe_close_fd(struct pt_regs *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;

--- a/internal/ebpf/probes/gosym.go
+++ b/internal/ebpf/probes/gosym.go
@@ -52,6 +52,26 @@ func goSymbolFileOffset(exePath, symbol string) (offset uint64, ok bool) {
 	return 0, false
 }
 
+// executableExportsSSL reports whether the ELF at path exposes the OpenSSL
+// SSL_write symbol in its dynamic symbol table.
+func executableExportsSSL(path string) bool {
+	f, err := elf.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	syms, err := f.DynamicSymbols()
+	if err != nil {
+		return false
+	}
+	for i := range syms {
+		if syms[i].Name == "SSL_write" {
+			return true
+		}
+	}
+	return false
+}
+
 // vaddrToFileOffset maps a virtual address to its executable file offset using
 // the PT_LOAD segments.
 func vaddrToFileOffset(f *elf.File, vaddr uint64) (uint64, bool) {

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -1669,6 +1669,20 @@ func findTLSLibs(containerID string) []string {
 	return paths
 }
 
+// tlsExecutableForPID returns the target process's executable path
+// (/proc/<pid>/exe) when it statically bundles an attachable OpenSSL (i.e. it
+// exports SSL_write), else "".
+func tlsExecutableForPID(pid uint32) string {
+	if pid == 0 {
+		return ""
+	}
+	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
+	if executableExportsSSL(exePath) {
+		return exePath
+	}
+	return ""
+}
+
 func findTLSLibsWithPID(containerID string, pid uint32) []string {
 	var paths []string
 	seen := make(map[string]bool)
@@ -1682,6 +1696,14 @@ func findTLSLibsWithPID(containerID string, pid uint32) []string {
 				paths = append(paths, path)
 				seen[path] = true
 			}
+		}
+	}
+
+	if exe := tlsExecutableForPID(pid); exe != "" {
+		if !seen[exe] {
+			paths = append(paths, exe)
+			seen[exe] = true
+			logger.Debug("TLS probe: target executable bundles OpenSSL", zap.String("exe", exe))
 		}
 	}
 

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -2403,3 +2403,29 @@ func TestFindLibcPathWithPID_NonZeroPID(t *testing.T) {
 	got := FindLibcPathWithPID("", 99999)
 	_ = got
 }
+
+// TestExecutableExportsSSL covers the negative paths of the static-OpenSSL
+// detection used to attach SSL_* uprobes to executables (e.g. the Node.js
+// binary). The positive path is exercised end-to-end against a real Node
+// workload in the chainsaw suite.
+func TestExecutableExportsSSL(t *testing.T) {
+	if executableExportsSSL("/nonexistent/binary") {
+		t.Error("expected false for a nonexistent path")
+	}
+	// The test binary itself is Go-only and does not export SSL_write.
+	self, err := os.Executable()
+	if err == nil && executableExportsSSL(self) {
+		t.Error("expected false for the Go test binary (no SSL_write export)")
+	}
+}
+
+func TestTLSExecutableForPID(t *testing.T) {
+	if got := tlsExecutableForPID(0); got != "" {
+		t.Errorf("tlsExecutableForPID(0) = %q, want empty", got)
+	}
+	// A live process whose executable does not bundle OpenSSL (this test
+	// binary) must not be offered as a TLS target.
+	if got := tlsExecutableForPID(uint32(os.Getpid())); got != "" {
+		t.Errorf("tlsExecutableForPID(self) = %q, want empty for a non-SSL binary", got)
+	}
+}


### PR DESCRIPTION
Captures HTTPS endpoints for runtimes that statically bundle OpenSSL into the executable rather than linking libssl.so, Node.js most notably, which exports the full OpenSSL API from the `node` binary's dynamic symbol table.

When a traced process's executable exports `SSL_write`, `/proc/<pid>/exe` is added as a TLS attach target alongside the usual shared-library scan, so the existing `SSL_*` uprobes bind to the binary itself. Detection reads the dynamic symbol table (`executableExportsSSL`), which survives `strip`, so stripped Node images are covered too. No new BPF programs are introduced.

The `SSL_write` and `SSL_read` handlers now branch between HTTP/1.x and HTTP/2 the same way `gotls.c` does: an HTTP method or status line routes to the plaintext request/response emitters, otherwise the buffer is forwarded to the userspace HPACK decoder with the `SSL*` as the connection key. Because both directions are handled and the decode is role-agnostic, client and server are both captured for h1 and h2 over TLS, with request, response, status, and latency. The shared `ssl_read_args` map now carries the connection pointer in addition to the buffer.
