### PR TITLE
fixes two operator control-plane bugs that could silently drop a node from a trace or re-run privileged tracing Jobs forever

### DIFF
--- a/internal/operator/naming.go
+++ b/internal/operator/naming.go
@@ -8,7 +8,8 @@
 package operator
 
 import (
-	"fmt"
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,13 +79,27 @@ func AgentBundleRoleBindingName() string { return "podtrace-agent-bundles" }
 
 func OperatorWebhookServiceName() string { return "podtrace-webhook" }
 
+// SessionJobName returns a per-(session,node) Job name that fits the
+// 63-character DNS limit AND is unique per node.
 func SessionJobName(sessionUID types.UID, nodeName string) string {
-	raw := fmt.Sprintf("pts-%s-%s", shortUID(sessionUID), sanitiseDNS(nodeName))
-	if len(raw) > 63 {
-		raw = raw[:63]
+	prefix := "pts-" + shortUID(sessionUID) + "-"
+	sum := sha256.Sum256([]byte(nodeName))
+	suffix := hex.EncodeToString(sum[:])[:8]
+
+	budget := 63 - len(prefix) - 1 - len(suffix)
+	if budget < 0 {
+		budget = 0
 	}
-	raw = strings.TrimRight(raw, "-.")
-	return raw
+	node := sanitiseDNS(nodeName)
+	if len(node) > budget {
+		node = node[:budget]
+	}
+	node = strings.TrimRight(node, "-.")
+
+	if node == "" {
+		return strings.TrimRight(prefix+suffix, "-.")
+	}
+	return strings.TrimRight(prefix+node+"-"+suffix, "-.")
 }
 
 func ExporterBundleName(exporterUID types.UID) string {

--- a/internal/operator/naming_test.go
+++ b/internal/operator/naming_test.go
@@ -58,6 +58,30 @@ func TestSessionJobName_Properties(t *testing.T) {
 	}
 }
 
+// TestSessionJobName_LongSharedPrefixNoCollision is the HO1 regression: GKE/EKS
+// node names share a long common prefix that overflows the 63-char limit, so
+// plain truncation produced identical Job names and one node was never traced.
+func TestSessionJobName_LongSharedPrefixNoCollision(t *testing.T) {
+	const uid = types.UID("abcdef1234567890")
+	prefix := "gke-prod-cluster-default-pool-1a2b3c4d-node-group-us-central1-"
+	nodeA := prefix + "0aaa"
+	nodeB := prefix + "0bbb"
+
+	a := SessionJobName(uid, nodeA)
+	b := SessionJobName(uid, nodeB)
+	if a == b {
+		t.Fatalf("HO1 collision: nodes %q and %q both map to Job %q", nodeA, nodeB, a)
+	}
+	for _, n := range []string{a, b} {
+		if len(n) > 63 {
+			t.Errorf("%q exceeds 63 chars (%d)", n, len(n))
+		}
+		if !isDNS1123Label(n) {
+			t.Errorf("%q is not a valid DNS-1123 label", n)
+		}
+	}
+}
+
 func TestExporterBundleName_Properties(t *testing.T) {
 	n := ExporterBundleName("abcdef12345678")
 	if !strings.HasPrefix(n, "pt-bundle-") {

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -331,7 +331,7 @@ func makeSessionJobRefs(jobs []batchv1.Job) []podtracev1alpha1.SessionJobRef {
 		ref := podtracev1alpha1.SessionJobRef{
 			Node:      node,
 			Name:      j.Name,
-			Completed: j.Status.Succeeded > 0 || j.Status.Failed >= jobBackoffLimit(&j)+1,
+			Completed: jobSucceeded(&j) || jobFailed(&j),
 		}
 		if j.Status.StartTime != nil {
 			ref.StartTime = j.Status.StartTime
@@ -339,7 +339,7 @@ func makeSessionJobRefs(jobs []batchv1.Job) []podtracev1alpha1.SessionJobRef {
 		if j.Status.CompletionTime != nil {
 			ref.CompletionTime = j.Status.CompletionTime
 		}
-		if j.Status.Failed > 0 && j.Status.Succeeded == 0 {
+		if jobFailed(&j) && !jobSucceeded(&j) {
 			ref.Message = "Job failed"
 		}
 		refs = append(refs, ref)
@@ -352,6 +352,27 @@ func jobBackoffLimit(j *batchv1.Job) int32 {
 		return *j.Spec.BackoffLimit
 	}
 	return 6
+}
+
+// jobConditionTrue reports whether the Job carries condition t with status
+// True.
+func jobConditionTrue(j *batchv1.Job, t batchv1.JobConditionType) bool {
+	for i := range j.Status.Conditions {
+		c := &j.Status.Conditions[i]
+		if c.Type == t && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// jobSucceeded / jobFailed classify a Job terminally via its conditions.
+func jobSucceeded(j *batchv1.Job) bool {
+	return jobConditionTrue(j, batchv1.JobComplete) || j.Status.Succeeded > 0
+}
+
+func jobFailed(j *batchv1.Job) bool {
+	return jobConditionTrue(j, batchv1.JobFailed) || j.Status.Failed > jobBackoffLimit(j)
 }
 
 // computeSessionState maps Job statuses to a SessionState.
@@ -384,8 +405,8 @@ func computeSessionState(jobs []batchv1.Job, expectedJobs int) podtracev1alpha1.
 	anyFailedFatal := false
 	for i := range jobs {
 		j := &jobs[i]
-		succeeded := j.Status.Succeeded > 0
-		failed := j.Status.Failed > jobBackoffLimit(j)
+		succeeded := jobSucceeded(j)
+		failed := jobFailed(j)
 		running := j.Status.Active > 0
 
 		if !succeeded {

--- a/internal/operator/reconcile_robustness_test.go
+++ b/internal/operator/reconcile_robustness_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,6 +52,34 @@ func TestComputeSessionState_UndercountedJobsNotTerminal(t *testing.T) {
 	}
 	if state := computeSessionState([]batchv1.Job{succeeded}, 1); state != podtracev1alpha1.SessionStateCompleted {
 		t.Errorf("state = %s with all expected Jobs succeeded, want Completed", state)
+	}
+}
+
+// TestComputeSessionState_DeadlineExceededIsTerminal regression: a
+// Job killed by ActiveDeadlineSeconds carries a JobFailed condition (reason
+// DeadlineExceeded) but its .status.Failed count does not exceed backoffLimit.
+func TestComputeSessionState_DeadlineExceededIsTerminal(t *testing.T) {
+	backoff := int32(6)
+	deadlineKilled := batchv1.Job{
+		Spec: batchv1.JobSpec{BackoffLimit: &backoff},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{{
+				Type:   batchv1.JobFailed,
+				Status: corev1.ConditionTrue,
+				Reason: "DeadlineExceeded",
+			}},
+		},
+	}
+	if state := computeSessionState([]batchv1.Job{deadlineKilled}, 1); state != podtracev1alpha1.SessionStateFailed {
+		t.Errorf("deadline-exceeded Job: state = %s, want Failed (else the session re-runs forever)", state)
+	}
+
+	complete := batchv1.Job{Status: batchv1.JobStatus{
+		Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+	}}
+	if state := computeSessionState([]batchv1.Job{complete}, 1); state != podtracev1alpha1.SessionStateCompleted {
+		t.Errorf("JobComplete condition: state = %s, want Completed", state)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two operator control-plane bugs that could silently drop a node from a trace or re-run privileged tracing Jobs forever.

## What changed

- **Job-name collision (`naming.go`):** `SessionJobName` truncated `pts-<uid>-<node>` to 63 chars, so GKE/EKS nodes sharing a long prefix mapped to the same Job name, the second node was never traced and the session hung Pending. It now appends an 8-char hash of the full node name, keeping the name unique and DNS-valid regardless of prefix length.
- **immortal deadline-killed sessions (`podtracesession_job.go`):** failure was classified only by `Failed > backoffLimit`, which missed a Job killed by `ActiveDeadlineSeconds` (JobFailed/DeadlineExceeded with a Failed count below the limit). The session never went terminal, so after the TTL controller deleted the dead Job the reconciler recreated the privileged
  hostPID Job on a loop. Classification now uses the JobComplete/JobFailed conditions, so a deadline kill is terminal and the loop stops.