### PR TITLE
feat: capture rustls (Rust) TLS L7 via plaintext uprobes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ to CRs, see [docs/migration.md](docs/migration.md).
 
 ### Application Layer
 - **HTTP Tracing**: Captures request method and path with response status and latency across HTTP/1.x, HTTP/2, and HTTP/3 over QUIC, for both clients and servers
-- **HTTP-over-TLS L7**: Reads plaintext HTTP before encryption / after decryption via uprobes on OpenSSL, BoringSSL and GnuTLS, Go, Node.js, and Java over a native TLS provider.
+- **HTTP-over-TLS L7**: Reads plaintext HTTP before encryption / after decryption via uprobes on OpenSSL, BoringSSL and GnuTLS, Go, Node.js, Java over a native TLS provider, and Rust.
 - **L7 ↔ L4 Peer Fusion**: Annotates HTTP/1.x and HTTP/2 request/response events with the underlying TCP 4-tuple
 - **DNS Tracking**: Monitors DNS lookups with latency and error tracking
 - **Database Query Tracing**: Tracks PostgreSQL and MySQL query execution with pattern extraction and latency analysis

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -464,6 +464,13 @@ struct {
 	__type(value, struct ssl_read_state);
 } ssl_read_args SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u64);
+	__type(value, struct ssl_read_state);
+} rustls_read_args SEC(".maps");
+
 struct h2_recv_info {
 	u64 base;
 	u64 conn_id;

--- a/bpf/podtrace.bpf.c
+++ b/bpf/podtrace.bpf.c
@@ -23,6 +23,7 @@
 #include "h2.c"
 #include "gotls.c"
 #include "grpcgo.c"
+#include "rustls.c"
 #include "http3l7.c"
 #include "crypto.c"
 

--- a/bpf/rustls.c
+++ b/bpf/rustls.c
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "common.h"
+#include "maps.h"
+#include "events.h"
+#include "helpers.h"
+#include "protocols.h"
+
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+
+#if defined(__TARGET_ARCH_x86) || defined(__x86_64__)
+#define RUSTLS_BUF(ctx)       ((void *)(ctx)->si)
+#define RUSTLS_LEN(ctx)       ((u64)(ctx)->dx)
+#define RUSTLS_RET_OK(ctx)    ((ctx)->ax == 0)
+#define RUSTLS_RET_COUNT(ctx) ((u64)(ctx)->dx)
+#define RUSTLS_SUPPORTED 1
+#elif defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
+#define RUSTLS_BUF(ctx)       ((void *)(ctx)->regs[1])
+#define RUSTLS_LEN(ctx)       ((u64)(ctx)->regs[2])
+#define RUSTLS_RET_OK(ctx)    ((ctx)->regs[0] == 0)
+#define RUSTLS_RET_COUNT(ctx) ((u64)(ctx)->regs[1])
+#define RUSTLS_SUPPORTED 1
+#endif
+
+#endif
+
+#ifdef RUSTLS_SUPPORTED
+
+#define RUSTLS_PEEK 16
+
+static __always_inline u64 rustls_conn_key(void)
+{
+	struct tcp_peer *p = lookup_tcp_peer(PAIR_TCP_SENDMSG);
+	if (!p)
+		return 0;
+	return ((u64)p->saddr << 32) ^ (u64)p->daddr ^
+	       ((u64)p->sport << 16) ^ (u64)p->dport;
+}
+
+static __always_inline void rustls_dispatch(void *ctx, void *base, u64 len,
+					    u64 conn, u32 dir)
+{
+	if (!base || len == 0)
+		return;
+	u8 peek[RUSTLS_PEEK] = {};
+	u32 plen = len < sizeof(peek) ? (u32)len : sizeof(peek);
+	if (bpf_probe_read_user(peek, plen, base) != 0)
+		return;
+
+	if (peek[0] == 'H' && peek[1] == 'T' && peek[2] == 'T' && peek[3] == 'P' &&
+	    peek[4] == '/' && peek[5] == '1' && peek[6] == '.')
+		http_emit_response(ctx, base, len, HTTP_TRANSPORT_TLS, conn);
+	else if (http_method_len(peek) > 0)
+		http_emit_request(ctx, base, len, HTTP_TRANSPORT_TLS, conn);
+	else
+		h2_emit_frames(base, len, conn, dir, HTTP_TRANSPORT_H2_TLS);
+}
+
+SEC("uprobe/rustls_write")
+int uprobe_rustls_write(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	rustls_dispatch(ctx, RUSTLS_BUF(ctx), RUSTLS_LEN(ctx), rustls_conn_key(),
+			H2_DIR_EGRESS);
+	return 0;
+}
+
+SEC("uprobe/rustls_read")
+int uprobe_rustls_read(struct pt_regs *ctx)
+{
+	if (!http_should_trace())
+		return 0;
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	struct ssl_read_state st = {
+		.buf = (u64)RUSTLS_BUF(ctx),
+		.conn = rustls_conn_key(),
+	};
+	bpf_map_update_elem(&rustls_read_args, &key, &st, BPF_ANY);
+	return 0;
+}
+
+SEC("uretprobe/rustls_read")
+int uretprobe_rustls_read(struct pt_regs *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+	struct ssl_read_state *st = bpf_map_lookup_elem(&rustls_read_args, &key);
+	if (!st)
+		return 0;
+	void *base = (void *)st->buf;
+	u64 conn = st->conn;
+	bpf_map_delete_elem(&rustls_read_args, &key);
+
+	if (!RUSTLS_RET_OK(ctx))
+		return 0;
+	u64 count = RUSTLS_RET_COUNT(ctx);
+	if (count == 0 || count >= MAX_BYTES_THRESHOLD)
+		return 0;
+	rustls_dispatch(ctx, base, count, conn, H2_DIR_INGRESS);
+	return 0;
+}
+
+#else
+
+SEC("uprobe/rustls_write")
+int uprobe_rustls_write(struct pt_regs *ctx) { return 0; }
+
+SEC("uprobe/rustls_read")
+int uprobe_rustls_read(struct pt_regs *ctx) { return 0; }
+
+SEC("uretprobe/rustls_read")
+int uretprobe_rustls_read(struct pt_regs *ctx) { return 0; }
+
+#endif

--- a/internal/ebpf/probes/rustlsresolve.go
+++ b/internal/ebpf/probes/rustlsresolve.go
@@ -1,0 +1,124 @@
+package probes
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+// elfIsRust reports whether an ELF was produced by rustc, detected via the
+// ".comment" section.
+func elfIsRust(f *elf.File) bool {
+	sec := f.Section(".comment")
+	if sec == nil {
+		return false
+	}
+	data, err := sec.Data()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(data, []byte("rustc"))
+}
+
+// findSymbolContaining returns the virtual address of the first defined function
+// symbol whose name contains every given substring.
+func nameContainsAll(name string, subs ...string) bool {
+	for _, s := range subs {
+		if !strings.Contains(name, s) {
+			return false
+		}
+	}
+	return true
+}
+
+func findSymbolContaining(f *elf.File, subs ...string) (uint64, bool) {
+	syms, err := f.Symbols()
+	if err != nil {
+		return 0, false
+	}
+	for i := range syms {
+		if syms[i].Value == 0 || elf.ST_TYPE(syms[i].Info) != elf.STT_FUNC {
+			continue
+		}
+		if nameContainsAll(syms[i].Name, subs...) {
+			return syms[i].Value, true
+		}
+	}
+	return 0, false
+}
+
+var (
+	rustlsWriteSymbolPattern = []string{"rustls", "Writer", "io..Write$GT$5write"}
+	rustlsReadSymbolPattern  = []string{"rustls", "Reader", "io..Read$GT$4read"}
+)
+
+// AttachRustlsProbes attaches uprobes on rustls' plaintext boundary in a
+// statically-linked Rust binary: <rustls::conn::Writer as io::Write>::write
+// (outbound) and <rustls::conn::Reader as io::Read>::read (inbound), capturing
+// HTTP/1.x, HTTP/2 and gRPC L7 over rustls TLS before encryption / after
+// decryption.
+func AttachRustlsProbes(coll *ebpf.Collection, pid uint32) []link.Link {
+	var links []link.Link
+	if pid == 0 {
+		return links
+	}
+	writeProg := coll.Programs["uprobe_rustls_write"]
+	readProg := coll.Programs["uprobe_rustls_read"]
+	readRetProg := coll.Programs["uretprobe_rustls_read"]
+	if writeProg == nil || readProg == nil || readRetProg == nil {
+		return links
+	}
+
+	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
+	f, err := elf.Open(exePath)
+	if err != nil {
+		return links
+	}
+	defer func() { _ = f.Close() }()
+	if !elfIsRust(f) {
+		return links
+	}
+
+	writeVaddr, okW := findSymbolContaining(f, rustlsWriteSymbolPattern...)
+	readVaddr, okR := findSymbolContaining(f, rustlsReadSymbolPattern...)
+	if !okW && !okR {
+		return links
+	}
+
+	exe, err := link.OpenExecutable(exePath)
+	if err != nil {
+		return links
+	}
+
+	if okW {
+		if off, ok := vaddrToFileOffset(f, writeVaddr); ok {
+			if l, err := exe.Uprobe("", writeProg, &link.UprobeOptions{Address: off}); err == nil {
+				links = append(links, l)
+				logger.Debug("rustls write uprobe attached", zap.Uint32("pid", pid), zap.Uint64("offset", off))
+			} else {
+				logger.Debug("rustls write uprobe not attached", zap.Uint32("pid", pid), zap.Error(err))
+			}
+		}
+	}
+	if okR {
+		if off, ok := vaddrToFileOffset(f, readVaddr); ok {
+			if l, err := exe.Uprobe("", readProg, &link.UprobeOptions{Address: off}); err == nil {
+				links = append(links, l)
+			}
+			if l, err := exe.Uretprobe("", readRetProg, &link.UprobeOptions{Address: off}); err == nil {
+				links = append(links, l)
+			}
+			logger.Debug("rustls read uprobes attached", zap.Uint32("pid", pid), zap.Uint64("offset", off))
+		}
+	}
+	return links
+}

--- a/internal/ebpf/probes/rustlsresolve_test.go
+++ b/internal/ebpf/probes/rustlsresolve_test.go
@@ -1,0 +1,30 @@
+package probes
+
+import "testing"
+
+func TestRustlsSymbolPatterns(t *testing.T) {
+	const writeSym = "_ZN67_$LT$rustls..conn..connection..Writer$u20$as$u20$std..io..Write$GT$5write17h047145b15f069e6fE"
+	const readSym = "_ZN66_$LT$rustls..conn..connection..Reader$u20$as$u20$std..io..Read$GT$4read17h879fa3fd0b5fb779E"
+	const flushSym = "_ZN67_$LT$rustls..conn..connection..Writer$u20$as$u20$std..io..Write$GT$5flush17h14ac3a26f8f7ff71E"
+	const writeAllSym = "_ZN67_$LT$rustls..conn..connection..Writer$u20$as$u20$std..io..Write$GT$9write_all17habcdef0123456789E"
+
+	if !nameContainsAll(writeSym, rustlsWriteSymbolPattern...) {
+		t.Errorf("write symbol should match the write pattern: %s", writeSym)
+	}
+	if !nameContainsAll(readSym, rustlsReadSymbolPattern...) {
+		t.Errorf("read symbol should match the read pattern: %s", readSym)
+	}
+	if nameContainsAll(flushSym, rustlsWriteSymbolPattern...) {
+		t.Error("flush symbol must not match the write pattern")
+	}
+	if nameContainsAll(writeAllSym, rustlsWriteSymbolPattern...) {
+		t.Error("write_all symbol must not match the write pattern (anchor is $GT$5write)")
+	}
+	if nameContainsAll(readSym, rustlsWriteSymbolPattern...) {
+		t.Error("read symbol must not match the write pattern")
+	}
+	const bufWriter = "_ZN3std2io8buffered9bufwriter18BufWriter$LT$W$GT$5write17hdeadbeefdeadbeefE"
+	if nameContainsAll(bufWriter, rustlsWriteSymbolPattern...) {
+		t.Error("non-rustls writer must not match the write pattern")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -175,6 +175,7 @@ func (t *Tracer) attachContainerUprobes(id string, pid uint32) []link.Link {
 	ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
 	ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
+	ls = append(ls, probes.AttachRustlsProbes(coll, pid)...)
 	ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 	ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
 	ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
@@ -246,6 +247,7 @@ func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
 		ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
 		ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
 		ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
+		ls = append(ls, probes.AttachRustlsProbes(coll, pid)...)
 		ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
 		return ls
 	case probes.GroupDatabase:
@@ -871,6 +873,7 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachTLSProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoTLSProbes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoGRPCProbes(t.collection, t.containerPID))
+	t.registerGroupLinks(probes.GroupTLS, probes.AttachRustlsProbes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupTLS, probes.AttachGoHTTP3Probes(t.collection, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachRedisProbesWithPID(t.collection, primary, t.containerPID))
 	t.registerGroupLinks(probes.GroupCache, probes.AttachMemcachedProbesWithPID(t.collection, primary, t.containerPID))


### PR DESCRIPTION
## Summary

Adds HTTP/gRPC L7 visibility for Rust services using rustls, the last mainstream TLS stack podtrace could not see into. rustls is pure Rust with no libssl symbol to hook, we uprobe the library at its plaintext boundary instead of decoding ciphertext:

- `<rustls::conn::Writer as std::io::Write>::write`: outbound plaintext (client request / server response), captured on entry.
- `<rustls::conn::Reader as std::io::Read>::read`: inbound plaintext, captured on return, because the decrypted buffer and byte count are only valid once the call completes. Reader::read returns `Result<usize>`, so the count is read from RDX (with RAX as the Ok/Err discriminant).