### PR TITLE
feat: decode HTTP/3 (QUIC) L7 requests and responses for quic-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,9 @@ to CRs, see [docs/migration.md](docs/migration.md).
 - **OOM Kill Detection**: Tracks out-of-memory kills with memory usage details
 
 ### Application Layer
-- **HTTP Tracing**: HTTP request/response tracking via uprobes
+- **HTTP Tracing**: Captures request method and path with response status and latency across HTTP/1.x, HTTP/2, and HTTP/3 over QUIC, for both clients and servers
+- **HTTP-over-TLS L7**: Reads plaintext HTTP before encryption / after decryption via uprobes on OpenSSL, BoringSSL and GnuTLS, Go, and Node.js
+- **L7 ↔ L4 Peer Fusion**: Annotates HTTP/1.x and HTTP/2 request/response events with the underlying TCP 4-tuple
 - **DNS Tracking**: Monitors DNS lookups with latency and error tracking
 - **Database Query Tracing**: Tracks PostgreSQL and MySQL query execution with pattern extraction and latency analysis
 - **TLS/SSL Handshake Tracking**: Track TLS handshake latency, errors and failures

--- a/bpf/events.h
+++ b/bpf/events.h
@@ -108,4 +108,21 @@ struct h2_hdr_record {
 	u8  peer_daddr6[16];
 };
 
+#define H3_TXN_METHOD_MAX 16
+#define H3_TXN_PATH_MAX   256
+
+struct h3_txn_record {
+	u64 timestamp;
+	u64 latency_ns;
+	u64 cgroup_id;
+	u32 pid;
+	u16 status;
+	u8  is_client;
+	u8  method_len;
+	u16 path_len;
+	u8  _pad[6];
+	char method[H3_TXN_METHOD_MAX];
+	char path[H3_TXN_PATH_MAX];
+};
+
 #endif

--- a/bpf/http3l7.c
+++ b/bpf/http3l7.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "common.h"
+#include "maps.h"
+#include "events.h"
+#include "helpers.h"
+#include "protocols.h"
+
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+
+#if defined(__TARGET_ARCH_x86) || defined(__x86_64__)
+#define GO_REG0(ctx)      ((u64)(ctx)->ax)
+#define GO_REG1(ctx)      ((u64)(ctx)->bx)
+#define GO_REG2(ctx)      ((u64)(ctx)->cx)
+#define GO_GOROUTINE(ctx) ((u64)(ctx)->r14)
+#define GO_H3_SUPPORTED 1
+#elif defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
+#define GO_REG0(ctx)      ((u64)PT_REGS_PARM1(ctx))
+#define GO_REG1(ctx)      ((u64)PT_REGS_PARM2(ctx))
+#define GO_REG2(ctx)      ((u64)PT_REGS_PARM3(ctx))
+#define GO_GOROUTINE(ctx) ((u64)(ctx)->regs[28])
+#define GO_H3_SUPPORTED 1
+#endif
+
+#endif
+
+#ifdef GO_H3_SUPPORTED
+
+#define GO_REQ_METHOD_OFF      0
+#define GO_REQ_URL_OFF         16
+#define GO_URL_PATH_OFF        56
+#define GO_RESP_STATUSCODE_OFF 16
+
+struct go_string {
+	u64 ptr;
+	u64 len;
+};
+
+static __always_inline u32 read_go_str(u64 base, u64 off, char *dst, u32 cap)
+{
+	struct go_string s = {};
+	if (bpf_probe_read_user(&s, sizeof(s), (void *)(base + off)) != 0)
+		return 0;
+	if (s.ptr == 0 || s.len == 0)
+		return 0;
+	u32 n = s.len > cap ? cap : (u32)s.len;
+	if (bpf_probe_read_user(dst, n, (void *)s.ptr) != 0)
+		return 0;
+	return n;
+}
+
+static __always_inline void h3_stash_request(u64 goroutine, u64 req)
+{
+	if (!req)
+		return;
+	struct h3_req_inflight in = {};
+	in.start_ts = bpf_ktime_get_ns();
+	in.method_len = (u8)read_go_str(req, GO_REQ_METHOD_OFF, in.method, H3_TXN_METHOD_MAX);
+
+	u64 url = 0;
+	if (bpf_probe_read_user(&url, sizeof(url), (void *)(req + GO_REQ_URL_OFF)) == 0 && url)
+		in.path_len = (u16)read_go_str(url, GO_URL_PATH_OFF, in.path, H3_TXN_PATH_MAX);
+
+	bpf_map_update_elem(&h3_req_stash, &goroutine, &in, BPF_ANY);
+}
+
+static __always_inline void h3_emit_txn(u64 goroutine, u16 status, u8 is_client)
+{
+	struct h3_req_inflight *in = bpf_map_lookup_elem(&h3_req_stash, &goroutine);
+	if (!in)
+		return;
+
+	u32 zero = 0;
+	struct h3_txn_scratch *s = bpf_map_lookup_elem(&h3_txn_scratch_map, &zero);
+	if (!s) {
+		bpf_map_delete_elem(&h3_req_stash, &goroutine);
+		return;
+	}
+	struct h3_txn_record *rec = &s->rec;
+	u64 now = bpf_ktime_get_ns();
+
+	rec->timestamp = in->start_ts;
+	rec->latency_ns = now > in->start_ts ? now - in->start_ts : 0;
+	rec->cgroup_id = bpf_get_current_cgroup_id();
+	rec->pid = bpf_get_current_pid_tgid() >> 32;
+	rec->status = status;
+	rec->is_client = is_client;
+	rec->method_len = in->method_len > H3_TXN_METHOD_MAX ? H3_TXN_METHOD_MAX : in->method_len;
+	rec->path_len = in->path_len > H3_TXN_PATH_MAX ? H3_TXN_PATH_MAX : in->path_len;
+	__builtin_memcpy(rec->method, in->method, H3_TXN_METHOD_MAX);
+	__builtin_memcpy(rec->path, in->path, H3_TXN_PATH_MAX);
+
+	bpf_map_delete_elem(&h3_req_stash, &goroutine);
+	bpf_ringbuf_output(&h3_txn_events, rec, sizeof(*rec), 0);
+}
+
+SEC("uprobe/h3_roundtrip")
+int uprobe_h3_roundtrip(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	h3_stash_request(GO_GOROUTINE(ctx), GO_REG1(ctx));
+	return 0;
+}
+
+SEC("uprobe/h3_roundtrip_ret")
+int uprobe_h3_roundtrip_ret(struct pt_regs *ctx)
+{
+	u64 resp = GO_REG0(ctx);
+	u16 status = 0;
+	if (resp) {
+		u64 sc = 0;
+		if (bpf_probe_read_user(&sc, sizeof(sc), (void *)(resp + GO_RESP_STATUSCODE_OFF)) == 0)
+			status = (u16)sc;
+	}
+	h3_emit_txn(GO_GOROUTINE(ctx), status, 1);
+	return 0;
+}
+
+SEC("uprobe/h3_req_from_headers_ret")
+int uprobe_h3_req_from_headers_ret(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	h3_stash_request(GO_GOROUTINE(ctx), GO_REG0(ctx));
+	return 0;
+}
+
+SEC("uprobe/h3_write_header")
+int uprobe_h3_write_header(struct pt_regs *ctx)
+{
+	h3_emit_txn(GO_GOROUTINE(ctx), (u16)GO_REG1(ctx), 0);
+	return 0;
+}
+
+#else
+
+SEC("uprobe/h3_roundtrip")
+int uprobe_h3_roundtrip(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_roundtrip_ret")
+int uprobe_h3_roundtrip_ret(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_req_from_headers_ret")
+int uprobe_h3_req_from_headers_ret(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_write_header")
+int uprobe_h3_write_header(struct pt_regs *ctx) { return 0; }
+
+#endif

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -516,6 +516,39 @@ struct {
 } go_tls_read_args SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 2 * 1024 * 1024);
+} h3_txn_events SEC(".maps");
+
+struct h3_txn_scratch {
+	struct h3_txn_record rec;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct h3_txn_scratch);
+} h3_txn_scratch_map SEC(".maps");
+
+/* h3_req_stash holds the in-flight request (method/path/start) between the
+ * request hook and the response hook on the same goroutine: client RoundTrip
+ * entry -> RoundTrip return; server requestFromHeaders return -> WriteHeader. */
+struct h3_req_inflight {
+	u64 start_ts;
+	u8  method_len;
+	u16 path_len;
+	u8  _pad[5];
+	char method[H3_TXN_METHOD_MAX];
+	char path[H3_TXN_PATH_MAX];
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, u64);
+	__type(value, struct h3_req_inflight);
+} h3_req_stash SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 8192);
 	__type(key, u64);

--- a/bpf/podtrace.bpf.c
+++ b/bpf/podtrace.bpf.c
@@ -22,6 +22,7 @@
 #include "http.c"
 #include "h2.c"
 #include "gotls.c"
+#include "http3l7.c"
 #include "crypto.c"
 
 char LICENSE[] SEC("license") = "GPL";

--- a/bpf/protocols.h
+++ b/bpf/protocols.h
@@ -50,11 +50,12 @@
 #define HTTP_MIN_REQUEST_LEN 16
 #define W3C_TRACEPARENT_LEN  55
 
-/* Bit 0 = TLS (encrypted), bit 1 = HTTP/2. */
+/* Bit 0 = TLS (encrypted), bit 1 = HTTP/2, bit 2 = HTTP/3. */
 #define HTTP_TRANSPORT_PLAINTEXT 0  /* HTTP/1.x cleartext */
 #define HTTP_TRANSPORT_TLS       1  /* HTTP/1.x over TLS (OpenSSL, GnuTLS, Go) */
 #define HTTP_TRANSPORT_H2C       2  /* HTTP/2 cleartext */
 #define HTTP_TRANSPORT_H2_TLS    3  /* HTTP/2 over TLS (Go crypto/tls) */
+#define HTTP_TRANSPORT_H3        5  /* HTTP/3 over QUIC (always encrypted): H3 bit | TLS bit */
 
 /* === FastCGI NV Pair Helpers === */
 #define FCGI_NV_LEN_4BYTE    0x80

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -454,9 +454,9 @@ func responseStatus(e *events.Event) string {
 }
 
 // httpTransportBreakdown tallies HTTP events by protocol label (HTTP, HTTPS,
-// HTTP/2) and renders a one-line summary. Returns "" when every event is plain
-// cleartext HTTP/1.x, so the line only appears when there is something to
-// distinguish (TLS or h2c traffic present).
+// HTTP/2, HTTP/3) and renders a one-line summary. Returns "" when every event is
+// plain cleartext HTTP/1.x, so the line only appears when there is something to
+// distinguish (TLS, h2c, or h3 traffic present).
 func httpTransportBreakdown(eventGroups ...[]*events.Event) string {
 	counts := make(map[string]int)
 	total := 0
@@ -470,7 +470,7 @@ func httpTransportBreakdown(eventGroups ...[]*events.Event) string {
 		return ""
 	}
 	parts := make([]string, 0, len(counts))
-	for _, label := range []string{"HTTP", "HTTPS", "HTTP/2"} {
+	for _, label := range []string{"HTTP", "HTTPS", "HTTP/2", "HTTP/3"} {
 		if n := counts[label]; n > 0 {
 			parts = append(parts, fmt.Sprintf("%d %s", n, label))
 		}

--- a/internal/diagnose/report/report_test.go
+++ b/internal/diagnose/report/report_test.go
@@ -289,6 +289,24 @@ func TestGenerateHTTPSection_H2CTransport(t *testing.T) {
 	}
 }
 
+func TestGenerateHTTPSection_H3Transport(t *testing.T) {
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventHTTPReq, LatencyNS: 5000000, Target: "GET /hello", TCPState: events.HTTPTransportH3},
+			{Type: events.EventHTTPResp, LatencyNS: 6000000, Target: "200", Details: "200", TCPState: events.HTTPTransportH3},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(1 * time.Second),
+	}
+	result := GenerateHTTPSection(d, d.endTime.Sub(d.startTime))
+	if !strings.Contains(result, "Transport: 2 HTTP/3") {
+		t.Errorf("expected HTTP/3 transport breakdown, got:\n%s", result)
+	}
+	if !strings.Contains(result, "GET /hello (https)") {
+		t.Errorf("expected https-scheme-tagged h3 URL, got:\n%s", result)
+	}
+}
+
 func TestGenerateHTTPSection_PlaintextOmitsBreakdown(t *testing.T) {
 	d := &mockDiagnostician{
 		events: []*events.Event{

--- a/internal/ebpf/h3decode/decode.go
+++ b/internal/ebpf/h3decode/decode.go
@@ -1,0 +1,96 @@
+// Package h3decode turns one HTTP/3 transaction record (emitted by
+// bpf/http3l7.c from the net/http boundary) into a paired EventHTTPReq +
+// EventHTTPResp. Because the record already carries method, path, status, and a
+// real latency — correlated on a single goroutine at the RoundTrip / handler
+// boundary — no header reassembly or cross-event stitching is needed.
+package h3decode
+
+import (
+	"encoding/binary"
+	"strconv"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/safeconv"
+)
+
+// Offsets mirror struct h3_txn_record in bpf/events.h.
+const (
+	methodMax    = 16  // H3_TXN_METHOD_MAX
+	pathMax      = 256 // H3_TXN_PATH_MAX
+	methodOffset = 40  // start of method[]
+	pathOffset   = methodOffset + methodMax
+	recordSize   = pathOffset + pathMax
+)
+
+// Txn is one decoded HTTP/3 transaction.
+type Txn struct {
+	Timestamp uint64
+	LatencyNS uint64
+	CgroupID  uint64
+	PID       uint32
+	Status    uint16
+	IsClient  bool
+	Method    string
+	Path      string
+}
+
+// ParseRecord decodes one ringbuf sample into a Txn.
+func ParseRecord(data []byte) (*Txn, bool) {
+	if len(data) < recordSize {
+		return nil, false
+	}
+	methodLen := int(data[31])
+	if methodLen > methodMax {
+		methodLen = methodMax
+	}
+	pathLen := int(binary.LittleEndian.Uint16(data[32:34]))
+	if pathLen > pathMax {
+		pathLen = pathMax
+	}
+	return &Txn{
+		Timestamp: binary.LittleEndian.Uint64(data[0:8]),
+		LatencyNS: binary.LittleEndian.Uint64(data[8:16]),
+		CgroupID:  binary.LittleEndian.Uint64(data[16:24]),
+		PID:       binary.LittleEndian.Uint32(data[24:28]),
+		Status:    binary.LittleEndian.Uint16(data[28:30]),
+		IsClient:  data[30] != 0,
+		Method:    string(data[methodOffset : methodOffset+methodLen]),
+		Path:      string(data[pathOffset : pathOffset+pathLen]),
+	}, true
+}
+
+// Events turns a transaction into the request and response events that flow
+// through the same enrichment + reporting path as other L7 events. Both carry
+// "METHOD path" as their target so the response is reported against its
+// endpoint; the response carries the status and the measured latency.
+func (t *Txn) Events() []*events.Event {
+	method := t.Method
+	if method == "" {
+		method = "GET"
+	}
+	target := method + " " + t.Path
+	status := strconv.Itoa(int(t.Status))
+
+	req := &events.Event{
+		Timestamp: t.Timestamp,
+		PID:       t.PID,
+		CgroupID:  t.CgroupID,
+		Type:      events.EventHTTPReq,
+		TCPState:  events.HTTPTransportH3,
+		Target:    target,
+	}
+	resp := &events.Event{
+		Timestamp: t.Timestamp + t.LatencyNS,
+		PID:       t.PID,
+		CgroupID:  t.CgroupID,
+		Type:      events.EventHTTPResp,
+		TCPState:  events.HTTPTransportH3,
+		Target:    target,
+		Details:   status,
+		LatencyNS: t.LatencyNS,
+	}
+	if t.Status >= 500 && t.Status <= 599 {
+		resp.Error = safeconv.IntToInt32(int(t.Status))
+	}
+	return []*events.Event{req, resp}
+}

--- a/internal/ebpf/h3decode/decode_test.go
+++ b/internal/ebpf/h3decode/decode_test.go
@@ -1,0 +1,92 @@
+package h3decode
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// buildRecord assembles a wire-format struct h3_txn_record, mirroring
+// bpf/http3l7.c.
+func buildRecord(latencyNS uint64, status uint16, isClient bool, method, path string) []byte {
+	buf := make([]byte, recordSize)
+	binary.LittleEndian.PutUint64(buf[0:8], 1000)      // timestamp
+	binary.LittleEndian.PutUint64(buf[8:16], latencyNS) // latency
+	binary.LittleEndian.PutUint64(buf[16:24], 222)      // cgroup
+	binary.LittleEndian.PutUint32(buf[24:28], 4242)     // pid
+	binary.LittleEndian.PutUint16(buf[28:30], status)
+	if isClient {
+		buf[30] = 1
+	}
+	m := method
+	if len(m) > methodMax {
+		m = m[:methodMax]
+	}
+	p := path
+	if len(p) > pathMax {
+		p = p[:pathMax]
+	}
+	buf[31] = uint8(len(m))
+	binary.LittleEndian.PutUint16(buf[32:34], uint16(len(p)))
+	copy(buf[methodOffset:], m)
+	copy(buf[pathOffset:], p)
+	return buf
+}
+
+func TestParseRecord(t *testing.T) {
+	tx, ok := ParseRecord(buildRecord(1_500_000, 200, true, "GET", "/hello"))
+	if !ok {
+		t.Fatal("ParseRecord returned false")
+	}
+	if tx.Method != "GET" || tx.Path != "/hello" || tx.Status != 200 || !tx.IsClient {
+		t.Fatalf("unexpected txn: %+v", tx)
+	}
+	if tx.LatencyNS != 1_500_000 {
+		t.Fatalf("unexpected latency: %d", tx.LatencyNS)
+	}
+}
+
+func TestParseRecordTooShort(t *testing.T) {
+	if _, ok := ParseRecord(make([]byte, 50)); ok {
+		t.Fatal("expected ParseRecord to reject a short sample")
+	}
+}
+
+func TestEventsPairedWithLatency(t *testing.T) {
+	tx, _ := ParseRecord(buildRecord(2_000_000, 200, true, "GET", "/hello"))
+	evs := tx.Events()
+	if len(evs) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(evs))
+	}
+	req, resp := evs[0], evs[1]
+	if req.Type != events.EventHTTPReq || req.Target != "GET /hello" {
+		t.Fatalf("unexpected request event: %+v", req)
+	}
+	// The response is reported against its endpoint (not a bare status) and
+	// carries the measured latency.
+	if resp.Type != events.EventHTTPResp || resp.Target != "GET /hello" {
+		t.Fatalf("unexpected response target: %+v", resp)
+	}
+	if resp.Details != "200" || resp.LatencyNS != 2_000_000 {
+		t.Fatalf("unexpected response status/latency: %+v", resp)
+	}
+	if resp.HTTPProtoLabel() != "HTTP/3" || resp.HTTPScheme() != "https" {
+		t.Fatalf("unexpected transport: label=%q scheme=%q", resp.HTTPProtoLabel(), resp.HTTPScheme())
+	}
+}
+
+func TestEvents5xxSetsError(t *testing.T) {
+	tx, _ := ParseRecord(buildRecord(1, 503, false, "GET", "/boom"))
+	resp := tx.Events()[1]
+	if resp.Error != 503 {
+		t.Fatalf("expected 5xx to set Error, got %d", resp.Error)
+	}
+}
+
+func TestEventsDefaultMethod(t *testing.T) {
+	tx, _ := ParseRecord(buildRecord(1, 200, true, "", "/x"))
+	if got := tx.Events()[0].Target; got != "GET /x" {
+		t.Fatalf("expected empty method to default to GET, got %q", got)
+	}
+}

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -2018,6 +2018,113 @@ func attachGoTLSReadProbes(coll *ebpf.Collection, exe *link.Executable, exePath 
 	return links
 }
 
+// AttachGoHTTP3Probes attaches uprobes that read already-decoded HTTP/3 header
+// fields from a quic-go process: http3.parseHeaders for inbound headers and
+// qpack.(*Encoder).WriteField for outbound.
+func AttachGoHTTP3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
+	var links []link.Link
+	if pid == 0 {
+		return links
+	}
+	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
+	exe, err := link.OpenExecutable(exePath)
+	if err != nil {
+		logger.Debug("Go HTTP/3 probe: cannot open executable",
+			zap.String("path", exePath), zap.Error(err))
+		return links
+	}
+
+	links = append(links, attachGoEntryReturnProbes(coll, exe, exePath, pid,
+		"github.com/quic-go/quic-go/http3.(*Transport).RoundTrip",
+		"uprobe_h3_roundtrip", "uprobe_h3_roundtrip_ret")...)
+
+	links = append(links, attachGoReturnProbes(coll, exe, exePath, pid,
+		"github.com/quic-go/quic-go/http3.requestFromHeaders",
+		"uprobe_h3_req_from_headers_ret")...)
+	if prog := coll.Programs["uprobe_h3_write_header"]; prog != nil {
+		const sym = "github.com/quic-go/quic-go/http3.(*responseWriter).WriteHeader"
+		if l, ok := attachGoUprobeBySymbol(exe, exePath, sym, prog); ok {
+			links = append(links, l)
+			logger.Debug("Go HTTP/3 WriteHeader uprobe attached", zap.Uint32("pid", pid))
+		}
+	}
+	return links
+}
+
+// attachGoUprobeBySymbol attaches an entry uprobe, falling back to a gopclntab
+// file-offset attach when the symbol is absent from the dynamic symbol table.
+func attachGoUprobeBySymbol(exe *link.Executable, exePath, sym string, prog *ebpf.Program) (link.Link, bool) {
+	l, err := exe.Uprobe(sym, prog, nil)
+	if err != nil {
+		off, ok := goSymbolFileOffset(exePath, sym)
+		if !ok {
+			return nil, false
+		}
+		l, err = exe.Uprobe("", prog, &link.UprobeOptions{Address: off})
+		if err != nil {
+			return nil, false
+		}
+	}
+	return l, true
+}
+
+// attachGoHTTP3ParseProbes attaches the http3.parseHeaders entry uprobe plus a
+// uprobe at each return site.
+func attachGoEntryReturnProbes(coll *ebpf.Collection, exe *link.Executable, exePath string, pid uint32,
+	sym, entryProgName, retProgName string) []link.Link {
+	var links []link.Link
+	entryProg := coll.Programs[entryProgName]
+	retProg := coll.Programs[retProgName]
+	if entryProg == nil || retProg == nil {
+		return links
+	}
+	entryOff, retOffs, ok := goFuncReturnOffsets(exePath, sym)
+	if !ok {
+		logger.Debug("Go HTTP/3: no return sites resolved (non-quic-go, non-x86, or symbol missing)",
+			zap.String("symbol", sym), zap.Uint32("pid", pid))
+		return links
+	}
+	el, err := exe.Uprobe("", entryProg, &link.UprobeOptions{Address: entryOff})
+	if err != nil {
+		logger.Debug("Go HTTP/3 entry uprobe not attached", zap.String("symbol", sym), zap.Error(err))
+		return links
+	}
+	links = append(links, el)
+	for _, ro := range retOffs {
+		if rl, err := exe.Uprobe("", retProg, &link.UprobeOptions{Address: ro}); err == nil {
+			links = append(links, rl)
+		}
+	}
+	logger.Debug("Go HTTP/3 entry+return uprobes attached",
+		zap.String("symbol", sym), zap.Uint32("pid", pid), zap.Int("ret_sites", len(links)-1))
+	return links
+}
+
+// attachGoReturnProbes attaches a uprobe at each return site of a Go function
+// (no entry probe). Used when only the function's result is needed.
+func attachGoReturnProbes(coll *ebpf.Collection, exe *link.Executable, exePath string, pid uint32,
+	sym, retProgName string) []link.Link {
+	var links []link.Link
+	retProg := coll.Programs[retProgName]
+	if retProg == nil {
+		return links
+	}
+	_, retOffs, ok := goFuncReturnOffsets(exePath, sym)
+	if !ok {
+		logger.Debug("Go HTTP/3: no return sites resolved",
+			zap.String("symbol", sym), zap.Uint32("pid", pid))
+		return links
+	}
+	for _, ro := range retOffs {
+		if rl, err := exe.Uprobe("", retProg, &link.UprobeOptions{Address: ro}); err == nil {
+			links = append(links, rl)
+		}
+	}
+	logger.Debug("Go HTTP/3 return uprobes attached",
+		zap.String("symbol", sym), zap.Uint32("pid", pid), zap.Int("ret_sites", len(links)))
+	return links
+}
+
 // kernelVersionString returns the running kernel version for use in error messages.
 func kernelVersionString() string {
 	data, err := os.ReadFile("/proc/version")

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/podtrace/podtrace/internal/ebpf/cache"
 	"github.com/podtrace/podtrace/internal/ebpf/filter"
 	"github.com/podtrace/podtrace/internal/ebpf/h2decode"
+	"github.com/podtrace/podtrace/internal/ebpf/h3decode"
 	"github.com/podtrace/podtrace/internal/ebpf/quicinitial"
 	"github.com/podtrace/podtrace/internal/ebpf/loader"
 	"github.com/podtrace/podtrace/internal/ebpf/parser"
@@ -82,6 +83,7 @@ type Tracer struct {
 	reader                   *ringbuf.Reader
 	h2Reader                 *ringbuf.Reader
 	h2Decoder                *h2decode.Decoder
+	h3Reader                 *ringbuf.Reader
 	quicReader               *ringbuf.Reader
 	filter                   *filter.CgroupFilter
 	containerID              string
@@ -172,6 +174,7 @@ func (t *Tracer) attachContainerUprobes(id string, pid uint32) []link.Link {
 	ls = append(ls, probes.AttachPoolProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
+	ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 	ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachKafkaProbesWithPID(coll, id, pid)...)
@@ -241,6 +244,7 @@ func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
 		ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid)...)
 		ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 		ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
+		ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 		return ls
 	case probes.GroupDatabase:
 		if id == "" {
@@ -510,6 +514,15 @@ func NewTracer() (*Tracer, error) {
 		}
 	}
 
+	var h3rd *ringbuf.Reader
+	if m := coll.Maps["h3_txn_events"]; m != nil {
+		if r, herr := ringbuf.NewReader(m); herr == nil {
+			h3rd = r
+		} else {
+			logger.Warn("HTTP/3 L7 decode disabled: ringbuf reader unavailable", zap.Error(herr))
+		}
+	}
+
 	var quicrd *ringbuf.Reader
 	if m := coll.Maps["quic_initial_events"]; m != nil {
 		if r, qerr := ringbuf.NewReader(m); qerr == nil {
@@ -530,6 +543,7 @@ func NewTracer() (*Tracer, error) {
 		reader:                rd,
 		h2Reader:              h2rd,
 		h2Decoder:             h2dec,
+		h3Reader:              h3rd,
 		quicReader:            quicrd,
 		filter:                filter.NewCgroupFilter(),
 		processNameCache:      processCache,
@@ -854,6 +868,7 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 	t.registerGroupLinks(probes.GroupPool, probes.AttachPoolProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachTLSProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoTLSProbes(t.collection, t.containerPID))
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoHTTP3Probes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachRedisProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachMemcachedProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupMessaging, probes.AttachKafkaProbesWithPID(t.collection, primary, t.containerPID))
@@ -1056,6 +1071,10 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		go t.runH2DecodeReader(ctx, eventChan, stackMap, ec)
 	}
 
+	if t.h3Reader != nil {
+		go t.runH3DecodeReader(ctx, eventChan, stackMap, ec)
+	}
+
 	if t.quicReader != nil {
 		go t.runQUICInitialReader(ctx, eventChan, stackMap, ec)
 	}
@@ -1241,6 +1260,45 @@ func (t *Tracer) runH2DecodeReader(ctx context.Context, eventChan chan<- *events
 	}
 }
 
+// runH3DecodeReader drains the HTTP/3 transaction ringbuf (one record per
+// request/response captured at the net/http boundary) and dispatches the paired
+// EventHTTPReq/EventHTTPResp through the same enrichment + filtering path as
+// kernel events.
+func (t *Tracer) runH3DecodeReader(ctx context.Context, eventChan chan<- *events.Event,
+	stackMap *ebpf.Map, ec *eventCounters) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic in HTTP/3 L7 decode reader",
+				zap.Any("panic", r), zap.ByteString("stack", debug.Stack()))
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		record, err := t.h3Reader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, ringbuf.ErrClosed) ||
+				strings.Contains(err.Error(), "closed") {
+				return
+			}
+			continue
+		}
+
+		txn, ok := h3decode.ParseRecord(record.RawSample)
+		if !ok {
+			continue
+		}
+		for _, ev := range txn.Events() {
+			t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+		}
+	}
+}
+
 // runQUICInitialReader drains the QUIC Initial packet ringbuf, extracts the SNI
 // (server name) from the client's ClientHello via the quicinitial package, and
 // emits an EVENT_HTTP3 connection event with the peer and SNI.
@@ -1310,6 +1368,9 @@ func (t *Tracer) Stop() error {
 	}
 	if t.h2Reader != nil {
 		_ = t.h2Reader.Close()
+	}
+	if t.h3Reader != nil {
+		_ = t.h3Reader.Close()
 	}
 	if t.quicReader != nil {
 		_ = t.quicReader.Close()

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -142,9 +142,11 @@ const (
 	HTTPTransportTLS       uint32 = 1 // HTTP/1.x over TLS (OpenSSL/GnuTLS/Go)
 	HTTPTransportH2C       uint32 = 2 // HTTP/2 cleartext
 	HTTPTransportH2TLS     uint32 = 3 // HTTP/2 over TLS (Go crypto/tls)
+	HTTPTransportH3        uint32 = 5 // HTTP/3 over QUIC: H3 bit | TLS bit
 
 	httpTransportTLSBit uint32 = 1
 	httpTransportH2Bit  uint32 = 2
+	httpTransportH3Bit  uint32 = 4
 )
 
 // HTTPScheme returns the URL scheme implied by an HTTP event's transport:
@@ -157,8 +159,12 @@ func (e *Event) HTTPScheme() string {
 }
 
 // HTTPProtoLabel is the protocol label for an HTTP event, reflecting its
-// transport: "HTTP/2" for any h2 traffic, else "HTTPS" over TLS or "HTTP".
+// transport: "HTTP/3" for QUIC, "HTTP/2" for any h2 traffic, else "HTTPS" over
+// TLS or "HTTP".
 func (e *Event) HTTPProtoLabel() string {
+	if e.TCPState&httpTransportH3Bit != 0 {
+		return "HTTP/3"
+	}
 	if e.TCPState&httpTransportH2Bit != 0 {
 		return "HTTP/2"
 	}

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -132,6 +132,32 @@ func TestEvent_HTTPTransport(t *testing.T) {
 	}
 }
 
+func TestEvent_HTTPTransport_H2AndH3(t *testing.T) {
+	h2cReq := &Event{Type: EventHTTPReq, TCPState: HTTPTransportH2C}
+	h2tlsReq := &Event{Type: EventHTTPReq, TCPState: HTTPTransportH2TLS}
+	h3Req := &Event{Type: EventHTTPReq, TCPState: HTTPTransportH3}
+
+	if got := h2cReq.HTTPProtoLabel(); got != "HTTP/2" {
+		t.Errorf("h2c HTTPProtoLabel() = %q, want HTTP/2", got)
+	}
+	if got := h2cReq.HTTPScheme(); got != "http" {
+		t.Errorf("h2c HTTPScheme() = %q, want http", got)
+	}
+	if got := h2tlsReq.HTTPProtoLabel(); got != "HTTP/2" {
+		t.Errorf("h2-tls HTTPProtoLabel() = %q, want HTTP/2", got)
+	}
+	if got := h3Req.HTTPProtoLabel(); got != "HTTP/3" {
+		t.Errorf("h3 HTTPProtoLabel() = %q, want HTTP/3", got)
+	}
+	// QUIC is always encrypted: H3 transport must imply the https scheme.
+	if got := h3Req.HTTPScheme(); got != "https" {
+		t.Errorf("h3 HTTPScheme() = %q, want https", got)
+	}
+	if got := h3Req.TypeString(); got != "HTTP/3" {
+		t.Errorf("h3 TypeString() = %q, want HTTP/3", got)
+	}
+}
+
 func TestEvent_FormatMessage_DNS(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Adds HTTP/3 (QUIC) L7 visibility for **quic-go** services: method, path, status code, and per-request latency, with request and response **paired**, tagged `HTTP/3`, and flowing into the existing HTTP report sections.

Reads the decoded `*http.Request` / `*http.Response` structs at the **net/http boundary** instead of the QPACK codec layer. quic-go runs QPACK encode/decode on connection-level goroutines decoupled from the request owner, so codec-layer correlation is unreliable; the RoundTrip and server-handler boundaries each run one exchange to completion on a single goroutine, giving reliable pairing and latency.

**Hooks**
- **Client:** `http3.(*Transport).RoundTrip`: entry reads `req.Method` / `req.URL.Path`, return sites read `resp.StatusCode`
- **Server:** `http3.requestFromHeaders` (request) + `http3.(*responseWriter).WriteHeader` (status)

State is keyed by goroutine; one transaction record per exchange is split into a paired `EVENT_HTTP_REQ` / `EVENT_HTTP_RESP` in userspace.