### PR TITLE
feat: fuse L4 peer 4-tuple onto L7 events

### DIFF
--- a/bpf/events.h
+++ b/bpf/events.h
@@ -67,6 +67,14 @@ struct event {
 	u8  dns_transport;
 	u8  _pad3[3];
 	u8  dns_server_ip6[16];
+	u32 peer_saddr;
+	u32 peer_daddr;
+	u16 peer_sport;
+	u16 peer_dport;
+	u8  peer_family;
+	u8  _pad4[3];
+	u8  peer_saddr6[16];
+	u8  peer_daddr6[16];
 };
 
 #define H2_HDR_FRAG_MAX 1024
@@ -89,6 +97,14 @@ struct h2_hdr_record {
 	u8  transport;
 	u8  flags;
 	u8  _pad[7];
+	u32 peer_saddr;
+	u32 peer_daddr;
+	u16 peer_sport;
+	u16 peer_dport;
+	u8  peer_family;
+	u8  _pad5[3];
+	u8  peer_saddr6[16];
+	u8  peer_daddr6[16];
 };
 
 #endif

--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -87,6 +87,7 @@ static long h2_frames_cb(u32 idx, void *vctx)
 				s->rec.flags =
 					((completes && (fs->flags & HTTP2_FLAG_END_HEADERS)) ? H2_HDR_FLAG_END_HEADERS : 0) |
 					((type == HTTP2_CONTINUATION) ? H2_HDR_FLAG_CONTINUATION : 0);
+				fill_h2_record_peer(&s->rec, c->dir);
 				bpf_ringbuf_output(&h2_hdr_events, &s->rec,
 						   sizeof(s->rec) + frag, 0);
 			}

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -17,6 +17,48 @@ static inline struct pair_key make_pair_key(u32 pair) {
 	return k;
 }
 
+// fill_event_peer fuses an L7 event with its L4 peer 4-tuple, read from the
+// per-thread stash that the tcp_sendmsg/tcp_recvmsg kprobes maintain.
+static inline struct tcp_peer *lookup_tcp_peer(u32 prefer_pair) {
+	struct pair_key k = {};
+	k.pid_tgid = bpf_get_current_pid_tgid();
+	k.pair = prefer_pair;
+	struct tcp_peer *p = bpf_map_lookup_elem(&tcp_peer_stash, &k);
+	if (p)
+		return p;
+	k.pair = (prefer_pair == PAIR_TCP_SENDMSG) ? PAIR_TCP_RECVMSG : PAIR_TCP_SENDMSG;
+	return bpf_map_lookup_elem(&tcp_peer_stash, &k);
+}
+
+static inline void fill_event_peer(struct event *e) {
+	struct tcp_peer *p = lookup_tcp_peer(PAIR_TCP_SENDMSG);
+	if (!p)
+		return;
+	e->peer_family = (u8)p->family;
+	e->peer_sport = p->sport;
+	e->peer_dport = p->dport;
+	e->peer_saddr = p->saddr;
+	e->peer_daddr = p->daddr;
+	__builtin_memcpy(e->peer_saddr6, p->saddr6, 16);
+	__builtin_memcpy(e->peer_daddr6, p->daddr6, 16);
+}
+
+// fill_h2_record_peer fuses an h2 header record with its L4 peer, preferring the
+// stash matching the record's direction (egress->send, ingress->recv).
+static inline void fill_h2_record_peer(struct h2_hdr_record *rec, u32 dir) {
+	u32 prefer = (dir == H2_DIR_EGRESS) ? PAIR_TCP_SENDMSG : PAIR_TCP_RECVMSG;
+	struct tcp_peer *p = lookup_tcp_peer(prefer);
+	if (!p)
+		return;
+	rec->peer_family = (u8)p->family;
+	rec->peer_sport = p->sport;
+	rec->peer_dport = p->dport;
+	rec->peer_saddr = p->saddr;
+	rec->peer_daddr = p->daddr;
+	__builtin_memcpy(rec->peer_saddr6, p->saddr6, 16);
+	__builtin_memcpy(rec->peer_daddr6, p->daddr6, 16);
+}
+
 static inline void record_start_time(const struct pair_key *key) {
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, key, &ts, BPF_ANY);

--- a/bpf/http.c
+++ b/bpf/http.c
@@ -160,6 +160,7 @@ static __noinline void http_emit_request(void *ctx, void *base, u64 avail,
 		e->tcp_state = transport;
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), endpoint);
 		http_capture_traceparent(base, avail, e->details);
+		fill_event_peer(e);
 		capture_user_stack(ctx, pid, tid, e);
 		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	}
@@ -225,6 +226,7 @@ static __noinline void http_emit_response(void *ctx, void *base, u64 len,
 		e->tcp_state = transport;
 		bpf_probe_read_kernel_str(e->target, sizeof(e->target), req->endpoint);
 		bpf_probe_read_kernel_str(e->details, sizeof(e->details), status);
+		fill_event_peer(e);
 		capture_user_stack(ctx, pid, tid, e);
 		bpf_ringbuf_output(&events, e, sizeof(*e), 0);
 	}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -161,6 +161,23 @@ struct {
 	__type(value, char[MAX_STRING_LEN]);
 } tcp_target SEC(".maps");
 
+struct tcp_peer {
+	u32 saddr;
+	u32 daddr;
+	u16 sport;
+	u16 dport;
+	u16 family;
+	u16 _pad;
+	u8  saddr6[16];
+	u8  daddr6[16];
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, struct pair_key);
+	__type(value, struct tcp_peer);
+} tcp_peer_stash SEC(".maps");
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -16,20 +16,27 @@ static __noinline void stash_tcp_peer(struct pt_regs *ctx, u32 pair)
 		return;
 	u16 family = BPF_CORE_READ(sk, __sk_common.skc_family);
 	char buf[MAX_STRING_LEN] = {};
+	struct tcp_peer peer = {};
+	peer.family = family;
+	peer.dport = __builtin_bswap16(dport_be);
+	peer.sport = BPF_CORE_READ(sk, __sk_common.skc_num); /* host order already */
 	if (family == AF_INET) {
 		u32 daddr_be = BPF_CORE_READ(sk, __sk_common.skc_daddr);
 		if (daddr_be == 0)
 			return;
-		format_ip_port(__builtin_bswap32(daddr_be), __builtin_bswap16(dport_be), buf);
+		peer.daddr = __builtin_bswap32(daddr_be);
+		peer.saddr = __builtin_bswap32(BPF_CORE_READ(sk, __sk_common.skc_rcv_saddr));
+		format_ip_port(peer.daddr, peer.dport, buf);
 	} else if (family == AF_INET6) {
-		u8 d6[16] = {};
-		BPF_CORE_READ_INTO(&d6, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr8);
-		format_ipv6_port(d6, __builtin_bswap16(dport_be), buf);
+		BPF_CORE_READ_INTO(&peer.daddr6, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr8);
+		BPF_CORE_READ_INTO(&peer.saddr6, sk, __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8);
+		format_ipv6_port(peer.daddr6, peer.dport, buf);
 	} else {
 		return;
 	}
 	struct pair_key key = make_pair_key(pair);
 	bpf_map_update_elem(&tcp_target, &key, buf, BPF_ANY);
+	bpf_map_update_elem(&tcp_peer_stash, &key, &peer, BPF_ANY);
 }
 #else
 static __always_inline void stash_tcp_peer(struct pt_regs *ctx, u32 pair)

--- a/internal/agent/sdk_event_exporter.go
+++ b/internal/agent/sdk_event_exporter.go
@@ -184,6 +184,18 @@ func (e *sdkEventExporter) Export(ctx context.Context, batch []*events.Event) er
 				attribute.String("podtrace.http.transport", ev.HTTPProtoLabel()),
 			)
 		}
+		if ev.PeerDstIP != "" {
+			attrs = append(attrs,
+				attribute.String("network.peer.address", ev.PeerDstIP),
+				attribute.Int("network.peer.port", int(ev.PeerDstPort)),
+			)
+		}
+		if ev.PeerSrcIP != "" {
+			attrs = append(attrs,
+				attribute.String("network.local.address", ev.PeerSrcIP),
+				attribute.Int("network.local.port", int(ev.PeerSrcPort)),
+			)
+		}
 		attrs = appendK8sAttributes(attrs, ev.K8s)
 		attrs = e.appendThresholdAttributes(attrs, ev)
 		span.SetAttributes(attrs...)

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -334,9 +334,28 @@ func GenerateHTTPSection(d Diagnostician, duration time.Duration) string {
 				report += formatter.TopItemsWithRate(statusMap, config.TopURLsLimit, "response status codes", "responses", duration)
 			}
 		}
+		peerEvents := make([]*events.Event, 0, len(httpReqEvents)+len(httpRespEvents))
+		peerEvents = append(peerEvents, httpReqEvents...)
+		peerEvents = append(peerEvents, httpRespEvents...)
+		peerMap := buildPeerMap(peerEvents)
+		if len(peerMap) > 0 {
+			report += formatter.TopItemsWithRate(peerMap, config.TopURLsLimit, "L7 peers", "events", duration)
+		}
 	}
 	report += "\n"
 	return report
+}
+
+// buildPeerMap counts L7 events by their fused L4 remote peer (ip:port).
+func buildPeerMap(httpEvents []*events.Event) map[string]int {
+	m := make(map[string]int)
+	for _, e := range httpEvents {
+		if e.PeerDstIP == "" {
+			continue
+		}
+		m[fmt.Sprintf("%s:%d", e.PeerDstIP, e.PeerDstPort)]++
+	}
+	return m
 }
 
 func analyzeHTTPEvents(allHTTP []*events.Event) ([]float64, float64, uint64) {

--- a/internal/ebpf/h2decode/decode.go
+++ b/internal/ebpf/h2decode/decode.go
@@ -15,8 +15,9 @@ import (
 	"github.com/podtrace/podtrace/internal/safeconv"
 )
 
-// recordHeaderSize is the fixed prefix of struct h2_hdr_record.
-const recordHeaderSize = 48
+// recordHeaderSize is the fixed prefix of struct h2_hdr_record incl. the
+// L7<->L4 peer 4-tuple appended after _pad.
+const recordHeaderSize = 96
 
 // Flag bits mirror H2_HDR_FLAG_* in bpf/events.h.
 const (
@@ -56,6 +57,11 @@ type RawRecord struct {
 	Transport uint8
 	Flags     uint8
 	Frag      []byte
+
+	PeerSrcIP   string
+	PeerDstIP   string
+	PeerSrcPort uint16
+	PeerDstPort uint16
 }
 
 func (r *RawRecord) endHeaders() bool { return r.Flags&flagEndHeaders != 0 }
@@ -83,6 +89,14 @@ func ParseRecord(data []byte) (*RawRecord, bool) {
 		Transport: data[39],
 		Flags:     data[40],
 	}
+	var sa6, da6 [16]byte
+	copy(sa6[:], data[64:80])
+	copy(da6[:], data[80:96])
+	family := data[60]
+	r.PeerSrcIP = events.PeerIP(family, binary.LittleEndian.Uint32(data[48:52]), sa6)
+	r.PeerDstIP = events.PeerIP(family, binary.LittleEndian.Uint32(data[52:56]), da6)
+	r.PeerSrcPort = binary.LittleEndian.Uint16(data[56:58])
+	r.PeerDstPort = binary.LittleEndian.Uint16(data[58:60])
 	if fragLen > 0 {
 		r.Frag = make([]byte, fragLen)
 		copy(r.Frag, data[recordHeaderSize:recordHeaderSize+int(fragLen)])
@@ -274,7 +288,16 @@ func (d *Decoder) buildRequestLocked(rec *RawRecord, method, path, traceparent s
 	if traceparent != "" {
 		ev.Details = "traceparent: " + traceparent
 	}
+	setEventPeer(ev, rec)
 	return ev
+}
+
+// setEventPeer copies the L7<->L4 fused peer 4-tuple onto a decoded event.
+func setEventPeer(ev *events.Event, rec *RawRecord) {
+	ev.PeerSrcIP = rec.PeerSrcIP
+	ev.PeerDstIP = rec.PeerDstIP
+	ev.PeerSrcPort = rec.PeerSrcPort
+	ev.PeerDstPort = rec.PeerDstPort
 }
 
 func (d *Decoder) buildResponseLocked(rec *RawRecord, status, traceparent string) *events.Event {
@@ -302,6 +325,7 @@ func (d *Decoder) buildResponseLocked(rec *RawRecord, status, traceparent string
 	if traceparent != "" && ev.Details == status {
 		ev.Details = "traceparent: " + traceparent
 	}
+	setEventPeer(ev, rec)
 	return ev
 }
 

--- a/internal/ebpf/h2decode/peer_test.go
+++ b/internal/ebpf/h2decode/peer_test.go
@@ -1,0 +1,31 @@
+package h2decode
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestParseRecordPeer verifies the L7<->L4 peer 4-tuple is decoded from the
+// fixed header (offsets 48..96 of struct h2_hdr_record).
+func TestParseRecordPeer(t *testing.T) {
+	data := make([]byte, recordHeaderSize)        // 96, no frag
+	binary.LittleEndian.PutUint16(data[36:38], 0) // frag_len = 0
+	data[38] = DirIngress                         // direction
+	// peer: AF_INET, src 10.0.0.1:54321 -> dst 10.0.0.2:8443
+	binary.LittleEndian.PutUint32(data[48:52], 0x0A000001) // saddr 10.0.0.1 (host order)
+	binary.LittleEndian.PutUint32(data[52:56], 0x0A000002) // daddr 10.0.0.2
+	binary.LittleEndian.PutUint16(data[56:58], 54321)      // sport
+	binary.LittleEndian.PutUint16(data[58:60], 8443)       // dport
+	data[60] = 2                                           // AF_INET
+
+	r, ok := ParseRecord(data)
+	if !ok {
+		t.Fatal("ParseRecord failed")
+	}
+	if r.PeerSrcIP != "10.0.0.1" || r.PeerDstIP != "10.0.0.2" {
+		t.Errorf("peer IPs = %q -> %q, want 10.0.0.1 -> 10.0.0.2", r.PeerSrcIP, r.PeerDstIP)
+	}
+	if r.PeerSrcPort != 54321 || r.PeerDstPort != 8443 {
+		t.Errorf("peer ports = %d -> %d, want 54321 -> 8443", r.PeerSrcPort, r.PeerDstPort)
+	}
+}

--- a/internal/ebpf/parser/parser.go
+++ b/internal/ebpf/parser/parser.go
@@ -130,6 +130,38 @@ func ParseEvent(data []byte) *events.Event {
 		DNSServerIP6 [16]byte
 	}
 
+	type rawEventV7 struct {
+		Timestamp    uint64
+		PID          uint32
+		Type         uint32
+		LatencyNS    uint64
+		Error        int32
+		_            uint32
+		Bytes        uint64
+		TCPState     uint32
+		_            uint32
+		StackKey     uint64
+		CgroupID     uint64
+		Comm         [16]byte
+		Target       [128]byte
+		Details      [128]byte
+		NetNsID      uint32
+		_            uint32
+		DNSServerIP  uint32
+		DNSTransport uint8
+		_            [3]uint8
+		DNSServerIP6 [16]byte
+		PeerSaddr    uint32
+		PeerDaddr    uint32
+		PeerSport    uint16
+		PeerDport    uint16
+		PeerFamily   uint8
+		_            [3]uint8
+		PeerSaddr6   [16]byte
+		PeerDaddr6   [16]byte
+	}
+
+	expectedV7 := int(unsafe.Sizeof(rawEventV7{}))
 	expectedV6 := int(unsafe.Sizeof(rawEventV6{}))
 	expectedV5 := int(unsafe.Sizeof(rawEventV5{}))
 	expectedV4 := int(unsafe.Sizeof(rawEventV4{}))
@@ -148,6 +180,38 @@ func ParseEvent(data []byte) *events.Event {
 	event.DNSServerIP = 0
 	event.DNSTransport = 0
 	event.DNSServerIP6 = [16]byte{}
+	event.PeerSrcIP = ""
+	event.PeerDstIP = ""
+	event.PeerSrcPort = 0
+	event.PeerDstPort = 0
+
+	if len(data) >= expectedV7 {
+		var e rawEventV7
+		if err := binaryRead(bytes.NewReader(data[:expectedV7]), binary.LittleEndian, &e); err != nil {
+			return nil
+		}
+		event.Timestamp = e.Timestamp
+		event.PID = e.PID
+		event.Type = events.EventType(e.Type)
+		event.LatencyNS = e.LatencyNS
+		event.Error = e.Error
+		event.Bytes = e.Bytes
+		event.TCPState = e.TCPState
+		event.StackKey = e.StackKey
+		event.CgroupID = e.CgroupID
+		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
+		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
+		event.NetNsID = e.NetNsID
+		event.DNSServerIP = e.DNSServerIP
+		event.DNSTransport = e.DNSTransport
+		event.DNSServerIP6 = e.DNSServerIP6
+		event.PeerSrcIP = events.PeerIP(e.PeerFamily, e.PeerSaddr, e.PeerSaddr6)
+		event.PeerDstIP = events.PeerIP(e.PeerFamily, e.PeerDaddr, e.PeerDaddr6)
+		event.PeerSrcPort = e.PeerSport
+		event.PeerDstPort = e.PeerDport
+		return event
+	}
 
 	if len(data) >= expectedV6 {
 		var e rawEventV6

--- a/internal/ebpf/parser/peer_test.go
+++ b/internal/ebpf/parser/peer_test.go
@@ -1,0 +1,33 @@
+package parser
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// TestParseEventPeerV7 locks the rawEventV7 ABI: a 416-byte event with the peer
+// 4-tuple at offsets 368.. must decode into events.Event peer fields.
+func TestParseEventPeerV7(t *testing.T) {
+	const size = 416
+	data := make([]byte, size)
+	binary.LittleEndian.PutUint32(data[12:16], uint32(events.EventHTTPReq)) // Type
+	// peer block (pahole: saddr@368 daddr@372 sport@376 dport@378 family@380)
+	binary.LittleEndian.PutUint32(data[368:372], 0xC0A80005) // 192.168.0.5
+	binary.LittleEndian.PutUint32(data[372:376], 0xC0A80001) // 192.168.0.1
+	binary.LittleEndian.PutUint16(data[376:378], 40000)      // sport
+	binary.LittleEndian.PutUint16(data[378:380], 443)        // dport
+	data[380] = 2                                            // AF_INET
+
+	ev := ParseEvent(data)
+	if ev == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if ev.PeerSrcIP != "192.168.0.5" || ev.PeerDstIP != "192.168.0.1" {
+		t.Errorf("peer IPs = %q -> %q, want 192.168.0.5 -> 192.168.0.1", ev.PeerSrcIP, ev.PeerDstIP)
+	}
+	if ev.PeerSrcPort != 40000 || ev.PeerDstPort != 443 {
+		t.Errorf("peer ports = %d -> %d, want 40000 -> 443", ev.PeerSrcPort, ev.PeerDstPort)
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,7 +1,9 @@
 package events
 
 import (
+	"encoding/binary"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -9,6 +11,28 @@ import (
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/safeconv"
 )
+
+// PeerIP formats a fused L7<->L4 peer address. v4 is host byte order; family is
+// the AF_* value (2=AF_INET, 10=AF_INET6). Returns "" if unknown/unspecified.
+func PeerIP(family uint8, v4 uint32, v6 [16]byte) string {
+	switch family {
+	case 2:
+		if v4 == 0 {
+			return ""
+		}
+		ip := make(net.IP, net.IPv4len)
+		binary.BigEndian.PutUint32(ip, v4)
+		return ip.String()
+	case 10:
+		ip := net.IP(v6[:])
+		if ip.IsUnspecified() {
+			return ""
+		}
+		return ip.String()
+	default:
+		return ""
+	}
+}
 
 func sanitizeString(s string) string {
 	return strings.ReplaceAll(s, "%", "%%")
@@ -77,6 +101,10 @@ type Event struct {
 	DNSServerIP  uint32   // V5: upstream resolver IPv4 for DNS events (0 otherwise)
 	DNSTransport uint8    // V5: 0=UDP, 1=TCP for DNS events
 	DNSServerIP6 [16]byte // V6: upstream resolver IPv6 for DNS events
+	PeerSrcIP    string   // V7: L7<->L4 fused local address ("" if unknown)
+	PeerDstIP    string   // V7: L7<->L4 fused remote/peer address
+	PeerSrcPort  uint16   // V7: local port
+	PeerDstPort  uint16   // V7: remote/peer port
 	ProcessName  string
 	Type         EventType
 	LatencyNS    uint64


### PR DESCRIPTION
Fuses every decoded L7 event (HTTP/1.x, HTTPS, h2c, h2-over-TLS) with its L4 peer 4-tuple, so requests and responses carry the real source and destination address and port.

The socket kprobes already observe the peer; they now also stash the raw 4-tuple per (thread, direction) alongside the existing formatted string. Kernel-built events (plaintext HTTP and HTTPS/1.x) read that stash directly into a new structured peer block, carried over the wire as a versioned rawEventV7 event (the parser size-detects it, as with prior versions). HTTP/2 events are built in userspace from raw records, so the same 4-tuple is appended to the h2 header record and read back in the decoder. TLS uprobe paths, which have no socket pointer, resolve the peer from the per-thread stash maintained by the socket kprobes.