### PR TITLE
fix: build arm64 BPF objects with correct arch registers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,44 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  bpf-objects:
+    if: ${{ !inputs.olm_bundle_only }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            goarch: amd64
+          - runner: ubuntu-24.04-arm
+            goarch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install BPF toolchain
+        uses: ./.github/actions/setup-bpf-toolchain
+      - name: Build native BPF object (full kernel BTF)
+        run: make internal/ebpf/embedded/podtrace.${{ matrix.goarch }}.bpf.o BPF_GOARCH=${{ matrix.goarch }}
+      - name: Refuse a stub fallback on the native runner
+        run: |
+          lines=$(wc -l < bpf/.generated/vmlinux.h)
+          if [ "$lines" -lt 1000 ]; then
+            echo "ERROR: ${{ matrix.goarch }} object fell back to the stub (vmlinux.h=$lines lines); a native runner must have full BTF" >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bpf-object-${{ matrix.goarch }}
+          path: internal/ebpf/embedded/podtrace.${{ matrix.goarch }}.bpf.o
+          if-no-files-found: error
+          retention-days: 1
+
   image:
+    needs: bpf-objects
     if: (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') && !inputs.olm_bundle_only
     runs-on: ubuntu-latest
     outputs:
@@ -61,6 +98,13 @@ jobs:
           sudo apt-get install -y "linux-tools-$(uname -r)" || sudo apt-get install -y linux-tools-generic
           make bpf-btf-header
           wc -l bpf/.generated/vmlinux.h
+
+      - name: Stage native BPF objects into the build context
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          pattern: bpf-object-*
+          path: internal/ebpf/embedded
+          merge-multiple: true
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
@@ -218,6 +262,7 @@ jobs:
           fail_on_unmatched_files: true
 
   cli:
+    needs: bpf-objects
     if: ${{ !inputs.olm_bundle_only }}
     runs-on: ubuntu-latest
     permissions:
@@ -244,6 +289,13 @@ jobs:
             echo "ERROR: vmlinux.h has only $lines lines — stub fallback; refusing to release stub-built binaries" >&2
             exit 1
           fi
+
+      - name: Stage native BPF objects (reused by make release)
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          pattern: bpf-object-*
+          path: internal/ebpf/embedded
+          merge-multiple: true
 
       - name: Build CLI tarballs (linux+darwin x amd64+arm64)
         run: make release VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # binary. The runtime stage is distroless and carries only the binary.
 #
 # The same image serves the CLI, the agent DaemonSet, the operator
-# Deployment, and per-session Jobs — one binary, multiple subcommands.
+# Deployment, and per-session Jobs, one binary, multiple subcommands.
 
 ARG GO_VERSION=1.26.4
 ARG DEBIAN_RELEASE=trixie
@@ -39,6 +39,7 @@ COPY . .
 
 ARG TARGETARCH=amd64
 ARG TARGETOS=linux
+ARG BUILDARCH
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG IMAGE_REPO=ghcr.io/gma1k/podtrace
@@ -67,6 +68,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     if [ -s internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o ]; then \
         touch internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o; \
         echo "Reusing prebuilt BPF object from build context"; \
+    elif [ -n "${BUILDARCH}" ] && [ "${BUILDARCH}" != "${TARGETARCH}" ]; then \
+        echo "Cross-arch build (${BUILDARCH} host -> ${TARGETARCH} target) with no prebuilt object: using arch-correct stub, not the build host's foreign BTF" >&2; \
+        make internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o BPF_VMLINUX_MODE=stub; \
     else \
         make internal/ebpf/embedded/podtrace.${BPF_GOARCH}.bpf.o; \
     fi

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ BPF_GEN_DIR = bpf/.generated
 VMLINUX_GEN = $(BPF_GEN_DIR)/vmlinux.h
 BINARY = bin/podtrace
 
-# Export GOTOOLCHAIN=auto to automatically download required Go version (Go 1.21+)
-# For Go < 1.21, user needs to upgrade Go manually
 export GOTOOLCHAIN=auto
 
 BPF_MCPU ?= v2
@@ -60,21 +58,11 @@ check-go:
 		exit 1; \
 	fi
 
-# Regenerate vmlinux.h from the running kernel's BTF when bpftool is available.
-# This gives CO-RE-correct type definitions and avoids register-name mismatches
-# between the kernel BTF (short names: ax/si/di) and user-space ptrace.h headers.
-# When vmlinux.h is generated from BTF, pass -DPODTRACE_VMLINUX_FROM_BTF so that
-# common.h skips its placeholder struct definitions (pt_regs, sockaddr_in).
 VMLINUX_BTF  = /sys/kernel/btf/vmlinux
 HAVE_BPFTOOL := $(shell command -v bpftool 2>/dev/null)
 HAVE_WORKING_BPFTOOL := $(shell bpftool version >/dev/null 2>&1 && echo yes)
 HAVE_BTF     := $(shell test -r $(VMLINUX_BTF) && echo yes)
 
-# BPF_VMLINUX_MODE=stub forces the committed stub header. Used for
-# CROSS-ARCH object builds: a BTF header dumped from this host's kernel
-# lacks the foreign architecture's register structs (e.g. user_pt_regs
-# on arm64), so cross builds against it fail to compile. Native-arch
-# builds keep full BTF.
 ifeq ($(BPF_VMLINUX_MODE),stub)
   HAVE_BPFTOOL :=
   HAVE_WORKING_BPFTOOL :=
@@ -90,13 +78,6 @@ ifneq ($(HAVE_BPFTOOL),)
   endif
 endif
 
-# A pre-generated BTF header in the tree (docker build context, produced
-# by `make bpf-btf-header` on the host) must ALSO enable the BTF define:
-# the gate above keys on bpftool being runnable HERE, but inside a build
-# container bpftool is absent while the full header is present — without
-# this, the gRPC/FastCGI probe bodies (#ifdef PODTRACE_VMLINUX_FROM_BTF)
-# still compiled to no-ops despite the full vmlinux.h. The stub header is
-# 79 lines; any real BTF dump is six figures.
 ifneq ($(USE_BTF_VMLINUX),yes)
 ifneq ($(BPF_VMLINUX_MODE),stub)
   HAVE_PREGEN_BTF := $(shell test -f $(VMLINUX_GEN) && [ "$$(wc -l < $(VMLINUX_GEN))" -gt 1000 ] && echo yes)
@@ -143,8 +124,6 @@ build: $(BPF_OBJ)
 	            -X $(MODULE)/internal/config.Image=$(IMAGE_REPO)" \
 	  -o $(BINARY) ./cmd/podtrace
 
-# Release: produce cross-arch tarballs for linux+darwin × amd64+arm64.
-# Each binary embeds the per-arch BPF object via the embed_bpf tag.
 RELEASE_DIR ?= release
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -153,14 +132,20 @@ RELEASE_TARGETS = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
 
 .PHONY: release release-bpf-objects
 
-# Native-arch objects build against full kernel BTF; cross-arch objects
-# fall back to the stub header (this host's BTF lacks the foreign arch's
-# register structs). Stub objects compile the BTF-dependent gRPC/FastCGI
-# probes into no-ops — full cross-arch coverage needs a native runner
-# per arch (the ebpf-build workflow matrix already does this for PR CI).
 HOST_GOARCH := $(shell $(GO) env GOHOSTARCH)
 release-bpf-objects:
-	@set -e; for arch in amd64 arm64; do 	  if [ "$$arch" = "$(HOST_GOARCH)" ]; then 	    $(MAKE) internal/ebpf/embedded/podtrace.$$arch.bpf.o BPF_GOARCH=$$arch; 	  else 	    echo "WARNING: cross-building $$arch BPF object from the stub header (gRPC/FastCGI no-ops); use a native $$arch runner for full coverage" >&2; 	    $(MAKE) internal/ebpf/embedded/podtrace.$$arch.bpf.o BPF_GOARCH=$$arch BPF_VMLINUX_MODE=stub; 	  fi; 	done
+	@set -e; \
+	for arch in amd64 arm64; do \
+	  obj=internal/ebpf/embedded/podtrace.$$arch.bpf.o; \
+	  if [ -s "$$obj" ]; then \
+	    echo "Reusing prebuilt $$arch BPF object (native-built)"; touch "$$obj"; \
+	  elif [ "$$arch" = "$(HOST_GOARCH)" ]; then \
+	    $(MAKE) $$obj BPF_GOARCH=$$arch; \
+	  else \
+	    echo "WARNING: cross-building $$arch from the arch-correct stub (gRPC/FastCGI no-ops); supply a native $$arch object for full coverage" >&2; \
+	    $(MAKE) $$obj BPF_GOARCH=$$arch BPF_VMLINUX_MODE=stub; \
+	  fi; \
+	done
 
 release: release-bpf-objects
 	@rm -rf $(RELEASE_DIR)
@@ -259,12 +244,6 @@ coverage: test-unit
 	@echo "Coverage summary:"
 	$(GO) tool cover -func=coverage.out | tail -1
 
-# ------------------------------------------------------------------------------
-# Operator — CRD code generation, manifest generation, container
-# image. These targets are independent of the eBPF build; they operate on the
-# Go type definitions under ./api/v1alpha1 and on ./deploy/charts.
-# ------------------------------------------------------------------------------
-
 CONTROLLER_GEN_VERSION ?= v0.18.0
 CONTROLLER_GEN ?= $(shell go env GOPATH 2>/dev/null)/bin/controller-gen
 CRD_OUT_DIR ?= deploy/charts/podtrace/templates/crds
@@ -282,10 +261,6 @@ operator-tools:
 generate: operator-tools
 	$(CONTROLLER_GEN) object:headerFile=$(BOILERPLATE) paths=./api/v1alpha1/...
 
-# clientset regenerates the typed Kubernetes clientset under pkg/client/.
-# Controller-runtime operators do not need this (client.Client covers CRUD),
-# but external tooling and hook scripts commonly expect a typed clientset.
-# The generated files are committed so consumers do not need codegen.
 CLIENT_GEN_VERSION ?= v0.36.1
 CLIENT_GEN ?= $(shell go env GOPATH 2>/dev/null)/bin/client-gen
 APPLYCONFIGURATION_GEN ?= $(shell go env GOPATH 2>/dev/null)/bin/applyconfiguration-gen
@@ -316,8 +291,6 @@ manifests: operator-tools
 	@mkdir -p hack/reference
 	$(CONTROLLER_GEN) webhook paths=./internal/webhook/v1alpha1/... output:webhook:artifacts:config=hack/reference
 
-# docker-build produces the container image used by the CLI, agent, operator,
-# and session Jobs. Override IMAGE_REPO / IMAGE_TAG to push to your registry.
 .PHONY: bpf-btf-header
 bpf-btf-header: $(VMLINUX_GEN)
 
@@ -331,11 +304,6 @@ docker-build: bpf-btf-header
 	  --build-arg IMAGE_REPO=$(IMAGE_REPO) \
 	  -t $(IMAGE) .
 
-# envtest runs the CRD schema validation suite against a real
-# kube-apiserver + etcd managed by controller-runtime's envtest harness.
-# The harness binaries are downloaded on demand by setup-envtest. Gated
-# by the `envtest` build tag so `go test ./...` stays CI-friendly when
-# the binaries are absent.
 ENVTEST_K8S_VERSION ?= 1.36.x
 ENVTEST_BIN_DIR ?= $(shell go env GOPATH 2>/dev/null)/envtest-assets
 SETUP_ENVTEST ?= $(shell go env GOPATH 2>/dev/null)/bin/setup-envtest
@@ -348,20 +316,12 @@ envtest:
 helm-lint:
 	helm lint deploy/charts/podtrace
 
-# e2e-kind runs the smoke script against whatever kind cluster
-# the user's KUBECONFIG currently points at. The script is idempotent;
-# re-running it upgrades an existing release in place.
 e2e-kind:
 	test/e2e/kind-smoke.sh
 
-# e2e-kind-cleanup tears down the e2e release and sample namespace.
 e2e-kind-cleanup:
 	test/e2e/kind-smoke.sh cleanup
 
-# chainsaw runs the declarative e2e suite under test/chainsaw/. Expects
-# a working operator install (run e2e-kind first) and the chainsaw CLI
-# on PATH. Each test case creates its own namespace, so they can run
-# in parallel against the same cluster.
 CHAINSAW ?= $(shell command -v chainsaw 2>/dev/null)
 CHAINSAW_VERSION ?= latest
 chainsaw-tools:

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -37,6 +37,33 @@ typedef __u64 u64;
 #include <bpf/bpf_core_read.h>
 
 #ifndef PODTRACE_VMLINUX_FROM_BTF
+#undef PT_REGS_PARM1
+#undef PT_REGS_PARM2
+#undef PT_REGS_PARM3
+#undef PT_REGS_PARM4
+#undef PT_REGS_PARM5
+#undef PT_REGS_RC
+#undef PT_REGS_IP
+#undef PT_REGS_SP
+#undef PT_REGS_FP
+
+#if defined(__TARGET_ARCH_arm64)
+struct pt_regs {
+	unsigned long regs[31];
+	unsigned long sp;
+	unsigned long pc;
+	unsigned long pstate;
+};
+#define PT_REGS_PARM1(x) ((x)->regs[0])
+#define PT_REGS_PARM2(x) ((x)->regs[1])
+#define PT_REGS_PARM3(x) ((x)->regs[2])
+#define PT_REGS_PARM4(x) ((x)->regs[3])
+#define PT_REGS_PARM5(x) ((x)->regs[4])
+#define PT_REGS_RC(x)    ((x)->regs[0])
+#define PT_REGS_IP(x)    ((x)->pc)
+#define PT_REGS_SP(x)    ((x)->sp)
+#define PT_REGS_FP(x)    ((x)->regs[29])
+#else
 struct pt_regs {
 	unsigned long r15;
 	unsigned long r14;
@@ -60,16 +87,6 @@ struct pt_regs {
 	unsigned long sp;
 	unsigned long ss;
 };
-
-#undef PT_REGS_PARM1
-#undef PT_REGS_PARM2
-#undef PT_REGS_PARM3
-#undef PT_REGS_PARM4
-#undef PT_REGS_PARM5
-#undef PT_REGS_RC
-#undef PT_REGS_IP
-#undef PT_REGS_SP
-#undef PT_REGS_FP
 #define PT_REGS_PARM1(x) ((x)->di)
 #define PT_REGS_PARM2(x) ((x)->si)
 #define PT_REGS_PARM3(x) ((x)->dx)
@@ -79,6 +96,7 @@ struct pt_regs {
 #define PT_REGS_IP(x)    ((x)->ip)
 #define PT_REGS_SP(x)    ((x)->sp)
 #define PT_REGS_FP(x)    ((x)->bp)
+#endif
 
 struct sockaddr_in {
 	u16 sin_family;

--- a/deploy/charts/podtrace/Chart.yaml
+++ b/deploy/charts/podtrace/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: podtrace
 description: |
-  Podtrace — a lightweight yet powerful eBPF-driven diagnostic tool for
+  Podtrace: a lightweight yet powerful eBPF-driven diagnostic tool for
   Kubernetes applications. It delivers full-stack observability from
   kernel events to application-layer behavior, activated on demand with
   no prior configuration or instrumentation.

--- a/deploy/charts/podtrace/README.md
+++ b/deploy/charts/podtrace/README.md
@@ -1,4 +1,4 @@
-# podtrace
+# Podtrace
 
 eBPF-driven diagnostic tool for Kubernetes applications.
 

--- a/internal/ebpf/probes/safeelf.go
+++ b/internal/ebpf/probes/safeelf.go
@@ -80,10 +80,8 @@ func safeDebugName(name string) bool {
 }
 
 
-// recoverParse converts a panic from an ELF/DWARF/gosym parser, a malformed
-// untrusted binary, into a logged warning so a hostile pod cannot crash the
-// agent. from an ELF/DWARF/gosym parser, a malformed
-// untrusted binary, into a logged warning so a hostile pod cannot crash the
+// recoverParse converts a panic from an ELF/DWARF/gosym parser on a malformed
+// untrusted binary into a logged warning so a hostile pod cannot crash the
 // agent.
 func recoverParse(where string) {
 	if r := recover(); r != nil {


### PR DESCRIPTION
Stub-mode pt_regs and PT_REGS_* macros were hardcoded x86, so the released linux-arm64 CLI decoded every kprobe argument from the wrong register. Arch-gate the stub, force the arch-correct stub for cross-arch builds, and build each arch's BPF object natively on its own release runner so gRPC/FastCGI probes are no longer stubbed out on arm64.