### PR TITLE
fix: drop bpf_get_current_comm from cgroup_skb programs

### DIFF
--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -301,7 +301,8 @@ int dns_egress(struct __sk_buff *skb) {
 	q.ts_ns = bpf_ktime_get_ns();
 	q.pid = bpf_get_current_pid_tgid() >> 32;
 	q.transport = transport;
-	bpf_get_current_comm(&q.comm, sizeof(q.comm));
+	/* bpf_get_current_comm is not available to cgroup_skb programs;
+	 * q.comm stays zeroed and userspace resolves the name from q.pid. */
 	if (!is_v6) {
 		__u32 daddr = 0;
 		if (bpf_skb_load_bytes(skb, 16, &daddr, sizeof(daddr)) == 0)

--- a/bpf/http3.c
+++ b/bpf/http3.c
@@ -58,7 +58,9 @@ static __always_inline void quic_ship(struct __sk_buff *skb, u8 is_v6,
 	rec->timestamp = bpf_ktime_get_ns();
 	rec->cgroup_id = k.cgroup_id;
 	rec->pid = bpf_get_current_pid_tgid() >> 32;
-	bpf_get_current_comm(&rec->comm, sizeof(rec->comm));
+	/* bpf_get_current_comm is not available to cgroup_skb programs;
+	 * userspace resolves the name from rec->pid instead. */
+	__builtin_memset(rec->comm, 0, sizeof(rec->comm));
 	rec->family = is_v6 ? 10 : 2;
 	rec->_pad = 0;
 	rec->dport = k.dport;


### PR DESCRIPTION
## Problem

With #303 applied, loading the eBPF collection still fails, now on the HTTP/3 QUIC probes:

```
program http3_egress: load program: invalid argument:
program of this type cannot use helper bpf_get_current_comm#16
```

Observed on a DigitalOcean managed Kubernetes node. `http3_egress`/`http3_ingress` (`bpf/http3.c`) and the DNS query probe (`bpf/dns.c`) are `cgroup_skb` programs, and the kernel does not include `bpf_get_current_comm` in the helpers available to that program type — unlike `bpf_get_current_pid_tgid`, which was added to the base helper set and passes. The failure was previously masked because v0.13.7 died earlier on the combined stack-size rejection that #303 fixed.

## Fix

Drop the two `bpf_get_current_comm` calls and leave the `comm` field zeroed. Userspace already handles this: `processAndDispatch` resolves the process name from the pid (`getProcessNameQuick`) whenever `ProcessName` is empty, so event output is unaffected.

## Verification

Built the image from this branch and ran it against a production pod on the DigitalOcean cluster that previously failed: all programs now pass the verifier and the tracer streams events (~575 events/sec from the target pod, TCP/connection/filesystem stats all populated).

Also re-checked bpf-to-bpf stack depth on the rebuilt object (clang 19, x86): worst chain is 448 bytes of the 512 limit.