### PR TITLE
build: bump Go to 1.26.5 and add govulncheck to CI

### DIFF
--- a/.github/workflows/chainsaw.yml
+++ b/.github/workflows/chainsaw.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
         with:
-          version: v4.2.2
+          version: v4.2.3
 
       - name: Install chainsaw
         run: |
@@ -166,7 +166,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
         with:
-          version: v4.2.2
+          version: v4.2.3
 
       - name: Install BPF toolchain
         uses: ./.github/actions/setup-bpf-toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ env:
   CHART_PATH: deploy/charts/podtrace
   CHART_REPO: ghcr.io/gma1k/charts
   COSIGN_VERSION: v3.0.6
-  HELM_VERSION: v4.2.2
+  HELM_VERSION: v4.2.3
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,3 +90,23 @@ jobs:
 
       - name: Analyze
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+
+  govulncheck:
+    name: govulncheck
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # The same image serves the CLI, the agent DaemonSet, the operator
 # Deployment, and per-session Jobs, one binary, multiple subcommands.
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 ARG DEBIAN_RELEASE=trixie
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_RELEASE} AS builder


### PR DESCRIPTION
Addresses three dependency scanner findings.

## Go 1.26.5

Bumps the builder base image from `golang:1.26.4` to `golang:1.26.5`, which fixes two reachable standard-library CVEs: CVE-2026-39822 (os.Root improperly follows a trailing-slash symlink out of the root, the sysfs/procfs sandbox relies on os.Root) and CVE-2026-42505 (Encrypted Client Hello de-anonymization). `go.mod` already required `go 1.26.5`; only the base image lagged.

## Helm CLI v4.2.3

Bump Helm CLI to v4.2.3 in CI

## govulncheck

Adds a reachability-based `govulncheck` job to `security.yml`. It gates vulnerabilities in code paths podtrace actually compiles and calls, and reports module-only findings as not affecting.

This covers the third finding, GO-2026-5932 (`golang.org/x/crypto/openpgp`): the advisory is "unsafe by design" with no fixed version, but podtrace never imports the package, `x/crypto` is pulled in transitively only for `pkcs12` (Azure SDK). govulncheck confirms 0 affected, so the alert can be dismissed as not applicable.