### PR TITLE
feat: decode HTTP/2 :path mid-stream and stop idle-agent whole-node OOM

### DIFF
--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -39,6 +39,28 @@ struct h2_raw_ctx {
 	u8  transport;
 };
 
+static __always_inline int h2_preface_signal(void *base, u64 avail)
+{
+	u8 b[16];
+	if (avail >= 16) {
+		if (bpf_probe_read_user(b, 16, base) != 0)
+			return 0;
+		if (b[0] == 'P' && b[1] == 'R' && b[2] == 'I' && b[3] == ' ' &&
+		    b[4] == '*' && b[5] == ' ' && b[6] == 'H' && b[7] == 'T' &&
+		    b[8] == 'T' && b[9] == 'P' && b[10] == '/' && b[11] == '2' &&
+		    b[12] == '.' && b[13] == '0' && b[14] == '\r' && b[15] == '\n')
+			return 2;
+		return 0;
+	}
+	if (avail >= 4) {
+		if (bpf_probe_read_user(b, 4, base) != 0)
+			return 0;
+		if (b[0] == 'P' && b[1] == 'R' && b[2] == 'I' && b[3] == ' ')
+			return 1;
+	}
+	return 0;
+}
+
 static __always_inline int h2_start_looks_h2(void *base, u64 avail)
 {
 	if (avail < HTTP2_FRAME_HDR)
@@ -168,11 +190,34 @@ static __always_inline void h2_emit_frames(void *base, u64 avail, u64 conn,
 		return;
 
 	u32 start = 0;
-	if (!fs->preface_seen && fs->remaining == 0 && avail >= HTTP2_PREFACE_LEN) {
-		u8 pf[4];
-		if (bpf_probe_read_user(pf, sizeof(pf), base) == 0 &&
-		    pf[0] == 'P' && pf[1] == 'R' && pf[2] == 'I' && pf[3] == ' ')
-			start = HTTP2_PREFACE_LEN;
+	int pfx = h2_preface_signal(base, avail);
+	if (pfx == 2 || (pfx == 1 && fs->remaining == 0)) {
+		struct h2_seq_key ke = { .conn_id = conn, .dir = H2_DIR_EGRESS };
+		struct h2_seq_key ki = { .conn_id = conn, .dir = H2_DIR_INGRESS };
+		bpf_map_delete_elem(&h2_seq, &ke);
+		bpf_map_delete_elem(&h2_seq, &ki);
+		bpf_map_delete_elem(&h2_frame_state, &ke);
+		bpf_map_delete_elem(&h2_frame_state, &ki);
+
+		__builtin_memset(&s->rec, 0, sizeof(s->rec));
+		s->rec.conn_id = conn;
+		s->rec.timestamp = bpf_ktime_get_ns();
+		s->rec.flags = H2_HDR_FLAG_CLOSE;
+		bpf_ringbuf_output(&h2_hdr_events, &s->rec, sizeof(s->rec), 0);
+
+		struct h2_frame_state fresh = {};
+		bpf_map_update_elem(&h2_frame_state, &fk, &fresh, BPF_ANY);
+		fs = bpf_map_lookup_elem(&h2_frame_state, &fk);
+		if (!fs)
+			return;
+
+		if (avail < HTTP2_PREFACE_LEN) {
+			fs->preface_seen = 1;
+			fs->type = HTTP2_SETTINGS;
+			fs->remaining = HTTP2_PREFACE_LEN - (u32)avail;
+			return;
+		}
+		start = HTTP2_PREFACE_LEN;
 	}
 	fs->preface_seen = 1;
 	s->off = start;

--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -115,6 +115,9 @@ func agentBackendFactory() (tracer.TracerBackend, error) {
 	if err != nil {
 		return nil, err
 	}
+	if deny, ok := tr.(interface{ SetDenyWhenNoTargets(bool) }); ok {
+		deny.SetDenyWhenNoTargets(true)
+	}
 	return &ebpfBackendAdapter{tr: tr}, nil
 }
 

--- a/internal/analysis/criticalpath/criticalpath.go
+++ b/internal/analysis/criticalpath/criticalpath.go
@@ -83,6 +83,8 @@ func isBoundary(t events.EventType) bool {
 	return t == events.EventHTTPResp || t == events.EventFastCGIResp || t == events.EventGRPCMethod
 }
 
+const maxWindows = 8192
+
 // Feed processes one event. It is safe to call from multiple goroutines.
 // The emit callback runs after the analyzer's lock is released, so a slow
 // (or re-entrant) callback can neither stall the event hot path nor
@@ -96,6 +98,10 @@ func (a *Analyzer) Feed(e *events.Event) {
 	pid := e.PID
 	w, ok := a.windows[pid]
 	if !ok {
+		if !isBoundary(e.Type) && len(a.windows) >= maxWindows {
+			a.mu.Unlock()
+			return
+		}
 		w = &requestWindow{}
 		a.windows[pid] = w
 	}

--- a/internal/analysis/criticalpath/windows_bound_test.go
+++ b/internal/analysis/criticalpath/windows_bound_test.go
@@ -1,0 +1,60 @@
+package criticalpath
+
+import (
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func nonBoundaryEvent(pid uint32) *events.Event {
+	return &events.Event{Type: events.EventDBQuery, PID: pid, LatencyNS: 1_000_000, Details: "SELECT"}
+}
+
+func TestFeed_WindowMapBounded(t *testing.T) {
+	a := New(time.Minute, nil)
+	for pid := uint32(1); pid <= maxWindows+500; pid++ {
+		a.Feed(nonBoundaryEvent(pid))
+	}
+	a.mu.Lock()
+	n := len(a.windows)
+	a.mu.Unlock()
+	if n > maxWindows {
+		t.Fatalf("windows map grew to %d, cap is %d", n, maxWindows)
+	}
+}
+
+func TestFeed_BoundaryStillEmitsWhenFull(t *testing.T) {
+	var emitted []CriticalPath
+	a := New(time.Minute, func(cp CriticalPath) { emitted = append(emitted, cp) })
+	for pid := uint32(1); pid <= maxWindows; pid++ {
+		a.Feed(nonBoundaryEvent(pid))
+	}
+	a.Feed(&events.Event{Type: events.EventHTTPResp, PID: maxWindows + 1, LatencyNS: 2_000_000})
+	if len(emitted) != 1 {
+		t.Fatalf("boundary at capacity emitted %d paths, want 1", len(emitted))
+	}
+	a.mu.Lock()
+	n := len(a.windows)
+	a.mu.Unlock()
+	if n > maxWindows {
+		t.Fatalf("windows map grew to %d after boundary, cap is %d", n, maxWindows)
+	}
+}
+
+func TestEvict_FreesRoomForNewWindows(t *testing.T) {
+	a := New(time.Millisecond, nil)
+	for pid := uint32(1); pid <= maxWindows; pid++ {
+		a.Feed(nonBoundaryEvent(pid))
+	}
+	time.Sleep(5 * time.Millisecond)
+	a.Evict()
+
+	a.Feed(nonBoundaryEvent(maxWindows + 1))
+	a.mu.Lock()
+	_, ok := a.windows[maxWindows+1]
+	a.mu.Unlock()
+	if !ok {
+		t.Fatal("post-eviction feed did not create a window")
+	}
+}

--- a/internal/ebpf/filter/filter.go
+++ b/internal/ebpf/filter/filter.go
@@ -76,6 +76,21 @@ func (f *CgroupFilter) snapshotTargets() []string {
 	return targets
 }
 
+// HasTargets reports whether any cgroup target is configured.
+func (f *CgroupFilter) HasTargets() bool {
+	f.pathsMu.RLock()
+	defer f.pathsMu.RUnlock()
+	if f.cgroupPath != "" {
+		return true
+	}
+	for p := range f.cgroupPaths {
+		if p != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	configuredTargets := f.snapshotTargets()
 	if len(configuredTargets) == 0 {

--- a/internal/ebpf/filter/has_targets_test.go
+++ b/internal/ebpf/filter/has_targets_test.go
@@ -1,0 +1,25 @@
+package filter
+
+import "testing"
+
+func TestHasTargets(t *testing.T) {
+	f := NewCgroupFilter()
+	if f.HasTargets() {
+		t.Fatal("fresh filter must report no targets")
+	}
+
+	f.SetCgroupPaths([]string{"/sys/fs/cgroup/kubepods/pod-a"})
+	if !f.HasTargets() {
+		t.Fatal("filter with a configured path must report targets")
+	}
+
+	f.SetCgroupPaths(nil)
+	if f.HasTargets() {
+		t.Fatal("cleared filter must report no targets")
+	}
+
+	f.SetCgroupPath("/sys/fs/cgroup/kubepods/pod-b")
+	if !f.HasTargets() {
+		t.Fatal("filter with a single legacy path must report targets")
+	}
+}

--- a/internal/ebpf/h2decode/decode.go
+++ b/internal/ebpf/h2decode/decode.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/http2/hpack"
-
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/safeconv"
 )
@@ -41,7 +39,17 @@ const (
 	defaultMaxStreams       = 8192
 	defaultTTL              = 60 * time.Second
 	defaultGapTimeout       = 2 * time.Second
-	hpackMaxDynTableSize    = 4096
+)
+
+// unknownPathPlaceholder stands in for a request :path that was HPACK-indexed
+// into the connection's dynamic table before capture attached, so its literal
+// was never observed.
+const unknownPathPlaceholder = "<unknown-path>"
+
+const (
+	roleUnknown uint8 = iota
+	roleRequest
+	roleResponse
 )
 
 // RawRecord is a parsed struct h2_hdr_record plus its raw HPACK fragment.
@@ -116,7 +124,8 @@ type streamKey struct {
 
 // dirState is the ordered decode state for one (connection, direction).
 type dirState struct {
-	dec      *hpack.Decoder
+	dec      *lateJoinDecoder
+	role     uint8
 	nextSeq  uint32
 	pending  map[uint32]*RawRecord
 	asm      []byte
@@ -150,9 +159,11 @@ type Decoder struct {
 
 	nowFn func() time.Time
 
-	decodeErrors uint64
-	gapsSkipped  uint64
-	evictions    uint64
+	decodeErrors      uint64
+	gapsSkipped       uint64
+	evictions         uint64
+	partialBlocks     uint64
+	anonymousRequests uint64
 }
 
 // New returns a Decoder with default tunables.
@@ -200,7 +211,7 @@ func (d *Decoder) Ingest(rec *RawRecord) []*events.Event {
 	if st == nil {
 		d.evictIfFullLocked()
 		st = &dirState{
-			dec:     hpack.NewDecoder(hpackMaxDynTableSize, nil),
+			dec:     &lateJoinDecoder{},
 			nextSeq: 0,
 			pending: make(map[uint32]*RawRecord),
 		}
@@ -257,11 +268,14 @@ func (d *Decoder) drainLocked(st *dirState) []*events.Event {
 
 // decodeBlockLocked decodes one complete header block and builds an event.
 func (d *Decoder) decodeBlockLocked(st *dirState, rec *RawRecord, block []byte) *events.Event {
-	fields, err := st.dec.DecodeFull(block)
+	fields, complete, err := st.dec.decodeBlock(block)
 	if err != nil {
 		d.decodeErrors++
-		st.dec = hpack.NewDecoder(hpackMaxDynTableSize, nil)
+		st.dec.resetEpoch()
 		return nil
+	}
+	if !complete {
+		d.partialBlocks++
 	}
 
 	var method, path, status, traceparent, grpcStatus string
@@ -290,8 +304,10 @@ func (d *Decoder) decodeBlockLocked(st *dirState, rec *RawRecord, block []byte) 
 
 	switch {
 	case path != "":
+		st.role = roleRequest
 		return d.buildRequestLocked(rec, method, path, traceparent, extra)
 	case status != "":
+		st.role = roleResponse
 		if len(status) == 3 && status[0] == '1' {
 			return nil
 		}
@@ -306,10 +322,44 @@ func (d *Decoder) decodeBlockLocked(st *dirState, rec *RawRecord, block []byte) 
 		}
 		return ev
 	case grpcStatus != "":
+		st.role = roleResponse
 		return d.buildGrpcTrailerLocked(rec, grpcStatus)
+	case !complete:
+		return d.buildAnonymousRequestLocked(st, rec, method, traceparent, extra)
 	default:
 		return nil
 	}
+}
+
+// buildAnonymousRequestLocked handles a partially-decoded block carrying no
+// recognizable pseudo-header: on a late-joined connection this is the
+// steady-state shape of a request whose :path was indexed before capture
+// attached.
+func (d *Decoder) buildAnonymousRequestLocked(st *dirState, rec *RawRecord, method,
+	traceparent string, extra []string) *events.Event {
+	requestDir := st.role == roleRequest
+	if !requestDir && st.role == roleUnknown {
+		other := d.dirs[connKey{conn: rec.ConnID, dir: otherDirection(rec.Direction)}]
+		requestDir = other != nil && other.role == roleResponse
+	}
+	if !requestDir {
+		return nil
+	}
+	if _, exists := d.streams[streamKey{conn: rec.ConnID, stream: rec.StreamID}]; exists {
+		return nil
+	}
+	if method == "" {
+		method = "?"
+	}
+	d.anonymousRequests++
+	return d.buildRequestLocked(rec, method, unknownPathPlaceholder, traceparent, extra)
+}
+
+func otherDirection(dir uint8) uint8 {
+	if dir == DirEgress {
+		return DirIngress
+	}
+	return DirEgress
 }
 
 func (d *Decoder) buildRequestLocked(rec *RawRecord, method, path, traceparent string,
@@ -423,7 +473,8 @@ func (d *Decoder) rememberStreamLocked(rec *RawRecord, method, path string) {
 }
 
 // skipGapLocked advances past the lowest missing seq so a lost fragment cannot
-// stall the connection.
+// stall the connection. Dynamic-table insertions may have happened inside the
+// gap, so the observed-insertion window restarts.
 func (d *Decoder) skipGapLocked(st *dirState) {
 	lowest, ok := lowestSeq(st.pending)
 	if !ok {
@@ -432,7 +483,7 @@ func (d *Decoder) skipGapLocked(st *dirState) {
 	st.nextSeq = lowest
 	st.asm = nil
 	st.stalled = time.Time{}
-	st.dec = hpack.NewDecoder(hpackMaxDynTableSize, nil)
+	st.dec.resetEpoch()
 	d.gapsSkipped++
 }
 
@@ -514,22 +565,26 @@ func (d *Decoder) evictOldestStreamLocked() {
 
 // Stats reports diagnostic counters.
 type Stats struct {
-	Conns        int
-	Streams      int
-	DecodeErrors uint64
-	GapsSkipped  uint64
-	Evictions    uint64
+	Conns             int
+	Streams           int
+	DecodeErrors      uint64
+	GapsSkipped       uint64
+	Evictions         uint64
+	PartialBlocks     uint64
+	AnonymousRequests uint64
 }
 
 func (d *Decoder) Stats() Stats {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return Stats{
-		Conns:        len(d.dirs),
-		Streams:      len(d.streams),
-		DecodeErrors: d.decodeErrors,
-		GapsSkipped:  d.gapsSkipped,
-		Evictions:    d.evictions,
+		Conns:             len(d.dirs),
+		Streams:           len(d.streams),
+		DecodeErrors:      d.decodeErrors,
+		GapsSkipped:       d.gapsSkipped,
+		Evictions:         d.evictions,
+		PartialBlocks:     d.partialBlocks,
+		AnonymousRequests: d.anonymousRequests,
 	}
 }
 

--- a/internal/ebpf/h2decode/decode_test.go
+++ b/internal/ebpf/h2decode/decode_test.go
@@ -540,6 +540,105 @@ func TestCaptureHeadersOnRequestAndResponse(t *testing.T) {
 	}
 }
 
+func TestLateJoinNewRouteRecoversPath(t *testing.T) {
+	d := New()
+	enc := newBlockEncoder()
+	_ = enc.encode(reqFields("POST", "/pkg.Svc/Old")...)
+
+	const conn = 90
+	first := singleEvent(t, d.Ingest(rec(conn, DirEgress, 0, 1,
+		enc.encode(reqFields("POST", "/pkg.Svc/New")...))))
+	if first.Target != "POST /pkg.Svc/New" {
+		t.Fatalf("post-attach literal route: target = %q", first.Target)
+	}
+	repeat := singleEvent(t, d.Ingest(rec(conn, DirEgress, 1, 3,
+		enc.encode(reqFields("POST", "/pkg.Svc/New")...))))
+	if repeat.Target != "POST /pkg.Svc/New" {
+		t.Fatalf("indexed repeat of post-attach route: target = %q", repeat.Target)
+	}
+	if d.Stats().DecodeErrors != 0 {
+		t.Fatalf("late join must not count decode errors: %+v", d.Stats())
+	}
+	if d.Stats().PartialBlocks == 0 {
+		t.Fatal("blocks referencing pre-attach state should count as partial")
+	}
+}
+
+func TestLateJoinAnonymousRequestPairsWithResponse(t *testing.T) {
+	d := New()
+	reqEnc := newBlockEncoder()
+	_ = reqEnc.encode(reqFields("POST", "/pkg.Svc/Do")...) // pre-attach literal
+	steadyState := reqEnc.encode(reqFields("POST", "/pkg.Svc/Do")...)
+
+	const conn = 91
+	respEnc := newBlockEncoder()
+	singleEvent(t, d.Ingest(rec(conn, DirIngress, 0, 99, respEnc.encode(hf(":status", "200")))))
+
+	reqEv := singleEvent(t, d.Ingest(rec(conn, DirEgress, 0, 1, steadyState)))
+	if reqEv.Type != events.EventHTTPReq {
+		t.Fatalf("expected request event, got %v", reqEv.Type)
+	}
+	if reqEv.Target != "POST "+unknownPathPlaceholder {
+		t.Fatalf("anonymous request target = %q", reqEv.Target)
+	}
+
+	respEv := singleEvent(t, d.Ingest(rec(conn, DirIngress, 1, 1, respEnc.encode(hf(":status", "200")))))
+	if respEv.Target != "POST "+unknownPathPlaceholder {
+		t.Fatalf("response lost anonymous-request correlation: %q", respEv.Target)
+	}
+	if respEv.LatencyNS == 0 {
+		t.Fatal("anonymous request must still yield latency")
+	}
+	if d.Stats().AnonymousRequests != 1 {
+		t.Fatalf("AnonymousRequests = %d, want 1", d.Stats().AnonymousRequests)
+	}
+}
+
+func TestLateJoinAnonymousRequestNeedsRoleEvidence(t *testing.T) {
+	d := New()
+	enc := newBlockEncoder()
+	_ = enc.encode(reqFields("POST", "/pkg.Svc/Do")...)
+	steadyState := enc.encode(reqFields("POST", "/pkg.Svc/Do")...)
+
+	if evs := d.Ingest(rec(92, DirEgress, 0, 1, steadyState)); len(evs) != 0 {
+		t.Fatalf("unclassifiable partial block emitted %d events, want 0", len(evs))
+	}
+	if d.Stats().AnonymousRequests != 0 {
+		t.Fatalf("AnonymousRequests = %d, want 0", d.Stats().AnonymousRequests)
+	}
+}
+
+func TestLateJoinAnonymousRequestFromOwnRole(t *testing.T) {
+	d := New()
+	enc := newBlockEncoder()
+	_ = enc.encode(reqFields("POST", "/pkg.Svc/Old")...)
+
+	const conn = 93
+	singleEvent(t, d.Ingest(rec(conn, DirEgress, 0, 1,
+		enc.encode(reqFields("POST", "/pkg.Svc/New")...))))
+
+	ev := singleEvent(t, d.Ingest(rec(conn, DirEgress, 1, 3,
+		enc.encode(reqFields("POST", "/pkg.Svc/Old")...))))
+	if ev.Type != events.EventHTTPReq || ev.Target != "POST "+unknownPathPlaceholder {
+		t.Fatalf("anonymous request on request-role direction: type=%v target=%q", ev.Type, ev.Target)
+	}
+}
+
+func TestIndexedResponseTrailerNotMisreported(t *testing.T) {
+	d := New()
+	respEnc := newBlockEncoder()
+	_ = respEnc.encode(hf("grpc-status", "0"))
+
+	const conn = 94
+	singleEvent(t, d.Ingest(rec(conn, DirIngress, 0, 1, respEnc.encode(hf(":status", "200")))))
+	if evs := d.Ingest(rec(conn, DirIngress, 1, 1, respEnc.encode(hf("grpc-status", "0")))); len(evs) != 0 {
+		t.Fatalf("indexed trailer on response direction emitted %d events, want 0", len(evs))
+	}
+	if d.Stats().AnonymousRequests != 0 {
+		t.Fatalf("trailer misreported as request: %+v", d.Stats())
+	}
+}
+
 func TestCaptureHeadersDisabledByDefault(t *testing.T) {
 	d := New()
 	be := newBlockEncoder()

--- a/internal/ebpf/h2decode/latejoin.go
+++ b/internal/ebpf/h2decode/latejoin.go
@@ -1,0 +1,290 @@
+// Late-join tolerant HPACK block decoder.
+
+package h2decode
+
+import (
+	"errors"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+const (
+	hpackStaticTableSize = 61
+
+	maxTrackedInserts = 1024
+
+	maxDynamicIndex = hpackStaticTableSize + 8192
+
+	maxFieldsPerBlock = 256
+)
+
+var (
+	errHPACKTruncated       = errors.New("hpack: truncated block")
+	errHPACKIntegerOverflow = errors.New("hpack: integer overflow")
+	errHPACKZeroIndex       = errors.New("hpack: zero index")
+	errHPACKIndexRange      = errors.New("hpack: index out of range")
+	errHPACKTooManyFields   = errors.New("hpack: too many fields in block")
+)
+
+// tableEntry is one observed dynamic-table insertion.
+type tableEntry struct {
+	field       hpack.HeaderField
+	unknownName bool
+}
+
+// lateJoinDecoder decodes HPACK header blocks tolerantly, resolving what the
+// observed insertion window allows and skipping pre-attach references instead
+// of failing the block.
+type lateJoinDecoder struct {
+	inserts []tableEntry
+}
+
+// resetEpoch discards the observed insertion window.
+func (d *lateJoinDecoder) resetEpoch() {
+	d.inserts = d.inserts[:0]
+}
+
+// decodeBlock decodes one complete header block. complete is false when one
+// or more fields referenced pre-attach dynamic-table state and were skipped.
+func (d *lateJoinDecoder) decodeBlock(block []byte) (fields []hpack.HeaderField, complete bool, err error) {
+	complete = true
+	pos := 0
+	for pos < len(block) {
+		if len(fields) >= maxFieldsPerBlock {
+			return nil, false, errHPACKTooManyFields
+		}
+		b := block[pos]
+		switch {
+		case b&0x80 != 0:
+			index, n, err := readInteger(block[pos:], 7)
+			if err != nil {
+				return nil, false, err
+			}
+			pos += n
+			field, ok, err := d.resolveIndex(index)
+			if err != nil {
+				return nil, false, err
+			}
+			if ok {
+				fields = append(fields, field)
+			} else {
+				complete = false
+			}
+		case b&0xc0 == 0x40:
+			field, ok, n, err := d.readLiteral(block[pos:], 6)
+			if err != nil {
+				return nil, false, err
+			}
+			pos += n
+			d.insert(tableEntry{field: field, unknownName: !ok})
+			if ok {
+				fields = append(fields, field)
+			} else {
+				complete = false
+			}
+		case b&0xe0 == 0x20:
+			_, n, err := readInteger(block[pos:], 5)
+			if err != nil {
+				return nil, false, err
+			}
+			pos += n
+		default:
+			field, ok, n, err := d.readLiteral(block[pos:], 4)
+			if err != nil {
+				return nil, false, err
+			}
+			pos += n
+			if ok {
+				fields = append(fields, field)
+			} else {
+				complete = false
+			}
+		}
+	}
+	return fields, complete, nil
+}
+
+// readLiteral parses a literal header field representation whose name-index
+// integer uses the given prefix width.
+func (d *lateJoinDecoder) readLiteral(buf []byte, prefix uint8) (field hpack.HeaderField, ok bool, consumed int, err error) {
+	nameIndex, n, err := readInteger(buf, prefix)
+	if err != nil {
+		return hpack.HeaderField{}, false, 0, err
+	}
+	pos := n
+
+	name := ""
+	nameOK := true
+	if nameIndex == 0 {
+		name, n, err = readString(buf[pos:])
+		if err != nil {
+			return hpack.HeaderField{}, false, 0, err
+		}
+		pos += n
+	} else {
+		var ref hpack.HeaderField
+		ref, nameOK, err = d.resolveIndex(nameIndex)
+		if err != nil {
+			return hpack.HeaderField{}, false, 0, err
+		}
+		name = ref.Name
+	}
+
+	value, n, err := readString(buf[pos:])
+	if err != nil {
+		return hpack.HeaderField{}, false, 0, err
+	}
+	pos += n
+
+	return hpack.HeaderField{Name: name, Value: value}, nameOK, pos, nil
+}
+
+// resolveIndex maps an HPACK index to a header field.
+func (d *lateJoinDecoder) resolveIndex(index int) (hpack.HeaderField, bool, error) {
+	switch {
+	case index == 0:
+		return hpack.HeaderField{}, false, errHPACKZeroIndex
+	case index <= hpackStaticTableSize:
+		return hpackStaticTable[index-1], true, nil
+	case index > maxDynamicIndex:
+		return hpack.HeaderField{}, false, errHPACKIndexRange
+	}
+	ordinal := index - hpackStaticTableSize
+	if ordinal > len(d.inserts) {
+		return hpack.HeaderField{}, false, nil
+	}
+	entry := d.inserts[len(d.inserts)-ordinal]
+	if entry.unknownName {
+		return hpack.HeaderField{}, false, nil
+	}
+	return entry.field, true, nil
+}
+
+func (d *lateJoinDecoder) insert(entry tableEntry) {
+	d.inserts = append(d.inserts, entry)
+	if len(d.inserts) > maxTrackedInserts {
+		n := copy(d.inserts, d.inserts[len(d.inserts)-maxTrackedInserts:])
+		d.inserts = d.inserts[:n]
+	}
+}
+
+// readInteger decodes an HPACK variable-length integer (RFC 7541 §5.1) whose
+// first byte carries a prefix-bit payload.
+func readInteger(buf []byte, prefix uint8) (value int, consumed int, err error) {
+	if len(buf) == 0 {
+		return 0, 0, errHPACKTruncated
+	}
+	mask := int(1)<<prefix - 1
+	value = int(buf[0]) & mask
+	if value < mask {
+		return value, 1, nil
+	}
+	consumed = 1
+	var shift uint
+	for {
+		if consumed >= len(buf) {
+			return 0, 0, errHPACKTruncated
+		}
+		if shift > 21 {
+			return 0, 0, errHPACKIntegerOverflow
+		}
+		b := buf[consumed]
+		consumed++
+		value += int(b&0x7f) << shift
+		if b&0x80 == 0 {
+			return value, consumed, nil
+		}
+		shift += 7
+	}
+}
+
+// readString decodes an HPACK string literal (RFC 7541 §5.2), applying
+// Huffman decoding when the H bit is set.
+func readString(buf []byte) (s string, consumed int, err error) {
+	if len(buf) == 0 {
+		return "", 0, errHPACKTruncated
+	}
+	huffman := buf[0]&0x80 != 0
+	length, n, err := readInteger(buf, 7)
+	if err != nil {
+		return "", 0, err
+	}
+	if length > len(buf)-n {
+		return "", 0, errHPACKTruncated
+	}
+	raw := buf[n : n+length]
+	consumed = n + length
+	if !huffman {
+		return string(raw), consumed, nil
+	}
+	s, err = hpack.HuffmanDecodeToString(raw)
+	if err != nil {
+		return "", 0, err
+	}
+	return s, consumed, nil
+}
+
+// hpackStaticTable is the RFC 7541 Appendix A static table (indices 1-61).
+var hpackStaticTable = [hpackStaticTableSize]hpack.HeaderField{
+	{Name: ":authority"},
+	{Name: ":method", Value: "GET"},
+	{Name: ":method", Value: "POST"},
+	{Name: ":path", Value: "/"},
+	{Name: ":path", Value: "/index.html"},
+	{Name: ":scheme", Value: "http"},
+	{Name: ":scheme", Value: "https"},
+	{Name: ":status", Value: "200"},
+	{Name: ":status", Value: "204"},
+	{Name: ":status", Value: "206"},
+	{Name: ":status", Value: "304"},
+	{Name: ":status", Value: "400"},
+	{Name: ":status", Value: "404"},
+	{Name: ":status", Value: "500"},
+	{Name: "accept-charset"},
+	{Name: "accept-encoding", Value: "gzip, deflate"},
+	{Name: "accept-language"},
+	{Name: "accept-ranges"},
+	{Name: "accept"},
+	{Name: "access-control-allow-origin"},
+	{Name: "age"},
+	{Name: "allow"},
+	{Name: "authorization"},
+	{Name: "cache-control"},
+	{Name: "content-disposition"},
+	{Name: "content-encoding"},
+	{Name: "content-language"},
+	{Name: "content-length"},
+	{Name: "content-location"},
+	{Name: "content-range"},
+	{Name: "content-type"},
+	{Name: "cookie"},
+	{Name: "date"},
+	{Name: "etag"},
+	{Name: "expect"},
+	{Name: "expires"},
+	{Name: "from"},
+	{Name: "host"},
+	{Name: "if-match"},
+	{Name: "if-modified-since"},
+	{Name: "if-none-match"},
+	{Name: "if-range"},
+	{Name: "if-unmodified-since"},
+	{Name: "last-modified"},
+	{Name: "link"},
+	{Name: "location"},
+	{Name: "max-forwards"},
+	{Name: "proxy-authenticate"},
+	{Name: "proxy-authorization"},
+	{Name: "range"},
+	{Name: "referer"},
+	{Name: "refresh"},
+	{Name: "retry-after"},
+	{Name: "server"},
+	{Name: "set-cookie"},
+	{Name: "strict-transport-security"},
+	{Name: "transfer-encoding"},
+	{Name: "user-agent"},
+	{Name: "vary"},
+	{Name: "via"},
+	{Name: "www-authenticate"},
+}

--- a/internal/ebpf/h2decode/latejoin_test.go
+++ b/internal/ebpf/h2decode/latejoin_test.go
@@ -1,0 +1,296 @@
+package h2decode
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+// literalInsert hand-crafts a "literal with incremental indexing, literal
+// name" representation (RFC 7541 §6.2.1) for short ASCII strings.
+func literalInsert(name, value string) []byte {
+	block := []byte{0x40, byte(len(name))}
+	block = append(block, name...)
+	block = append(block, byte(len(value)))
+	block = append(block, value...)
+	return block
+}
+
+func fieldNames(fields []hpack.HeaderField) []string {
+	var names []string
+	for _, f := range fields {
+		names = append(names, f.Name+"="+f.Value)
+	}
+	return names
+}
+
+func TestReadInteger(t *testing.T) {
+	cases := []struct {
+		name     string
+		buf      []byte
+		prefix   uint8
+		value    int
+		consumed int
+		err      error
+	}{
+		{"single byte", []byte{0x0a}, 5, 10, 1, nil},
+		{"prefix boundary continues", []byte{0x1f, 0x00}, 5, 31, 2, nil},
+		{"multi byte", []byte{0x1f, 0x9a, 0x0a}, 5, 1337, 3, nil},
+		{"empty", nil, 7, 0, 0, errHPACKTruncated},
+		{"missing continuation", []byte{0xff}, 7, 0, 0, errHPACKTruncated},
+		{"overflow", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}, 7, 0, 0, errHPACKIntegerOverflow},
+	}
+	for _, tc := range cases {
+		value, consumed, err := readInteger(tc.buf, tc.prefix)
+		if !errors.Is(err, tc.err) {
+			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.err)
+		}
+		if err == nil && (value != tc.value || consumed != tc.consumed) {
+			t.Fatalf("%s: got (%d, %d), want (%d, %d)", tc.name, value, consumed, tc.value, tc.consumed)
+		}
+	}
+}
+
+func TestStaticTableIndexedFields(t *testing.T) {
+	d := &lateJoinDecoder{}
+	fields, complete, err := d.decodeBlock([]byte{0x82, 0x87, 0x88})
+	if err != nil || !complete {
+		t.Fatalf("static-only block: complete=%v err=%v", complete, err)
+	}
+	want := []string{":method=GET", ":scheme=https", ":status=200"}
+	got := fieldNames(fields)
+	if len(got) != len(want) {
+		t.Fatalf("fields = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("field %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStaticTableMatchesRFC(t *testing.T) {
+	checks := map[int]hpack.HeaderField{
+		1:  {Name: ":authority"},
+		4:  {Name: ":path", Value: "/"},
+		8:  {Name: ":status", Value: "200"},
+		14: {Name: ":status", Value: "500"},
+		15: {Name: "accept-charset"},
+		31: {Name: "content-type"},
+		61: {Name: "www-authenticate"},
+	}
+	for index, want := range checks {
+		got := hpackStaticTable[index-1]
+		if got != want {
+			t.Fatalf("static[%d] = %v, want %v", index, got, want)
+		}
+	}
+}
+
+func TestLateJoinSkipsPreAttachAndRecovers(t *testing.T) {
+	enc := newBlockEncoder()
+	preAttach := enc.encode(reqFields("POST", "/pkg.Svc/Old")...)
+	steadyState := enc.encode(reqFields("POST", "/pkg.Svc/Old")...)
+	newRoute := enc.encode(reqFields("POST", "/pkg.Svc/New")...)
+	newRouteRepeat := enc.encode(reqFields("POST", "/pkg.Svc/New")...)
+	_ = preAttach
+
+	d := &lateJoinDecoder{}
+
+	fields, complete, err := d.decodeBlock(steadyState)
+	if err != nil {
+		t.Fatalf("steady-state block errored: %v", err)
+	}
+	if complete {
+		t.Fatal("steady-state block cannot be complete on a late join")
+	}
+	for _, f := range fields {
+		if f.Name == ":path" {
+			t.Fatalf("pre-attach :path must not resolve, got %q", f.Value)
+		}
+	}
+
+	fields, _, err = d.decodeBlock(newRoute)
+	if err != nil {
+		t.Fatalf("new-route block errored: %v", err)
+	}
+	if !hasField(fields, ":path", "/pkg.Svc/New") {
+		t.Fatalf("new-route literal :path missing: %v", fieldNames(fields))
+	}
+
+	fields, _, err = d.decodeBlock(newRouteRepeat)
+	if err != nil {
+		t.Fatalf("new-route repeat errored: %v", err)
+	}
+	if !hasField(fields, ":path", "/pkg.Svc/New") {
+		t.Fatalf("indexed post-attach :path did not resolve: %v", fieldNames(fields))
+	}
+}
+
+func TestPlaceholderInsertKeepsOrdinalsCorrect(t *testing.T) {
+	enc := newBlockEncoder()
+	_ = enc.encode(hf("x-token", "alpha"))
+	nameRefInsert := enc.encode(hf("x-token", "beta"))
+	fullLiteral := enc.encode(hf("x-other", "gamma"))
+	bothIndexed := enc.encode(hf("x-token", "beta"), hf("x-other", "gamma"))
+
+	d := &lateJoinDecoder{}
+
+	fields, complete, err := d.decodeBlock(nameRefInsert)
+	if err != nil || complete || len(fields) != 0 {
+		t.Fatalf("name-ref insert: fields=%v complete=%v err=%v", fieldNames(fields), complete, err)
+	}
+
+	fields, complete, err = d.decodeBlock(fullLiteral)
+	if err != nil || !complete || !hasField(fields, "x-other", "gamma") {
+		t.Fatalf("full literal: fields=%v complete=%v err=%v", fieldNames(fields), complete, err)
+	}
+
+	fields, complete, err = d.decodeBlock(bothIndexed)
+	if err != nil {
+		t.Fatalf("indexed pair errored: %v", err)
+	}
+	if complete {
+		t.Fatal("placeholder-backed reference must mark the block partial")
+	}
+	if len(fields) != 1 || !hasField(fields, "x-other", "gamma") {
+		t.Fatalf("expected exactly x-other=gamma, got %v", fieldNames(fields))
+	}
+}
+
+func TestSensitiveNeverIndexedField(t *testing.T) {
+	enc := newBlockEncoder()
+	block := enc.encode(hpack.HeaderField{Name: "authorization", Value: "secret", Sensitive: true})
+	d := &lateJoinDecoder{}
+	fields, complete, err := d.decodeBlock(block)
+	if err != nil || !complete || !hasField(fields, "authorization", "secret") {
+		t.Fatalf("never-indexed field: fields=%v complete=%v err=%v", fieldNames(fields), complete, err)
+	}
+}
+
+func TestDynamicTableSizeUpdateParsed(t *testing.T) {
+	enc := newBlockEncoder()
+	enc.enc.SetMaxDynamicTableSize(256)
+	block := enc.encode(reqFields("GET", "/sized")...)
+	d := &lateJoinDecoder{}
+	fields, complete, err := d.decodeBlock(block)
+	if err != nil || !complete || !hasField(fields, ":path", "/sized") {
+		t.Fatalf("size-update block: fields=%v complete=%v err=%v", fieldNames(fields), complete, err)
+	}
+}
+
+func TestMalformedBlocks(t *testing.T) {
+	cases := []struct {
+		name  string
+		block []byte
+		err   error
+	}{
+		{"zero index", []byte{0x80}, errHPACKZeroIndex},
+		{"index out of range", []byte{0xff, 0xff, 0xff, 0x0f}, errHPACKIndexRange},
+		{"truncated integer", []byte{0xff}, errHPACKTruncated},
+		{"truncated string", []byte{0x00, 0x05, 'a'}, errHPACKTruncated},
+	}
+	for _, tc := range cases {
+		d := &lateJoinDecoder{}
+		_, _, err := d.decodeBlock(tc.block)
+		if !errors.Is(err, tc.err) {
+			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.err)
+		}
+	}
+}
+
+func TestResetEpochDiscardsWindow(t *testing.T) {
+	enc := newBlockEncoder()
+	first := enc.encode(hf("x-route", "/a"))
+	repeat := enc.encode(hf("x-route", "/a"))
+
+	d := &lateJoinDecoder{}
+	if _, complete, err := d.decodeBlock(first); err != nil || !complete {
+		t.Fatalf("literal insert failed: complete=%v err=%v", complete, err)
+	}
+	d.resetEpoch()
+	fields, complete, err := d.decodeBlock(repeat)
+	if err != nil {
+		t.Fatalf("post-reset block errored: %v", err)
+	}
+	if complete || len(fields) != 0 {
+		t.Fatalf("post-reset reference resolved from a discarded window: %v", fieldNames(fields))
+	}
+}
+
+func TestInsertWindowBounded(t *testing.T) {
+	d := &lateJoinDecoder{}
+	for i := 0; i < maxTrackedInserts+50; i++ {
+		block := literalInsert("x-k", fmt.Sprintf("v%d", i))
+		if _, _, err := d.decodeBlock(block); err != nil {
+			t.Fatalf("insert %d errored: %v", i, err)
+		}
+	}
+	if len(d.inserts) > maxTrackedInserts {
+		t.Fatalf("window grew to %d, cap is %d", len(d.inserts), maxTrackedInserts)
+	}
+	// The newest insertion must still resolve at dynamic index 62.
+	fields, complete, err := d.decodeBlock([]byte{0x80 | 62})
+	if err != nil || !complete || !hasField(fields, "x-k", fmt.Sprintf("v%d", maxTrackedInserts+49)) {
+		t.Fatalf("newest entry lost after compaction: fields=%v complete=%v err=%v",
+			fieldNames(fields), complete, err)
+	}
+}
+
+func TestDifferentialAgainstReferenceDecoder(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	names := []string{":authority", "x-request-id", "content-type", "grpc-timeout",
+		"user-agent", "x-b3-traceid", "cookie", "x-very-long-header-name-for-huffman"}
+	values := []string{"demo.svc:443", "application/grpc", "10S", "podtrace-test/1.0",
+		"aa", "session=0123456789abcdef0123456789abcdef", "text/plain; charset=utf-8"}
+	paths := []string{"/pkg.Svc/Do", "/pkg.Svc/Other", "/api/v1/orders", "/healthz"}
+
+	enc := newBlockEncoder()
+	lateJoin := &lateJoinDecoder{}
+	reference := hpack.NewDecoder(4096, nil)
+
+	for i := 0; i < 300; i++ {
+		fields := reqFields("POST", paths[rng.Intn(len(paths))])
+		for n := rng.Intn(4); n > 0; n-- {
+			fields = append(fields, hpack.HeaderField{
+				Name:      names[rng.Intn(len(names))],
+				Value:     values[rng.Intn(len(values))],
+				Sensitive: rng.Intn(8) == 0,
+			})
+		}
+		block := enc.encode(fields...)
+
+		got, complete, err := lateJoin.decodeBlock(block)
+		if err != nil {
+			t.Fatalf("block %d: late-join errored: %v", i, err)
+		}
+		if !complete {
+			t.Fatalf("block %d: fully-observed stream decoded partial", i)
+		}
+		want, err := reference.DecodeFull(block)
+		if err != nil {
+			t.Fatalf("block %d: reference decoder errored: %v", i, err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("block %d: %d fields, reference has %d", i, len(got), len(want))
+		}
+		for j := range want {
+			if got[j].Name != want[j].Name || got[j].Value != want[j].Value {
+				t.Fatalf("block %d field %d: got %s=%s, want %s=%s",
+					i, j, got[j].Name, got[j].Value, want[j].Name, want[j].Value)
+			}
+		}
+	}
+}
+
+func hasField(fields []hpack.HeaderField, name, value string) bool {
+	for _, f := range fields {
+		if f.Name == name && f.Value == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ebpf/tracer/idle_deny_test.go
+++ b/internal/ebpf/tracer/idle_deny_test.go
@@ -1,0 +1,49 @@
+package tracer
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/ebpf/filter"
+)
+
+func TestIdleDeny(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+
+	if tr.idleDeny() {
+		t.Fatal("permissive default: idleDeny must be false without the mode")
+	}
+
+	tr.SetDenyWhenNoTargets(true)
+	if !tr.idleDeny() {
+		t.Fatal("deny mode with zero targets must report idleDeny")
+	}
+
+	tr.storeCgroupIDs(map[uint64]struct{}{42: {}})
+	if tr.idleDeny() {
+		t.Fatal("kernel-side cgroup ids present: idleDeny must be false")
+	}
+	tr.storeCgroupIDs(map[uint64]struct{}{})
+
+	tr.filter.SetCgroupPaths([]string{"/sys/fs/cgroup/kubepods/pod-a"})
+	if tr.idleDeny() {
+		t.Fatal("userspace filter paths present: idleDeny must be false")
+	}
+	tr.filter.SetCgroupPaths(nil)
+
+	if !tr.idleDeny() {
+		t.Fatal("targets cleared again: idleDeny must be true")
+	}
+
+	tr.SetDenyWhenNoTargets(false)
+	if tr.idleDeny() {
+		t.Fatal("mode disabled: idleDeny must be false")
+	}
+}
+
+func TestSyncTargetCgroupMapWithoutCollection(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	tr.SetDenyWhenNoTargets(true)
+	if err := tr.syncTargetCgroupMap(); err != nil {
+		t.Fatalf("syncTargetCgroupMap without collection errored: %v", err)
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -96,6 +96,7 @@ type Tracer struct {
 	lastDNSDrops             uint64
 	cgroupPaths              []string
 	useUserspaceCgroupFilter atomic.Bool
+	denyWhenNoTargets        atomic.Bool
 	targetCgroupID           atomic.Uint64
 	targetCgroupIDs          atomic.Pointer[map[uint64]struct{}]
 	cgroupWriteMu            sync.Mutex
@@ -591,6 +592,19 @@ func NewTracer() (*Tracer, error) {
 	return t, nil
 }
 
+// SetDenyWhenNoTargets makes an empty target set mean "capture nothing"
+// instead of "capture everything".
+func (t *Tracer) SetDenyWhenNoTargets(deny bool) {
+	t.denyWhenNoTargets.Store(deny)
+}
+
+// idleDeny reports whether the tracer is in deny-when-no-targets mode with
+// no targets configured on either filter layer.
+func (t *Tracer) idleDeny() bool {
+	return t.denyWhenNoTargets.Load() &&
+		len(t.loadCgroupIDs()) == 0 && !t.filter.HasTargets()
+}
+
 // SetCgroups replaces the tracer's entire cgroup filter set with the
 // given paths.
 func (t *Tracer) SetCgroups(cgroupPaths []string) error {
@@ -760,7 +774,8 @@ func (t *Tracer) syncTargetCgroupMap() error {
 	ids := t.loadCgroupIDs()
 
 	if len(ids) == 0 {
-		if err := t.setCgroupFilterEnabled(false); err != nil {
+		deny := t.denyWhenNoTargets.Load() && len(t.cgroupPaths) == 0
+		if err := t.setCgroupFilterEnabled(deny); err != nil {
 			return err
 		}
 	}
@@ -906,6 +921,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 
 	t.cgroupWriteMu.Lock()
 	dnsCgroups := append([]string(nil), t.cgroupPaths...)
+	if err := t.syncTargetCgroupMap(); err != nil {
+		logger.Warn("Failed initial target cgroup map sync", zap.Error(err))
+	}
 	t.cgroupWriteMu.Unlock()
 	t.syncDNSPacketProbes(dnsCgroups)
 	t.syncHTTP3Probes(dnsCgroups)
@@ -925,6 +943,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 			case <-ticker.C:
 				if t.pathCache != nil {
 					t.pathCache.CleanupExpired()
+				}
+				if t.cpAnalyzer != nil {
+					t.cpAnalyzer.Evict()
 				}
 				t.pollBPFMapUtilization()
 			}
@@ -965,6 +986,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 			case <-ctx.Done():
 				return
 			case <-eventCollectionTicker.C:
+				if t.idleDeny() {
+					continue
+				}
 				elapsed := time.Since(startTime)
 				if !filteringDisabled.Load() && eventsParsed.Load() > 10 && eventsCollected.Load() == 0 && elapsed > 10*time.Second {
 					if config.AllowCgroupFilterAutoDisable() {
@@ -1179,6 +1203,9 @@ func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 					zap.String("process", event.ProcessName))
 			}
 		}
+	} else if t.idleDeny() {
+		allowed = false
+		ec.filtered.Add(1)
 	} else if t.useUserspaceCgroupFilter.Load() {
 		allowed = t.filter.IsPIDInCgroup(event.PID)
 		if !allowed {


### PR DESCRIPTION
## Summary

Attaching to a live HTTP/2 connection (a long-lived gRPC channel) no longer loses all request headers to missing HPACK dynamic-table state. This lifts the "Java gRPC responses only" ceiling from #272: podtrace now shows the gRPC method (`:path`) for Java/netty-tcnative traffic, fully for any connection or route first seen after attach, and as a counted, latency-paired `<unknown-path>` request for routes indexed before attach.

Also fixes the idle-agent OOM: agents with no PodTrace CR selecting pods on their node used to capture whole-node traffic through userspace filtering and OOM a 1Gi limit within ~2 minutes on a busy node.

## Late-join HPACK decoder (`internal/ebpf/h2decode`)

`hpack.Decoder.DecodeFull` is all-or-nothing: one reference to a dynamic-table entry populated before capture fails the whole block, and the old error path reset the decoder, re-poisoning state for everything after it. Replaced with a custom RFC 7541 parser that exploits an HPACK invariant: dynamic-table indices count newest-first, so an append-only window of insertions observed since attach resolves every post-attach reference exactly, while pre-attach references are structurally skipped (each entry is self-delimiting). Insertions whose name is itself an unresolvable reference are kept as placeholder entries so ordinal arithmetic never drifts.

Partially-decoded request blocks surface as `<unknown-path>`, still counted, still latency-paired via stream id, gated by direction-role evidence so indexed response trailers are never misreported as requests. Sequence gaps now restart the observation window instead of destroying the decoder. New `Stats`: `PartialBlocks`, `AnonymousRequests`.

## Two BPF capture bugs (`bpf/h2.c`)

Root-caused with hex-level record diagnostics; these not HPACK were why fresh connections showed `Requests: 0`:

- **Split preface**: a first `SSL_read` shorter than 24 bytes skipped the preface check but still set `preface_seen`, so `"PRI * HTT"` was parsed as a frame header, a bogus ~5.3 MB frame length muted ingress for the connection's lifetime. Partial prefaces now consume their tail through the existing remaining-skip machinery.
- **Conn-id recycling**: the conn id is the `SSL*` pointer; a new connection often gets the just-freed address of the previous one and inherits its stale frame state (`tcp_close` cleanup only matches h2c's `sock*` keys). An observed client preface (strong 16-byte match) now resets both directions' state and emits a close record so userspace evicts its decoder state.

## Idle-agent OOM fix (`cmd/podtrace/agent.go`, tracer, criticalpath)

Three compounding defects: both filter layers default-allow on an empty target set (BPF `cgroup_filter_enabled=0` captures everything; userspace `IsPIDInCgroup` passes everything), the agent starts collection unconditionally at boot, and the critical-path analyzer's per-PID window map was fed every event while its `Evict()` was never called, an unbounded leak. Deleting the *last* PodTrace CR landed in the same capture-everything state.

- New `Tracer.SetDenyWhenNoTargets(true)`, enabled only by the agent backend adapter: with no targets the kernel prefilter stays enabled against an empty map (default-deny at the source), applied at `Start` and on every target sync. CLI and session Jobs keep the permissive default, they always attach an explicit target.
- The filter auto-disable fallback and "no events" diagnostics are suppressed in idle-deny mode so they can't silently re-enable whole-node capture.
- Cgroup-v1 path filtering is preserved (kernel deny only engages when no userspace path targets exist; new `filter.HasTargets()`).
- Leak fix for all flows: `cpAnalyzer.Evict()` wired into the existing 30s housekeeping ticker, plus a `maxWindows` cap in `Feed`.