### PR TITLE
feat: attach TLS uprobes by offset via build-id debug info

### DIFF
--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -1871,6 +1871,20 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 		}
 	}
 
+	if pid > 0 {
+		exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
+		if !executableExportsSSL(exePath) {
+			if off, ok := resolveSSLOffsets(exePath, pid); ok {
+				if l := attachSSLByOffset(coll, exePath, off); len(l) > 0 {
+					links = append(links, l...)
+					logger.Info("TLS probes attached by offset (stripped binary)",
+						zap.String("exe", exePath), zap.String("source", off.source),
+						zap.Int("links", len(l)))
+				}
+			}
+		}
+	}
+
 	logger.Debug("TLS probe attach complete", zap.Int("links", len(links)))
 	return links
 }

--- a/internal/ebpf/probes/tlsresolve.go
+++ b/internal/ebpf/probes/tlsresolve.go
@@ -1,0 +1,170 @@
+package probes
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+// sslOffsets holds the file offsets (within the target executable) of the TLS
+// read/write entry points, suitable for link.UprobeOptions.Address, plus a
+// label describing how they were resolved.
+type sslOffsets struct {
+	write  uint64
+	read   uint64
+	source string
+}
+
+// resolveSSLOffsets locates SSL_write/SSL_read in a statically-linked,
+// symbol-stripped executable that executableExportsSSL could not gate (no
+// SSL_write in .symtab/.dynsym).
+func resolveSSLOffsets(exePath string, pid uint32) (sslOffsets, bool) {
+	target, err := elf.Open(exePath)
+	if err != nil {
+		return sslOffsets{}, false
+	}
+	defer func() { _ = target.Close() }()
+
+	dbg, source := openDebugInfo(target, exePath, pid)
+	if dbg == nil {
+		return sslOffsets{}, false
+	}
+	defer func() { _ = dbg.Close() }()
+
+	wv, okW := symbolVaddr(dbg, "SSL_write")
+	rv, okR := symbolVaddr(dbg, "SSL_read")
+	if !okW || !okR {
+		return sslOffsets{}, false
+	}
+	wOff, okW := vaddrToFileOffset(target, wv)
+	rOff, okR := vaddrToFileOffset(target, rv)
+	if !okW || !okR {
+		return sslOffsets{}, false
+	}
+	return sslOffsets{write: wOff, read: rOff, source: source}, true
+}
+
+// symbolVaddr returns the virtual address of a defined symbol from either the
+// static or dynamic symbol table.
+func symbolVaddr(f *elf.File, name string) (uint64, bool) {
+	if syms, err := f.Symbols(); err == nil {
+		for i := range syms {
+			if syms[i].Name == name && syms[i].Value != 0 {
+				return syms[i].Value, true
+			}
+		}
+	}
+	if syms, err := f.DynamicSymbols(); err == nil {
+		for i := range syms {
+			if syms[i].Name == name && syms[i].Value != 0 {
+				return syms[i].Value, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// openDebugInfo finds and opens a separate debug file for the target binary
+// within the target's rootfs, returning the opened ELF and a source label, or
+// (nil, "") if none is found.
+func openDebugInfo(target *elf.File, exePath string, pid uint32) (*elf.File, string) {
+	root := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "root")
+
+	if buildID := elfBuildID(target); len(buildID) > 2 {
+		p := filepath.Join(root, "usr/lib/debug/.build-id", buildID[:2], buildID[2:]+".debug")
+		if f, err := elf.Open(p); err == nil {
+			return f, "debug-buildid"
+		}
+	}
+	if name := debugLink(target); name != "" {
+		dir := filepath.Dir(exePath)
+		for _, p := range []string{
+			filepath.Join(dir, name),
+			filepath.Join(dir, ".debug", name),
+			filepath.Join(root, "usr/lib/debug", name),
+		} {
+			if f, err := elf.Open(p); err == nil {
+				return f, "debug-link"
+			}
+		}
+	}
+	return nil, ""
+}
+
+// elfBuildID parses the GNU build-id (.note.gnu.build-id) into a lowercase hex
+// string, or "" if absent.
+func elfBuildID(f *elf.File) string {
+	sec := f.Section(".note.gnu.build-id")
+	if sec == nil {
+		return ""
+	}
+	data, err := sec.Data()
+	if err != nil || len(data) < 12 {
+		return ""
+	}
+	namesz := f.ByteOrder.Uint32(data[0:4])
+	descsz := f.ByteOrder.Uint32(data[4:8])
+	nameEnd := 12 + int((namesz+3)&^uint32(3))
+	if descsz == 0 || nameEnd+int(descsz) > len(data) {
+		return ""
+	}
+	return hex.EncodeToString(data[nameEnd : nameEnd+int(descsz)])
+}
+
+// debugLink returns the filename recorded in .gnu_debuglink, or "".
+func debugLink(f *elf.File) string {
+	sec := f.Section(".gnu_debuglink")
+	if sec == nil {
+		return ""
+	}
+	data, err := sec.Data()
+	if err != nil {
+		return ""
+	}
+	if i := bytes.IndexByte(data, 0); i > 0 {
+		return string(data[:i])
+	}
+	return ""
+}
+
+// attachSSLByOffset attaches the SSL_write/SSL_read uprobes (and the SSL_read
+// uretprobe) to the target executable at resolved file offsets, used when no
+// symbol is available for the linker to bind against.
+func attachSSLByOffset(coll *ebpf.Collection, exePath string, off sslOffsets) []link.Link {
+	exe, err := link.OpenExecutable(exePath)
+	if err != nil {
+		return nil
+	}
+	var links []link.Link
+	attach := func(progName string, addr uint64, ret bool) {
+		prog := coll.Programs[progName]
+		if prog == nil {
+			return
+		}
+		var l link.Link
+		var aerr error
+		if ret {
+			l, aerr = exe.Uretprobe("", prog, &link.UprobeOptions{Address: addr})
+		} else {
+			l, aerr = exe.Uprobe("", prog, &link.UprobeOptions{Address: addr})
+		}
+		if aerr == nil {
+			links = append(links, l)
+		} else {
+			logger.Debug("TLS offset attach failed", zap.String("prog", progName), zap.Error(aerr))
+		}
+	}
+	attach("uprobe_SSL_write", off.write, false)
+	attach("uprobe_SSL_read", off.read, false)
+	attach("uretprobe_SSL_read", off.read, true)
+	return links
+}

--- a/internal/ebpf/probes/tlsresolve_test.go
+++ b/internal/ebpf/probes/tlsresolve_test.go
@@ -1,0 +1,120 @@
+package probes
+
+import (
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func TestResolveSSLOffsetsNoDebugInfo(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("cannot resolve test executable")
+	}
+	if _, ok := resolveSSLOffsets(self, uint32(os.Getpid())); ok {
+		t.Error("resolveSSLOffsets unexpectedly succeeded for a binary with no SSL debug info")
+	}
+}
+
+func TestResolveSSLOffsetsViaBuildIDDebug(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		if cc, err = exec.LookPath("gcc"); err != nil {
+			t.Skip("no C compiler available")
+		}
+	}
+	objcopy, err := exec.LookPath("objcopy")
+	if err != nil {
+		t.Skip("objcopy not available")
+	}
+	strip, err := exec.LookPath("strip")
+	if err != nil {
+		t.Skip("strip not available")
+	}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "fake_ssl.c")
+	if err := os.WriteFile(src, []byte(`
+int SSL_read(void *s, void *b, int n)  { return n; }
+int SSL_write(void *s, void *b, int n) { return n; }
+int main(void) { return SSL_read(0,0,0) + SSL_write(0,0,0); }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "fake_ssl")
+	if out, err := exec.Command(cc, "-O0", "-no-pie", "-Wl,--build-id", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Skipf("compile failed (toolchain limitation): %v\n%s", err, out)
+	}
+
+	wantW, wantR, buildID := offsetsAndBuildID(t, bin)
+	if buildID == "" {
+		t.Skip("compiler did not emit a GNU build-id")
+	}
+
+	root := filepath.Join(dir, "root")
+	debugDir := filepath.Join(root, "usr/lib/debug/.build-id", buildID[:2])
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	debugFile := filepath.Join(debugDir, buildID[2:]+".debug")
+	if out, err := exec.Command(objcopy, "--only-keep-debug", bin, debugFile).CombinedOutput(); err != nil {
+		t.Fatalf("objcopy: %v\n%s", err, out)
+	}
+	if out, err := exec.Command(strip, "--strip-all", bin).CombinedOutput(); err != nil {
+		t.Fatalf("strip: %v\n%s", err, out)
+	}
+
+	if executableExportsSSL(bin) {
+		t.Fatal("binary still exports SSL_write after strip; test fixture invalid")
+	}
+
+	origBase := config.ProcBasePath
+	defer func() { config.ProcBasePath = origBase }()
+	const pid = 4242
+	config.ProcBasePath = dir
+	if err := os.Rename(root, filepath.Join(dir, "4242", "root")); err != nil {
+		_ = os.MkdirAll(filepath.Join(dir, "4242"), 0o755)
+		if err := os.Rename(root, filepath.Join(dir, "4242", "root")); err != nil {
+			t.Fatalf("stage rootfs: %v", err)
+		}
+	}
+
+	off, ok := resolveSSLOffsets(bin, pid)
+	if !ok {
+		t.Fatal("resolveSSLOffsets failed to resolve via build-id debug file")
+	}
+	if off.source != "debug-buildid" {
+		t.Errorf("source = %q, want debug-buildid", off.source)
+	}
+	if off.write != wantW {
+		t.Errorf("SSL_write offset = %#x, want %#x", off.write, wantW)
+	}
+	if off.read != wantR {
+		t.Errorf("SSL_read offset = %#x, want %#x", off.read, wantR)
+	}
+}
+
+func offsetsAndBuildID(t *testing.T, path string) (w, r uint64, buildID string) {
+	t.Helper()
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	buildID = elfBuildID(f)
+	wv, okW := symbolVaddr(f, "SSL_write")
+	rv, okR := symbolVaddr(f, "SSL_read")
+	if !okW || !okR {
+		t.Fatal("fixture binary missing SSL_write/SSL_read symbols")
+	}
+	w, okW = vaddrToFileOffset(f, wv)
+	r, okR = vaddrToFileOffset(f, rv)
+	if !okW || !okR {
+		t.Fatal("could not map fixture symbol vaddr to file offset")
+	}
+	return w, r, buildID
+}


### PR DESCRIPTION
Adds a fallback for statically-linked, symbol-stripped executables: when SSL_write isn't present in a binary's symbol tables (so the linker can't bind the SSL_* uprobes by name), podtrace now resolves the SSL_write/SSL_read file offsets from a separate debug file and attaches the existing uprobes by offset via UprobeOptions.Address.