### PR TITLE
feat: capture grpc-go and netty-tcnative HTTP/2 L7 over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ to CRs, see [docs/migration.md](docs/migration.md).
 
 ### Application Layer
 - **HTTP Tracing**: Captures request method and path with response status and latency across HTTP/1.x, HTTP/2, and HTTP/3 over QUIC, for both clients and servers
-- **HTTP-over-TLS L7**: Reads plaintext HTTP before encryption / after decryption via uprobes on OpenSSL, BoringSSL and GnuTLS, Go, and Node.js
+- **HTTP-over-TLS L7**: Reads plaintext HTTP before encryption / after decryption via uprobes on OpenSSL, BoringSSL and GnuTLS, Go, Node.js, and Java over a native TLS provider.
 - **L7 ↔ L4 Peer Fusion**: Annotates HTTP/1.x and HTTP/2 request/response events with the underlying TCP 4-tuple
 - **DNS Tracking**: Monitors DNS lookups with latency and error tracking
 - **Database Query Tracing**: Tracks PostgreSQL and MySQL query execution with pattern extraction and latency analysis

--- a/bpf/grpcgo.c
+++ b/bpf/grpcgo.c
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "common.h"
+#include "maps.h"
+#include "events.h"
+#include "helpers.h"
+#include "protocols.h"
+
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+
+#if defined(__TARGET_ARCH_x86) || defined(__x86_64__)
+#define GRPC_GO_HF_PTR(ctx)       ((u64)(ctx)->di)
+#define GRPC_GO_HF_LEN(ctx)       ((u64)(ctx)->si)
+#define GRPC_GO_WH_STREAM(ctx)    ((u32)(ctx)->bx)
+#define GRPC_GO_SRV_FRAME(ctx)    ((u64)(ctx)->di)
+#define GRPC_GO_CLI_FRAME(ctx)    ((u64)(ctx)->bx)
+#define GRPC_GO_SUPPORTED 1
+#elif defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
+#define GRPC_GO_HF_PTR(ctx)       ((u64)(ctx)->regs[3])
+#define GRPC_GO_HF_LEN(ctx)       ((u64)(ctx)->regs[4])
+#define GRPC_GO_WH_STREAM(ctx)    ((u32)(ctx)->regs[1])
+#define GRPC_GO_SRV_FRAME(ctx)    ((u64)(ctx)->regs[3])
+#define GRPC_GO_CLI_FRAME(ctx)    ((u64)(ctx)->regs[1])
+#define GRPC_GO_SUPPORTED 1
+#endif
+
+#endif
+
+#ifdef GRPC_GO_SUPPORTED
+
+#define GRPC_HF_STRIDE 40
+#define GRPC_HF_MAX    32
+#define GRPC_NAME_PEEK 12
+
+#define GRPC_METAFRAME_HEADERS_PTR 0
+#define GRPC_METAFRAME_FIELDS_PTR 8
+#define GRPC_METAFRAME_FIELDS_LEN 16
+#define GRPC_FRAMEHEADER_STREAMID 8
+
+struct grpc_hf_ctx {
+	u64 fields;
+	u32 n;
+};
+
+static long grpc_hf_cb(u32 i, void *vctx)
+{
+	struct grpc_hf_ctx *c = (struct grpc_hf_ctx *)vctx;
+	if (i >= c->n)
+		return 1;
+	u32 zero = 0;
+	struct grpc_go_scratch *s = bpf_map_lookup_elem(&grpc_go_scratch_map, &zero);
+	if (!s)
+		return 1;
+
+	u64 fptr = c->fields + (u64)i * GRPC_HF_STRIDE;
+	u64 nptr = 0, nlen = 0;
+	if (bpf_probe_read_user(&nptr, sizeof(nptr), (void *)fptr) != 0)
+		return 0;
+	if (bpf_probe_read_user(&nlen, sizeof(nlen), (void *)(fptr + 8)) != 0)
+		return 0;
+	if (nlen == 0 || nptr == 0)
+		return 0;
+
+	char name[GRPC_NAME_PEEK] = {};
+	u32 rn = nlen < GRPC_NAME_PEEK ? (u32)nlen : GRPC_NAME_PEEK;
+	if (bpf_probe_read_user(name, rn, (void *)nptr) != 0)
+		return 0;
+
+	if (name[0] != ':')
+		return 0;
+
+	u64 vptr = 0, vlen = 0;
+	if (bpf_probe_read_user(&vptr, sizeof(vptr), (void *)(fptr + 16)) != 0)
+		return 0;
+	if (bpf_probe_read_user(&vlen, sizeof(vlen), (void *)(fptr + 24)) != 0)
+		return 0;
+	if (vptr == 0)
+		return 0;
+
+	if (name[1] == 'p' && name[2] == 'a' && name[3] == 't' && name[4] == 'h') {
+		u32 vl = vlen < (MAX_STRING_LEN - 1) ? (u32)vlen : (MAX_STRING_LEN - 1);
+		if (vl > 0 && bpf_probe_read_user(s->path, vl, (void *)vptr) == 0)
+			s->have_path = 1;
+	} else if (name[1] == 'm' && name[2] == 'e' && name[3] == 't') {
+		u32 vl = vlen < (sizeof(s->method) - 1) ? (u32)vlen : (sizeof(s->method) - 1);
+		if (vl > 0)
+			bpf_probe_read_user(s->method, vl, (void *)vptr);
+	} else if (name[1] == 's' && name[2] == 't' && name[3] == 'a') {
+		u32 vl = vlen < (sizeof(s->status) - 1) ? (u32)vlen : (sizeof(s->status) - 1);
+		if (vl > 0 && bpf_probe_read_user(s->status, vl, (void *)vptr) == 0)
+			s->have_status = 1;
+	}
+	return 0;
+}
+
+static __always_inline int grpc_pair_key_build(struct grpc_pair_key *k, u32 stream)
+{
+	struct tcp_peer *p = lookup_tcp_peer(PAIR_TCP_SENDMSG);
+	if (!p)
+		return 0;
+	__builtin_memset(k, 0, sizeof(*k));
+	k->saddr = p->saddr;
+	k->daddr = p->daddr;
+	k->sport = p->sport;
+	k->dport = p->dport;
+	k->stream = stream;
+	return 1;
+}
+
+static __always_inline void grpc_go_process(void *ctx, u64 fields, u64 n, u32 stream)
+{
+	if (!fields || n == 0)
+		return;
+
+	u32 zero = 0;
+	struct grpc_go_scratch *s = bpf_map_lookup_elem(&grpc_go_scratch_map, &zero);
+	if (!s)
+		return;
+	__builtin_memset(s, 0, sizeof(*s));
+
+	struct grpc_hf_ctx c = {
+		.fields = fields,
+		.n = n < GRPC_HF_MAX ? (u32)n : GRPC_HF_MAX,
+	};
+	bpf_loop(GRPC_HF_MAX, grpc_hf_cb, &c, 0);
+
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	struct grpc_pair_key pk;
+	int have_key = grpc_pair_key_build(&pk, stream);
+
+	if (s->have_path) {
+		if (have_key) {
+			u32 pz = 0;
+			struct grpc_pair_val *pv = bpf_map_lookup_elem(&grpc_go_pairval_map, &pz);
+			if (pv) {
+				pv->start_ns = bpf_ktime_get_ns();
+				__builtin_memcpy(pv->path, s->path, sizeof(pv->path));
+				bpf_map_update_elem(&grpc_go_pairs, &pk, pv, BPF_ANY);
+			}
+		}
+		struct event *e = get_event_buf();
+		if (e) {
+			e->timestamp = bpf_ktime_get_ns();
+			e->pid = pid;
+			e->type = EVENT_HTTP_REQ;
+			e->latency_ns = 0;
+			e->error = 0;
+			e->bytes = 0;
+			e->tcp_state = HTTP_TRANSPORT_H2_TLS;
+			bpf_probe_read_kernel_str(e->target, sizeof(e->target), s->path);
+			fill_event_peer(e);
+			capture_user_stack(ctx, pid, tid, e);
+			bpf_ringbuf_output(&events, e, sizeof(*e), 0);
+		}
+	} else if (s->have_status) {
+		struct event *e = get_event_buf();
+		if (e) {
+			e->timestamp = bpf_ktime_get_ns();
+			e->pid = pid;
+			e->type = EVENT_HTTP_RESP;
+			e->latency_ns = 0;
+			s32 code = (s->status[0] - '0') * 100 + (s->status[1] - '0') * 10 +
+				   (s->status[2] - '0');
+			e->error = code >= 500 ? code : 0;
+			e->bytes = 0;
+			e->tcp_state = HTTP_TRANSPORT_H2_TLS;
+			bpf_probe_read_kernel_str(e->details, sizeof(e->details), s->status);
+			if (have_key) {
+				struct grpc_pair_val *v = bpf_map_lookup_elem(&grpc_go_pairs, &pk);
+				if (v) {
+					bpf_probe_read_kernel_str(e->target, sizeof(e->target), v->path);
+					e->latency_ns = calc_latency(v->start_ns);
+					bpf_map_delete_elem(&grpc_go_pairs, &pk);
+				}
+			}
+			fill_event_peer(e);
+			capture_user_stack(ctx, pid, tid, e);
+			bpf_ringbuf_output(&events, e, sizeof(*e), 0);
+		}
+	}
+}
+
+static __always_inline u32 grpc_go_stream_from_frame(u64 frame)
+{
+	u64 hf = 0;
+	if (bpf_probe_read_user(&hf, sizeof(hf), (void *)(frame + GRPC_METAFRAME_HEADERS_PTR)) != 0 || !hf)
+		return 0;
+	u32 sid = 0;
+	if (bpf_probe_read_user(&sid, sizeof(sid), (void *)(hf + GRPC_FRAMEHEADER_STREAMID)) != 0)
+		return 0;
+	return sid;
+}
+
+static __always_inline void grpc_go_process_frame(void *ctx, u64 frame)
+{
+	if (!frame)
+		return;
+	u64 fptr = 0, flen = 0;
+	if (bpf_probe_read_user(&fptr, sizeof(fptr), (void *)(frame + GRPC_METAFRAME_FIELDS_PTR)) != 0)
+		return;
+	if (bpf_probe_read_user(&flen, sizeof(flen), (void *)(frame + GRPC_METAFRAME_FIELDS_LEN)) != 0)
+		return;
+	grpc_go_process(ctx, fptr, flen, grpc_go_stream_from_frame(frame));
+}
+
+SEC("uprobe/grpc_go_write_header")
+int uprobe_grpc_go_write_header(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	grpc_go_process(ctx, GRPC_GO_HF_PTR(ctx), GRPC_GO_HF_LEN(ctx), GRPC_GO_WH_STREAM(ctx));
+	return 0;
+}
+
+SEC("uprobe/grpc_go_server_headers")
+int uprobe_grpc_go_server_headers(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	grpc_go_process_frame(ctx, GRPC_GO_SRV_FRAME(ctx));
+	return 0;
+}
+
+SEC("uprobe/grpc_go_client_headers")
+int uprobe_grpc_go_client_headers(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	grpc_go_process_frame(ctx, GRPC_GO_CLI_FRAME(ctx));
+	return 0;
+}
+
+#else
+
+SEC("uprobe/grpc_go_write_header")
+int uprobe_grpc_go_write_header(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/grpc_go_server_headers")
+int uprobe_grpc_go_server_headers(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/grpc_go_client_headers")
+int uprobe_grpc_go_client_headers(struct pt_regs *ctx) { return 0; }
+
+#endif

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -492,6 +492,46 @@ struct {
 	__type(value, struct h2_hdr_scratch);
 } h2_hdr_scratch_map SEC(".maps");
 
+struct grpc_go_scratch {
+	char method[16];
+	char path[MAX_STRING_LEN];
+	char status[8];
+	u8 have_path;
+	u8 have_status;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct grpc_go_scratch);
+} grpc_go_scratch_map SEC(".maps");
+
+struct grpc_pair_key {
+	u32 saddr;
+	u32 daddr;
+	u16 sport;
+	u16 dport;
+	u32 stream;
+	u32 _pad;
+};
+struct grpc_pair_val {
+	u64 start_ns;
+	char path[MAX_STRING_LEN];
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct grpc_pair_key);
+	__type(value, struct grpc_pair_val);
+} grpc_go_pairs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct grpc_pair_val);
+} grpc_go_pairval_map SEC(".maps");
+
 struct h2_seq_key {
 	u64 conn_id;
 	u32 dir;
@@ -530,9 +570,6 @@ struct {
 	__type(value, struct h3_txn_scratch);
 } h3_txn_scratch_map SEC(".maps");
 
-/* h3_req_stash holds the in-flight request (method/path/start) between the
- * request hook and the response hook on the same goroutine: client RoundTrip
- * entry -> RoundTrip return; server requestFromHeaders return -> WriteHeader. */
 struct h3_req_inflight {
 	u64 start_ts;
 	u8  method_len;

--- a/bpf/podtrace.bpf.c
+++ b/bpf/podtrace.bpf.c
@@ -22,6 +22,7 @@
 #include "http.c"
 #include "h2.c"
 #include "gotls.c"
+#include "grpcgo.c"
 #include "http3l7.c"
 #include "crypto.c"
 

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -839,6 +839,20 @@ func fileInProcRoot(pid uint32, containerPath string) string {
 	return ""
 }
 
+// fileInProcMapFiles resolves a memory-mapped file through
+// /proc/<pid>/map_files/<start>-<end> using the address range from a
+// /proc/<pid>/maps line.
+func fileInProcMapFiles(pid uint32, addrRange string) string {
+	if addrRange == "" || !strings.Contains(addrRange, "-") {
+		return ""
+	}
+	p := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "map_files", addrRange)
+	if info, err := os.Stat(p); err == nil && info.Mode().IsRegular() {
+		return p
+	}
+	return ""
+}
+
 func findContainerProcess(containerID string) uint32 {
 	entries, err := os.ReadDir(config.ProcBasePath)
 	if err != nil {
@@ -1241,9 +1255,16 @@ func findDBLibsViaProcessMapsProcRoot(pid uint32, libNames []string) []string {
 				parts := strings.Fields(line)
 				if len(parts) >= 6 {
 					containerPath := parts[5]
-					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" && !seen[hostPath] {
-						paths = append(paths, hostPath)
-						seen[hostPath] = true
+					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" {
+						if !seen[hostPath] {
+							paths = append(paths, hostPath)
+							seen[hostPath] = true
+						}
+					} else if strings.Contains(parts[1], "x") && !seen[containerPath] {
+						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
+							paths = append(paths, mf)
+							seen[containerPath] = true
+						}
 					}
 				}
 			}
@@ -1412,6 +1433,7 @@ func findTLSLibsViaProcessMaps(pid uint32, libPatterns []string) []string {
 		return paths
 	}
 
+	seen := make(map[string]bool)
 	for _, line := range strings.Split(string(data), "\n") {
 		for _, pattern := range libPatterns {
 			if strings.Contains(line, pattern) {
@@ -1420,6 +1442,11 @@ func findTLSLibsViaProcessMaps(pid uint32, libPatterns []string) []string {
 					path := parts[5]
 					if hostfs.IsRegularFile(path) {
 						paths = append(paths, path)
+					} else if strings.Contains(parts[1], "x") && !seen[path] {
+						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
+							paths = append(paths, mf)
+							seen[path] = true
+						}
 					}
 				}
 			}
@@ -1442,9 +1469,21 @@ func findTLSLibsViaProcessMapsProcRoot(pid uint32, libPatterns []string) []strin
 				parts := strings.Fields(line)
 				if len(parts) >= 6 {
 					containerPath := parts[5]
-					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" && !seen[hostPath] {
-						paths = append(paths, hostPath)
-						seen[hostPath] = true
+					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" {
+						if !seen[hostPath] {
+							paths = append(paths, hostPath)
+							seen[hostPath] = true
+						}
+					} else if strings.Contains(parts[1], "x") && !seen[containerPath] {
+						// Backing file may be unlinked (e.g. netty-tcnative
+						// extracted to /tmp then deleted after dlopen); reach the
+						// live inode via map_files. All VMAs of the library share
+						// one inode, so restrict to the executable segment and
+						// dedup by path to attach the code mapping exactly once.
+						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
+							paths = append(paths, mf)
+							seen[containerPath] = true
+						}
 					}
 				}
 			}
@@ -1532,9 +1571,7 @@ func findTLSLibsInContainerWithPID(containerID string, pid uint32, libPatterns [
 
 // findTLSLibsViaProcRootScan walks the container rootfs (via /proc/<pid>/root)
 // looking for shared-library files whose name matches one of libPatterns,
-// independent of whether the resolved process has them mapped. Symlinks are
-// resolved and de-duplicated so a uprobe is not attached twice to the same
-// underlying file.
+// independent of whether the resolved process has them mapped.
 func findTLSLibsViaProcRootScan(pid uint32, libPatterns []string) []string {
 	root := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "root")
 	dirs := append(config.GetDefaultLibSearchPaths(),
@@ -1643,11 +1680,15 @@ func findTLSLibsViaLdSoConf(libPatterns []string) []string {
 	return paths
 }
 
+// tlsLibPatterns are the shared library basename substrings we scan for when
+// attaching TLS uprobes.
+var tlsLibPatterns = []string{"libssl", "libgnutls", "libnss", "libmbedtls", "libmbedx509", "ssl", "tcnative"}
+
 func findTLSLibs(containerID string) []string {
 	var paths []string
 	seen := make(map[string]bool)
 
-	libPatterns := []string{"libssl", "libgnutls", "libnss", "libmbedtls", "libmbedx509", "ssl"}
+	libPatterns := tlsLibPatterns
 
 	if containerID != "" {
 		containerPaths := findTLSLibsInContainer(containerID, libPatterns)
@@ -1722,8 +1763,7 @@ func findTLSLibs(containerID string) []string {
 }
 
 // tlsExecutableForPID returns the target process's executable path
-// (/proc/<pid>/exe) when it statically bundles an attachable OpenSSL (i.e. it
-// exports SSL_write), else "".
+// (/proc/<pid>/exe) when it statically bundles an attachable OpenSSL.
 func tlsExecutableForPID(pid uint32) string {
 	if pid == 0 {
 		return ""
@@ -1739,7 +1779,7 @@ func findTLSLibsWithPID(containerID string, pid uint32) []string {
 	var paths []string
 	seen := make(map[string]bool)
 
-	libPatterns := []string{"libssl", "libgnutls", "libnss", "libmbedtls", "libmbedx509", "ssl"}
+	libPatterns := tlsLibPatterns
 
 	if containerID != "" || pid > 0 {
 		containerPaths := findTLSLibsInContainerWithPID(containerID, pid, libPatterns)
@@ -1978,6 +2018,46 @@ func AttachGoTLSProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 	logger.Debug("Go TLS uprobe attached", zap.Uint32("pid", pid))
 
 	links = append(links, attachGoTLSReadProbes(coll, exe, exePath, pid)...)
+	return links
+}
+
+// AttachGoGRPCProbes attaches entry uprobes on grpc-go's internal/transport
+// header functions in a statically-linked Go binary, capturing gRPC
+// :method/:path/:status from the plaintext []hpack.HeaderField slice.
+func AttachGoGRPCProbes(coll *ebpf.Collection, pid uint32) []link.Link {
+	var links []link.Link
+	if pid == 0 {
+		return links
+	}
+	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
+	exe, err := link.OpenExecutable(exePath)
+	if err != nil {
+		return links
+	}
+	targets := []struct{ prog, sym string }{
+		{"uprobe_grpc_go_write_header", "google.golang.org/grpc/internal/transport.(*loopyWriter).writeHeader"},
+		{"uprobe_grpc_go_server_headers", "google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders"},
+		{"uprobe_grpc_go_client_headers", "google.golang.org/grpc/internal/transport.(*http2Client).operateHeaders"},
+	}
+	for _, t := range targets {
+		prog := coll.Programs[t.prog]
+		if prog == nil {
+			continue
+		}
+		l, err := exe.Uprobe(t.sym, prog, nil)
+		if err != nil {
+			if off, ok := goSymbolFileOffset(exePath, t.sym); ok {
+				l, err = exe.Uprobe("", prog, &link.UprobeOptions{Address: off})
+			}
+		}
+		if err != nil {
+			logger.Debug("Go gRPC uprobe not attached",
+				zap.String("symbol", t.sym), zap.Uint32("pid", pid), zap.Error(err))
+			continue
+		}
+		links = append(links, l)
+		logger.Debug("Go gRPC uprobe attached", zap.String("symbol", t.sym), zap.Uint32("pid", pid))
+	}
 	return links
 }
 

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -2429,3 +2429,47 @@ func TestTLSExecutableForPID(t *testing.T) {
 		t.Errorf("tlsExecutableForPID(self) = %q, want empty for a non-SSL binary", got)
 	}
 }
+
+// TestTLSLibPatternsMatchNativeProviders guards the TLS library discovery
+// pattern list. The matching semantics mirror the production walk callbacks:
+// a case-insensitive substring match of the pattern against the .so basename.
+// In particular "tcnative" must match netty-tcnative-boringssl-static (used by
+// gRPC-Java, Reactor Netty / Spring WebFlux, Kafka) including the random suffix
+// the JVM appends when it extracts the library, while unrelated libraries and
+// the non-attachable Conscrypt provider must not be matched by accident.
+func TestTLSLibPatternsMatchNativeProviders(t *testing.T) {
+	matches := func(baseName string) bool {
+		b := strings.ToLower(baseName)
+		for _, p := range tlsLibPatterns {
+			if strings.Contains(b, strings.ToLower(p)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	shouldMatch := []string{
+		"libssl.so.3",
+		"libgnutls.so.30",
+		"libnetty_tcnative_linux_x86_64.so",
+		"libnetty_tcnative_linux_x86_646080899174755123456.so", // JVM temp-extraction suffix
+		"libnetty_tcnative_linux_aarch_64.so",
+	}
+	for _, name := range shouldMatch {
+		if !matches(name) {
+			t.Errorf("expected %q to match a TLS library pattern, but it did not", name)
+		}
+	}
+
+	shouldNotMatch := []string{
+		"libc.so.6",
+		"libpthread.so.0",
+		"libjvm.so",
+		"libconscrypt_openjdk_jni-linux-x86_64.so", // stripped, dynamic JNI registration: not uprobe-able
+	}
+	for _, name := range shouldNotMatch {
+		if matches(name) {
+			t.Errorf("expected %q not to match any TLS library pattern, but it did", name)
+		}
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -174,6 +174,7 @@ func (t *Tracer) attachContainerUprobes(id string, pid uint32) []link.Link {
 	ls = append(ls, probes.AttachPoolProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
+	ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
 	ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 	ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
@@ -244,6 +245,7 @@ func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
 		ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid)...)
 		ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 		ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
+		ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
 		ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 		return ls
 	case probes.GroupDatabase:
@@ -868,6 +870,7 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 	t.registerGroupLinks(probes.GroupPool, probes.AttachPoolProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachTLSProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoTLSProbes(t.collection, t.containerPID))
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoGRPCProbes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoHTTP3Probes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachRedisProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachMemcachedProbesWithPID(t.collection, primary, t.containerPID))


### PR DESCRIPTION
## Summary

Adds HTTP/2 L7 visibility over TLS for two ecosystems that the existing wire-level h2 decoder cannot handle on long-lived connections, because HPACK's dynamic table is unrecoverable once tracing starts mid-stream.

### grpc-go

Uprobes the grpc-go transport at its clear-text header boundary:

- `(*loopyWriter).writeHeader`: outbound headers before HPACK encoding
- `(*http2Server).operateHeaders`: inbound request headers (server)
- `(*http2Client).operateHeaders`: inbound response headers (client)

Reading the plaintext `[]hpack.HeaderField` sidesteps HPACK entirely and works on persistent connections. Symbols resolve via `.gopclntab`, so stripped Go binaries are supported. Requests and responses are paired by the L4 4-tuple plus
the HTTP/2 stream id, yielding the request `:path` (gRPC method), the response `:status`, per-endpoint breakdowns, and end-to-end latency. Hooking both the outbound and inbound boundaries means tracing either the client or the server
surfaces both directions.

### Java over a native TLS provider

Extends TLS library discovery to netty-tcnative (the BoringSSL-backed provider used by gRPC-Java, Reactor Netty, Spring WebFlux and Kafka clients). The JVM extracts this `.so` to a temp path and unlinks it after `dlopen`, so it is
reached through the still-mapped inode via `/proc/<pid>/map_files`. Because it is standard BoringSSL, the existing `SSL_write`/`SSL_read` handlers capture the HTTP/2 traffic; response status codes and transport are surfaced.