### PR TITLE
feat: bound and sandbox untrusted container-binary parsing

### DIFF
--- a/internal/ebpf/probes/gosym.go
+++ b/internal/ebpf/probes/gosym.go
@@ -11,7 +11,8 @@ import (
 // goSymbolFileOffset resolves the executable file offset of a Go function
 // (e.g. "crypto/tls.(*Conn).Write") from the binary's .gopclntab.
 func goSymbolFileOffset(exePath, symbol string) (offset uint64, ok bool) {
-	f, err := elf.Open(exePath)
+	defer recoverParse("goSymbolFileOffset")
+	f, err := openELFCapped(exePath)
 	if err != nil {
 		return 0, false
 	}
@@ -22,15 +23,12 @@ func goSymbolFileOffset(exePath, symbol string) (offset uint64, ok bool) {
 	if pcln == nil || text == nil {
 		return 0, false
 	}
-	pclnData, err := pcln.Data()
+	pclnData, err := sectionDataCapped(pcln)
 	if err != nil {
 		return 0, false
 	}
 
-	var symtabData []byte
-	if s := f.Section(".gosymtab"); s != nil {
-		symtabData, _ = s.Data()
-	}
+	symtabData, _ := sectionDataCapped(f.Section(".gosymtab"))
 
 	tbl, err := gosym.NewTable(symtabData, gosym.NewLineTable(pclnData, text.Addr))
 	if err != nil {
@@ -54,23 +52,28 @@ func goSymbolFileOffset(exePath, symbol string) (offset uint64, ok bool) {
 
 // executableExportsSSL reports whether the ELF at path exposes the OpenSSL
 // SSL_write symbol so the SSL_* uprobes can attach to the executable itself.
-func executableExportsSSL(path string) bool {
-	f, err := elf.Open(path)
+func executableExportsSSL(path string) (exports bool) {
+	defer recoverParse("executableExportsSSL")
+	f, err := openELFCapped(path)
 	if err != nil {
 		return false
 	}
 	defer func() { _ = f.Close() }()
-	if dyn, err := f.DynamicSymbols(); err == nil {
-		for i := range dyn {
-			if dyn[i].Name == "SSL_write" {
-				return true
+	if symbolSectionWithinCap(f, ".dynsym") {
+		if dyn, err := f.DynamicSymbols(); err == nil {
+			for i := range dyn {
+				if dyn[i].Name == "SSL_write" {
+					return true
+				}
 			}
 		}
 	}
-	if sym, err := f.Symbols(); err == nil {
-		for i := range sym {
-			if sym[i].Name == "SSL_write" {
-				return true
+	if symbolSectionWithinCap(f, ".symtab") {
+		if sym, err := f.Symbols(); err == nil {
+			for i := range sym {
+				if sym[i].Name == "SSL_write" {
+					return true
+				}
 			}
 		}
 	}
@@ -95,7 +98,8 @@ func vaddrToFileOffset(f *elf.File, vaddr uint64) (uint64, bool) {
 // file offsets of every RET instruction within it, by scanning the function's
 // machine code.
 func goFuncReturnOffsets(exePath, symbol string) (entryOff uint64, retOffs []uint64, ok bool) {
-	f, err := elf.Open(exePath)
+	defer recoverParse("goFuncReturnOffsets")
+	f, err := openELFCapped(exePath)
 	if err != nil {
 		return 0, nil, false
 	}
@@ -110,14 +114,11 @@ func goFuncReturnOffsets(exePath, symbol string) (entryOff uint64, retOffs []uin
 	if pcln == nil || text == nil {
 		return 0, nil, false
 	}
-	pclnData, err := pcln.Data()
+	pclnData, err := sectionDataCapped(pcln)
 	if err != nil {
 		return 0, nil, false
 	}
-	var symtabData []byte
-	if s := f.Section(".gosymtab"); s != nil {
-		symtabData, _ = s.Data()
-	}
+	symtabData, _ := sectionDataCapped(f.Section(".gosymtab"))
 	tbl, err := gosym.NewTable(symtabData, gosym.NewLineTable(pclnData, text.Addr))
 	if err != nil {
 		return 0, nil, false
@@ -132,7 +133,7 @@ func goFuncReturnOffsets(exePath, symbol string) (entryOff uint64, retOffs []uin
 		return 0, nil, false
 	}
 
-	textData, err := text.Data()
+	textData, err := sectionDataCapped(text)
 	if err != nil || fn.Entry < text.Addr {
 		return 0, nil, false
 	}

--- a/internal/ebpf/probes/h3offsets.go
+++ b/internal/ebpf/probes/h3offsets.go
@@ -3,7 +3,7 @@ package probes
 import (
 	"debug/buildinfo"
 	"debug/dwarf"
-	"debug/elf"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -45,20 +45,28 @@ func resolveH3FieldOffsets(exePath string) (h3FieldOffsets, string) {
 
 // h3OffsetsFromDWARF reads the four field offsets from the binary's DWARF (or a
 // build-id debug-info file).
-func h3OffsetsFromDWARF(exePath string) (h3FieldOffsets, bool) {
-	target, err := elf.Open(exePath)
+func h3OffsetsFromDWARF(exePath string) (result h3FieldOffsets, ok bool) {
+	defer recoverParse("h3OffsetsFromDWARF")
+	target, err := openELFCapped(exePath)
 	if err != nil {
 		return h3FieldOffsets{}, false
 	}
 	defer func() { _ = target.Close() }()
 
-	d, err := target.DWARF()
+	var d *dwarf.Data
+	if dwarfWithinCap(target) {
+		d, err = target.DWARF()
+	} else {
+		err = fmt.Errorf("dwarf sections exceed cap")
+	}
 	if err != nil {
 		if dbg, _ := openDebugInfo(target, exePath, 0); dbg != nil && dbg != target {
 			defer func() { _ = dbg.Close() }()
-			d, err = dbg.DWARF()
+			if dwarfWithinCap(dbg) {
+				d, err = dbg.DWARF()
+			}
 		}
-		if err != nil {
+		if err != nil || d == nil {
 			return h3FieldOffsets{}, false
 		}
 	}

--- a/internal/ebpf/probes/h3peer.go
+++ b/internal/ebpf/probes/h3peer.go
@@ -2,7 +2,6 @@ package probes
 
 import (
 	"debug/dwarf"
-	"debug/elf"
 	"strings"
 )
 
@@ -88,18 +87,22 @@ func resolveH3PeerPaths(exePath, clientRootType string) (h3PeerPaths, bool) {
 
 // openDWARF opens the binary's DWARF, falling back to a build-id /
 // .gnu_debuglink debug file.
-func openDWARF(exePath string) (*dwarf.Data, func(), bool) {
-	target, err := elf.Open(exePath)
+func openDWARF(exePath string) (data *dwarf.Data, cleanup func(), ok bool) {
+	defer recoverParse("openDWARF")
+	target, err := openELFCapped(exePath)
 	if err != nil {
 		return nil, nil, false
 	}
-	d, err := target.DWARF()
-	if err == nil {
-		return d, func() { _ = target.Close() }, true
+	if dwarfWithinCap(target) {
+		if d, err := target.DWARF(); err == nil {
+			return d, func() { _ = target.Close() }, true
+		}
 	}
 	if dbg, _ := openDebugInfo(target, exePath, 0); dbg != nil && dbg != target {
-		if d, err = dbg.DWARF(); err == nil {
-			return d, func() { _ = dbg.Close(); _ = target.Close() }, true
+		if dwarfWithinCap(dbg) {
+			if d, err := dbg.DWARF(); err == nil {
+				return d, func() { _ = dbg.Close(); _ = target.Close() }, true
+			}
 		}
 		_ = dbg.Close()
 	}

--- a/internal/ebpf/probes/rustlsresolve.go
+++ b/internal/ebpf/probes/rustlsresolve.go
@@ -18,11 +18,7 @@ import (
 // elfIsRust reports whether an ELF was produced by rustc, detected via the
 // ".comment" section.
 func elfIsRust(f *elf.File) bool {
-	sec := f.Section(".comment")
-	if sec == nil {
-		return false
-	}
-	data, err := sec.Data()
+	data, err := sectionDataCapped(f.Section(".comment"))
 	if err != nil {
 		return false
 	}
@@ -41,6 +37,9 @@ func nameContainsAll(name string, subs ...string) bool {
 }
 
 func findSymbolContaining(f *elf.File, subs ...string) (uint64, bool) {
+	if !symbolSectionWithinCap(f, ".symtab") {
+		return 0, false
+	}
 	syms, err := f.Symbols()
 	if err != nil {
 		return 0, false
@@ -66,8 +65,8 @@ var (
 // (outbound) and <rustls::conn::Reader as io::Read>::read (inbound), capturing
 // HTTP/1.x, HTTP/2 and gRPC L7 over rustls TLS before encryption / after
 // decryption.
-func AttachRustlsProbes(coll *ebpf.Collection, pid uint32) []link.Link {
-	var links []link.Link
+func AttachRustlsProbes(coll *ebpf.Collection, pid uint32) (links []link.Link) {
+	defer recoverParse("AttachRustlsProbes")
 	if pid == 0 {
 		return links
 	}
@@ -79,7 +78,7 @@ func AttachRustlsProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 	}
 
 	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
-	f, err := elf.Open(exePath)
+	f, err := openELFCapped(exePath)
 	if err != nil {
 		return links
 	}

--- a/internal/ebpf/probes/safeelf.go
+++ b/internal/ebpf/probes/safeelf.go
@@ -1,15 +1,12 @@
 package probes
 
 import (
-	"bytes"
 	"debug/elf"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	"github.com/podtrace/podtrace/internal/logger"
 )
@@ -82,47 +79,10 @@ func safeDebugName(name string) bool {
 	return !strings.ContainsRune(name, '/') && !strings.ContainsRune(name, 0)
 }
 
-// openELFWithinRoot opens rel as an ELF resolved strictly within rootDir using
-// openat2(RESOLVE_IN_ROOT|RESOLVE_NO_MAGICLINKS): a "..", an absolute segment,
-// or a symlink in the container-controlled path cannot escape rootDir, closing
-// the .gnu_debuglink traversal that let the root agent open host files such as
-// /proc/kcore.
-func openELFWithinRoot(rootDir, rel string) (*elf.File, error) {
-	rootFd, err := unix.Open(rootDir, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = unix.Close(rootFd) }()
-
-	how := &unix.OpenHow{
-		Flags:   uint64(unix.O_RDONLY | unix.O_CLOEXEC),
-		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
-	}
-	fd, err := unix.Openat2(rootFd, rel, how)
-	if err != nil {
-		return nil, err
-	}
-	file := os.NewFile(uintptr(fd), rel)
-	defer func() { _ = file.Close() }()
-
-	fi, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if !fi.Mode().IsRegular() {
-		return nil, fmt.Errorf("debug file %q is not a regular file", rel)
-	}
-	if fi.Size() > maxELFFileSize {
-		return nil, fmt.Errorf("debug file %q too large: %d bytes", rel, fi.Size())
-	}
-	buf := make([]byte, fi.Size())
-	if _, err := io.ReadFull(file, buf); err != nil {
-		return nil, err
-	}
-	return elf.NewFile(bytes.NewReader(buf))
-}
 
 // recoverParse converts a panic from an ELF/DWARF/gosym parser, a malformed
+// untrusted binary, into a logged warning so a hostile pod cannot crash the
+// agent. from an ELF/DWARF/gosym parser, a malformed
 // untrusted binary, into a logged warning so a hostile pod cannot crash the
 // agent.
 func recoverParse(where string) {

--- a/internal/ebpf/probes/safeelf.go
+++ b/internal/ebpf/probes/safeelf.go
@@ -1,0 +1,133 @@
+package probes
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+// The probes package resolves uprobe offsets by parsing the target's own
+// executable and debug files, which for a traced pod are attacker-controlled.
+const (
+	maxELFFileSize = int64(1) << 30
+
+	maxELFSectionSize = uint64(512) << 20
+
+	maxDWARFTotalSize = uint64(512) << 20
+)
+
+// openELFCapped opens a fixed-path ELF (e.g. /proc/<pid>/exe) after rejecting
+// oversized files.
+func openELFCapped(path string) (*elf.File, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() > maxELFFileSize {
+		return nil, fmt.Errorf("elf %q too large to parse safely: %d bytes", path, fi.Size())
+	}
+	return elf.Open(path)
+}
+
+// sectionDataCapped returns sec.Data only when the section's declared size is
+// within maxELFSectionSize, so a lying/huge section header cannot drive a
+// multi-GB allocation. A nil section yields (nil, nil).
+func sectionDataCapped(sec *elf.Section) ([]byte, error) {
+	if sec == nil {
+		return nil, nil
+	}
+	if sec.Size > maxELFSectionSize {
+		return nil, fmt.Errorf("section %q too large: %d bytes", sec.Name, sec.Size)
+	}
+	return sec.Data()
+}
+
+// symbolSectionWithinCap reports whether the named symbol table is small enough
+// to parse; debug/elf.Symbols allocates proportional to the section size, so a
+// huge .symtab/.dynsym must be skipped rather than parsed.
+func symbolSectionWithinCap(f *elf.File, section string) bool {
+	sec := f.Section(section)
+	return sec != nil && sec.Size <= maxELFSectionSize
+}
+
+// dwarfWithinCap reports whether the combined DWARF sections are within cap,
+// bounding DWARF() memory (including decompression of .zdebug_*).
+func dwarfWithinCap(f *elf.File) bool {
+	var total uint64
+	for _, s := range f.Sections {
+		if strings.HasPrefix(s.Name, ".debug_") || strings.HasPrefix(s.Name, ".zdebug_") {
+			total += s.Size
+			if total > maxDWARFTotalSize {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// safeDebugName reports whether a .gnu_debuglink filename is a plain basename.
+// The name is attacker-controlled bytes.
+func safeDebugName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return !strings.ContainsRune(name, '/') && !strings.ContainsRune(name, 0)
+}
+
+// openELFWithinRoot opens rel as an ELF resolved strictly within rootDir using
+// openat2(RESOLVE_IN_ROOT|RESOLVE_NO_MAGICLINKS): a "..", an absolute segment,
+// or a symlink in the container-controlled path cannot escape rootDir, closing
+// the .gnu_debuglink traversal that let the root agent open host files such as
+// /proc/kcore.
+func openELFWithinRoot(rootDir, rel string) (*elf.File, error) {
+	rootFd, err := unix.Open(rootDir, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(rootFd) }()
+
+	how := &unix.OpenHow{
+		Flags:   uint64(unix.O_RDONLY | unix.O_CLOEXEC),
+		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+	}
+	fd, err := unix.Openat2(rootFd, rel, how)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), rel)
+	defer func() { _ = file.Close() }()
+
+	fi, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("debug file %q is not a regular file", rel)
+	}
+	if fi.Size() > maxELFFileSize {
+		return nil, fmt.Errorf("debug file %q too large: %d bytes", rel, fi.Size())
+	}
+	buf := make([]byte, fi.Size())
+	if _, err := io.ReadFull(file, buf); err != nil {
+		return nil, err
+	}
+	return elf.NewFile(bytes.NewReader(buf))
+}
+
+// recoverParse converts a panic from an ELF/DWARF/gosym parser, a malformed
+// untrusted binary, into a logged warning so a hostile pod cannot crash the
+// agent.
+func recoverParse(where string) {
+	if r := recover(); r != nil {
+		logger.Warn("recovered from panic parsing untrusted binary",
+			zap.String("where", where), zap.Any("panic", r))
+	}
+}

--- a/internal/ebpf/probes/safeelf_linux.go
+++ b/internal/ebpf/probes/safeelf_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package probes
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openELFWithinRoot opens rel as an ELF resolved strictly within rootDir using
+// openat2(RESOLVE_IN_ROOT|RESOLVE_NO_MAGICLINKS): a "..", an absolute segment,
+// or a symlink in the container-controlled path cannot escape rootDir, closing
+// the .gnu_debuglink traversal that let the root agent open host files such as
+// /proc/kcore.
+func openELFWithinRoot(rootDir, rel string) (*elf.File, error) {
+	rootFd, err := unix.Open(rootDir, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(rootFd) }()
+
+	how := &unix.OpenHow{
+		Flags:   uint64(unix.O_RDONLY | unix.O_CLOEXEC),
+		Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+	}
+	fd, err := unix.Openat2(rootFd, rel, how)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), rel)
+	defer func() { _ = file.Close() }()
+
+	fi, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("debug file %q is not a regular file", rel)
+	}
+	if fi.Size() > maxELFFileSize {
+		return nil, fmt.Errorf("debug file %q too large: %d bytes", rel, fi.Size())
+	}
+	buf := make([]byte, fi.Size())
+	if _, err := io.ReadFull(file, buf); err != nil {
+		return nil, err
+	}
+	return elf.NewFile(bytes.NewReader(buf))
+}

--- a/internal/ebpf/probes/safeelf_linux_test.go
+++ b/internal/ebpf/probes/safeelf_linux_test.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package probes
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// minimalELF64 returns the bytes of a valid, empty ELF64 executable header
+// (no sections, no program headers) — enough for debug/elf.NewFile to parse.
+func minimalELF64() []byte {
+	b := make([]byte, 64)
+	copy(b, []byte{0x7f, 'E', 'L', 'F'})
+	b[4] = 2                                    // ELFCLASS64
+	b[5] = 1                                    // ELFDATA2LSB
+	b[6] = 1                                    // EV_CURRENT
+	binary.LittleEndian.PutUint16(b[16:], 2)    // e_type = ET_EXEC
+	binary.LittleEndian.PutUint16(b[18:], 0x3e) // e_machine = x86-64
+	binary.LittleEndian.PutUint32(b[20:], 1)    // e_version
+	binary.LittleEndian.PutUint16(b[52:], 64)   // e_ehsize
+	return b
+}
+
+// TestOpenELFWithinRoot_ConfinesToRoot is the HS2 regression: a ".." or a
+// symlink in the container-controlled debug path must not escape the confining
+// directory, while a legitimate file inside it is still reachable. Linux-only
+// because openELFWithinRoot uses openat2(RESOLVE_IN_ROOT).
+func TestOpenELFWithinRoot_ConfinesToRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	secret := filepath.Join(outside, "secret")
+	if err := os.WriteFile(secret, minimalELF64(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "good.debug"), minimalELF64(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "escape.debug")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("legit file inside root opens", func(t *testing.T) {
+		f, err := openELFWithinRoot(root, "good.debug")
+		if err != nil {
+			t.Fatalf("expected to open a valid file inside root, got %v", err)
+		}
+		_ = f.Close()
+	})
+	t.Run("dotdot traversal blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, "../"+filepath.Base(outside)+"/secret"); err == nil {
+			t.Error("openELFWithinRoot escaped root via ../ — must be blocked")
+		}
+	})
+	t.Run("absolute path blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, secret); err == nil {
+			t.Error("openELFWithinRoot followed an absolute path out of root")
+		}
+	})
+	t.Run("symlink escape blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, "escape.debug"); err == nil {
+			t.Error("openELFWithinRoot followed a symlink out of root — RESOLVE_IN_ROOT should block it")
+		}
+	})
+}

--- a/internal/ebpf/probes/safeelf_other.go
+++ b/internal/ebpf/probes/safeelf_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package probes
+
+import (
+	"debug/elf"
+	"errors"
+)
+
+func openELFWithinRoot(_, _ string) (*elf.File, error) {
+	return nil, errors.New("openELFWithinRoot: unsupported on this platform")
+}

--- a/internal/ebpf/probes/safeelf_test.go
+++ b/internal/ebpf/probes/safeelf_test.go
@@ -1,7 +1,6 @@
 package probes
 
 import (
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,63 +29,6 @@ func TestSafeDebugName(t *testing.T) {
 			}
 		})
 	}
-}
-
-// minimalELF64 returns the bytes of a valid, empty ELF64 executable header
-// (no sections, no program headers) — enough for debug/elf.NewFile to parse.
-func minimalELF64() []byte {
-	b := make([]byte, 64)
-	copy(b, []byte{0x7f, 'E', 'L', 'F'})
-	b[4] = 2                                    // ELFCLASS64
-	b[5] = 1                                    // ELFDATA2LSB
-	b[6] = 1                                    // EV_CURRENT
-	binary.LittleEndian.PutUint16(b[16:], 2)    // e_type = ET_EXEC
-	binary.LittleEndian.PutUint16(b[18:], 0x3e) // e_machine = x86-64
-	binary.LittleEndian.PutUint32(b[20:], 1)    // e_version
-	binary.LittleEndian.PutUint16(b[52:], 64)   // e_ehsize
-	return b
-}
-
-// TestOpenELFWithinRoot_ConfinesToRoot is the HS2 regression: a ".." or a
-// symlink in the container-controlled debug path must not escape the confining
-// directory, while a legitimate file inside it is still reachable.
-func TestOpenELFWithinRoot_ConfinesToRoot(t *testing.T) {
-	root := t.TempDir()
-	outside := t.TempDir()
-
-	secret := filepath.Join(outside, "secret")
-	if err := os.WriteFile(secret, minimalELF64(), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "good.debug"), minimalELF64(), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(secret, filepath.Join(root, "escape.debug")); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("legit file inside root opens", func(t *testing.T) {
-		f, err := openELFWithinRoot(root, "good.debug")
-		if err != nil {
-			t.Fatalf("expected to open a valid file inside root, got %v", err)
-		}
-		_ = f.Close()
-	})
-	t.Run("dotdot traversal blocked", func(t *testing.T) {
-		if _, err := openELFWithinRoot(root, "../"+filepath.Base(outside)+"/secret"); err == nil {
-			t.Error("openELFWithinRoot escaped root via ../ — must be blocked")
-		}
-	})
-	t.Run("absolute path blocked", func(t *testing.T) {
-		if _, err := openELFWithinRoot(root, secret); err == nil {
-			t.Error("openELFWithinRoot followed an absolute path out of root")
-		}
-	})
-	t.Run("symlink escape blocked", func(t *testing.T) {
-		if _, err := openELFWithinRoot(root, "escape.debug"); err == nil {
-			t.Error("openELFWithinRoot followed a symlink out of root — RESOLVE_IN_ROOT should block it")
-		}
-	})
 }
 
 // TestOpenELFCapped_RejectsOversized is the HS1 regression: an oversized

--- a/internal/ebpf/probes/safeelf_test.go
+++ b/internal/ebpf/probes/safeelf_test.go
@@ -1,0 +1,109 @@
+package probes
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeDebugName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"plain", "libfoo.so.debug", true},
+		{"plain dashed", "my-app.debug", true},
+		{"empty", "", false},
+		{"dot", ".", false},
+		{"dotdot", "..", false},
+		{"traversal", "../../../proc/kcore", false},
+		{"leading slash absolute", "/etc/shadow", false},
+		{"embedded slash", "a/b.debug", false},
+		{"nul byte", "a\x00b", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeDebugName(tc.in); got != tc.want {
+				t.Errorf("safeDebugName(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// minimalELF64 returns the bytes of a valid, empty ELF64 executable header
+// (no sections, no program headers) — enough for debug/elf.NewFile to parse.
+func minimalELF64() []byte {
+	b := make([]byte, 64)
+	copy(b, []byte{0x7f, 'E', 'L', 'F'})
+	b[4] = 2                                    // ELFCLASS64
+	b[5] = 1                                    // ELFDATA2LSB
+	b[6] = 1                                    // EV_CURRENT
+	binary.LittleEndian.PutUint16(b[16:], 2)    // e_type = ET_EXEC
+	binary.LittleEndian.PutUint16(b[18:], 0x3e) // e_machine = x86-64
+	binary.LittleEndian.PutUint32(b[20:], 1)    // e_version
+	binary.LittleEndian.PutUint16(b[52:], 64)   // e_ehsize
+	return b
+}
+
+// TestOpenELFWithinRoot_ConfinesToRoot is the HS2 regression: a ".." or a
+// symlink in the container-controlled debug path must not escape the confining
+// directory, while a legitimate file inside it is still reachable.
+func TestOpenELFWithinRoot_ConfinesToRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	secret := filepath.Join(outside, "secret")
+	if err := os.WriteFile(secret, minimalELF64(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "good.debug"), minimalELF64(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "escape.debug")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("legit file inside root opens", func(t *testing.T) {
+		f, err := openELFWithinRoot(root, "good.debug")
+		if err != nil {
+			t.Fatalf("expected to open a valid file inside root, got %v", err)
+		}
+		_ = f.Close()
+	})
+	t.Run("dotdot traversal blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, "../"+filepath.Base(outside)+"/secret"); err == nil {
+			t.Error("openELFWithinRoot escaped root via ../ — must be blocked")
+		}
+	})
+	t.Run("absolute path blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, secret); err == nil {
+			t.Error("openELFWithinRoot followed an absolute path out of root")
+		}
+	})
+	t.Run("symlink escape blocked", func(t *testing.T) {
+		if _, err := openELFWithinRoot(root, "escape.debug"); err == nil {
+			t.Error("openELFWithinRoot followed a symlink out of root — RESOLVE_IN_ROOT should block it")
+		}
+	})
+}
+
+// TestOpenELFCapped_RejectsOversized is the HS1 regression: an oversized
+// (here sparse) /proc/<pid>/exe must be rejected before parsing, not allocated.
+func TestOpenELFCapped_RejectsOversized(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(maxELFFileSize + 1); err != nil {
+		_ = f.Close()
+		t.Skipf("cannot create sparse file: %v", err)
+	}
+	_ = f.Close()
+
+	if _, err := openELFCapped(path); err == nil {
+		t.Errorf("openELFCapped accepted a %d-byte file; must reject over %d", maxELFFileSize+1, maxELFFileSize)
+	}
+}

--- a/internal/ebpf/probes/tlsresolve.go
+++ b/internal/ebpf/probes/tlsresolve.go
@@ -27,8 +27,9 @@ type sslOffsets struct {
 // resolveSSLOffsets locates SSL_write/SSL_read in a statically-linked,
 // symbol-stripped executable that executableExportsSSL could not gate (no
 // SSL_write in .symtab/.dynsym).
-func resolveSSLOffsets(exePath string, pid uint32) (sslOffsets, bool) {
-	target, err := elf.Open(exePath)
+func resolveSSLOffsets(exePath string, pid uint32) (off sslOffsets, ok bool) {
+	defer recoverParse("resolveSSLOffsets")
+	target, err := openELFCapped(exePath)
 	if err != nil {
 		return sslOffsets{}, false
 	}
@@ -56,17 +57,21 @@ func resolveSSLOffsets(exePath string, pid uint32) (sslOffsets, bool) {
 // symbolVaddr returns the virtual address of a defined symbol from either the
 // static or dynamic symbol table.
 func symbolVaddr(f *elf.File, name string) (uint64, bool) {
-	if syms, err := f.Symbols(); err == nil {
-		for i := range syms {
-			if syms[i].Name == name && syms[i].Value != 0 {
-				return syms[i].Value, true
+	if symbolSectionWithinCap(f, ".symtab") {
+		if syms, err := f.Symbols(); err == nil {
+			for i := range syms {
+				if syms[i].Name == name && syms[i].Value != 0 {
+					return syms[i].Value, true
+				}
 			}
 		}
 	}
-	if syms, err := f.DynamicSymbols(); err == nil {
-		for i := range syms {
-			if syms[i].Name == name && syms[i].Value != 0 {
-				return syms[i].Value, true
+	if symbolSectionWithinCap(f, ".dynsym") {
+		if syms, err := f.DynamicSymbols(); err == nil {
+			for i := range syms {
+				if syms[i].Name == name && syms[i].Value != 0 {
+					return syms[i].Value, true
+				}
 			}
 		}
 	}
@@ -80,19 +85,20 @@ func openDebugInfo(target *elf.File, exePath string, pid uint32) (*elf.File, str
 	root := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "root")
 
 	if buildID := elfBuildID(target); len(buildID) > 2 {
-		p := filepath.Join(root, "usr/lib/debug/.build-id", buildID[:2], buildID[2:]+".debug")
-		if f, err := elf.Open(p); err == nil {
+		rel := filepath.Join("usr/lib/debug/.build-id", buildID[:2], buildID[2:]+".debug")
+		if f, err := openELFWithinRoot(root, rel); err == nil {
 			return f, "debug-buildid"
 		}
 	}
-	if name := debugLink(target); name != "" {
+	if name := debugLink(target); safeDebugName(name) {
 		dir := filepath.Dir(exePath)
-		for _, p := range []string{
-			filepath.Join(dir, name),
-			filepath.Join(dir, ".debug", name),
-			filepath.Join(root, "usr/lib/debug", name),
-		} {
-			if f, err := elf.Open(p); err == nil {
+		candidates := []struct{ root, rel string }{
+			{dir, name},
+			{dir, filepath.Join(".debug", name)},
+			{root, filepath.Join("usr/lib/debug", name)},
+		}
+		for _, c := range candidates {
+			if f, err := openELFWithinRoot(c.root, c.rel); err == nil {
 				return f, "debug-link"
 			}
 		}
@@ -103,11 +109,7 @@ func openDebugInfo(target *elf.File, exePath string, pid uint32) (*elf.File, str
 // elfBuildID parses the GNU build-id (.note.gnu.build-id) into a lowercase hex
 // string, or "" if absent.
 func elfBuildID(f *elf.File) string {
-	sec := f.Section(".note.gnu.build-id")
-	if sec == nil {
-		return ""
-	}
-	data, err := sec.Data()
+	data, err := sectionDataCapped(f.Section(".note.gnu.build-id"))
 	if err != nil || len(data) < 12 {
 		return ""
 	}
@@ -122,11 +124,7 @@ func elfBuildID(f *elf.File) string {
 
 // debugLink returns the filename recorded in .gnu_debuglink, or "".
 func debugLink(f *elf.File) string {
-	sec := f.Section(".gnu_debuglink")
-	if sec == nil {
-		return ""
-	}
-	data, err := sec.Data()
+	data, err := sectionDataCapped(f.Section(".gnu_debuglink"))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

Hardens the agent's biggest security surface: parsing untrusted container binaries (`/proc/<pid>/exe` and their debug files) during uprobe attach. A hostile pod could previously OOM-kill the agent or make it read arbitrary host files.

## What changed

New `internal/ebpf/probes/safeelf.go` centralizes the defenses, and the five resolvers (`gosym.go`, `tlsresolve.go`, `h3offsets.go`, `h3peer.go`, `rustlsresolve.go`) now route through it.

**unbounded parsing (OOM / tenant DoS):** every ELF/DWARF parse is now bounded and panic-isolated. `openELFCapped` rejects a binary over 1 GiB before parsing; `sectionDataCapped` caps any `Section.Data()` at 512 MiB (which, since a compressed section's declared size is the *uncompressed* size, also defuses a zlib-bombed `.debug_info`); `symbolSectionWithinCap`/`dwarfWithinCap` skip oversized symbol/DWARF sections before `Symbols()`/`DWARF()` allocate; and every top-level resolver runs under `recoverParse`, so a malformed binary that panics Go's ELF/DWARF parser is logged and contained instead of crashing the root-privileged agent node-wide.

**`.gnu_debuglink` path traversal:** the attacker-controlled debug filename is validated as a plain basename (`safeDebugName`), and every build-id / debuglink candidate is opened with `openELFWithinRoot`, which resolves strictly inside the container rootfs via `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)`. This blocks both the `../../../proc/kcore` traversal and symlink-escape, so the agent can no longer be tricked into opening host files.