### PR TITLE
feat: capture HTTP/3 (QUIC) connections and SNI from the Initial packet

### DIFF
--- a/bpf/events.h
+++ b/bpf/events.h
@@ -46,6 +46,7 @@ enum event_type {
 	EVENT_KAFKA_FETCH,
 	EVENT_DNS_QUERY,
 	EVENT_AF_ALG,
+	EVENT_HTTP3,
 };
 
 struct event {

--- a/bpf/http3.c
+++ b/bpf/http3.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "common.h"
+#include "maps.h"
+#include "events.h"
+#include "helpers.h"
+
+#ifndef IPPROTO_UDP
+#define IPPROTO_UDP 17
+#endif
+
+static __always_inline int quic_is_initial(struct __sk_buff *skb, int l4) {
+	u8 first = 0;
+	if (bpf_skb_load_bytes(skb, l4 + 8, &first, 1) < 0)
+		return 0;
+	if ((first & 0xC0) != 0xC0 || (first & 0x30) != 0x00)
+		return 0;
+	u32 version = 0;
+	if (bpf_skb_load_bytes(skb, l4 + 9, &version, sizeof(version)) < 0)
+		return 0;
+	return bpf_ntohl(version) == 0x00000001;
+}
+
+static __always_inline void quic_ship(struct __sk_buff *skb, u8 is_v6,
+				      u32 addr_off, u32 port_l4_off, int l4) {
+	struct quic_flow_key k = {};
+	k.cgroup_id = bpf_skb_cgroup_id(skb);
+	u16 port_be = 0;
+	if (bpf_skb_load_bytes(skb, l4 + port_l4_off, &port_be, sizeof(port_be)) < 0)
+		return;
+	k.dport = bpf_ntohs(port_be);
+	if (is_v6) {
+		if (bpf_skb_load_bytes(skb, addr_off, k.daddr6, 16) < 0)
+			return;
+	} else {
+		if (bpf_skb_load_bytes(skb, addr_off, k.daddr6, 4) < 0)
+			return;
+	}
+	if (bpf_map_lookup_elem(&quic_seen, &k))
+		return;
+	u8 one = 1;
+	bpf_map_update_elem(&quic_seen, &k, &one, BPF_ANY);
+
+	struct quic_initial_record *rec =
+		bpf_ringbuf_reserve(&quic_initial_events, sizeof(*rec), 0);
+	if (!rec)
+		return;
+	rec->timestamp = bpf_ktime_get_ns();
+	rec->cgroup_id = k.cgroup_id;
+	rec->pid = bpf_get_current_pid_tgid() >> 32;
+	bpf_get_current_comm(&rec->comm, sizeof(rec->comm));
+	rec->family = is_v6 ? 10 : 2;
+	rec->_pad = 0;
+	rec->dport = k.dport;
+	rec->_pad2 = 0;
+	__builtin_memcpy(rec->daddr6, k.daddr6, 16);
+	u32 off = (u32)l4 + 8;
+	u32 caplen = skb->len > off ? skb->len - off : 0;
+	if (caplen > QUIC_PKT_CAP)
+		caplen = QUIC_PKT_CAP;
+	if (caplen < 20 || bpf_skb_load_bytes(skb, off, rec->pkt, caplen) < 0) {
+		bpf_ringbuf_discard(rec, 0);
+		return;
+	}
+	rec->pktlen = (u16)caplen;
+	bpf_ringbuf_submit(rec, 0);
+}
+
+SEC("cgroup_skb/egress")
+int http3_egress(struct __sk_buff *skb) {
+	u8 is_v6 = 0, proto = 0;
+	int l4 = l4_offset(skb, &is_v6, &proto);
+	if (l4 < 0 || proto != IPPROTO_UDP)
+		return 1;
+	if (!quic_is_initial(skb, l4))
+		return 1;
+	quic_ship(skb, is_v6, is_v6 ? 24 : 16, 2, l4);
+	return 1;
+}
+
+SEC("cgroup_skb/ingress")
+int http3_ingress(struct __sk_buff *skb) {
+	u8 is_v6 = 0, proto = 0;
+	int l4 = l4_offset(skb, &is_v6, &proto);
+	if (l4 < 0 || proto != IPPROTO_UDP)
+		return 1;
+	if (!quic_is_initial(skb, l4))
+		return 1;
+	quic_ship(skb, is_v6, is_v6 ? 8 : 12, 0, l4);
+	return 1;
+}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -178,6 +178,38 @@ struct {
 	__type(value, struct tcp_peer);
 } tcp_peer_stash SEC(".maps");
 
+struct quic_flow_key {
+	u64 cgroup_id;
+	u8  daddr6[16];
+	u16 dport;
+	u16 _pad;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct quic_flow_key);
+	__type(value, u8);
+} quic_seen SEC(".maps");
+
+#define QUIC_PKT_CAP 1500
+struct quic_initial_record {
+	u64 timestamp;
+	u64 cgroup_id;
+	u32 pid;
+	u8  family;
+	u8  _pad;
+	u16 dport;
+	u8  daddr6[16];
+	u16 pktlen;
+	u16 _pad2;
+	char comm[COMM_LEN];
+	u8  pkt[QUIC_PKT_CAP];
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 512 * 1024);
+} quic_initial_events SEC(".maps");
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1024);

--- a/bpf/podtrace.bpf.c
+++ b/bpf/podtrace.bpf.c
@@ -5,10 +5,10 @@
 #include "events.h"
 #include "helpers.h"
 #include "protocols.h"
-
 #include "resources.c"
 #include "network.c"
 #include "dns.c"
+#include "http3.c"
 #include "filesystem.c"
 #include "cpu.c"
 #include "memory.c"

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -892,7 +892,7 @@ func filterEvents(ctx context.Context, in <-chan *events.Event, out chan<- *even
 			case filterMap["net"] && (event.Type == events.EventConnect || event.Type == events.EventTCPSend || event.Type == events.EventTCPRecv ||
 				event.Type == events.EventFastCGIReq || event.Type == events.EventFastCGIResp ||
 				event.Type == events.EventHTTPReq || event.Type == events.EventHTTPResp ||
-				event.Type == events.EventGRPCMethod):
+				event.Type == events.EventGRPCMethod || event.Type == events.EventHTTP3):
 				shouldInclude = true
 			case filterMap["fs"] && (event.Type == events.EventRead || event.Type == events.EventWrite || event.Type == events.EventFsync):
 				shouldInclude = true

--- a/internal/agent/otlp_event_exporter.go
+++ b/internal/agent/otlp_event_exporter.go
@@ -131,5 +131,6 @@ var eventTypeNames = map[events.EventType]string{
 	events.EventFork:           "proc.fork",
 	events.EventHTTPReq:        "http.req",
 	events.EventHTTPResp:       "http.resp",
+	events.EventHTTP3:          "http3.conn",
 	events.EventDBQuery:        "db.query",
 }

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -765,7 +765,7 @@ func filterToEventTypes(f podtracev1alpha1.EventFilter) []events.EventType {
 			events.EventTCPRetrans, events.EventNetDevError,
 			events.EventFastCGIReq, events.EventFastCGIResp,
 			events.EventHTTPReq, events.EventHTTPResp,
-			events.EventGRPCMethod,
+			events.EventGRPCMethod, events.EventHTTP3,
 		}
 	case podtracev1alpha1.FilterFS:
 		return []events.EventType{

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -217,6 +217,7 @@ func (d *Diagnostician) GenerateReportWithContext(ctx context.Context) string {
 	result += report.GenerateFileSystemSection(d, duration)
 	result += report.GenerateUDPSection(d, duration)
 	result += report.GenerateHTTPSection(d, duration)
+	result += report.GenerateHTTP3Section(d, duration)
 	result += report.GenerateCPUSection(d, duration)
 	result += report.GenerateTCPStateSection(d, duration)
 	result += report.GenerateMemorySection(d, duration)

--- a/internal/diagnose/profiling/cpu_profiling.go
+++ b/internal/diagnose/profiling/cpu_profiling.go
@@ -46,7 +46,7 @@ func GenerateCPUUsageReport(allEvents []*events.Event, duration time.Duration) s
 	}
 
 	if len(pidCPUTimes) == 0 && len(pidActivity) > 0 {
-		report += "  Process Activity Ranking (event count — CPU samples unavailable for short-lived processes):\n"
+		report += "  Process Activity Ranking:\n"
 		limit := config.TopProcessesLimit
 		if limit > len(pidActivity) {
 			limit = len(pidActivity)

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -358,6 +358,34 @@ func buildPeerMap(httpEvents []*events.Event) map[string]int {
 	return m
 }
 
+// GenerateHTTP3Section reports observed HTTP/3 (QUIC) connections by peer.
+func GenerateHTTP3Section(d Diagnostician, duration time.Duration) string {
+	h3 := d.FilterEvents(events.EventHTTP3)
+	if len(h3) == 0 {
+		return ""
+	}
+	report := "HTTP/3 (QUIC) Connections:\n"
+	report += fmt.Sprintf("  Connections: %d (%.1f/sec)\n", len(h3), d.CalculateRate(len(h3), duration))
+	peerMap := make(map[string]int, len(h3))
+	sniMap := make(map[string]int)
+	for _, e := range h3 {
+		if e.Target != "" {
+			peerMap[e.Target]++
+		}
+		if name, ok := strings.CutPrefix(e.Details, "sni: "); ok && name != "" {
+			sniMap[name]++
+		}
+	}
+	if len(peerMap) > 0 {
+		report += formatter.TopItemsWithRate(peerMap, config.TopURLsLimit, "h3 peers", "connections", duration)
+	}
+	if len(sniMap) > 0 {
+		report += formatter.TopItemsWithRate(sniMap, config.TopURLsLimit, "h3 server names (SNI)", "connections", duration)
+	}
+	report += "\n"
+	return report
+}
+
 func analyzeHTTPEvents(allHTTP []*events.Event) ([]float64, float64, uint64) {
 	var latencies []float64
 	var totalLatency float64

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -346,6 +346,58 @@ func AttachDNSPacketProbes(coll *ebpf.Collection, cgroupPaths []string) []link.L
 	return links
 }
 
+// AttachHTTP3Probes attaches the cgroup_skb HTTP/3 (QUIC) detector to each
+// target pod cgroup, emitting one HTTP/3 connection event per (cgroup, peer,
+// port).
+func AttachHTTP3Probes(coll *ebpf.Collection, cgroupPaths []string) []link.Link {
+	egress := coll.Programs["http3_egress"]
+	ingress := coll.Programs["http3_ingress"]
+	if egress == nil && ingress == nil {
+		return nil
+	}
+	attach := []struct {
+		prog *ebpf.Program
+		typ  ebpf.AttachType
+		name string
+	}{
+		{egress, ebpf.AttachCGroupInetEgress, "egress"},
+		{ingress, ebpf.AttachCGroupInetIngress, "ingress"},
+	}
+
+	var links []link.Link
+	seen := make(map[string]struct{}, len(cgroupPaths))
+	for _, path := range cgroupPaths {
+		if path == "" {
+			continue
+		}
+		if _, dup := seen[path]; dup {
+			continue
+		}
+		seen[path] = struct{}{}
+		for _, a := range attach {
+			if a.prog == nil {
+				continue
+			}
+			l, err := link.AttachCgroup(link.CgroupOptions{
+				Path:    path,
+				Attach:  a.typ,
+				Program: a.prog,
+			})
+			if err != nil {
+				logger.Info("HTTP/3 detection unavailable for cgroup",
+					zap.String("cgroup", path), zap.String("direction", a.name), zap.Error(err))
+				continue
+			}
+			links = append(links, l)
+		}
+	}
+	if len(links) > 0 {
+		logger.Info("HTTP/3 (QUIC) detection attached",
+			zap.Int("cgroups", len(seen)), zap.Int("links", len(links)))
+	}
+	return links
+}
+
 func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
 	var links []link.Link
 	libcPath := FindLibcPathWithPID(containerID, pid)

--- a/internal/ebpf/quicinitial/quicinitial.go
+++ b/internal/ebpf/quicinitial/quicinitial.go
@@ -1,0 +1,343 @@
+// Package quicinitial extracts the SNI (server name) from a QUIC v1 Initial
+// packet.
+package quicinitial
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+)
+
+// quicV1InitialSalt is the fixed salt for QUIC v1 initial-secret derivation
+// (RFC 9001 §5.2).
+var quicV1InitialSalt = []byte{
+	0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
+	0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a,
+}
+
+// hkdfExtract = HMAC-SHA256(salt, ikm) (RFC 5869).
+func hkdfExtract(salt, ikm []byte) []byte {
+	h := hmac.New(sha256.New, salt)
+	h.Write(ikm)
+	return h.Sum(nil)
+}
+
+// hkdfExpand derives length bytes from prk+info (RFC 5869).
+func hkdfExpand(prk, info []byte, length int) []byte {
+	out := make([]byte, 0, length)
+	var t []byte
+	for i := byte(1); len(out) < length; i++ {
+		h := hmac.New(sha256.New, prk)
+		h.Write(t)
+		h.Write(info)
+		h.Write([]byte{i})
+		t = h.Sum(nil)
+		out = append(out, t...)
+	}
+	return out[:length]
+}
+
+// hkdfExpandLabel implements the TLS 1.3 / QUIC labeled HKDF-Expand
+// (RFC 8446 §7.1): the info is a structured HkdfLabel with the "tls13 " prefix.
+func hkdfExpandLabel(secret []byte, label string, length int) []byte {
+	full := "tls13 " + label
+	info := make([]byte, 0, 2+1+len(full)+1)
+	info = append(info, byte((length>>8)&0xff), byte(length&0xff))
+	info = append(info, byte(len(full)&0xff))
+	info = append(info, full...)
+	info = append(info, 0) // empty context
+	return hkdfExpand(secret, info, length)
+}
+
+// InitialKeys holds the client-side Initial protection keys.
+type InitialKeys struct {
+	Key []byte
+	IV  []byte
+	HP  []byte
+}
+
+// DeriveClientInitialKeys derives the client Initial keys from the Destination
+// Connection ID (RFC 9001 §5.2).
+func DeriveClientInitialKeys(dcid []byte) InitialKeys {
+	initialSecret := hkdfExtract(quicV1InitialSalt, dcid)
+	clientSecret := hkdfExpandLabel(initialSecret, "client in", 32)
+	return InitialKeys{
+		Key: hkdfExpandLabel(clientSecret, "quic key", 16),
+		IV:  hkdfExpandLabel(clientSecret, "quic iv", 12),
+		HP:  hkdfExpandLabel(clientSecret, "quic hp", 16),
+	}
+}
+
+// readVarint reads a QUIC variable-length integer (RFC 9000 §16) at off,
+// returning the value and the number of bytes consumed.
+func readVarint(b []byte, off int) (uint64, int, bool) {
+	if off >= len(b) {
+		return 0, 0, false
+	}
+	prefix := b[off] >> 6
+	n := 1 << prefix
+	if off+n > len(b) {
+		return 0, 0, false
+	}
+	v := uint64(b[off] & 0x3f)
+	for i := 1; i < n; i++ {
+		v = (v << 8) | uint64(b[off+i])
+	}
+	return v, n, true
+}
+
+func asLen(v uint64) (int, bool) {
+	if v > 1<<20 {
+		return 0, false
+	}
+	return int(v), true
+}
+
+// ExtractSNI parses a QUIC v1 long-header Initial packet and returns the SNI
+// (server_name) from the client's ClientHello, or ("", false) if the packet is
+// not a decodable client Initial or carries no SNI.
+func ExtractSNI(b []byte) (string, bool) {
+	s, err := extractSNI(b)
+	return s, err == nil
+}
+
+func ExtractSNIErr(b []byte) (string, error) { return extractSNI(b) }
+
+func extractSNI(b []byte) (string, error) {
+	if len(b) < 7 {
+		return "", fmt.Errorf("too short (%d)", len(b))
+	}
+	first := b[0]
+	if first&0xC0 != 0xC0 || first&0x30 != 0x00 {
+		return "", fmt.Errorf("not a long-header Initial (0x%02x)", first)
+	}
+	if binary.BigEndian.Uint32(b[1:5]) != 0x00000001 {
+		return "", fmt.Errorf("not QUIC v1")
+	}
+	p := 5
+	dcidLen := int(b[p])
+	p++
+	if p+dcidLen > len(b) {
+		return "", fmt.Errorf("dcid out of range")
+	}
+	dcid := b[p : p+dcidLen]
+	p += dcidLen
+	if p >= len(b) {
+		return "", fmt.Errorf("scid len out of range")
+	}
+	scidLen := int(b[p])
+	p++
+	p += scidLen
+	tokenLen, n, ok := readVarint(b, p)
+	if !ok {
+		return "", fmt.Errorf("token len varint")
+	}
+	tl, ok := asLen(tokenLen)
+	if !ok {
+		return "", fmt.Errorf("token len too large")
+	}
+	p += n + tl
+	lengthVarint, n, ok := readVarint(b, p)
+	if !ok {
+		return "", fmt.Errorf("length varint")
+	}
+	length, ok := asLen(lengthVarint)
+	if !ok {
+		return "", fmt.Errorf("length too large")
+	}
+	p += n
+	pnOffset := p
+	if pnOffset+length > len(b) || length < 20 {
+		return "", fmt.Errorf("length %d vs buf %d (pnOffset %d)", length, len(b), pnOffset)
+	}
+
+	keys := DeriveClientInitialKeys(dcid)
+
+	sampleOff := pnOffset + 4
+	if sampleOff+16 > len(b) {
+		return "", fmt.Errorf("sample out of range")
+	}
+	block, err := aes.NewCipher(keys.HP)
+	if err != nil {
+		return "", err
+	}
+	mask := make([]byte, 16)
+	block.Encrypt(mask, b[sampleOff:sampleOff+16])
+
+	hdr := make([]byte, pnOffset+4)
+	copy(hdr, b[:pnOffset+4])
+	hdr[0] = first ^ (mask[0] & 0x0f)
+	pnLen := int(hdr[0]&0x03) + 1
+	var pn uint64
+	for i := 0; i < pnLen; i++ {
+		hdr[pnOffset+i] = b[pnOffset+i] ^ mask[(1+i)&0x0f]
+		pn = (pn << 8) | uint64(hdr[pnOffset+i])
+	}
+	hdr = hdr[:pnOffset+pnLen]
+
+	nonce := make([]byte, 12)
+	copy(nonce, keys.IV)
+	var pnbuf [8]byte
+	binary.BigEndian.PutUint64(pnbuf[:], pn)
+	for i := 0; i < 8; i++ {
+		nonce[4+i] ^= pnbuf[i]
+	}
+	gcm, err := cipher.NewGCM(block2(keys.Key))
+	if err != nil {
+		return "", err
+	}
+	ctStart := pnOffset + pnLen
+	ctEnd := pnOffset + length
+	if ctStart > ctEnd || ctEnd > len(b) {
+		return "", fmt.Errorf("ciphertext range")
+	}
+	plain, err := gcm.Open(nil, nonce, b[ctStart:ctEnd], hdr)
+	if err != nil {
+		return "", fmt.Errorf("aead open: %w", err)
+	}
+	hs := reassembleCrypto(plain)
+	if hs == nil {
+		return "", fmt.Errorf("no CRYPTO frame")
+	}
+	sni, ok := parseClientHelloSNI(hs)
+	if !ok {
+		return "", fmt.Errorf("no SNI in ClientHello (hslen %d)", len(hs))
+	}
+	return sni, nil
+}
+
+// block2 builds an AES cipher for the GCM key.
+func block2(key []byte) cipher.Block {
+	b, _ := aes.NewCipher(key)
+	return b
+}
+
+// reassembleCrypto concatenates the CRYPTO frames (type 0x06) in a decrypted
+// Initial payload in offset order, returning the handshake bytes.
+func reassembleCrypto(plain []byte) []byte {
+	type chunk struct {
+		off  int
+		data []byte
+	}
+	var chunks []chunk
+	maxEnd := 0
+	i := 0
+	for i < len(plain) {
+		ft := plain[i]
+		if ft == 0x00 || ft == 0x01 {
+			i++
+			continue
+		}
+		if ft != 0x06 {
+			break
+		}
+		i++
+		offv, n, ok := readVarint(plain, i)
+		if !ok {
+			break
+		}
+		i += n
+		lv, n, ok := readVarint(plain, i)
+		if !ok {
+			break
+		}
+		i += n
+		off, ok := asLen(offv)
+		if !ok {
+			break
+		}
+		l, ok := asLen(lv)
+		if !ok || i+l > len(plain) {
+			break
+		}
+		chunks = append(chunks, chunk{off: off, data: plain[i : i+l]})
+		if off+l > maxEnd {
+			maxEnd = off + l
+		}
+		i += l
+	}
+	if maxEnd == 0 || maxEnd > 1<<20 {
+		return nil
+	}
+	out := make([]byte, maxEnd)
+	for _, c := range chunks {
+		copy(out[c.off:], c.data)
+	}
+	return out
+}
+
+// parseClientHelloSNI parses a TLS ClientHello handshake message and returns the
+// server_name from the SNI extension.
+func parseClientHelloSNI(hs []byte) (string, bool) {
+	if len(hs) < 4 || hs[0] != 0x01 {
+		return "", false
+	}
+	body := hs[4:]
+	p := 2 + 32
+	if p+1 > len(body) {
+		return "", false
+	}
+	sidLen := int(body[p])
+	p += 1 + sidLen
+	if p+2 > len(body) {
+		return "", false
+	}
+	csLen := int(binary.BigEndian.Uint16(body[p:]))
+	p += 2 + csLen
+	if p+1 > len(body) {
+		return "", false
+	}
+	compLen := int(body[p])
+	p += 1 + compLen
+	if p+2 > len(body) {
+		return "", false
+	}
+	extTotal := int(binary.BigEndian.Uint16(body[p:]))
+	p += 2
+	if p+extTotal > len(body) {
+		extTotal = len(body) - p
+	}
+	ext := body[p : p+extTotal]
+	for q := 0; q+4 <= len(ext); {
+		etype := binary.BigEndian.Uint16(ext[q:])
+		elen := int(binary.BigEndian.Uint16(ext[q+2:]))
+		q += 4
+		if q+elen > len(ext) {
+			break
+		}
+		if etype == 0x0000 {
+			return parseSNIExtension(ext[q : q+elen])
+		}
+		q += elen
+	}
+	return "", false
+}
+
+// parseSNIExtension reads the first host_name from a server_name extension body.
+func parseSNIExtension(d []byte) (string, bool) {
+	if len(d) < 2 {
+		return "", false
+	}
+	listLen := int(binary.BigEndian.Uint16(d))
+	p := 2
+	end := p + listLen
+	if end > len(d) {
+		end = len(d)
+	}
+	for p+3 <= end {
+		nameType := d[p]
+		nameLen := int(binary.BigEndian.Uint16(d[p+1:]))
+		p += 3
+		if p+nameLen > end {
+			break
+		}
+		if nameType == 0x00 { // host_name
+			return string(d[p : p+nameLen]), true
+		}
+		p += nameLen
+	}
+	return "", false
+}

--- a/internal/ebpf/quicinitial/quicinitial_test.go
+++ b/internal/ebpf/quicinitial/quicinitial_test.go
@@ -1,0 +1,63 @@
+package quicinitial
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+// TestDeriveClientInitialKeys is the RFC 9001 Appendix A.1 known-answer vector:
+// DCID 0x8394c8f03e515708 must derive these exact client Initial key/iv/hp.
+func TestDeriveClientInitialKeys(t *testing.T) {
+	dcid, _ := hex.DecodeString("8394c8f03e515708")
+	k := DeriveClientInitialKeys(dcid)
+	checks := []struct {
+		name, got, want string
+	}{
+		{"key", hex.EncodeToString(k.Key), "1f369613dd76d5467730efcbe3b1a22d"},
+		{"iv", hex.EncodeToString(k.IV), "fa044b2f42a3fd3b46fb255c"},
+		{"hp", hex.EncodeToString(k.HP), "9f50449e04a0e810283a1e9933adedd2"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %s, want %s", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestParseClientHelloSNI builds a minimal ClientHello carrying a server_name
+// extension and checks extraction.
+func TestParseClientHelloSNI(t *testing.T) {
+	host := "example.com"
+	// server_name extension body: list_len(2) | type(1)=0 | name_len(2) | name
+	sni := []byte{0, 0}
+	sni = append(sni, 0x00)
+	sni = append(sni, byte(len(host)>>8), byte(len(host)))
+	sni = append(sni, host...)
+	binary.BigEndian.PutUint16(sni, uint16(len(sni)-2)) // list_len
+
+	// one extension: type(2)=0x0000 | len(2) | sni
+	ext := []byte{0x00, 0x00, byte(len(sni) >> 8), byte(len(sni))}
+	ext = append(ext, sni...)
+
+	body := make([]byte, 2+32) // legacy_version + random
+	body = append(body, 0x00)  // session_id len = 0
+	body = append(body, 0x00, 0x02, 0x13, 0x01) // cipher_suites len=2 + one suite
+	body = append(body, 0x01, 0x00)             // compression len=1 + null
+	body = append(body, byte(len(ext)>>8), byte(len(ext))) // extensions len
+	body = append(body, ext...)
+
+	hs := []byte{0x01, byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body))}
+	hs = append(hs, body...)
+
+	got, ok := parseClientHelloSNI(hs)
+	if !ok || got != host {
+		t.Errorf("parseClientHelloSNI = %q,%v want %q,true", got, ok, host)
+	}
+}
+
+func TestExtractSNINonInitial(t *testing.T) {
+	if _, ok := ExtractSNI([]byte{0x40, 0, 0, 0}); ok {
+		t.Error("short-header / non-initial should not parse")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -1,7 +1,9 @@
 package tracer
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +33,7 @@ import (
 	"github.com/podtrace/podtrace/internal/ebpf/cache"
 	"github.com/podtrace/podtrace/internal/ebpf/filter"
 	"github.com/podtrace/podtrace/internal/ebpf/h2decode"
+	"github.com/podtrace/podtrace/internal/ebpf/quicinitial"
 	"github.com/podtrace/podtrace/internal/ebpf/loader"
 	"github.com/podtrace/podtrace/internal/ebpf/parser"
 	"github.com/podtrace/podtrace/internal/ebpf/probes"
@@ -69,6 +72,7 @@ type Tracer struct {
 	probeGroupsMu  sync.Mutex
 	probeGroups    map[probes.ProbeGroup][]link.Link
 	dnsPacketLinks map[string][]link.Link
+	http3Links     map[string][]link.Link
 
 	intentionallyDisabled map[probes.ProbeGroup]struct{}
 	detachWarned          map[probes.ProbeGroup]struct{}
@@ -78,6 +82,7 @@ type Tracer struct {
 	reader                   *ringbuf.Reader
 	h2Reader                 *ringbuf.Reader
 	h2Decoder                *h2decode.Decoder
+	quicReader               *ringbuf.Reader
 	filter                   *filter.CgroupFilter
 	containerID              string
 	containerPID             uint32
@@ -314,6 +319,48 @@ func (t *Tracer) syncDNSPacketProbes(paths []string) {
 	}
 }
 
+// syncHTTP3Probes reconciles the per-cgroup http3_egress/http3_ingress QUIC
+// detector attachments with the current target set.
+func (t *Tracer) syncHTTP3Probes(paths []string) {
+	if t.collection == nil {
+		return
+	}
+	want := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		if p != "" {
+			want[p] = struct{}{}
+		}
+	}
+
+	t.probeGroupsMu.Lock()
+	if t.http3Links == nil {
+		t.http3Links = map[string][]link.Link{}
+	}
+	for p, ls := range t.http3Links {
+		if _, ok := want[p]; ok {
+			continue
+		}
+		for _, l := range ls {
+			_ = l.Close()
+		}
+		delete(t.http3Links, p)
+	}
+	var missing []string
+	for p := range want {
+		if _, ok := t.http3Links[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	t.probeGroupsMu.Unlock()
+
+	for _, p := range missing {
+		ls := probes.AttachHTTP3Probes(t.collection, []string{p})
+		t.probeGroupsMu.Lock()
+		t.http3Links[p] = ls
+		t.probeGroupsMu.Unlock()
+	}
+}
+
 // SetProfilingController wires an optional profiling controller into the
 // management API server.
 func (t *Tracer) SetProfilingController(ctrl ProfilingController) {
@@ -463,6 +510,15 @@ func NewTracer() (*Tracer, error) {
 		}
 	}
 
+	var quicrd *ringbuf.Reader
+	if m := coll.Maps["quic_initial_events"]; m != nil {
+		if r, qerr := ringbuf.NewReader(m); qerr == nil {
+			quicrd = r
+		} else {
+			logger.Warn("HTTP/3 SNI extraction disabled: ringbuf reader unavailable", zap.Error(qerr))
+		}
+	}
+
 	ttl := time.Duration(config.CacheTTLSeconds) * time.Second
 	processCache := cache.NewLRUCache(config.CacheMaxSize, ttl)
 
@@ -474,6 +530,7 @@ func NewTracer() (*Tracer, error) {
 		reader:                rd,
 		h2Reader:              h2rd,
 		h2Decoder:             h2dec,
+		quicReader:            quicrd,
 		filter:                filter.NewCgroupFilter(),
 		processNameCache:      processCache,
 		pathCache:             cache.NewPathCache(),
@@ -520,6 +577,7 @@ func (t *Tracer) SetCgroups(cgroupPaths []string) error {
 		}
 		t.cgroupWriteMu.Unlock()
 		t.syncDNSPacketProbes(nil)
+		t.syncHTTP3Probes(nil)
 		logger.Debug("Detached all cgroups")
 		return nil
 	}
@@ -646,6 +704,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 	}
 	currentPaths := append([]string(nil), t.cgroupPaths...)
 	t.syncDNSPacketProbes(currentPaths)
+	t.syncHTTP3Probes(currentPaths)
 
 	if t.resourceMgr != nil {
 		t.resourceMgr.reconcile(currentPaths)
@@ -815,6 +874,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 	dnsCgroups := append([]string(nil), t.cgroupPaths...)
 	t.cgroupWriteMu.Unlock()
 	t.syncDNSPacketProbes(dnsCgroups)
+	t.syncHTTP3Probes(dnsCgroups)
 
 	t.resourceMgr.activate(ctx, eventChan,
 		t.collection.Maps["cgroup_limits"],
@@ -994,6 +1054,10 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 
 	if t.h2Reader != nil && t.h2Decoder != nil {
 		go t.runH2DecodeReader(ctx, eventChan, stackMap, ec)
+	}
+
+	if t.quicReader != nil {
+		go t.runQUICInitialReader(ctx, eventChan, stackMap, ec)
 	}
 
 	return nil
@@ -1177,12 +1241,78 @@ func (t *Tracer) runH2DecodeReader(ctx context.Context, eventChan chan<- *events
 	}
 }
 
+// runQUICInitialReader drains the QUIC Initial packet ringbuf, extracts the SNI
+// (server name) from the client's ClientHello via the quicinitial package, and
+// emits an EVENT_HTTP3 connection event with the peer and SNI.
+func (t *Tracer) runQUICInitialReader(ctx context.Context, eventChan chan<- *events.Event,
+	stackMap *ebpf.Map, ec *eventCounters) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic in HTTP/3 reader",
+				zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
+		}
+	}()
+	const hdr = 60
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		record, err := t.quicReader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, ringbuf.ErrClosed) ||
+				strings.Contains(err.Error(), "closed") {
+				return
+			}
+			continue
+		}
+		data := record.RawSample
+		if len(data) <= hdr {
+			continue
+		}
+		family := data[20]
+		dport := binary.LittleEndian.Uint16(data[22:24])
+		var v6 [16]byte
+		copy(v6[:], data[24:40])
+		var ip string
+		if family == 10 {
+			ip = events.PeerIP(10, 0, v6)
+		} else {
+			ip = events.PeerIP(2, binary.BigEndian.Uint32(data[24:28]), v6)
+		}
+
+		ev := &events.Event{}
+		ev.Timestamp = binary.LittleEndian.Uint64(data[0:8])
+		ev.CgroupID = binary.LittleEndian.Uint64(data[8:16])
+		ev.PID = binary.LittleEndian.Uint32(data[16:20])
+		ev.ProcessName = string(bytes.TrimRight(data[44:60], "\x00"))
+		ev.Type = events.EventHTTP3
+		ev.Target = fmt.Sprintf("%s:%d", ip, dport)
+		ev.PeerDstIP = ip
+		ev.PeerDstPort = dport
+		pktEnd := hdr + int(binary.LittleEndian.Uint16(data[40:42]))
+		if pktEnd > len(data) {
+			pktEnd = len(data)
+		}
+		if sni, ok := quicinitial.ExtractSNI(data[hdr:pktEnd]); ok {
+			ev.Details = "sni: " + sni
+		} else {
+			ev.Details = "HTTP/3 (QUIC)"
+		}
+		t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+	}
+}
+
 func (t *Tracer) Stop() error {
 	if t.reader != nil {
 		_ = t.reader.Close()
 	}
 	if t.h2Reader != nil {
 		_ = t.h2Reader.Close()
+	}
+	if t.quicReader != nil {
+		_ = t.quicReader.Close()
 	}
 
 	t.probeGroupsMu.Lock()
@@ -1193,6 +1323,10 @@ func (t *Tracer) Stop() error {
 		closing = append(closing, ls...)
 	}
 	t.dnsPacketLinks = nil
+	for _, ls := range t.http3Links {
+		closing = append(closing, ls...)
+	}
+	t.http3Links = nil
 	for _, set := range t.containerUprobes {
 		closing = append(closing, set.links...)
 	}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -80,17 +80,18 @@ const (
 	EventPoolAcquire
 	EventPoolRelease
 	EventPoolExhausted
-	EventUnlink       // 29
-	EventRename       // 30
-	EventRedisCmd     // 31: Redis command (hiredis)
-	EventMemcachedCmd // 32: Memcached operation (libmemcached)
-	EventFastCGIReq   // 33: FastCGI request begin (BTF-only)
-	EventFastCGIResp  // 34: FastCGI request complete (BTF-only)
-	EventGRPCMethod   // 35: gRPC method call (BTF-only h2c)
-	EventKafkaProduce // 36: Kafka produce (librdkafka)
-	EventKafkaFetch   // 37: Kafka consumer_poll result (librdkafka)
-	EventDNSQuery     // 38: DNS query seen on egress
-	EventAFALG        // 39: AF_ALG crypto socket bind
+	EventUnlink
+	EventRename
+	EventRedisCmd
+	EventMemcachedCmd
+	EventFastCGIReq
+	EventFastCGIResp
+	EventGRPCMethod
+	EventKafkaProduce
+	EventKafkaFetch
+	EventDNSQuery
+	EventAFALG
+	EventHTTP3
 )
 
 type Event struct {
@@ -128,11 +129,7 @@ func (e *Event) Latency() time.Duration {
 	return time.Duration(safeconv.Uint64ToInt64(e.LatencyNS)) * time.Nanosecond
 }
 
-// TimestampTime returns the event's timestamp as wall-clock time. Timestamp
-// holds a raw bpf_ktime_get_ns() value (nanoseconds since boot,
-// CLOCK_MONOTONIC), so it must be anchored to the wall clock before being
-// formatted or compared against time.Now(). Deltas between two events can use
-// Timestamp directly; absolute times must go through this method.
+// TimestampTime returns the event's timestamp as wall-clock time.
 func (e *Event) TimestampTime() time.Time {
 	return clock.BPFTimestampToWall(e.Timestamp)
 }
@@ -217,6 +214,8 @@ func (e *Event) TypeString() string {
 		return "KAFKA"
 	case EventAFALG:
 		return "CRYPTO"
+	case EventHTTP3:
+		return "HTTP/3"
 	default:
 		return "UNKNOWN"
 	}


### PR DESCRIPTION
Adds HTTP/3 visibility, QUIC runs over UDP.

A net-gated cgroup_skb program (bpf/http3.c) detects QUIC v1 long-header Initial packets on a pod's traffic and ships the packet to userspace, deduplicated to one per connection. The userspace quicinitial package then extracts the server name: QUIC Initial packets are protected with keys derived from the Destination Connection ID via a well-known salt (RFC 9001), so no negotiated secrets are needed, it derives the Initial keys (HKDF), removes header protection, AES-128-GCM-decrypts the payload, reassembles the CRYPTO frames into the TLS ClientHello, and reads the server_name extension. Each connection becomes an EVENT_HTTP3 carrying the peer 4-tuple, process, and SNI.