### PR TITLE
fix: export session events and evict consumed stack traces

### DIFF
--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -134,7 +134,7 @@ struct {
 } tcp_sockets SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 2048);
 	__type(key, u64);
 	__type(value, struct stack_trace_t);

--- a/cmd/podtrace/exporter_from_file.go
+++ b/cmd/podtrace/exporter_from_file.go
@@ -47,12 +47,12 @@ func applyExporterFromFile(path string) error {
 
 	applyPayloadToConfig(p)
 	config.TracingEnabled = true
+	enableTracing = true
 	return nil
 }
 
 // applyPayloadToConfig translates a bundle.Payload into the process-
 // global config.* knobs the existing tracing manager reads on startup.
-// Split out so tests can exercise it without touching the filesystem.
 func applyPayloadToConfig(p *bundle.Payload) {
 	if p == nil {
 		return

--- a/cmd/podtrace/exporter_from_file_test.go
+++ b/cmd/podtrace/exporter_from_file_test.go
@@ -123,6 +123,26 @@ sample: 0.1
 	}
 }
 
+// Regression test: the export gates in runPodtrace check the enableTracing
+// flag var, not config.TracingEnabled.
+func TestApplyExporterFromFile_EnablesExportGate(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+	enableTracing = false
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.yaml")
+	if err := os.WriteFile(path, []byte("type: otlp\nendpoint: otel:4318\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyExporterFromFile(path); err != nil {
+		t.Fatalf("applyExporterFromFile: %v", err)
+	}
+	if !enableTracing {
+		t.Error("exporter bundle did not enable the export gate (enableTracing)")
+	}
+}
+
 func TestApplyExporterFromFile_MissingFileErrors(t *testing.T) {
 	defer resetTracingConfig()
 	if err := applyExporterFromFile("/no/such/path"); err == nil {

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -188,6 +188,35 @@ func main() {
 	}
 }
 
+// applyTracingFlags copies the --tracing-* flag values into the process-
+// global config knobs.
+func applyTracingFlags(cmd *cobra.Command) error {
+	if !enableTracing {
+		return nil
+	}
+	config.TracingEnabled = true
+	flags := cmd.Flags()
+	if flags.Changed("tracing-otlp-endpoint") && tracingOTLPEndpoint != "" {
+		config.OTLPEndpoint = tracingOTLPEndpoint
+	}
+	if flags.Changed("tracing-jaeger-endpoint") && tracingJaegerEndpoint != "" {
+		config.JaegerEndpoint = tracingJaegerEndpoint
+	}
+	if flags.Changed("tracing-splunk-endpoint") && tracingSplunkEndpoint != "" {
+		config.SplunkEndpoint = tracingSplunkEndpoint
+	}
+	if tracingSplunkToken != "" {
+		config.SplunkToken = tracingSplunkToken
+	}
+	if flags.Changed("tracing-sample-rate") {
+		if tracingSampleRate < 0.0 || tracingSampleRate > 1.0 {
+			return fmt.Errorf("--tracing-sample-rate must be between 0.0 and 1.0, got %v", tracingSampleRate)
+		}
+		config.TracingSampleRate = tracingSampleRate
+	}
+	return nil
+}
+
 func runPodtrace(cmd *cobra.Command, args []string) error {
 	if showVersion {
 		fmt.Println(config.GetVersion())
@@ -223,24 +252,8 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if enableTracing {
-		config.TracingEnabled = true
-		if tracingOTLPEndpoint != "" {
-			config.OTLPEndpoint = tracingOTLPEndpoint
-		}
-		if tracingJaegerEndpoint != "" {
-			config.JaegerEndpoint = tracingJaegerEndpoint
-		}
-		if tracingSplunkEndpoint != "" {
-			config.SplunkEndpoint = tracingSplunkEndpoint
-		}
-		if tracingSplunkToken != "" {
-			config.SplunkToken = tracingSplunkToken
-		}
-		if tracingSampleRate < 0.0 || tracingSampleRate > 1.0 {
-			return fmt.Errorf("--tracing-sample-rate must be between 0.0 and 1.0, got %v", tracingSampleRate)
-		}
-		config.TracingSampleRate = tracingSampleRate
+	if err := applyTracingFlags(cmd); err != nil {
+		return err
 	}
 
 	alertManager, err := alerting.NewManager()

--- a/cmd/podtrace/tracing_flags_unit_test.go
+++ b/cmd/podtrace/tracing_flags_unit_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newTracingFlagsCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolVar(&enableTracing, "tracing", config.DefaultTracingEnabled, "")
+	cmd.Flags().StringVar(&tracingOTLPEndpoint, "tracing-otlp-endpoint", config.DefaultOTLPEndpoint, "")
+	cmd.Flags().StringVar(&tracingJaegerEndpoint, "tracing-jaeger-endpoint", config.DefaultJaegerEndpoint, "")
+	cmd.Flags().StringVar(&tracingSplunkEndpoint, "tracing-splunk-endpoint", config.DefaultSplunkEndpoint, "")
+	cmd.Flags().StringVar(&tracingSplunkToken, "tracing-splunk-token", "", "")
+	cmd.Flags().Float64Var(&tracingSampleRate, "tracing-sample-rate", config.DefaultTracingSampleRate, "")
+	return cmd
+}
+
+func restoreTracingFlagGlobals(t *testing.T) {
+	t.Helper()
+	origEnable := enableTracing
+	origOTLP := tracingOTLPEndpoint
+	origJaeger := tracingJaegerEndpoint
+	origSplunk := tracingSplunkEndpoint
+	origToken := tracingSplunkToken
+	origRate := tracingSampleRate
+	t.Cleanup(func() {
+		enableTracing = origEnable
+		tracingOTLPEndpoint = origOTLP
+		tracingJaegerEndpoint = origJaeger
+		tracingSplunkEndpoint = origSplunk
+		tracingSplunkToken = origToken
+		tracingSampleRate = origRate
+	})
+}
+
+func TestApplyTracingFlags_PreservesBundleConfig(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+
+	cmd := newTracingFlagsCommand()
+	if err := cmd.Flags().Set("tracing", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	config.OTLPEndpoint = "otel.observability:4318"
+	config.TracingSampleRate = 0.25
+
+	if err := applyTracingFlags(cmd); err != nil {
+		t.Fatalf("applyTracingFlags: %v", err)
+	}
+	if !config.TracingEnabled {
+		t.Error("TracingEnabled not set")
+	}
+	if config.OTLPEndpoint != "otel.observability:4318" {
+		t.Errorf("bundle OTLP endpoint clobbered by flag default: %q", config.OTLPEndpoint)
+	}
+	if config.TracingSampleRate != 0.25 {
+		t.Errorf("bundle sample rate clobbered by flag default: %v", config.TracingSampleRate)
+	}
+}
+
+func TestApplyTracingFlags_ExplicitFlagsWin(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+
+	cmd := newTracingFlagsCommand()
+	for flag, value := range map[string]string{
+		"tracing":               "true",
+		"tracing-otlp-endpoint": "cli-otel:4318",
+		"tracing-sample-rate":   "0.5",
+	} {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config.OTLPEndpoint = "bundle-otel:4318"
+	config.TracingSampleRate = 0.25
+
+	if err := applyTracingFlags(cmd); err != nil {
+		t.Fatalf("applyTracingFlags: %v", err)
+	}
+	if config.OTLPEndpoint != "cli-otel:4318" {
+		t.Errorf("explicit --tracing-otlp-endpoint not applied: %q", config.OTLPEndpoint)
+	}
+	if config.TracingSampleRate != 0.5 {
+		t.Errorf("explicit --tracing-sample-rate not applied: %v", config.TracingSampleRate)
+	}
+}
+
+func TestApplyTracingFlags_InvalidSampleRateErrors(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+
+	cmd := newTracingFlagsCommand()
+	if err := cmd.Flags().Set("tracing", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("tracing-sample-rate", "1.5"); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyTracingFlags(cmd); err == nil {
+		t.Error("expected error for out-of-range --tracing-sample-rate")
+	}
+}
+
+func TestApplyTracingFlags_DisabledIsNoOp(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+
+	cmd := newTracingFlagsCommand()
+	config.TracingEnabled = false
+
+	if err := applyTracingFlags(cmd); err != nil {
+		t.Fatalf("applyTracingFlags: %v", err)
+	}
+	if config.TracingEnabled {
+		t.Error("TracingEnabled set without --tracing")
+	}
+}

--- a/internal/ebpf/tracer/stack_consume_test.go
+++ b/internal/ebpf/tracer/stack_consume_test.go
@@ -1,0 +1,79 @@
+package tracer
+
+import (
+	"os"
+	"regexp"
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestStackTracesMapDeclaredLRU(t *testing.T) {
+	src, err := os.ReadFile("../../../bpf/maps.h")
+	if err != nil {
+		t.Fatalf("read bpf/maps.h: %v", err)
+	}
+	decl := regexp.MustCompile(`(?s)struct \{[^}]*\} stack_traces SEC`).Find(src)
+	if decl == nil {
+		t.Fatal("stack_traces map declaration not found in bpf/maps.h")
+	}
+	if !regexp.MustCompile(`BPF_MAP_TYPE_LRU_HASH`).Match(decl) {
+		t.Errorf("stack_traces must be BPF_MAP_TYPE_LRU_HASH, got declaration:\n%s", decl)
+	}
+}
+
+func TestResolveAndConsumeStack_DeletesEntry(t *testing.T) {
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.LRUHash,
+		KeySize:    8,
+		ValueSize:  uint32(unsafe.Sizeof(stackTraceValue{})),
+		MaxEntries: 8,
+	})
+	if err != nil {
+		t.Skipf("cannot create BPF map (requires CAP_BPF): %v", err)
+	}
+	defer m.Close()
+
+	key := uint64(0xdeadbeef)
+	value := stackTraceValue{Nr: 2}
+	value.IPs[0] = 0x1000
+	value.IPs[1] = 0x2000
+	if err := m.Put(&key, &value); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	event := &events.Event{StackKey: key}
+	resolveAndConsumeStack(m, event)
+
+	if len(event.Stack) != 2 || event.Stack[0] != 0x1000 || event.Stack[1] != 0x2000 {
+		t.Errorf("stack not resolved onto event: %#v", event.Stack)
+	}
+	var out stackTraceValue
+	if err := m.Lookup(&key, &out); err == nil {
+		t.Error("consumed stack entry still present in map; it must be deleted after the read")
+	}
+}
+
+func TestResolveAndConsumeStack_NilMapAndZeroKey(t *testing.T) {
+	resolveAndConsumeStack(nil, &events.Event{StackKey: 1})
+
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.LRUHash,
+		KeySize:    8,
+		ValueSize:  uint32(unsafe.Sizeof(stackTraceValue{})),
+		MaxEntries: 8,
+	})
+	if err != nil {
+		t.Skipf("cannot create BPF map (requires CAP_BPF): %v", err)
+	}
+	defer m.Close()
+
+	event := &events.Event{StackKey: 0}
+	resolveAndConsumeStack(m, event)
+	if event.Stack != nil {
+		t.Errorf("zero StackKey must not resolve a stack, got %#v", event.Stack)
+	}
+}

--- a/internal/ebpf/tracer/stack_consume_test.go
+++ b/internal/ebpf/tracer/stack_consume_test.go
@@ -35,7 +35,7 @@ func TestResolveAndConsumeStack_DeletesEntry(t *testing.T) {
 	if err != nil {
 		t.Skipf("cannot create BPF map (requires CAP_BPF): %v", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	key := uint64(0xdeadbeef)
 	value := stackTraceValue{Nr: 2}
@@ -69,7 +69,7 @@ func TestResolveAndConsumeStack_NilMapAndZeroKey(t *testing.T) {
 	if err != nil {
 		t.Skipf("cannot create BPF map (requires CAP_BPF): %v", err)
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 
 	event := &events.Event{StackKey: 0}
 	resolveAndConsumeStack(m, event)

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -1177,26 +1177,35 @@ type eventCounters struct {
 }
 
 // processAndDispatch enriches a parsed event (stack, process name, redaction,
+// resolveAndConsumeStack copies the captured user stack for event.StackKey
+// out of stackMap onto the event, then deletes the entry.
+func resolveAndConsumeStack(stackMap *ebpf.Map, event *events.Event) {
+	if stackMap == nil || event.StackKey == 0 {
+		return
+	}
+	var stack stackTraceValue
+	key := event.StackKey
+	if err := stackMap.Lookup(&key, &stack); err != nil {
+		return
+	}
+	n := int(stack.Nr)
+	if n > len(stack.IPs) {
+		n = len(stack.IPs)
+	}
+	if n > 0 {
+		frames := make([]uint64, n)
+		copy(frames, stack.IPs[:n])
+		event.Stack = frames
+	}
+	_ = stackMap.Delete(&key)
+}
+
 // critical-path), applies cgroup filtering, and forwards it to eventChan.
 func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 	eventChan chan<- *events.Event, stackMap *ebpf.Map, ec *eventCounters,
 	processingStart time.Time) {
 	ec.parsed.Add(1)
-	if stackMap != nil && event.StackKey != 0 {
-		var stack stackTraceValue
-		key := event.StackKey
-		if err := stackMap.Lookup(&key, &stack); err == nil {
-			n := int(stack.Nr)
-			if n > len(stack.IPs) {
-				n = len(stack.IPs)
-			}
-			if n > 0 {
-				frames := make([]uint64, n)
-				copy(frames, stack.IPs[:n])
-				event.Stack = frames
-			}
-		}
-	}
+	resolveAndConsumeStack(stackMap, event)
 	if event.ProcessName == "" {
 		event.ProcessName = t.getProcessNameQuick(event.PID)
 	}

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -98,6 +98,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 
 	sessionArgs := append([]string{}, args...)
 	sessionArgs = append(sessionArgs,
+		"--tracing",
 		"--exporter-from-file", "/etc/podtrace/exporter/bundle.yaml",
 		"--summary-file", "/var/run/podtrace/summary.json",
 		"--termination-message-path", "/dev/termination-log",

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -110,28 +111,25 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	if spec.TTLSecondsAfterFinished == nil || *spec.TTLSecondsAfterFinished != 600 {
 		t.Errorf("TTL: %v", spec.TTLSecondsAfterFinished)
 	}
-	// 5m + 45s = 345s
 	if spec.ActiveDeadlineSeconds == nil || *spec.ActiveDeadlineSeconds != 345 {
 		t.Errorf("activeDeadlineSeconds=%v want 345", spec.ActiveDeadlineSeconds)
 	}
-	// Pinned to the right node
 	if spec.Template.Spec.NodeSelector["kubernetes.io/hostname"] != "node-a" {
 		t.Errorf("nodeSelector wrong: %v", spec.Template.Spec.NodeSelector)
 	}
 	if spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("restartPolicy=%v want Never", spec.Template.Spec.RestartPolicy)
 	}
-	// Image propagated
 	if spec.Template.Spec.Containers[0].Image != "ghcr.io/gma1k/podtrace:test" {
 		t.Errorf("image: %q", spec.Template.Spec.Containers[0].Image)
 	}
 	if spec.Template.Spec.ServiceAccountName != SessionServiceAccountName() {
 		t.Errorf("SA=%q want %q", spec.Template.Spec.ServiceAccountName, SessionServiceAccountName())
 	}
-	// Main container must carry the operator-supplied session flags so
-	// the CLI knows where to load the exporter bundle and emit
-	// artifacts.
 	args := strings.Join(spec.Template.Spec.Containers[0].Args, " ")
+	if !slices.Contains(spec.Template.Spec.Containers[0].Args, "--tracing") {
+		t.Errorf("missing --tracing: %v", spec.Template.Spec.Containers[0].Args)
+	}
 	if !strings.Contains(args, "--exporter-from-file /etc/podtrace/exporter/bundle.yaml") {
 		t.Errorf("missing --exporter-from-file: %v", spec.Template.Spec.Containers[0].Args)
 	}
@@ -141,14 +139,9 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	if !strings.Contains(args, "--termination-message-path /dev/termination-log") {
 		t.Errorf("missing --termination-message-path: %v", spec.Template.Spec.Containers[0].Args)
 	}
-	// Mount count sanity: bpf, btf, proc, cgroup, debugfs, tracefs,
-	// exporter, exporter-credential, rundir = 9.
 	if n := len(spec.Template.Spec.Containers[0].VolumeMounts); n != 9 {
 		t.Errorf("main container mounts=%d want 9", n)
 	}
-	// Tracepoints (sched_switch, inet_sock_set_state, ...) attach via
-	// tracefs; without these mounts every tracepoint silently failed in
-	// session Jobs while the agent DaemonSet carried them.
 	mountPaths := make(map[string]bool)
 	for _, m := range spec.Template.Spec.Containers[0].VolumeMounts {
 		mountPaths[m.MountPath] = true
@@ -158,7 +151,6 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 			t.Errorf("session Job is missing the %s mount required for tracepoint attach", required)
 		}
 	}
-	// Sidecar must not be present when TracerConfig.Session.SidecarUploader is false.
 	if len(spec.Template.Spec.InitContainers) != 0 {
 		t.Errorf("sidecar should be disabled by default: %d init containers", len(spec.Template.Spec.InitContainers))
 	}
@@ -197,8 +189,6 @@ func TestBuildSessionJobSpec_SidecarOptedIn(t *testing.T) {
 }
 
 func TestBuildSessionJobSpec_SidecarSuppressedWithoutReportRef(t *testing.T) {
-	// Even when SidecarUploader is on, there is nothing to upload
-	// without a report sink — the sidecar must be suppressed.
 	tc := &podtracev1alpha1.TracerConfig{
 		Spec: podtracev1alpha1.TracerConfigSpec{
 			Image: "ghcr.io/gma1k/podtrace:test",

--- a/internal/tracing/exporter/otlp.go
+++ b/internal/tracing/exporter/otlp.go
@@ -75,6 +75,7 @@ func NewOTLPExporter(endpoint string, sampleRate float64) (*OTLPExporter, error)
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpointURL(endpointURL),
 		otlptracehttp.WithTimeout(config.TracingExporterTimeout),
+		otlptracehttp.WithRetry(otlptracehttp.RetryConfig{Enabled: false}),
 	}
 	if useInsecure {
 		opts = append(opts, otlptracehttp.WithInsecure())

--- a/internal/tracing/manager.go
+++ b/internal/tracing/manager.go
@@ -284,40 +284,50 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	}
 
 	m.stopOnce.Do(func() { close(m.stopCh) })
-	m.wg.Wait()
 
-	// Final flush: force-export spans of traces that are still settling.
-	m.exportTraces(true)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.wg.Wait()
+		// Final flush: force-export spans of traces still settling.
+		m.exportTraces(true)
+		m.shutdownExporters(ctx)
+	}()
 
+	select {
+	case <-done:
+	case <-ctx.Done():
+		logger.Warn("Tracing shutdown exceeded its deadline; abandoning in-flight export", zap.Error(ctx.Err()))
+	}
+	return nil
+}
+
+// shutdownExporters closes every configured exporter, logging but not
+// propagating individual failures.
+func (m *Manager) shutdownExporters(ctx context.Context) {
 	if m.otlpExporter != nil {
 		if err := m.otlpExporter.Shutdown(ctx); err != nil {
 			logger.Warn("Failed to shutdown OTLP exporter", zap.Error(err))
 		}
 	}
-
 	if m.jaegerExporter != nil {
 		if err := m.jaegerExporter.Shutdown(ctx); err != nil {
 			logger.Warn("Failed to shutdown Jaeger exporter", zap.Error(err))
 		}
 	}
-
 	if m.splunkExporter != nil {
 		if err := m.splunkExporter.Shutdown(ctx); err != nil {
 			logger.Warn("Failed to shutdown Splunk exporter", zap.Error(err))
 		}
 	}
-
 	if m.datadogExporter != nil {
 		if err := m.datadogExporter.Shutdown(ctx); err != nil {
 			logger.Warn("Failed to shutdown DataDog exporter", zap.Error(err))
 		}
 	}
-
 	if m.zipkinExporter != nil {
 		if err := m.zipkinExporter.Shutdown(ctx); err != nil {
 			logger.Warn("Failed to shutdown Zipkin exporter", zap.Error(err))
 		}
 	}
-
-	return nil
 }

--- a/internal/tracing/manager_test.go
+++ b/internal/tracing/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/tracing/exporter"
 	"github.com/podtrace/podtrace/internal/tracing/extractor"
 	"github.com/podtrace/podtrace/internal/tracing/graph"
 )
@@ -155,6 +156,41 @@ func TestManager_Shutdown_Enabled(t *testing.T) {
 	err = manager.Shutdown(ctx)
 	if err != nil {
 		t.Errorf("Shutdown() error = %v", err)
+	}
+}
+
+// TestManager_Shutdown_BoundedWhenExporterUnreachable is a regression test
+// for the diagnose session Jobs that were SIGKILLed (session state Failed,
+// report lost) when their configured OTLP endpoint was unreachable.
+func TestManager_Shutdown_BoundedWhenExporterUnreachable(t *testing.T) {
+	t.Setenv("PODTRACE_OTLP_INSECURE", "1")
+	exp, err := exporter.NewOTLPExporter("http://192.0.2.1:4318", 1.0)
+	if err != nil {
+		t.Fatalf("NewOTLPExporter() error = %v", err)
+	}
+	m := &Manager{
+		enabled:        true,
+		extractor:      extractor.NewHTTPExtractor(),
+		traceTracker:   tracker.NewTraceTracker(),
+		otlpExporter:   exp,
+		exportInterval: 5 * time.Second,
+		stopCh:         make(chan struct{}),
+	}
+	m.traceTracker.ProcessEvent(&events.Event{
+		TraceID: "0af7651916cd43dd8448eb211c80319c",
+		SpanID:  "b7ad6b7169203331",
+		Type:    events.EventHTTPReq,
+	}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if err := m.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("Shutdown blocked for %v; it must be bounded by the context deadline, not the exporter", elapsed)
 	}
 }
 


### PR DESCRIPTION
Session Jobs completed green but sent zero events to the configured exporter: --exporter-from-file flipped config.TracingEnabled while every export gate checks the --tracing flag var the operator never passed. The Job argv now carries --tracing, the bundle loader flips the flag gate itself, and flag values are copied into config only when actually passed so defaults cannot clobber bundle endpoints.

stack_traces was a plain HASH written on nearly every event and never deleted; after ~2048 events every insert failed silently and stack capture died node-wide. The map is now LRU and userspace deletes each entry after consuming it.