### PR TITLE
fix: repair cgroup v1 resource monitoring and agent credential rotation

### DIFF
--- a/internal/agent/exporter_loader.go
+++ b/internal/agent/exporter_loader.go
@@ -16,15 +16,12 @@ import (
 )
 
 // BundlePayload is an alias for bundle.Payload so existing agent callers
-// keep their familiar type name. New code should import
-// pkg/exporter/bundle directly.
+// keep their familiar type name.
 type BundlePayload = bundle.Payload
 
 // LoadBundle reads the ConfigMap+optional-Secret pair the operator
 // maintains in systemNamespace for the given PodTrace UID, and returns
-// the parsed payload. Returns a NotFound error when the ConfigMap is
-// missing so the caller can distinguish "not yet synced" from real
-// failures.
+// the parsed payload.
 func LoadBundle(ctx context.Context, c client.Client, systemNamespace string, podtraceUID types.UID) (*BundlePayload, error) {
 	name := operator.ExporterBundleName(podtraceUID)
 
@@ -41,8 +38,7 @@ func LoadBundle(ctx context.Context, c client.Client, systemNamespace string, po
 
 	// Credential Secret is only present when the exporter needed one
 	// (Splunk HEC token, DataDog API key, or an OTLP Secret-backed
-	// header). NotFound is non-fatal and returns a credential-less
-	// payload — valid for credential-less exporters like Jaeger/Zipkin.
+	// header).
 	var sec corev1.Secret
 	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: systemNamespace}, &sec); err == nil {
 		payload.Credential = sec.Data[bundle.CredentialKey]
@@ -54,6 +50,7 @@ func LoadBundle(ctx context.Context, c client.Client, systemNamespace string, po
 				payload.SecretHeaders[rest] = string(v)
 			}
 		}
+		payload.ResourceVer = cm.ResourceVersion + "/" + sec.ResourceVersion
 	} else if !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("get bundle Secret: %w", err)
 	}

--- a/internal/agent/exporter_loader_test.go
+++ b/internal/agent/exporter_loader_test.go
@@ -89,6 +89,52 @@ func TestLoadBundle_WithCredential(t *testing.T) {
 	}
 }
 
+// TestLoadBundle_CredentialRotationChangesRevision is the regression guard:
+// a credential-only rotation leaves the bundle ConfigMap untouched,
+// so the ConfigMap ResourceVersion alone cannot detect it.
+func TestLoadBundle_CredentialRotationChangesRevision(t *testing.T) {
+	const systemNS = "podtrace-system"
+	uid := types.UID("e8c32c91-0000-0000-0000-000000000003")
+	name := operator.ExporterBundleName(uid)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	load := func(cmRV, secRV, token string) *BundlePayload {
+		t.Helper()
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: systemNS, ResourceVersion: cmRV},
+			Data:       map[string]string{"type": "datadog", "site": "datadoghq.com"},
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: systemNS, ResourceVersion: secRV},
+			Data:       map[string][]byte{"credential": []byte(token)},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, secret).Build()
+		p, err := LoadBundle(context.Background(), c, systemNS, uid)
+		if err != nil {
+			t.Fatalf("LoadBundle: %v", err)
+		}
+		return p
+	}
+
+	base := load("100", "7", "token-old")
+	if base.ResourceVer != "100/7" {
+		t.Fatalf("ResourceVer=%q want 100/7", base.ResourceVer)
+	}
+
+	rotated := load("100", "8", "token-new")
+	if rotated.ResourceVer == base.ResourceVer {
+		t.Fatalf("ResourceVer unchanged after credential rotation (%q): the cached exporter would keep exporting with the dead token", rotated.ResourceVer)
+	}
+	if rotated.ResourceVer != "100/8" {
+		t.Errorf("ResourceVer=%q want 100/8", rotated.ResourceVer)
+	}
+	if string(rotated.Credential) != "token-new" {
+		t.Errorf("credential=%q want token-new", rotated.Credential)
+	}
+}
+
 func TestLoadBundle_MissingConfigMap(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -69,7 +69,7 @@ type cachedExporter struct {
 }
 
 // SetupWithManager registers the reconciler onto the manager with all
-// three watched sources.
+// four watched sources.
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.ExporterBuilder == nil {
 		metrics := r.Metrics
@@ -93,6 +93,9 @@ func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(podChangePredicates()),
 		).
 		Watches(&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueOnBundleChange),
+		).
+		Watches(&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueOnBundleChange),
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
@@ -278,9 +281,11 @@ func (r *AgentReconciler) enqueueAllPodTraces(ctx context.Context, _ client.Obje
 	return out
 }
 
-// enqueueOnBundleChange handles ConfigMap watches: only bundle
-// ConfigMaps (with our managed-by label) produce reconcile requests,
-// and each such event enqueues every PodTrace.
+// enqueueOnBundleChange handles the ConfigMap and Secret bundle watches:
+// only bundle objects (with our managed-by + exporter-bundle labels)
+// produce reconcile requests, and each such event enqueues every
+// PodTrace. Watching the Secret is what lets a credential-only rotation,
+// which never touches the bundle ConfigMap, trigger a reconcile.
 func (r *AgentReconciler) enqueueOnBundleChange(ctx context.Context, obj client.Object) []reconcile.Request {
 	if obj.GetLabels()[operator.LabelManagedBy] != operator.ManagedByValue {
 		return nil

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -815,6 +815,19 @@ func TestEnqueueOnBundleChange(t *testing.T) {
 	if len(got) != 1 {
 		t.Errorf("bundle CM enqueued %d, want 1", len(got))
 	}
+
+	gotSecret := r.enqueueOnBundleChange(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "x", Namespace: "ns",
+			Labels: map[string]string{
+				operator.LabelManagedBy: operator.ManagedByValue,
+				operator.LabelComponent: operator.ComponentBundle,
+			},
+		},
+	})
+	if len(gotSecret) != 1 {
+		t.Errorf("bundle Secret enqueued %d, want 1", len(gotSecret))
+	}
 }
 
 func TestObtainAndReleaseExporter(t *testing.T) {

--- a/internal/resource/monitor.go
+++ b/internal/resource/monitor.go
@@ -174,12 +174,7 @@ func (rm *ResourceMonitor) readLimits() error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
-	isV2, err := isCgroupV2(rm.cgroupPath)
-	if err != nil {
-		return err
-	}
-
-	if isV2 {
+	if isCgroupV2(rm.cgroupPath) {
 		return rm.readLimitsV2()
 	}
 	return rm.readLimitsV1()
@@ -239,9 +234,60 @@ func (rm *ResourceMonitor) readLimitsV2() error {
 	return rm.syncToBPF()
 }
 
+// cgroup v1 controller mount directory candidates, relative to
+// config.CgroupBasePath. Each controller is its own hierarchy; cpu and cpuacct
+// are usually co-mounted ("cpu,cpuacct") but may be split, so try both forms.
+var (
+	cgroupV1CPUDirs     = []string{"cpu,cpuacct", "cpuacct,cpu", "cpu"}
+	cgroupV1CPUAcctDirs = []string{"cpu,cpuacct", "cpuacct,cpu", "cpuacct"}
+	cgroupV1MemoryDirs  = []string{"memory"}
+	cgroupV1BlkioDirs   = []string{"blkio"}
+)
+
+// cgroupV1Subpath returns the pod's cgroup path relative to a v1 controller
+// root: the discovered path with the base and the leading controller segment
+// stripped. For "/sys/fs/cgroup/cpu,cpuacct/kubepods/pod123" it returns
+// "kubepods/pod123", which then reattaches under any controller hierarchy.
+func cgroupV1Subpath(cgroupPath string) (string, bool) {
+	rel, ok := sysfs.CgroupRelative(cgroupPath)
+	if !ok || rel == "." {
+		return "", false
+	}
+	slash := strings.IndexByte(rel, '/')
+	if slash < 0 {
+		return "", false
+	}
+	return rel[slash+1:], true
+}
+
+// readV1ControllerFile reads a cgroup v1 file from the first controller mount
+// that has it: <base>/<controller>/<subpath>/<file>. Unlike v2, the controller
+// is a path PREFIX (a separate hierarchy), not a subdirectory of the pod path.
+func readV1ControllerFile(controllers []string, subpath, file string) (string, error) {
+	var lastErr error
+	for _, ctrl := range controllers {
+		content, err := readCgroupFile(filepath.Join(config.CgroupBasePath, ctrl, subpath, file))
+		if err == nil {
+			return content, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no controller mount found for %s among %v", file, controllers)
+	}
+	return "", lastErr
+}
+
 func (rm *ResourceMonitor) readLimitsV1() error {
-	cpuQuota, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "cpu", "cpu.cfs_quota_us"))
-	cpuPeriod, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "cpu", "cpu.cfs_period_us"))
+	subpath, ok := cgroupV1Subpath(rm.cgroupPath)
+	if !ok {
+		logger.Debug("cgroup v1: cannot derive controller subpath from cgroup path",
+			zap.String("cgroup_path", rm.cgroupPath))
+		return rm.syncToBPF()
+	}
+
+	cpuQuota, _ := readV1ControllerFile(cgroupV1CPUDirs, subpath, "cpu.cfs_quota_us")
+	cpuPeriod, _ := readV1ControllerFile(cgroupV1CPUDirs, subpath, "cpu.cfs_period_us")
 	if cpuQuota != "" && cpuPeriod != "" {
 		quota, _ := strconv.ParseUint(strings.TrimSpace(cpuQuota), 10, 64)
 		period, _ := strconv.ParseUint(strings.TrimSpace(cpuPeriod), 10, 64)
@@ -255,7 +301,7 @@ func (rm *ResourceMonitor) readLimitsV1() error {
 		}
 	}
 
-	memLimit, err := readCgroupFile(filepath.Join(rm.cgroupPath, "memory", "memory.limit_in_bytes"))
+	memLimit, err := readV1ControllerFile(cgroupV1MemoryDirs, subpath, "memory.limit_in_bytes")
 	if err == nil {
 		limit := parseMemoryMax(memLimit)
 		if limit > 0 {
@@ -267,8 +313,8 @@ func (rm *ResourceMonitor) readLimitsV1() error {
 		}
 	}
 
-	ioRead, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.throttle.read_bps_device"))
-	ioWrite, _ := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.throttle.write_bps_device"))
+	ioRead, _ := readV1ControllerFile(cgroupV1BlkioDirs, subpath, "blkio.throttle.read_bps_device")
+	ioWrite, _ := readV1ControllerFile(cgroupV1BlkioDirs, subpath, "blkio.throttle.write_bps_device")
 	limit := parseBlkioThrottleBps(ioRead)
 	if w := parseBlkioThrottleBps(ioWrite); w > limit {
 		limit = w
@@ -293,12 +339,7 @@ func (rm *ResourceMonitor) updateResourceUsage() error {
 	}
 	defer rm.mu.Unlock()
 
-	isV2, err := isCgroupV2(rm.cgroupPath)
-	if err != nil {
-		return err
-	}
-
-	if isV2 {
+	if isCgroupV2(rm.cgroupPath) {
 		return rm.updateUsageV2()
 	}
 	return rm.updateUsageV1()
@@ -336,7 +377,12 @@ func (rm *ResourceMonitor) updateUsageV2() error {
 }
 
 func (rm *ResourceMonitor) updateUsageV1() error {
-	cpuUsage, err := readCgroupFile(filepath.Join(rm.cgroupPath, "cpuacct", "cpuacct.usage"))
+	subpath, ok := cgroupV1Subpath(rm.cgroupPath)
+	if !ok {
+		return rm.syncToBPF()
+	}
+
+	cpuUsage, err := readV1ControllerFile(cgroupV1CPUAcctDirs, subpath, "cpuacct.usage")
 	if err == nil {
 		usage, _ := strconv.ParseUint(strings.TrimSpace(cpuUsage), 10, 64)
 		if limit, ok := rm.limits[ResourceCPU]; ok {
@@ -345,7 +391,7 @@ func (rm *ResourceMonitor) updateUsageV1() error {
 		}
 	}
 
-	memUsage, err := readCgroupFile(filepath.Join(rm.cgroupPath, "memory", "memory.usage_in_bytes"))
+	memUsage, err := readV1ControllerFile(cgroupV1MemoryDirs, subpath, "memory.usage_in_bytes")
 	if err == nil {
 		usage := parseMemoryMax(memUsage)
 		if limit, ok := rm.limits[ResourceMemory]; ok {
@@ -354,7 +400,7 @@ func (rm *ResourceMonitor) updateUsageV1() error {
 		}
 	}
 
-	ioBytes, err := readCgroupFile(filepath.Join(rm.cgroupPath, "blkio", "blkio.io_service_bytes"))
+	ioBytes, err := readV1ControllerFile(cgroupV1BlkioDirs, subpath, "blkio.io_service_bytes")
 	if err == nil {
 		usage := parseBlkioServiceBytes(ioBytes)
 		if limit, ok := rm.limits[ResourceIO]; ok {
@@ -598,19 +644,27 @@ func getCgroupInode(cgroupPath string) (uint64, error) {
 	return uint64(stat.Ino), nil
 }
 
-func isCgroupV2(cgroupPath string) (bool, error) {
-	controllersPath := filepath.Join(cgroupPath, "cgroup.controllers")
-	_, err := os.Stat(controllersPath)
-	if err == nil {
-		return true, nil
+// isCgroupV2 reports whether the cgroup hierarchy backing cgroupPath is the
+// unified v2 hierarchy. A cgroup.controllers file exists only under v2 — never
+// inside a v1 controller hierarchy — so its presence at the mount root
+// (config.CgroupBasePath) is the authoritative signal, matching the check the
+// tracer and CLI use. The per-path check is a fallback for callers whose base
+// is itself a unified-hierarchy node. When neither is present the node is v1.
+//
+// The previous implementation probed for cpu/ and memory/ SUBDIRECTORIES of
+// the pod path and returned an error otherwise. That never matched a real v1
+// node — there the controllers are separate sibling hierarchies ABOVE the pod
+// path (/sys/fs/cgroup/cpu,cpuacct/..., /sys/fs/cgroup/memory/...), not
+// subdirectories of it — so v1 always fell through to "cannot determine
+// version" and resource monitoring silently did nothing.
+func isCgroupV2(cgroupPath string) bool {
+	if _, err := os.Stat(filepath.Join(config.CgroupBasePath, "cgroup.controllers")); err == nil {
+		return true
 	}
-	if _, err := os.Stat(filepath.Join(cgroupPath, "cpu")); err == nil {
-		return false, nil
+	if _, err := os.Stat(filepath.Join(cgroupPath, "cgroup.controllers")); err == nil {
+		return true
 	}
-	if _, err := os.Stat(filepath.Join(cgroupPath, "memory")); err == nil {
-		return false, nil
-	}
-	return false, fmt.Errorf("cannot determine cgroup version")
+	return false
 }
 
 func readCgroupFile(path string) (string, error) {

--- a/internal/resource/monitor_test.go
+++ b/internal/resource/monitor_test.go
@@ -51,6 +51,54 @@ func useCgroupBase(t *testing.T, base string) {
 	})
 }
 
+// writeCgroupV1Layout builds a realistic cgroup v1 layout under base: each
+// controller is its own hierarchy (<base>/<controller>/<subpath>/...), the way
+// a real node exposes it and the CLI's findCgroupPathV1 discovers it, NOT the
+// controller-as-subdirectory shape the old tests fabricated.
+func writeCgroupV1Layout(t *testing.T, base, subpath string, byController map[string]map[string]string) string {
+	t.Helper()
+	primary := filepath.Join(base, "cpu,cpuacct", subpath)
+	if err := os.MkdirAll(primary, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", primary, err)
+	}
+	for ctrl, files := range byController {
+		dir := filepath.Join(base, ctrl, subpath)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		for name, content := range files {
+			full := filepath.Join(dir, name)
+			if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+				t.Fatalf("write %s: %v", full, err)
+			}
+		}
+	}
+	return primary
+}
+
+func TestCgroupV1Subpath(t *testing.T) {
+	useCgroupBase(t, "/base")
+	cases := []struct {
+		name   string
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{"combined controller", "/base/cpu,cpuacct/kubepods/pod123", "kubepods/pod123", true},
+		{"memory hierarchy nested", "/base/memory/kubepods/burstable/pod123/abc", "kubepods/burstable/pod123/abc", true},
+		{"controller root only", "/base/cpu", "", false},
+		{"not under base", "/somewhere/else/cpu/pod", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := cgroupV1Subpath(tc.path)
+			if ok != tc.wantOK || got != tc.want {
+				t.Errorf("cgroupV1Subpath(%q)=(%q,%v) want (%q,%v)", tc.path, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
 func TestNewResourceMonitor(t *testing.T) {
 	tmpDir := t.TempDir()
 	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
@@ -156,73 +204,45 @@ func TestGetCgroupInode_NonExistent(t *testing.T) {
 
 func TestIsCgroupV2(t *testing.T) {
 	tests := []struct {
-		name        string
-		setup       func(string) error
-		expectedV2  bool
-		expectError bool
+		name       string
+		setup      func(base, cgroupPath string)
+		expectedV2 bool
 	}{
 		{
-			name: "cgroup v2 with controllers file",
-			setup: func(path string) error {
-				controllersFile := filepath.Join(path, "cgroup.controllers")
-				return os.WriteFile(controllersFile, []byte("cpu memory io"), 0644)
+			name: "v2 unified: cgroup.controllers at the mount root",
+			setup: func(base, _ string) {
+				_ = os.WriteFile(filepath.Join(base, "cgroup.controllers"), []byte("cpu memory io"), 0o644)
 			},
-			expectedV2:  true,
-			expectError: false,
+			expectedV2: true,
 		},
 		{
-			name: "cgroup v1 with cpu subdirectory",
-			setup: func(path string) error {
-				cpuDir := filepath.Join(path, "cpu")
-				return os.MkdirAll(cpuDir, 0755)
+			name: "v2 fallback: cgroup.controllers on the per-pod path only",
+			setup: func(_, cgroupPath string) {
+				_ = os.WriteFile(filepath.Join(cgroupPath, "cgroup.controllers"), []byte("cpu memory"), 0o644)
 			},
-			expectedV2:  false,
-			expectError: false,
+			expectedV2: true,
 		},
 		{
-			name: "cgroup v1 with memory subdirectory",
-			setup: func(path string) error {
-				memDir := filepath.Join(path, "memory")
-				return os.MkdirAll(memDir, 0755)
+			name: "v1: no cgroup.controllers anywhere (controllers are sibling hierarchies)",
+			setup: func(base, _ string) {
+				_ = os.MkdirAll(filepath.Join(base, "cpu,cpuacct"), 0o755)
+				_ = os.MkdirAll(filepath.Join(base, "memory"), 0o755)
 			},
-			expectedV2:  false,
-			expectError: false,
-		},
-		{
-			name: "neither v1 nor v2",
-			setup: func(path string) error {
-				return nil
-			},
-			expectedV2:  false,
-			expectError: true,
+			expectedV2: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-
-			if err := os.MkdirAll(cgroupPath, 0755); err != nil {
+			base := t.TempDir()
+			useCgroupBase(t, base)
+			cgroupPath := filepath.Join(base, "test-cgroup")
+			if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
 				t.Fatalf("Failed to create test cgroup dir: %v", err)
 			}
-
-			if err := tt.setup(cgroupPath); err != nil {
-				t.Fatalf("Setup failed: %v", err)
-			}
-
-			isV2, err := isCgroupV2(cgroupPath)
-			if tt.expectError {
-				if err == nil {
-					t.Error("Expected error but got none")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if isV2 != tt.expectedV2 {
-					t.Errorf("Expected isV2=%v, got %v", tt.expectedV2, isV2)
-				}
+			tt.setup(base, cgroupPath)
+			if got := isCgroupV2(cgroupPath); got != tt.expectedV2 {
+				t.Errorf("isCgroupV2()=%v want %v", got, tt.expectedV2)
 			}
 		})
 	}
@@ -492,21 +512,16 @@ func TestResourceMonitor_ReadLimitsV2(t *testing.T) {
 }
 
 func TestResourceMonitor_ReadLimitsV1(t *testing.T) {
-	tmpDir := t.TempDir()
-	useCgroupBase(t, tmpDir)
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("1073741824"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 1048576"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "100000",
+			"cpu.cfs_period_us": "100000",
+		},
+		"memory": {"memory.limit_in_bytes": "1073741824"},
+		"blkio":  {"blkio.throttle.read_bps_device": "8:0 1048576"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -589,20 +604,16 @@ func TestResourceMonitor_UpdateUsageV2(t *testing.T) {
 }
 
 func TestResourceMonitor_UpdateUsageV1(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpuacct"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("1073741824"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	const subpath = "kubepods/pod-test"
+	cgroupPath := writeCgroupV1Layout(t, base, subpath, map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "100000",
+			"cpu.cfs_period_us": "100000",
+		},
+		"memory": {"memory.limit_in_bytes": "1073741824"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -610,12 +621,14 @@ func TestResourceMonitor_UpdateUsageV1(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpuacct", "cpuacct.usage"), []byte("50000000000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.usage_in_bytes"), []byte("536870912"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.io_service_bytes"), []byte("8:0 Read 524288"), 0644)
+	// Usage counters appear after the monitor is constructed.
+	writeCgroupV1Layout(t, base, subpath, map[string]map[string]string{
+		"cpu,cpuacct": {"cpuacct.usage": "50000000000"},
+		"memory":      {"memory.usage_in_bytes": "536870912"},
+		"blkio":       {"blkio.io_service_bytes": "8:0 Read 524288"},
+	})
 
-	err = monitor.updateUsageV1()
-	if err != nil {
+	if err := monitor.updateUsageV1(); err != nil {
 		t.Errorf("updateUsageV1() error = %v", err)
 	}
 
@@ -798,11 +811,16 @@ func TestResourceMonitor_MonitorLoop_StopChannel(t *testing.T) {
 	monitor.Stop()
 }
 
-func TestResourceMonitor_ReadLimits_ErrorPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
+func TestResourceMonitor_ReadLimits_GracefulWhenUnreadable(t *testing.T) {
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	// A bare cgroup path with no readable controller files. The old code
+	// returned "cannot determine cgroup version" here, which is exactly how
+	// v1 monitoring silently disabled itself; the monitor must now degrade to
+	// a no-op instead of erroring.
+	cgroupPath := filepath.Join(base, "test-cgroup")
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
 	}
 
 	eventChan := make(chan *events.Event, 10)
@@ -811,17 +829,20 @@ func TestResourceMonitor_ReadLimits_ErrorPath(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	err = monitor.readLimits()
-	if err == nil {
-		t.Error("Expected error when cgroup version cannot be determined")
+	if err := monitor.readLimits(); err != nil {
+		t.Errorf("readLimits() should degrade gracefully, got error: %v", err)
+	}
+	if got := len(monitor.GetLimits()); got != 0 {
+		t.Errorf("expected no limits from an unreadable cgroup, got %d", got)
 	}
 }
 
-func TestResourceMonitor_UpdateResourceUsage_ErrorPath(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
+func TestResourceMonitor_UpdateResourceUsage_GracefulWhenUnreadable(t *testing.T) {
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := filepath.Join(base, "test-cgroup")
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
 	}
 
 	eventChan := make(chan *events.Event, 10)
@@ -830,9 +851,8 @@ func TestResourceMonitor_UpdateResourceUsage_ErrorPath(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	err = monitor.updateResourceUsage()
-	if err == nil {
-		t.Error("Expected error when cgroup version cannot be determined")
+	if err := monitor.updateResourceUsage(); err != nil {
+		t.Errorf("updateResourceUsage() should degrade gracefully, got error: %v", err)
 	}
 }
 
@@ -858,15 +878,14 @@ func TestResourceMonitor_ReadLimitsV2_ErrorReadingFiles(t *testing.T) {
 }
 
 func TestResourceMonitor_ReadLimitsV1_ErrorReadingFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	// Controller hierarchies exist but hold no limit files.
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {},
+		"memory":      {},
+		"blkio":       {},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -874,8 +893,7 @@ func TestResourceMonitor_ReadLimitsV1_ErrorReadingFiles(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	err = monitor.readLimitsV1()
-	if err != nil {
+	if err := monitor.readLimitsV1(); err != nil {
 		t.Logf("readLimitsV1() returned error (expected when files don't exist): %v", err)
 	}
 }
@@ -904,20 +922,15 @@ func TestResourceMonitor_UpdateUsageV2_ErrorReadingFiles(t *testing.T) {
 }
 
 func TestResourceMonitor_UpdateUsageV1_ErrorReadingFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpuacct"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("1073741824"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "100000",
+			"cpu.cfs_period_us": "100000",
+		},
+		"memory": {"memory.limit_in_bytes": "1073741824"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -925,38 +938,33 @@ func TestResourceMonitor_UpdateUsageV1_ErrorReadingFiles(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	err = monitor.updateUsageV1()
-	if err != nil {
+	// No usage counter files written → the reads fail but the call must not.
+	if err := monitor.updateUsageV1(); err != nil {
 		t.Logf("updateUsageV1() returned error (expected when stat files don't exist): %v", err)
 	}
 }
 
 func TestResourceMonitor_UpdateUsageV1_WithLimits(t *testing.T) {
-	tmpDir := t.TempDir()
-	useCgroupBase(t, tmpDir)
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpuacct"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("1073741824"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "100000",
+			"cpu.cfs_period_us": "100000",
+			"cpuacct.usage":     "50000000000",
+		},
+		"memory": {
+			"memory.limit_in_bytes": "1073741824",
+			"memory.usage_in_bytes": "536870912",
+		},
+		"blkio": {"blkio.io_service_bytes": "8:0 Read 524288\n8:0 Write 262144"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
 	if err != nil {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
-
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpuacct", "cpuacct.usage"), []byte("50000000000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.usage_in_bytes"), []byte("536870912"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.io_service_bytes"), []byte("8:0 Read 524288\n8:0 Write 262144"), 0644)
 
 	monitor.mu.Lock()
 	monitor.limits[ResourceCPU] = &ResourceLimit{
@@ -1071,16 +1079,15 @@ func TestResourceMonitor_UpdateUsageV2_NoLimits(t *testing.T) {
 }
 
 func TestResourceMonitor_UpdateUsageV1_NoLimits(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpuacct"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	// Usage counters exist but no limits were read, so the updates are
+	// no-ops — the call must still succeed without panicking.
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {"cpuacct.usage": "50000000000"},
+		"memory":      {"memory.usage_in_bytes": "536870912"},
+		"blkio":       {"blkio.io_service_bytes": "8:0 Read 524288"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1088,12 +1095,7 @@ func TestResourceMonitor_UpdateUsageV1_NoLimits(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpuacct", "cpuacct.usage"), []byte("50000000000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.usage_in_bytes"), []byte("536870912"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.io_service_bytes"), []byte("8:0 Read 524288"), 0644)
-
-	err = monitor.updateUsageV1()
-	if err != nil {
+	if err := monitor.updateUsageV1(); err != nil {
 		t.Errorf("updateUsageV1() error = %v", err)
 	}
 }
@@ -1148,15 +1150,14 @@ func TestResourceMonitor_ReadLimitsV2_ZeroCPUQuota(t *testing.T) {
 }
 
 func TestResourceMonitor_ReadLimitsV1_ZeroQuota(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("0"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("100000"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "0",
+			"cpu.cfs_period_us": "100000",
+		},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1164,21 +1165,17 @@ func TestResourceMonitor_ReadLimitsV1_ZeroQuota(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	limits := monitor.GetLimits()
-	if limits[ResourceCPU] != nil {
+	if monitor.GetLimits()[ResourceCPU] != nil {
 		t.Error("Expected no CPU limit for zero quota")
 	}
 }
 
 func TestResourceMonitor_ReadLimitsV1_MissingPeriod(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {"cpu.cfs_quota_us": "100000"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1186,22 +1183,20 @@ func TestResourceMonitor_ReadLimitsV1_MissingPeriod(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	limits := monitor.GetLimits()
-	if limits[ResourceCPU] != nil {
+	if monitor.GetLimits()[ResourceCPU] != nil {
 		t.Error("Expected no CPU limit when period is missing")
 	}
 }
 
 func TestResourceMonitor_ReadLimitsV1_ZeroPeriod(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "cpu"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_quota_us"), []byte("100000"), 0644)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "cpu", "cpu.cfs_period_us"), []byte("0"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"cpu,cpuacct": {
+			"cpu.cfs_quota_us":  "100000",
+			"cpu.cfs_period_us": "0",
+		},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1209,21 +1204,17 @@ func TestResourceMonitor_ReadLimitsV1_ZeroPeriod(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	limits := monitor.GetLimits()
-	if limits[ResourceCPU] != nil {
+	if monitor.GetLimits()[ResourceCPU] != nil {
 		t.Error("Expected no CPU limit for zero period")
 	}
 }
 
 func TestResourceMonitor_ReadLimitsV1_ZeroMemoryLimit(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "memory"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "memory", "memory.limit_in_bytes"), []byte("0"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"memory": {"memory.limit_in_bytes": "0"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1231,8 +1222,7 @@ func TestResourceMonitor_ReadLimitsV1_ZeroMemoryLimit(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	limits := monitor.GetLimits()
-	if limits[ResourceMemory] != nil {
+	if monitor.GetLimits()[ResourceMemory] != nil {
 		t.Error("Expected no memory limit for zero limit")
 	}
 }
@@ -1304,14 +1294,11 @@ func TestResourceMonitor_ReadLimitsV2_ZeroIOMax(t *testing.T) {
 }
 
 func TestResourceMonitor_ReadLimitsV1_ZeroIO(t *testing.T) {
-	tmpDir := t.TempDir()
-	cgroupPath := filepath.Join(tmpDir, "test-cgroup")
-	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
-		t.Fatalf("Failed to create test cgroup dir: %v", err)
-	}
-
-	_ = os.MkdirAll(filepath.Join(cgroupPath, "blkio"), 0755)
-	_ = os.WriteFile(filepath.Join(cgroupPath, "blkio", "blkio.throttle.read_bps_device"), []byte("8:0 0"), 0644)
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	cgroupPath := writeCgroupV1Layout(t, base, "kubepods/pod-test", map[string]map[string]string{
+		"blkio": {"blkio.throttle.read_bps_device": "8:0 0"},
+	})
 
 	eventChan := make(chan *events.Event, 10)
 	monitor, err := NewResourceMonitor(cgroupPath, nil, nil, eventChan, "test-ns")
@@ -1319,8 +1306,7 @@ func TestResourceMonitor_ReadLimitsV1_ZeroIO(t *testing.T) {
 		t.Fatalf("NewResourceMonitor() error = %v", err)
 	}
 
-	limits := monitor.GetLimits()
-	if limits[ResourceIO] != nil {
+	if monitor.GetLimits()[ResourceIO] != nil {
 		t.Error("Expected no IO limit for zero value")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two independent HIGH findings from the v0.13.7 deep scan. The changes touch disjoint packages (`internal/resource` and `internal/agent`) and can be reviewed as two logical units.

### 1. cgroup v1 resource monitoring never worked (`internal/resource/monitor.go`)

`isCgroupV2` probed for `cpu/` and `memory/` subdirectories of the pod cgroup path and returned "cannot determine version" otherwise, which never matches a real cgroup v1 node, where controllers are separate sibling hierarchies *above* the pod path (`/sys/fs/cgroup/cpu,cpuacct/...`, `/sys/fs/cgroup/memory/...`), not subdirectories of it. On top of that, `readLimitsV1`/`updateUsageV1` joined controller names as a path *suffix* (`<pod>/cpu/cpu.cfs_quota_us`). The net effect: on any v1 node, limits, utilization, and threshold alerts were all silent no-ops.

The fix detects the cgroup version at the mount root (`config.CgroupBasePath/cgroup.controllers`, matching the tracer and CLI), with a per-path fallback and no error case (v1 is now a definite answer that degrades gracefully). New helpers `cgroupV1Subpath` and `readV1ControllerFile` read limits from the real prefix layout `<base>/<controller>/<subpath>/<file>`, probing the `cpu,cpuacct`, `memory`, and `blkio` hierarchies.

### 2. Agent ignored credential-only rotations (`internal/agent/`)

The reconciler watched only PodTrace/Pod/ConfigMap, and cached exporters keyed on the bundle ConfigMap ResourceVersion only. A credential-only rotation leaves the bundle ConfigMap untouched, so no reconcile fired, and even when one did, the cached exporter was returned with the stale token. Rotating a Splunk/DataDog/OTLP credential meant every agent kept exporting with the dead token (only symptom: `export_delivery_dropped_total`) until the DaemonSet restarted.

The fix adds a `Watches(&corev1.Secret{}, ...)` source (the manager cache already scopes Secrets to the system namespace, and the operator labels the bundle Secret identically to the ConfigMap, so the existing handler matches unchanged), and folds the Secret's ResourceVersion into the bundle revision so the exporter cache invalidates on rotation.