### PR TITLE
feat: harden HTTP/3 L7 with DWARF offsets and traceparent capture

### DIFF
--- a/bpf/events.h
+++ b/bpf/events.h
@@ -111,6 +111,15 @@ struct h2_hdr_record {
 #define H3_TXN_METHOD_MAX 16
 #define H3_TXN_PATH_MAX   256
 
+struct h3_field_offsets {
+	u32 method;
+	u32 url;
+	u32 path;
+	u32 status;
+};
+
+#define H3_TXN_TP_MAX 64
+
 struct h3_txn_record {
 	u64 timestamp;
 	u64 latency_ns;
@@ -120,9 +129,11 @@ struct h3_txn_record {
 	u8  is_client;
 	u8  method_len;
 	u16 path_len;
-	u8  _pad[6];
+	u8  tp_len;
+	u8  _pad[5];
 	char method[H3_TXN_METHOD_MAX];
 	char path[H3_TXN_PATH_MAX];
+	char traceparent[H3_TXN_TP_MAX];
 };
 
 #endif

--- a/bpf/http3l7.c
+++ b/bpf/http3l7.c
@@ -12,12 +12,16 @@
 #define GO_REG0(ctx)      ((u64)(ctx)->ax)
 #define GO_REG1(ctx)      ((u64)(ctx)->bx)
 #define GO_REG2(ctx)      ((u64)(ctx)->cx)
+#define GO_REG3(ctx)      ((u64)(ctx)->di)
+#define GO_REG4(ctx)      ((u64)(ctx)->si)
 #define GO_GOROUTINE(ctx) ((u64)(ctx)->r14)
 #define GO_H3_SUPPORTED 1
 #elif defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
 #define GO_REG0(ctx)      ((u64)PT_REGS_PARM1(ctx))
 #define GO_REG1(ctx)      ((u64)PT_REGS_PARM2(ctx))
 #define GO_REG2(ctx)      ((u64)PT_REGS_PARM3(ctx))
+#define GO_REG3(ctx)      ((u64)PT_REGS_PARM4(ctx))
+#define GO_REG4(ctx)      ((u64)PT_REGS_PARM5(ctx))
 #define GO_GOROUTINE(ctx) ((u64)(ctx)->regs[28])
 #define GO_H3_SUPPORTED 1
 #endif
@@ -49,17 +53,62 @@ static __always_inline u32 read_go_str(u64 base, u64 off, char *dst, u32 cap)
 	return n;
 }
 
+#define H3_MAX_FIELDS 64
+
+struct go_header_field {
+	struct go_string name;
+	struct go_string value;
+};
+
+static __always_inline void h3_capture_tp(u64 goroutine, u64 name_ptr, u64 name_len,
+					  u64 val_ptr, u64 val_len)
+{
+	if (name_len != 11 || !name_ptr || !val_ptr || val_len == 0)
+		return;
+	char nm[11];
+	if (bpf_probe_read_user(nm, sizeof(nm), (void *)name_ptr) != 0)
+		return;
+	static const char want[11] = {'t', 'r', 'a', 'c', 'e', 'p', 'a', 'r', 'e', 'n', 't'};
+#pragma unroll
+	for (int i = 0; i < 11; i++) {
+		if (nm[i] != want[i])
+			return;
+	}
+	struct h3_pending_tp p = {};
+	u32 n = val_len > H3_TXN_TP_MAX ? H3_TXN_TP_MAX : (u32)val_len;
+	if (bpf_probe_read_user(p.buf, n, (void *)val_ptr) != 0)
+		return;
+	p.len = (u8)n;
+	bpf_map_update_elem(&h3_pending_tp, &goroutine, &p, BPF_ANY);
+}
+
+static __always_inline struct h3_field_offsets h3_field_offs(void)
+{
+	u32 tgid = bpf_get_current_pid_tgid() >> 32;
+	struct h3_field_offsets *o = bpf_map_lookup_elem(&h3_offsets, &tgid);
+	if (o)
+		return *o;
+	struct h3_field_offsets def = {
+		.method = GO_REQ_METHOD_OFF,
+		.url = GO_REQ_URL_OFF,
+		.path = GO_URL_PATH_OFF,
+		.status = GO_RESP_STATUSCODE_OFF,
+	};
+	return def;
+}
+
 static __always_inline void h3_stash_request(u64 goroutine, u64 req)
 {
 	if (!req)
 		return;
+	struct h3_field_offsets off = h3_field_offs();
 	struct h3_req_inflight in = {};
 	in.start_ts = bpf_ktime_get_ns();
-	in.method_len = (u8)read_go_str(req, GO_REQ_METHOD_OFF, in.method, H3_TXN_METHOD_MAX);
+	in.method_len = (u8)read_go_str(req, off.method, in.method, H3_TXN_METHOD_MAX);
 
 	u64 url = 0;
-	if (bpf_probe_read_user(&url, sizeof(url), (void *)(req + GO_REQ_URL_OFF)) == 0 && url)
-		in.path_len = (u16)read_go_str(url, GO_URL_PATH_OFF, in.path, H3_TXN_PATH_MAX);
+	if (bpf_probe_read_user(&url, sizeof(url), (void *)(req + off.url)) == 0 && url)
+		in.path_len = (u16)read_go_str(url, off.path, in.path, H3_TXN_PATH_MAX);
 
 	bpf_map_update_elem(&h3_req_stash, &goroutine, &in, BPF_ANY);
 }
@@ -90,6 +139,14 @@ static __always_inline void h3_emit_txn(u64 goroutine, u16 status, u8 is_client)
 	__builtin_memcpy(rec->method, in->method, H3_TXN_METHOD_MAX);
 	__builtin_memcpy(rec->path, in->path, H3_TXN_PATH_MAX);
 
+	rec->tp_len = 0;
+	struct h3_pending_tp *tp = bpf_map_lookup_elem(&h3_pending_tp, &goroutine);
+	if (tp) {
+		rec->tp_len = tp->len > H3_TXN_TP_MAX ? H3_TXN_TP_MAX : tp->len;
+		__builtin_memcpy(rec->traceparent, tp->buf, H3_TXN_TP_MAX);
+		bpf_map_delete_elem(&h3_pending_tp, &goroutine);
+	}
+
 	bpf_map_delete_elem(&h3_req_stash, &goroutine);
 	bpf_ringbuf_output(&h3_txn_events, rec, sizeof(*rec), 0);
 }
@@ -109,8 +166,9 @@ int uprobe_h3_roundtrip_ret(struct pt_regs *ctx)
 	u64 resp = GO_REG0(ctx);
 	u16 status = 0;
 	if (resp) {
+		struct h3_field_offsets off = h3_field_offs();
 		u64 sc = 0;
-		if (bpf_probe_read_user(&sc, sizeof(sc), (void *)(resp + GO_RESP_STATUSCODE_OFF)) == 0)
+		if (bpf_probe_read_user(&sc, sizeof(sc), (void *)(resp + off.status)) == 0)
 			status = (u16)sc;
 	}
 	h3_emit_txn(GO_GOROUTINE(ctx), status, 1);
@@ -133,6 +191,74 @@ int uprobe_h3_write_header(struct pt_regs *ctx)
 	return 0;
 }
 
+SEC("uprobe/h3_qpack_write_field")
+int uprobe_h3_qpack_write_field(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	h3_capture_tp(GO_GOROUTINE(ctx), GO_REG1(ctx), GO_REG2(ctx),
+		      GO_REG3(ctx), GO_REG4(ctx));
+	return 0;
+}
+
+SEC("uprobe/h3_parse_headers")
+int uprobe_h3_parse_headers(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	u64 g = GO_GOROUTINE(ctx);
+	struct h3_parse_state st = { .fields_ptr = GO_REG3(ctx) };
+	bpf_map_update_elem(&h3_parse_args, &g, &st, BPF_ANY);
+	return 0;
+}
+
+struct h3_tp_iter_ctx {
+	u64 data;
+	u32 count;
+	u64 goroutine;
+};
+
+static long h3_tp_field_cb(u32 idx, void *vctx)
+{
+	struct h3_tp_iter_ctx *c = vctx;
+	if (idx >= c->count)
+		return 1;
+	struct go_header_field f;
+	void *addr = (void *)(c->data + (u64)idx * sizeof(struct go_header_field));
+	if (bpf_probe_read_user(&f, sizeof(f), addr) != 0)
+		return 1;
+	h3_capture_tp(c->goroutine, f.name.ptr, f.name.len, f.value.ptr, f.value.len);
+	return 0;
+}
+
+SEC("uprobe/h3_parse_headers_ret")
+int uprobe_h3_parse_headers_ret(struct pt_regs *ctx)
+{
+	u64 g = GO_GOROUTINE(ctx);
+	struct h3_parse_state *st = bpf_map_lookup_elem(&h3_parse_args, &g);
+	if (!st)
+		return 0;
+	u64 fields_ptr = st->fields_ptr;
+	bpf_map_delete_elem(&h3_parse_args, &g);
+	if (!fields_ptr)
+		return 0;
+
+	struct go_string slice; // {data ptr, len}; cap ignored
+	if (bpf_probe_read_user(&slice, sizeof(slice), (void *)fields_ptr) != 0)
+		return 0;
+	if (!slice.ptr || slice.len == 0)
+		return 0;
+
+	u32 count = slice.len > H3_MAX_FIELDS ? H3_MAX_FIELDS : (u32)slice.len;
+	struct h3_tp_iter_ctx c = {
+		.data = slice.ptr,
+		.count = count,
+		.goroutine = g,
+	};
+	bpf_loop(count, h3_tp_field_cb, &c, 0);
+	return 0;
+}
+
 #else
 
 SEC("uprobe/h3_roundtrip")
@@ -146,5 +272,14 @@ int uprobe_h3_req_from_headers_ret(struct pt_regs *ctx) { return 0; }
 
 SEC("uprobe/h3_write_header")
 int uprobe_h3_write_header(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_qpack_write_field")
+int uprobe_h3_qpack_write_field(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_parse_headers")
+int uprobe_h3_parse_headers(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/h3_parse_headers_ret")
+int uprobe_h3_parse_headers_ret(struct pt_regs *ctx) { return 0; }
 
 #endif

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -549,6 +549,35 @@ struct {
 } h3_req_stash SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u32);
+	__type(value, struct h3_field_offsets);
+} h3_offsets SEC(".maps");
+
+struct h3_pending_tp {
+	u8   len;
+	u8   _pad[7];
+	char buf[H3_TXN_TP_MAX];
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, u64);
+	__type(value, struct h3_pending_tp);
+} h3_pending_tp SEC(".maps");
+
+struct h3_parse_state {
+	u64 fields_ptr;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u64);
+	__type(value, struct h3_parse_state);
+} h3_parse_args SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 8192);
 	__type(key, u64);

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -334,6 +334,10 @@ func GenerateHTTPSection(d Diagnostician, duration time.Duration) string {
 				report += formatter.TopItemsWithRate(statusMap, config.TopURLsLimit, "response status codes", "responses", duration)
 			}
 		}
+		if tp := traceContextCount(httpReqEvents); tp > 0 {
+			report += fmt.Sprintf("  Trace context: %d/%d requests carried a W3C traceparent\n",
+				tp, len(httpReqEvents))
+		}
 		peerEvents := make([]*events.Event, 0, len(httpReqEvents)+len(httpRespEvents))
 		peerEvents = append(peerEvents, httpReqEvents...)
 		peerEvents = append(peerEvents, httpRespEvents...)
@@ -344,6 +348,16 @@ func GenerateHTTPSection(d Diagnostician, duration time.Duration) string {
 	}
 	report += "\n"
 	return report
+}
+
+func traceContextCount(httpReqEvents []*events.Event) int {
+	n := 0
+	for _, e := range httpReqEvents {
+		if e.TraceID != "" || strings.HasPrefix(e.Details, "traceparent: ") {
+			n++
+		}
+	}
+	return n
 }
 
 // buildPeerMap counts L7 events by their fused L4 remote peer (ip:port).

--- a/internal/diagnose/report/report_test.go
+++ b/internal/diagnose/report/report_test.go
@@ -1127,3 +1127,19 @@ func TestGenerateIssuesSection_WarningKeyword(t *testing.T) {
 	result := GenerateIssuesSection(d)
 	_ = result
 }
+
+func TestGenerateHTTPSection_TraceContextCount(t *testing.T) {
+	d := &mockDiagnostician{
+		events: []*events.Event{
+			{Type: events.EventHTTPReq, Target: "GET /a", TCPState: events.HTTPTransportH3, Details: "traceparent: 00-abc-def-01"},
+			{Type: events.EventHTTPReq, Target: "GET /b", TCPState: events.HTTPTransportH3},
+			{Type: events.EventHTTPResp, Target: "GET /a", TCPState: events.HTTPTransportH3, Details: "200"},
+		},
+		startTime: time.Now(),
+		endTime:   time.Now().Add(1 * time.Second),
+	}
+	result := GenerateHTTPSection(d, d.endTime.Sub(d.startTime))
+	if !strings.Contains(result, "Trace context: 1/2 requests carried a W3C traceparent") {
+		t.Errorf("expected trace-context line, got:\n%s", result)
+	}
+}

--- a/internal/ebpf/h3decode/decode.go
+++ b/internal/ebpf/h3decode/decode.go
@@ -1,8 +1,6 @@
 // Package h3decode turns one HTTP/3 transaction record (emitted by
 // bpf/http3l7.c from the net/http boundary) into a paired EventHTTPReq +
-// EventHTTPResp. Because the record already carries method, path, status, and a
-// real latency — correlated on a single goroutine at the RoundTrip / handler
-// boundary — no header reassembly or cross-event stitching is needed.
+// EventHTTPResp.
 package h3decode
 
 import (
@@ -17,21 +15,24 @@ import (
 const (
 	methodMax    = 16  // H3_TXN_METHOD_MAX
 	pathMax      = 256 // H3_TXN_PATH_MAX
+	tpMax        = 64  // H3_TXN_TP_MAX
 	methodOffset = 40  // start of method[]
 	pathOffset   = methodOffset + methodMax
-	recordSize   = pathOffset + pathMax
+	tpOffset     = pathOffset + pathMax
+	recordSize   = tpOffset + tpMax
 )
 
 // Txn is one decoded HTTP/3 transaction.
 type Txn struct {
-	Timestamp uint64
-	LatencyNS uint64
-	CgroupID  uint64
-	PID       uint32
-	Status    uint16
-	IsClient  bool
-	Method    string
-	Path      string
+	Timestamp   uint64
+	LatencyNS   uint64
+	CgroupID    uint64
+	PID         uint32
+	Status      uint16
+	IsClient    bool
+	Method      string
+	Path        string
+	Traceparent string
 }
 
 // ParseRecord decodes one ringbuf sample into a Txn.
@@ -47,22 +48,25 @@ func ParseRecord(data []byte) (*Txn, bool) {
 	if pathLen > pathMax {
 		pathLen = pathMax
 	}
+	tpLen := int(data[34])
+	if tpLen > tpMax {
+		tpLen = tpMax
+	}
 	return &Txn{
-		Timestamp: binary.LittleEndian.Uint64(data[0:8]),
-		LatencyNS: binary.LittleEndian.Uint64(data[8:16]),
-		CgroupID:  binary.LittleEndian.Uint64(data[16:24]),
-		PID:       binary.LittleEndian.Uint32(data[24:28]),
-		Status:    binary.LittleEndian.Uint16(data[28:30]),
-		IsClient:  data[30] != 0,
-		Method:    string(data[methodOffset : methodOffset+methodLen]),
-		Path:      string(data[pathOffset : pathOffset+pathLen]),
+		Timestamp:   binary.LittleEndian.Uint64(data[0:8]),
+		LatencyNS:   binary.LittleEndian.Uint64(data[8:16]),
+		CgroupID:    binary.LittleEndian.Uint64(data[16:24]),
+		PID:         binary.LittleEndian.Uint32(data[24:28]),
+		Status:      binary.LittleEndian.Uint16(data[28:30]),
+		IsClient:    data[30] != 0,
+		Method:      string(data[methodOffset : methodOffset+methodLen]),
+		Path:        string(data[pathOffset : pathOffset+pathLen]),
+		Traceparent: string(data[tpOffset : tpOffset+tpLen]),
 	}, true
 }
 
 // Events turns a transaction into the request and response events that flow
-// through the same enrichment + reporting path as other L7 events. Both carry
-// "METHOD path" as their target so the response is reported against its
-// endpoint; the response carries the status and the measured latency.
+// through the same enrichment + reporting path as other L7 events.
 func (t *Txn) Events() []*events.Event {
 	method := t.Method
 	if method == "" {
@@ -78,6 +82,9 @@ func (t *Txn) Events() []*events.Event {
 		Type:      events.EventHTTPReq,
 		TCPState:  events.HTTPTransportH3,
 		Target:    target,
+	}
+	if t.Traceparent != "" {
+		req.Details = "traceparent: " + t.Traceparent
 	}
 	resp := &events.Event{
 		Timestamp: t.Timestamp + t.LatencyNS,

--- a/internal/ebpf/h3decode/decode_test.go
+++ b/internal/ebpf/h3decode/decode_test.go
@@ -10,8 +10,12 @@ import (
 // buildRecord assembles a wire-format struct h3_txn_record, mirroring
 // bpf/http3l7.c.
 func buildRecord(latencyNS uint64, status uint16, isClient bool, method, path string) []byte {
+	return buildRecordTP(latencyNS, status, isClient, method, path, "")
+}
+
+func buildRecordTP(latencyNS uint64, status uint16, isClient bool, method, path, tp string) []byte {
 	buf := make([]byte, recordSize)
-	binary.LittleEndian.PutUint64(buf[0:8], 1000)      // timestamp
+	binary.LittleEndian.PutUint64(buf[0:8], 1000)       // timestamp
 	binary.LittleEndian.PutUint64(buf[8:16], latencyNS) // latency
 	binary.LittleEndian.PutUint64(buf[16:24], 222)      // cgroup
 	binary.LittleEndian.PutUint32(buf[24:28], 4242)     // pid
@@ -27,10 +31,15 @@ func buildRecord(latencyNS uint64, status uint16, isClient bool, method, path st
 	if len(p) > pathMax {
 		p = p[:pathMax]
 	}
+	if len(tp) > tpMax {
+		tp = tp[:tpMax]
+	}
 	buf[31] = uint8(len(m))
 	binary.LittleEndian.PutUint16(buf[32:34], uint16(len(p)))
+	buf[34] = uint8(len(tp))
 	copy(buf[methodOffset:], m)
 	copy(buf[pathOffset:], p)
+	copy(buf[tpOffset:], tp)
 	return buf
 }
 
@@ -73,6 +82,31 @@ func TestEventsPairedWithLatency(t *testing.T) {
 	}
 	if resp.HTTPProtoLabel() != "HTTP/3" || resp.HTTPScheme() != "https" {
 		t.Fatalf("unexpected transport: label=%q scheme=%q", resp.HTTPProtoLabel(), resp.HTTPScheme())
+	}
+}
+
+func TestTraceparentSurfacedInDetails(t *testing.T) {
+	const tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	tx, ok := ParseRecord(buildRecordTP(1_000_000, 200, true, "GET", "/hello", tp))
+	if !ok {
+		t.Fatal("ParseRecord returned false")
+	}
+	if tx.Traceparent != tp {
+		t.Fatalf("traceparent = %q, want %q", tx.Traceparent, tp)
+	}
+	req := tx.Events()[0]
+	if req.Details != "traceparent: "+tp {
+		t.Fatalf("request Details = %q, want traceparent prefix", req.Details)
+	}
+}
+
+func TestNoTraceparentLeavesDetailsEmpty(t *testing.T) {
+	tx, _ := ParseRecord(buildRecord(1_000_000, 200, true, "GET", "/hello"))
+	if tx.Traceparent != "" {
+		t.Fatalf("expected empty traceparent, got %q", tx.Traceparent)
+	}
+	if got := tx.Events()[0].Details; got != "" {
+		t.Fatalf("expected empty request Details, got %q", got)
 	}
 }
 

--- a/internal/ebpf/probes/h3offsets.go
+++ b/internal/ebpf/probes/h3offsets.go
@@ -1,0 +1,153 @@
+package probes
+
+import (
+	"debug/buildinfo"
+	"debug/dwarf"
+	"debug/elf"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+// h3FieldOffsets mirrors struct h3_field_offsets in bpf/events.h: the offsets of
+// the net/http fields the HTTP/3 uprobes read.
+type h3FieldOffsets struct {
+	Method uint32 // net/http.Request.Method
+	URL    uint32 // net/http.Request.URL
+	Path   uint32 // net/url.URL.Path
+	Status uint32 // net/http.Response.StatusCode
+}
+
+// h3DefaultOffsets are the offsets for the supported Go range (1.17-1.26); they
+// double as the in-BPF compile-time default and the version-table fallback.
+var h3DefaultOffsets = h3FieldOffsets{Method: 0, URL: 16, Path: 56, Status: 16}
+
+// h3GoMinMinor / h3GoMaxMinor bound the Go versions whose offsets we've verified.
+const (
+	h3GoMinMinor = 17
+	h3GoMaxMinor = 26
+)
+
+const maxStructFieldOffset = 1 << 20
+
+// resolveH3FieldOffsets resolves the field offsets for a target binary,
+// preferring DWARF (exact for any Go version) and falling back to the
+// version-keyed defaults for stripped binaries.
+func resolveH3FieldOffsets(exePath string) (h3FieldOffsets, string) {
+	if off, ok := h3OffsetsFromDWARF(exePath); ok {
+		return off, "dwarf"
+	}
+	return h3OffsetsForGoVersion(exePath)
+}
+
+// h3OffsetsFromDWARF reads the four field offsets from the binary's DWARF (or a
+// build-id debug-info file).
+func h3OffsetsFromDWARF(exePath string) (h3FieldOffsets, bool) {
+	target, err := elf.Open(exePath)
+	if err != nil {
+		return h3FieldOffsets{}, false
+	}
+	defer func() { _ = target.Close() }()
+
+	d, err := target.DWARF()
+	if err != nil {
+		if dbg, _ := openDebugInfo(target, exePath, 0); dbg != nil && dbg != target {
+			defer func() { _ = dbg.Close() }()
+			d, err = dbg.DWARF()
+		}
+		if err != nil {
+			return h3FieldOffsets{}, false
+		}
+	}
+
+	type want struct {
+		dst   *uint32
+		found bool
+	}
+	fields := map[string]map[string]*want{
+		"net/http.Request":  {"Method": {dst: nil}, "URL": {dst: nil}},
+		"net/url.URL":       {"Path": {dst: nil}},
+		"net/http.Response": {"StatusCode": {dst: nil}},
+	}
+	var off h3FieldOffsets
+	fields["net/http.Request"]["Method"].dst = &off.Method
+	fields["net/http.Request"]["URL"].dst = &off.URL
+	fields["net/url.URL"]["Path"].dst = &off.Path
+	fields["net/http.Response"]["StatusCode"].dst = &off.Status
+
+	r := d.Reader()
+	for {
+		ent, err := r.Next()
+		if err != nil || ent == nil {
+			break
+		}
+		if ent.Tag != dwarf.TagStructType {
+			continue
+		}
+		name, _ := ent.Val(dwarf.AttrName).(string)
+		members, ok := fields[name]
+		if !ok {
+			continue
+		}
+		for {
+			c, err := r.Next()
+			if err != nil || c == nil || c.Tag == 0 {
+				break
+			}
+			if c.Tag != dwarf.TagMember {
+				continue
+			}
+			mn, _ := c.Val(dwarf.AttrName).(string)
+			w, ok := members[mn]
+			if !ok {
+				continue
+			}
+			loc, _ := c.Val(dwarf.AttrDataMemberLoc).(int64)
+			if loc < 0 || loc > maxStructFieldOffset {
+				continue
+			}
+			*w.dst = uint32(loc)
+			w.found = true
+		}
+	}
+	for _, members := range fields {
+		for _, w := range members {
+			if !w.found {
+				return h3FieldOffsets{}, false
+			}
+		}
+	}
+	return off, true
+}
+
+// h3OffsetsForGoVersion returns the version-keyed offsets (currently constant
+// across the supported range) and logs when the binary's Go version is outside
+// the verified window.
+func h3OffsetsForGoVersion(exePath string) (h3FieldOffsets, string) {
+	bi, err := buildinfo.ReadFile(exePath)
+	if err != nil {
+		return h3DefaultOffsets, "default"
+	}
+	if minor, ok := goMinorVersion(bi.GoVersion); ok && (minor < h3GoMinMinor || minor > h3GoMaxMinor) {
+		logger.Debug("HTTP/3 offsets: Go version outside verified range, using best-known offsets",
+			zap.String("go_version", bi.GoVersion))
+	}
+	return h3DefaultOffsets, "version:" + bi.GoVersion
+}
+
+// goMinorVersion parses the minor version from a "go1.23.4" string.
+func goMinorVersion(v string) (int, bool) {
+	v = strings.TrimPrefix(v, "go")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, false
+	}
+	return minor, true
+}

--- a/internal/ebpf/probes/h3offsets_test.go
+++ b/internal/ebpf/probes/h3offsets_test.go
@@ -1,0 +1,82 @@
+package probes
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveH3FieldOffsets_DWARF builds a tiny net/http binary so its DWARF
+// carries net/http.Request/Response and net/url.URL, then checks the resolver
+// reads the field offsets from DWARF.
+func TestResolveH3FieldOffsets_DWARF(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a helper binary; skipped in -short")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available")
+	}
+	dir := t.TempDir()
+	src := `package main
+import ("net/http";"net/url";"fmt")
+func main(){ r,_:=http.NewRequest("GET","http://x/y",nil); u,_:=url.Parse("http://x/y"); var resp http.Response; fmt.Println(r.Method,u.Path,resp.StatusCode) }
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module h3probe\ngo 1.23\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "h3probe")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not build helper binary: %v\n%s", err, out)
+	}
+
+	off, source := resolveH3FieldOffsets(bin)
+	if source != "dwarf" {
+		t.Fatalf("expected dwarf source, got %q", source)
+	}
+	want := h3FieldOffsets{Method: 0, URL: 16, Path: 56, Status: 16}
+	if off != want {
+		t.Fatalf("DWARF offsets = %+v, want %+v", off, want)
+	}
+}
+
+func TestH3OffsetsFromDWARF_MissingFileFallsBack(t *testing.T) {
+	if _, ok := h3OffsetsFromDWARF("/no/such/binary"); ok {
+		t.Fatal("expected ok=false for a missing binary")
+	}
+}
+
+func TestGoMinorVersion(t *testing.T) {
+	cases := []struct {
+		in    string
+		minor int
+		ok    bool
+	}{
+		{"go1.23.4", 23, true},
+		{"go1.21", 21, true},
+		{"go1.26.0", 26, true},
+		{"devel go1.27-abcdef", 0, false},
+		{"1.22.1", 22, true},
+		{"garbage", 0, false},
+		{"go1", 0, false},
+	}
+	for _, c := range cases {
+		minor, ok := goMinorVersion(c.in)
+		if ok != c.ok || (ok && minor != c.minor) {
+			t.Errorf("goMinorVersion(%q) = (%d,%v), want (%d,%v)", c.in, minor, ok, c.minor, c.ok)
+		}
+	}
+}
+
+func TestH3DefaultOffsetsStable(t *testing.T) {
+	want := h3FieldOffsets{Method: 0, URL: 16, Path: 56, Status: 16}
+	if h3DefaultOffsets != want {
+		t.Fatalf("h3DefaultOffsets = %+v, want %+v", h3DefaultOffsets, want)
+	}
+}

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -2034,6 +2034,19 @@ func AttachGoHTTP3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
 		return links
 	}
 
+	if m := coll.Maps["h3_offsets"]; m != nil {
+		off, src := resolveH3FieldOffsets(exePath)
+		tgid := pid
+		if err := m.Update(&tgid, &off, ebpf.UpdateAny); err != nil {
+			logger.Debug("HTTP/3 offsets: map update failed", zap.Uint32("pid", pid), zap.Error(err))
+		} else {
+			logger.Debug("HTTP/3 field offsets resolved",
+				zap.Uint32("pid", pid), zap.String("source", src),
+				zap.Uint32("method", off.Method), zap.Uint32("url", off.URL),
+				zap.Uint32("path", off.Path), zap.Uint32("status", off.Status))
+		}
+	}
+
 	links = append(links, attachGoEntryReturnProbes(coll, exe, exePath, pid,
 		"github.com/quic-go/quic-go/http3.(*Transport).RoundTrip",
 		"uprobe_h3_roundtrip", "uprobe_h3_roundtrip_ret")...)
@@ -2048,6 +2061,18 @@ func AttachGoHTTP3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
 			logger.Debug("Go HTTP/3 WriteHeader uprobe attached", zap.Uint32("pid", pid))
 		}
 	}
+
+	if prog := coll.Programs["uprobe_h3_qpack_write_field"]; prog != nil {
+		const sym = "github.com/quic-go/qpack.(*Encoder).WriteField"
+		if l, ok := attachGoUprobeBySymbol(exe, exePath, sym, prog); ok {
+			links = append(links, l)
+			logger.Debug("Go HTTP/3 WriteField (traceparent) uprobe attached", zap.Uint32("pid", pid))
+		}
+	}
+	links = append(links, attachGoEntryReturnProbes(coll, exe, exePath, pid,
+		"github.com/quic-go/quic-go/http3.parseHeaders",
+		"uprobe_h3_parse_headers", "uprobe_h3_parse_headers_ret")...)
+
 	return links
 }
 


### PR DESCRIPTION
## Summary

Hardens HTTP/3 L7: struct field offsets are now resolved per target binary instead of hardcoded, and request traceparent headers are captured so HTTP/3 gets the same W3C trace-context propagation as HTTP/1.x and HTTP/2.

The net/http field offsets used to read `*http.Request` / `*http.Response` are resolved at attach time, from the target binary's DWARF when present, falling back to a Go-version table for stripped binaries, and pushed into the new `h3_offsets` map keyed by tgid. The BPF side falls back to the compile-time defaults when no entry exists, so it keeps working unchanged on current Go while adapting if a future release reorders these fields.

Request trace context is captured on the request goroutine, where it correlates reliably: the client encodes it via `qpack.(*Encoder).WriteField`, and the server decodes it via `http3.parseHeaders`. The value is stashed by goroutine, merged into the transaction record, and surfaced as `traceparent: ...` in the event Details so the tracing manager extracts `TraceID`/`SpanID`, identical to the h1/h2 path. The HTTP report gains a `Trace context: N/M requests carried a W3C traceparent` line (covers h1/h2/h3).