### PR TITLE
fix: correct multi-namespace targeting and bundle/report lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 bin/
+/podtrace
 *.o
 *.so
 

--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -420,9 +420,6 @@ int dns_ingress(struct __sk_buff *skb) {
 		if (atype == DNS_TYPE_A) {
 			__u32 ip = 0;
 			if (bpf_skb_load_bytes(skb, rdata, &ip, sizeof(ip)) == 0) {
-				/* Map key stays network order (the connect probes look it
-				 * up with the raw sockaddr address); only the displayed
-				 * string needs host order. */
 				bpf_map_update_elem(&dns_resolved, &ip, q->name, BPF_ANY);
 				format_ip_port(__builtin_bswap32(ip), 0, e->details);
 				wrote_detail = 1;

--- a/bpf/http3.c
+++ b/bpf/http3.c
@@ -58,8 +58,6 @@ static __always_inline void quic_ship(struct __sk_buff *skb, u8 is_v6,
 	rec->timestamp = bpf_ktime_get_ns();
 	rec->cgroup_id = k.cgroup_id;
 	rec->pid = bpf_get_current_pid_tgid() >> 32;
-	/* bpf_get_current_comm is not available to cgroup_skb programs;
-	 * userspace resolves the name from rec->pid instead. */
 	__builtin_memset(rec->comm, 0, sizeof(rec->comm));
 	rec->family = is_v6 ? 10 : 2;
 	rec->_pad = 0;

--- a/cmd/podtrace/cmd_tracer_sink_unit_test.go
+++ b/cmd/podtrace/cmd_tracer_sink_unit_test.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
@@ -228,7 +229,7 @@ func TestUpsertReportConfigMap_CreateErrorPropagates(t *testing.T) {
 	client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, wantErr
 	})
-	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "body")
+	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "report.txt", "body")
 	if err == nil {
 		t.Fatal("expected error when ConfigMap create fails")
 	}
@@ -243,7 +244,7 @@ func TestUpsertReportConfigMap_GetErrorAfterAlreadyExists(t *testing.T) {
 	client.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("get failed")
 	})
-	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "body")
+	err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "report.txt", "body")
 	if err == nil {
 		t.Fatal("expected error when Get after AlreadyExists fails")
 	}
@@ -255,7 +256,7 @@ func TestUpsertReportSecret_CreateErrorPropagates(t *testing.T) {
 	client.PrependReactor("create", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, wantErr
 	})
-	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "body")
+	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "report.txt", "body")
 	if err == nil {
 		t.Fatal("expected error when Secret create fails")
 	}
@@ -270,9 +271,44 @@ func TestUpsertReportSecret_UpdateErrorPropagates(t *testing.T) {
 		return true, nil, errors.New("update failed")
 	})
 	// Create will return AlreadyExists (object seeded), Get succeeds, Update fails.
-	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "body")
+	err := upsertReportSecret(context.Background(), client, "ns", "rpt", "report.txt", "body")
 	if err == nil {
 		t.Fatal("expected error when Secret update fails")
+	}
+}
+
+func TestUpsertReportConfigMap_RetriesOnConflict(t *testing.T) {
+	existing := &corev1.ConfigMap{}
+	existing.Name = "rpt"
+	existing.Namespace = "ns"
+	existing.Data = map[string]string{"report-other.txt": "keep"}
+	client := fake.NewSimpleClientset(existing)
+
+	updates := 0
+	client.PrependReactor("update", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "configmaps"}, "rpt", errors.New("stale revision"))
+		}
+		return false, nil, nil // let the default tracker apply subsequent updates
+	})
+
+	if err := upsertReportConfigMap(context.Background(), client, "ns", "rpt", "report-node-a.txt", "A"); err != nil {
+		t.Fatalf("expected retry to succeed after conflict, got %v", err)
+	}
+	if updates < 2 {
+		t.Errorf("expected a retry after the 409, updates=%d", updates)
+	}
+	cm, err := client.CoreV1().ConfigMaps("ns").Get(context.Background(), "rpt", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cm.Data["report-node-a.txt"] != "A" {
+		t.Errorf("this node's key not written after retry: %+v", cm.Data)
+	}
+	if cm.Data["report-other.txt"] != "keep" {
+		t.Errorf("sibling node's key lost during retry: %+v", cm.Data)
 	}
 }
 

--- a/cmd/podtrace/report_key_test.go
+++ b/cmd/podtrace/report_key_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReportDataKey_PerNode(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	if got := reportDataKey(); got != "report.txt" {
+		t.Errorf("no NODE_NAME: got %q want report.txt", got)
+	}
+	t.Setenv("NODE_NAME", "kind-worker-2")
+	if got := reportDataKey(); got != "report-kind-worker-2.txt" {
+		t.Errorf("with NODE_NAME: got %q want report-kind-worker-2.txt", got)
+	}
+	t.Setenv("NODE_NAME", "weird/node name")
+	if got := reportDataKey(); got != "report-weird-node-name.txt" {
+		t.Errorf("sanitized key: got %q want report-weird-node-name.txt", got)
+	}
+}
+
+func TestUpsertReportConfigMap_PerNodeKeysCoexist(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "report-node-a.txt", "A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "report-node-b.txt", "B"); err != nil {
+		t.Fatal(err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps("ns").Get(ctx, "rpt", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cm.Data["report-node-a.txt"] != "A" || cm.Data["report-node-b.txt"] != "B" {
+		t.Errorf("per-node reports clobbered each other: %+v", cm.Data)
+	}
+}

--- a/cmd/podtrace/session_sink.go
+++ b/cmd/podtrace/session_sink.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/podtrace/podtrace/internal/diagnose"
 	"github.com/podtrace/podtrace/internal/hostfs"
@@ -201,11 +202,12 @@ func uploadReport(ctx context.Context, spec, reportText string) error {
 	writeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	key := reportDataKey()
 	switch kind {
 	case "configmap":
-		return upsertReportConfigMap(writeCtx, client, namespace, name, reportText)
+		return upsertReportConfigMap(writeCtx, client, namespace, name, key, reportText)
 	case "secret":
-		return upsertReportSecret(writeCtx, client, namespace, name, reportText)
+		return upsertReportSecret(writeCtx, client, namespace, name, key, reportText)
 	default:
 		return fmt.Errorf("unsupported report-to kind %q (want configmap|secret)", kind)
 	}
@@ -227,78 +229,109 @@ func parseReportToSpec(spec string) (kind, namespace, name string, err error) {
 	return strings.ToLower(parts[0]), parts[1], parts[2], nil
 }
 
-// upsertReportConfigMap creates or updates a ConfigMap with the report
-// under the deterministic data key "report.txt".
-func upsertReportConfigMap(ctx context.Context, client kubernetes.Interface, namespace, name, reportText string) error {
-	data := map[string]string{"report.txt": reportText}
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{
-			"podtrace.io/managed-by": "podtrace-cli",
-			"podtrace.io/kind":       "session-report",
-		}},
-		Data: data,
+// reportDataKey returns the ConfigMap/Secret data key the session report is
+// written under.
+func reportDataKey() string {
+	node := os.Getenv("NODE_NAME")
+	if node == "" {
+		return "report.txt"
 	}
-	_, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
-	if err == nil {
-		return nil
+	return "report-" + sanitizeReportKeySegment(node) + ".txt"
+}
+
+// sanitizeReportKeySegment maps a node name onto the characters a ConfigMap /
+// Secret data key allows ([-._a-zA-Z0-9]).
+func sanitizeReportKeySegment(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if !isReportKeyByte(c) {
+			b[i] = '-'
+		}
 	}
-	if !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create ConfigMap: %w", err)
-	}
-	existing, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	return string(b)
+}
+
+// isReportKeyByte reports whether c is valid in a ConfigMap/Secret data key
+// ([-._a-zA-Z0-9]).
+func isReportKeyByte(c byte) bool {
+	return c == '-' || c == '.' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+var reportSinkLabels = map[string]string{
+	"podtrace.io/managed-by": "podtrace-cli",
+	"podtrace.io/kind":       "session-report",
+}
+
+// upsertReportConfigMap writes reportText under the given per-node data key,
+// creating the ConfigMap if absent.
+func upsertReportConfigMap(ctx context.Context, client kubernetes.Interface, namespace, name, key, reportText string) error {
+	cms := client.CoreV1().ConfigMaps(namespace)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := cms.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: reportSinkLabels},
+				Data:       map[string]string{key: reportText},
+			}
+			_, cerr := cms.Create(ctx, cm, metav1.CreateOptions{})
+			if cerr == nil || !apierrors.IsAlreadyExists(cerr) {
+				return cerr
+			}
+			// Lost the create race; fall through to a get+update.
+			existing, err = cms.Get(ctx, name, metav1.GetOptions{})
+		}
+		if err != nil {
+			return err
+		}
+		if existing.Data == nil {
+			existing.Data = map[string]string{}
+		}
+		existing.Data[key] = reportText
+		_, uerr := cms.Update(ctx, existing, metav1.UpdateOptions{})
+		return uerr
+	})
 	if err != nil {
-		return fmt.Errorf("get existing ConfigMap: %w", err)
-	}
-	if existing.Data == nil {
-		existing.Data = map[string]string{}
-	}
-	existing.Data["report.txt"] = reportText
-	if _, err := client.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("update ConfigMap: %w", err)
+		return fmt.Errorf("upsert report ConfigMap: %w", err)
 	}
 	return nil
 }
 
 // upsertReportSecret mirrors upsertReportConfigMap for Secret sinks.
-// Secret is the right sink when the report may contain sensitive
-// hostnames, paths, or payloads — Kubernetes RBAC on Secrets is
-// typically stricter.
-func upsertReportSecret(ctx context.Context, client kubernetes.Interface, namespace, name, reportText string) error {
-	data := map[string][]byte{"report.txt": []byte(reportText)}
-	sec := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{
-			"podtrace.io/managed-by": "podtrace-cli",
-			"podtrace.io/kind":       "session-report",
-		}},
-		Type: corev1.SecretTypeOpaque,
-		Data: data,
-	}
-	_, err := client.CoreV1().Secrets(namespace).Create(ctx, sec, metav1.CreateOptions{})
-	if err == nil {
-		return nil
-	}
-	if !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("create Secret: %w", err)
-	}
-	existing, err := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+func upsertReportSecret(ctx context.Context, client kubernetes.Interface, namespace, name, key, reportText string) error {
+	secrets := client.CoreV1().Secrets(namespace)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := secrets.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			sec := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: reportSinkLabels},
+				Type:       corev1.SecretTypeOpaque,
+				Data:       map[string][]byte{key: []byte(reportText)},
+			}
+			_, cerr := secrets.Create(ctx, sec, metav1.CreateOptions{})
+			if cerr == nil || !apierrors.IsAlreadyExists(cerr) {
+				return cerr
+			}
+			existing, err = secrets.Get(ctx, name, metav1.GetOptions{})
+		}
+		if err != nil {
+			return err
+		}
+		if existing.Data == nil {
+			existing.Data = map[string][]byte{}
+		}
+		existing.Data[key] = []byte(reportText)
+		_, uerr := secrets.Update(ctx, existing, metav1.UpdateOptions{})
+		return uerr
+	})
 	if err != nil {
-		return fmt.Errorf("get existing Secret: %w", err)
-	}
-	if existing.Data == nil {
-		existing.Data = map[string][]byte{}
-	}
-	existing.Data["report.txt"] = []byte(reportText)
-	if _, err := client.CoreV1().Secrets(namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("update Secret: %w", err)
+		return fmt.Errorf("upsert report Secret: %w", err)
 	}
 	return nil
 }
 
 // buildInClusterClient constructs a kubernetes.Interface from the Job
-// pod's ServiceAccount. Falls back to KUBECONFIG for local development
-// so the same code path works when running the CLI outside a cluster
-// (e.g., in unit tests) — the fallback is gated on the in-cluster probe
-// failing, so production behavior is unchanged.
+// pod's ServiceAccount.
 func buildInClusterClient() (kubernetes.Interface, error) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/cmd/podtrace/session_sink_test.go
+++ b/cmd/podtrace/session_sink_test.go
@@ -118,7 +118,7 @@ func TestUpsertReportConfigMap_CreateThenUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "hello"); err != nil {
+	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "report.txt", "hello"); err != nil {
 		t.Fatal(err)
 	}
 	cm, err := client.CoreV1().ConfigMaps("ns").Get(ctx, "rpt", metav1.GetOptions{})
@@ -126,7 +126,7 @@ func TestUpsertReportConfigMap_CreateThenUpdate(t *testing.T) {
 		t.Fatalf("create wrong: %v %+v", err, cm)
 	}
 
-	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "updated"); err != nil {
+	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "report.txt", "updated"); err != nil {
 		t.Fatal(err)
 	}
 	cm2, err := client.CoreV1().ConfigMaps("ns").Get(ctx, "rpt", metav1.GetOptions{})
@@ -140,7 +140,7 @@ func TestUpsertReportSecret_CreateThenUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := upsertReportSecret(ctx, client, "ns", "rpt", "sensitive"); err != nil {
+	if err := upsertReportSecret(ctx, client, "ns", "rpt", "report.txt", "sensitive"); err != nil {
 		t.Fatal(err)
 	}
 	sec, err := client.CoreV1().Secrets("ns").Get(ctx, "rpt", metav1.GetOptions{})
@@ -148,7 +148,7 @@ func TestUpsertReportSecret_CreateThenUpdate(t *testing.T) {
 		t.Fatalf("create wrong: %v %+v", err, sec)
 	}
 
-	if err := upsertReportSecret(ctx, client, "ns", "rpt", "updated"); err != nil {
+	if err := upsertReportSecret(ctx, client, "ns", "rpt", "report.txt", "updated"); err != nil {
 		t.Fatal(err)
 	}
 	sec2, err := client.CoreV1().Secrets("ns").Get(ctx, "rpt", metav1.GetOptions{})
@@ -166,7 +166,7 @@ func TestUpsertReportConfigMap_PreservesExistingKeys(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "new report"); err != nil {
+	if err := upsertReportConfigMap(ctx, client, "ns", "rpt", "report.txt", "new report"); err != nil {
 		t.Fatal(err)
 	}
 	cm, _ := client.CoreV1().ConfigMaps("ns").Get(ctx, "rpt", metav1.GetOptions{})

--- a/docs/crd-podtracesession.md
+++ b/docs/crd-podtracesession.md
@@ -71,8 +71,8 @@ end of diagnose. Mutually exclusive with itself — exactly one of:
 
 | Field | What it produces |
 |---|---|
-| `configMap.name` | A ConfigMap in the session's namespace with `data["report.txt"]` populated. The CLI patches it via a per-session Role + RoleBinding scoped to that exact name. Capped at the etcd ConfigMap limit (~1MiB). |
-| `secret.name` | A Secret in the session's namespace with `data["report.txt"]`. Use this when the report may carry sensitive data (private hostnames, paths, payloads). Same size cap as ConfigMap. |
+| `configMap.name` | A ConfigMap in the session's namespace. Each traced node writes its report under a per-node key `data["report-<node>.txt"]` (so multi-node sessions don't overwrite each other). The CLI patches it via a per-session Role + RoleBinding scoped to that exact name. Capped at the etcd ConfigMap limit (~1MiB). |
+| `secret.name` | A Secret in the session's namespace, same per-node `data["report-<node>.txt"]` keys as the ConfigMap sink. Use this when the report may carry sensitive data (private hostnames, paths, payloads). Same size cap as ConfigMap. |
 | `objectStore` | Uploads to an S3-, GCS-, or Azure-Blob–compatible bucket via a [native sidecar](object-store-reports.md). The only sink that escapes the etcd object-size limit. Requires `TracerConfig.spec.session.sidecarUploader=true` and either ambient cloud credentials (IRSA / Workload Identity / Managed Identity) or an explicit `credentialsSecretRef`. |
 
 When `reportRef` is unset, only the exporter receives event spans and

--- a/examples/diagnose-demo.yaml
+++ b/examples/diagnose-demo.yaml
@@ -11,7 +11,7 @@
 #     → .status.jobs[].eventCount > 0
 #
 #   kubectl -n podtrace-demo get cm diag-demo-report
-#     → .data["report.txt"] carries the full human-readable report
+#     → .data["report-<node>.txt"] carries each node's human-readable report
 #
 # Prereqs:
 #   1. Helm chart installed (helm install podtrace ./deploy/charts/podtrace)

--- a/internal/kubernetes/target_registry.go
+++ b/internal/kubernetes/target_registry.go
@@ -66,8 +66,8 @@ type TargetRegistry struct {
 	clientset   kubernetes.Interface
 	selection   TargetSelection
 	maxTargets  int
-	podInf      cache.SharedIndexInformer
-	factory     informers.SharedInformerFactory
+	podInfs     []cache.SharedIndexInformer
+	factories   []informers.SharedInformerFactory
 	updates     chan []*PodInfo
 	podNameRefs map[string]map[string]struct{}
 
@@ -97,10 +97,9 @@ func (tr *TargetRegistry) Start(ctx context.Context) error {
 		return fmt.Errorf("target registry requires a kubernetes clientset")
 	}
 
-	nsOpts := tr.selection.EffectiveNamespaces()
-	namespace := metav1.NamespaceAll
-	if len(nsOpts) == 1 {
-		namespace = nsOpts[0]
+	watchNamespaces := tr.selection.EffectiveNamespaces()
+	if len(watchNamespaces) == 0 {
+		watchNamespaces = []string{metav1.NamespaceAll}
 	}
 
 	var tweak func(*metav1.ListOptions)
@@ -111,29 +110,29 @@ func (tr *TargetRegistry) Start(ctx context.Context) error {
 		}
 	}
 
-	var factory informers.SharedInformerFactory
-	if tweak != nil {
-		factory = informers.NewSharedInformerFactoryWithOptions(tr.clientset, 0, informers.WithNamespace(namespace), informers.WithTweakListOptions(tweak))
-	} else {
-		factory = informers.NewSharedInformerFactoryWithOptions(tr.clientset, 0, informers.WithNamespace(namespace))
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { tr.enqueueUpsert(obj) },
+		UpdateFunc: func(_, newObj interface{}) { tr.enqueueUpsert(newObj) },
+		DeleteFunc: func(obj interface{}) { tr.handlePodDelete(obj) },
 	}
-	podInf := factory.Core().V1().Pods().Informer()
-	_, _ = podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			tr.enqueueUpsert(obj)
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			tr.enqueueUpsert(newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			tr.handlePodDelete(obj)
-		},
-	})
 
-	tr.factory = factory
-	tr.podInf = podInf
-	factory.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), podInf.HasSynced) {
+	var syncFns []cache.InformerSynced
+	for _, ns := range watchNamespaces {
+		opts := []informers.SharedInformerOption{informers.WithNamespace(ns)}
+		if tweak != nil {
+			opts = append(opts, informers.WithTweakListOptions(tweak))
+		}
+		factory := informers.NewSharedInformerFactoryWithOptions(tr.clientset, 0, opts...)
+		podInf := factory.Core().V1().Pods().Informer()
+		if _, err := podInf.AddEventHandler(handlers); err != nil {
+			return fmt.Errorf("add pod event handler for namespace %q: %w", ns, err)
+		}
+		tr.factories = append(tr.factories, factory)
+		tr.podInfs = append(tr.podInfs, podInf)
+		syncFns = append(syncFns, podInf.HasSynced)
+		factory.Start(ctx.Done())
+	}
+	if !cache.WaitForCacheSync(ctx.Done(), syncFns...) {
 		return fmt.Errorf("timed out waiting for pod target registry cache sync")
 	}
 
@@ -160,9 +159,7 @@ func (tr *TargetRegistry) enqueueUpsert(obj interface{}) {
 }
 
 // resolveWorker drains pending pods and resolves them off the informer
-// goroutine. Cgroup resolution can take seconds per pod (CRI socket,
-// filesystem walks); doing it inline in the event handler stalled every
-// other informer callback.
+// goroutine.
 func (tr *TargetRegistry) resolveWorker(ctx context.Context) {
 	for {
 		select {
@@ -199,13 +196,11 @@ func (tr *TargetRegistry) Snapshot() []*PodInfo {
 }
 
 func (tr *TargetRegistry) rebuildFromStore(ctx context.Context) {
-	if tr.podInf == nil {
-		return
-	}
-	items := tr.podInf.GetStore().List()
-	for _, obj := range items {
-		if pod, ok := obj.(*corev1.Pod); ok && pod != nil {
-			tr.handlePodUpsert(ctx, pod)
+	for _, inf := range tr.podInfs {
+		for _, obj := range inf.GetStore().List() {
+			if pod, ok := obj.(*corev1.Pod); ok && pod != nil {
+				tr.handlePodUpsert(ctx, pod)
+			}
 		}
 	}
 }

--- a/internal/kubernetes/target_registry_unit_test.go
+++ b/internal/kubernetes/target_registry_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -235,6 +236,33 @@ func TestHandlePodUpsert_UpdatesExistingAtMaxTargets(t *testing.T) {
 	}
 }
 
+func TestStart_PerNamespaceInformers(t *testing.T) {
+	cases := []struct {
+		name string
+		sel  TargetSelection
+		want int
+	}{
+		{"two namespaces -> two scoped informers", TargetSelection{Namespaces: []string{"a", "b"}}, 2},
+		{"three namespaces -> three", TargetSelection{Namespaces: []string{"a", "b", "c"}}, 3},
+		{"one namespace -> one", TargetSelection{Namespaces: []string{"a"}}, 1},
+		{"default namespace -> one", TargetSelection{DefaultNamespace: "d"}, 1},
+		{"cluster-wide -> one", TargetSelection{}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTargetRegistry(fake.NewSimpleClientset(), tc.sel)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := tr.Start(ctx); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			if len(tr.podInfs) != tc.want {
+				t.Errorf("got %d pod informers, want %d", len(tr.podInfs), tc.want)
+			}
+		})
+	}
+}
+
 func TestRebuildFromStore_PopulatesFromInformerStore(t *testing.T) {
 	cid := hex64()
 	newCgroupV2Sandbox(t, cid)
@@ -242,14 +270,15 @@ func TestRebuildFromStore_PopulatesFromInformerStore(t *testing.T) {
 	tr := NewTargetRegistry(fake.NewSimpleClientset(), TargetSelection{Namespaces: []string{"prod"}})
 
 	factory := informers.NewSharedInformerFactory(tr.clientset, 0)
-	tr.podInf = factory.Core().V1().Pods().Informer()
+	podInf := factory.Core().V1().Pods().Informer()
+	tr.podInfs = append(tr.podInfs, podInf)
 
 	matching := runningPod("uid-a", "prod", "api-0", "app", cid)
 	nonMatching := runningPod("uid-b", "dev", "api-1", "app", hex64())
-	if err := tr.podInf.GetStore().Add(matching); err != nil {
+	if err := podInf.GetStore().Add(matching); err != nil {
 		t.Fatalf("store add matching: %v", err)
 	}
-	if err := tr.podInf.GetStore().Add(nonMatching); err != nil {
+	if err := podInf.GetStore().Add(nonMatching); err != nil {
 		t.Fatalf("store add non-matching: %v", err)
 	}
 

--- a/internal/operator/finalizer.go
+++ b/internal/operator/finalizer.go
@@ -58,6 +58,46 @@ func cleanupPodTraceChildren(ctx context.Context, c client.Client, pt *podtracev
 	return nil
 }
 
+// cleanupOrphanBundles deletes exporter-bundle ConfigMaps/Secrets for this
+// PodTrace that live in any namespace other than keepNS.
+func cleanupOrphanBundles(ctx context.Context, c client.Client, pt *podtracev1alpha1.PodTrace, keepNS string) error {
+	sel := client.MatchingLabels{
+		LabelManagedBy:    ManagedByValue,
+		LabelComponent:    ComponentBundle,
+		LabelPodTraceName: pt.Name,
+		LabelPodTraceNS:   pt.Namespace,
+	}
+
+	var cms corev1.ConfigMapList
+	if err := c.List(ctx, &cms, sel); err != nil {
+		return fmt.Errorf("list bundle ConfigMaps: %w", err)
+	}
+	for i := range cms.Items {
+		if cms.Items[i].Namespace == keepNS {
+			continue
+		}
+		if err := c.Delete(ctx, &cms.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete orphan bundle ConfigMap %s/%s: %w",
+				cms.Items[i].Namespace, cms.Items[i].Name, err)
+		}
+	}
+
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets, sel); err != nil {
+		return fmt.Errorf("list bundle Secrets: %w", err)
+	}
+	for i := range secrets.Items {
+		if secrets.Items[i].Namespace == keepNS {
+			continue
+		}
+		if err := c.Delete(ctx, &secrets.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete orphan bundle Secret %s/%s: %w",
+				secrets.Items[i].Namespace, secrets.Items[i].Name, err)
+		}
+	}
+	return nil
+}
+
 // candidateSystemNamespaces returns the deduplicated set of namespaces a
 // CR's children may live in: the currently effective system namespace plus
 // the operator default (they differ when TracerConfig.spec.systemNamespace
@@ -100,7 +140,6 @@ func cleanupPodTraceSessionChildren(ctx context.Context, c client.Client, s *pod
 		}
 	}
 
-	// Session-scoped exporter bundle lives in the system namespace.
 	bundleName := SessionBundleName(s.UID)
 	objstoreCredsName := SessionObjectStoreCredsName(s.UID)
 	for _, obj := range []client.Object{
@@ -113,8 +152,10 @@ func cleanupPodTraceSessionChildren(ctx context.Context, c client.Client, s *pod
 		}
 	}
 
-	// Per-session Role + RoleBinding in the user namespace.
 	if err := cleanupSessionReportRBAC(ctx, c, s); err != nil {
+		return err
+	}
+	if err := cleanupSessionPodReadRBAC(ctx, c, s); err != nil {
 		return err
 	}
 	return nil

--- a/internal/operator/naming.go
+++ b/internal/operator/naming.go
@@ -66,6 +66,17 @@ func SessionReportRoleBindingName(sessionUID types.UID) string {
 	return "podtrace-session-report-" + shortUID(sessionUID)
 }
 
+// SessionPodReadRoleName / SessionPodReadRoleBindingName name the per-namespace
+// Role+RoleBinding granting the session SA pods/events read in each extra
+// namespace a cross-namespace session targets (beyond its own).
+func SessionPodReadRoleName(sessionUID types.UID) string {
+	return "podtrace-session-podread-" + shortUID(sessionUID)
+}
+
+func SessionPodReadRoleBindingName(sessionUID types.UID) string {
+	return "podtrace-session-podread-" + shortUID(sessionUID)
+}
+
 // AgentClusterRoleName is the ClusterRole granting the agent read access to
 // PodTrace CRs cluster-wide and status-patch on the same.
 func AgentClusterRoleName() string { return "podtrace-agent" }

--- a/internal/operator/operator_regression_test.go
+++ b/internal/operator/operator_regression_test.go
@@ -1,0 +1,191 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func findingsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, rbacv1.AddToScheme, podtracev1alpha1.AddToScheme,
+	} {
+		if err := add(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+func hasFlagValue(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDiagnoseArgs_MultiNamespace(t *testing.T) {
+	s := newSession(nil)
+
+	multi := buildDiagnoseArgs(s, []string{"team-a", "team-b"})
+	if !hasFlagValue(multi, "--namespaces", "team-a,team-b") {
+		t.Errorf("expected --namespaces team-a,team-b; got %v", multi)
+	}
+	if hasFlagValue(multi, "--namespace", "default") {
+		t.Errorf("must not pin to the session namespace when an allowlist is resolved; got %v", multi)
+	}
+
+	own := buildDiagnoseArgs(s, nil)
+	if !hasFlagValue(own, "--namespace", "default") {
+		t.Errorf("expected --namespace default for own-namespace scope; got %v", own)
+	}
+	if hasFlag(own, "--namespaces") {
+		t.Errorf("must not emit --namespaces when no allowlist is resolved; got %v", own)
+	}
+}
+
+func TestSessionPodNamespaces(t *testing.T) {
+	s := newSession(func(s *podtracev1alpha1.PodTraceSession) {
+		s.Spec.PodRefs = []podtracev1alpha1.PodRef{
+			{Namespace: "team-c", Name: "p1"},
+			{Namespace: "default", Name: "p2"},
+			{Name: "p3"},
+		}
+	})
+	got := sessionPodNamespaces(s, []string{"team-a", "team-b", "default"})
+	want := map[string]bool{"team-a": true, "team-b": true, "team-c": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want keys %v", got, want)
+	}
+	for _, ns := range got {
+		if !want[ns] {
+			t.Errorf("unexpected namespace %q (own ns must be excluded): %v", ns, got)
+		}
+	}
+}
+
+func TestEnsureSessionPodReadRBAC(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(findingsScheme(t)).Build()
+	s := newSession(nil)
+	const systemNS = "podtrace-system"
+
+	if err := ensureSessionPodReadRBAC(context.Background(), c, s, []string{"team-a", "team-b"}, systemNS); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, ns := range []string{"team-a", "team-b"} {
+		var role rbacv1.Role
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: SessionPodReadRoleName(s.UID)}, &role); err != nil {
+			t.Fatalf("pod-read Role missing in %s: %v", ns, err)
+		}
+		if !roleAllowsPods(role.Rules) {
+			t.Errorf("pod-read Role in %s does not grant pods read: %+v", ns, role.Rules)
+		}
+		var rb rbacv1.RoleBinding
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: SessionPodReadRoleBindingName(s.UID)}, &rb); err != nil {
+			t.Fatalf("pod-read RoleBinding missing in %s: %v", ns, err)
+		}
+		if len(rb.Subjects) != 1 || rb.Subjects[0].Namespace != systemNS || rb.Subjects[0].Name != SessionServiceAccountName() {
+			t.Errorf("RoleBinding in %s bound to wrong subject: %+v", ns, rb.Subjects)
+		}
+	}
+
+	if err := cleanupSessionPodReadRBAC(context.Background(), c, s); err != nil {
+		t.Fatal(err)
+	}
+	var leftover rbacv1.RoleList
+	if err := c.List(context.Background(), &leftover); err != nil {
+		t.Fatal(err)
+	}
+	for i := range leftover.Items {
+		if leftover.Items[i].Name == SessionPodReadRoleName(s.UID) {
+			t.Errorf("pod-read Role in %s survived cleanup", leftover.Items[i].Namespace)
+		}
+	}
+}
+
+func roleAllowsPods(rules []rbacv1.PolicyRule) bool {
+	for _, r := range rules {
+		for _, res := range r.Resources {
+			if res == "pods" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestTracerConfigToPodTraces(t *testing.T) {
+	pt1 := &podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns1"}}
+	pt2 := &podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns2"}}
+	c := fake.NewClientBuilder().WithScheme(findingsScheme(t)).WithObjects(pt1, pt2).Build()
+	r := &PodTraceReconciler{Client: c}
+
+	def := &podtracev1alpha1.TracerConfig{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	if got := r.tracerConfigToPodTraces(context.Background(), def); len(got) != 2 {
+		t.Errorf("default TracerConfig should enqueue all PodTraces; got %d", len(got))
+	}
+	other := &podtracev1alpha1.TracerConfig{ObjectMeta: metav1.ObjectMeta{Name: "other"}}
+	if got := r.tracerConfigToPodTraces(context.Background(), other); len(got) != 0 {
+		t.Errorf("non-default TracerConfig should enqueue nothing; got %d", len(got))
+	}
+}
+
+func TestCleanupOrphanBundles(t *testing.T) {
+	pt := &podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "user", UID: "u1"}}
+	name := ExporterBundleName(pt.UID)
+	lbls := map[string]string{
+		LabelManagedBy:    ManagedByValue,
+		LabelComponent:    ComponentBundle,
+		LabelPodTraceName: pt.Name,
+		LabelPodTraceNS:   pt.Namespace,
+	}
+	var objs []client.Object
+	for _, ns := range []string{"sys-a", "sys-b", "sys-c"} {
+		objs = append(objs,
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: lbls}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: lbls}},
+		)
+	}
+	c := fake.NewClientBuilder().WithScheme(findingsScheme(t)).WithObjects(objs...).Build()
+
+	if err := cleanupOrphanBundles(context.Background(), c, pt, "sys-c"); err != nil {
+		t.Fatal(err)
+	}
+	for _, ns := range []string{"sys-a", "sys-b"} {
+		var cm corev1.ConfigMap
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &cm); err == nil {
+			t.Errorf("orphan bundle ConfigMap in %s survived", ns)
+		}
+		var sec corev1.Secret
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, &sec); err == nil {
+			t.Errorf("orphan bundle Secret in %s survived (credential leak)", ns)
+		}
+	}
+	var keep corev1.Secret
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "sys-c", Name: name}, &keep); err != nil {
+		t.Errorf("current bundle Secret in sys-c was wrongly deleted: %v", err)
+	}
+}

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -58,6 +58,9 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err
 			}
 		}
+		if err := cleanupOrphanBundles(ctx, r.Client, &pt, ""); err != nil {
+			return ctrl.Result{}, err
+		}
 		if removeFinalizer(&pt) {
 			if err := r.Update(ctx, &pt); err != nil {
 				if apierrors.IsConflict(err) {
@@ -70,9 +73,6 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	if ensureFinalizer(&pt) {
 		if err := r.Update(ctx, &pt); err != nil {
-			// Optimistic-concurrency conflict: the CR was modified between
-			// our Get and Update. Requeue and try again on the fresh
-			// version — this is normal, not an error.
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
@@ -120,6 +120,12 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 	}
 
+	if err := cleanupOrphanBundles(ctx, r.Client, &pt, r.effectiveSystemNamespace(ctx)); err != nil {
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "OrphanBundleCleanup", err.Error())
+		_ = r.Status().Update(ctx, &pt)
+		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+	}
+
 	pt.Status.TargetNamespaces = targetNamespaces
 	pt.Status.Policy = resolvePolicyStatus(policyFromPodTrace(&pt), &ec)
 	r.setCondition(&pt, ConditionPolicyApplied, metav1.ConditionTrue, "Reconciled", "policy resolved and written to bundle")
@@ -163,16 +169,38 @@ func (r *PodTraceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.namespaceToPodTraces),
 		).
-		// Bundle Secrets are copies of the referenced credential data, so a
-		// rotation must re-trigger the PodTraces that snapshot it; the
-		// ExporterConfig watch alone does not fire (the EC itself is
-		// unchanged and its readiness status stays equal).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.secretToPodTraces),
 		).
+		Watches(
+			&podtracev1alpha1.TracerConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.tracerConfigToPodTraces),
+		).
 		WithOptions(defaultControllerOptions()).
 		Complete(r)
+}
+
+// tracerConfigToPodTraces enqueues every PodTrace when the default
+// TracerConfig changes, so a spec.systemNamespace change rewrites each
+// bundle into the new namespace (and the reconcile then sweeps the orphan
+// left in the old one).
+func (r *PodTraceReconciler) tracerConfigToPodTraces(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetName() != "default" {
+		return nil
+	}
+	var list podtracev1alpha1.PodTraceList
+	if err := r.List(ctx, &list); err != nil {
+		return nil
+	}
+	out := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		pt := &list.Items[i]
+		out = append(out, reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: pt.Namespace, Name: pt.Name},
+		})
+	}
+	return out
 }
 
 // secretToPodTraces maps a Secret event to the PodTraces whose
@@ -227,11 +255,6 @@ func (r *PodTraceReconciler) exporterConfigToPodTraces(ctx context.Context, obj 
 }
 
 func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtracev1alpha1.PodTrace, ec *podtracev1alpha1.ExporterConfig, targetNamespaces []string) error {
-	// The bundle must live where agents read it. Agents are launched with
-	// --system-namespace set to the TracerConfig's systemNamespace override
-	// (tracerconfig_daemonset.go), so writing to the operator default here
-	// made continuous tracing silently export nothing whenever the override
-	// was set: agents looked in a namespace the operator never wrote.
 	systemNS := r.effectiveSystemNamespace(ctx)
 	name := ExporterBundleName(pt.UID)
 
@@ -299,9 +322,7 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 
 // effectiveSystemNamespace returns the namespace agents read bundles from:
 // the default TracerConfig's spec.systemNamespace override when set,
-// otherwise the operator default. Bundles must be written (and cleaned up)
-// there, mirroring the --system-namespace the rendered DaemonSet passes to
-// agents.
+// otherwise the operator default.
 func (r *PodTraceReconciler) effectiveSystemNamespace(ctx context.Context) string {
 	var tc podtracev1alpha1.TracerConfig
 	if err := r.Get(ctx, types.NamespacedName{Name: "default"}, &tc); err == nil && tc.Spec.SystemNamespace != "" {

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -24,9 +24,7 @@ import (
 )
 
 // PodTraceSessionReconciler turns a PodTraceSession CR into one Job per
-// node hosting at least one matched pod. Jobs invoke the standalone
-// `podtrace --diagnose <duration>` CLI, so session execution is
-// decoupled from the DaemonSet agent's lifecycle.
+// node hosting at least one matched pod.
 type PodTraceSessionReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
@@ -57,7 +55,6 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("get PodTraceSession: %w", err)
 	}
 
-	// Deletion path: clean up cross-namespace Jobs, then release the finalizer.
 	if !session.DeletionTimestamp.IsZero() {
 		tc, err := r.resolveTracerConfig(ctx)
 		if err != nil {
@@ -105,10 +102,6 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	targetNodes, targetNamespaces, err := r.resolveTargetNodes(ctx, &session)
 	if err != nil {
 		if strings.Contains(err.Error(), "invalid NamespaceSelector") {
-			// Terminal: an invalid selector cannot be fixed by retrying, and
-			// returning the error here put a permanently-failed object on
-			// the infinite-backoff treadmill. A spec edit re-triggers
-			// reconciliation.
 			r.failSessionTerminally(ctx, &session, "NamespaceSelectorInvalid", err.Error())
 			return ctrl.Result{}, nil
 		}
@@ -163,6 +156,11 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
+	if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, sessionPodNamespaces(&session, targetNamespaces), systemNS); err != nil {
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
+		_ = r.Status().Update(ctx, &session)
+		return ctrl.Result{}, err
+	}
 
 	cap := effectiveMaxConcurrentSessionsPerNode(tc)
 
@@ -179,7 +177,7 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	jobs, err := r.ensureJobs(ctx, &session, tc, targetNodes)
+	jobs, err := r.ensureJobs(ctx, &session, tc, targetNodes, targetNamespaces)
 	if err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "EnsureJobs", err.Error())
 		_ = r.Status().Update(ctx, &session)
@@ -235,9 +233,6 @@ func (r *PodTraceSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Namespace{},
 			handler.EnqueueRequestsFromMapFunc(r.namespaceToPodTraceSessions),
 		).
-		// Session bundle/object-store Secrets are copies of the referenced
-		// credential data; rotations must re-trigger the non-terminal
-		// sessions that snapshot them.
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.secretToPodTraceSessions),
@@ -401,8 +396,6 @@ func isPodEligible(p *corev1.Pod) bool {
 }
 
 // failSessionTerminally marks a session Failed with a CompletionTime stamp.
-// Failed-by-validation sessions used to be left without a CompletionTime, so
-// reconcileTerminalSession never TTL-garbage-collected them.
 func (r *PodTraceSessionReconciler) failSessionTerminally(ctx context.Context, s *podtracev1alpha1.PodTraceSession, reason, message string) {
 	s.Status.State = podtracev1alpha1.SessionStateFailed
 	if s.Status.CompletionTime == nil {
@@ -413,11 +406,7 @@ func (r *PodTraceSessionReconciler) failSessionTerminally(ctx context.Context, s
 	_ = r.Status().Update(ctx, s)
 }
 
-// resolveTracerConfig returns the "default" TracerConfig when present, nil
-// when it does not exist, and an error for any other Get failure — a
-// transient API error used to be indistinguishable from "no TracerConfig",
-// silently falling back to the default system namespace and an empty session
-// image.
+// resolveTracerConfig returns the "default" TracerConfig when present.
 func (r *PodTraceSessionReconciler) resolveTracerConfig(ctx context.Context) (*podtracev1alpha1.TracerConfig, error) {
 	var tc podtracev1alpha1.TracerConfig
 	if err := r.Get(ctx, types.NamespacedName{Name: DefaultTracerConfigName}, &tc); err != nil {
@@ -430,10 +419,7 @@ func (r *PodTraceSessionReconciler) resolveTracerConfig(ctx context.Context) (*p
 }
 
 // nodesAtCapacity returns the subset of the candidate node list whose
-// current active-session Job count is >= cap. "Active" excludes the
-// session currently being reconciled (its own Jobs don't count against
-// its own cap). Self-identity is (selfNS, selfName), which is unique
-// cluster-wide for PodTraceSession resources.
+// current active-session Job count is >= cap.
 func (r *PodTraceSessionReconciler) nodesAtCapacity(ctx context.Context, candidates []string, cap int32, selfNS, selfName string) ([]string, error) {
 	var allJobs batchv1.JobList
 	if err := r.List(ctx, &allJobs, client.MatchingLabels{
@@ -477,9 +463,8 @@ func effectiveMaxConcurrentSessionsPerNode(tc *podtracev1alpha1.TracerConfig) in
 }
 
 // ensureJobs creates-or-updates one Job per target node, owner-ref'd to
-// the session. Returns all Jobs currently owned by the session (not just
-// those created this call) so Reconcile can roll up status.
-func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, nodes []string) ([]batchv1.Job, error) {
+// the session.
+func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, nodes []string, targetNamespaces []string) ([]batchv1.Job, error) {
 	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
 
 	for _, node := range nodes {
@@ -498,7 +483,7 @@ func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev
 				LabelNodeName:    node,
 			})
 			if job.Spec.Template.Spec.Containers == nil {
-				job.Spec = buildSessionJobSpec(s, tc, node)
+				job.Spec = buildSessionJobSpec(s, tc, node, targetNamespaces)
 			}
 			return nil
 		}); err != nil {
@@ -518,9 +503,7 @@ func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev
 	return owned.Items, nil
 }
 
-// reconcileTerminalSession handles TTL-driven cleanup only. Terminal
-// sessions are not re-fanned-out; we just check if their TTL has
-// elapsed and delete the CR.
+// reconcileTerminalSession handles TTL-driven cleanup only.
 func (r *PodTraceSessionReconciler) reconcileTerminalSession(ctx context.Context, s *podtracev1alpha1.PodTraceSession) (ctrl.Result, error) {
 	ttl := sessionTTL(s)
 	if ttl == 0 || s.Status.CompletionTime == nil {
@@ -543,8 +526,7 @@ func sessionTTL(s *podtracev1alpha1.PodTraceSession) int32 {
 	return 300
 }
 
-// setCondition mirrors TracerConfigReconciler.setCondition; duplicated
-// rather than generic so the two reconcilers can evolve independently.
+// setCondition mirrors TracerConfigReconciler.setCondition.
 func (r *PodTraceSessionReconciler) setCondition(s *podtracev1alpha1.PodTraceSession, condType string, status metav1.ConditionStatus, reason, message string) {
 	s.Status.Conditions = upsertCondition(s.Status.Conditions, metav1.Condition{
 		Type:               condType,

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -11,7 +11,7 @@ import (
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
 
-func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, node string) batchv1.JobSpec {
+func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, node string, targetNamespaces []string) batchv1.JobSpec {
 	completions := int32(1)
 	parallelism := int32(1)
 
@@ -50,7 +50,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 	priv := true
 	runAsRoot := int64(0)
 
-	args := buildDiagnoseArgs(s)
+	args := buildDiagnoseArgs(s, targetNamespaces)
 	reportTo := reportToSpecFromReportRef(s)
 
 	volumes := []corev1.Volume{
@@ -261,7 +261,7 @@ func pointerBool(b bool) *bool {
 
 // buildDiagnoseArgs produces the `podtrace` CLI args that a session Job
 // executes.
-func buildDiagnoseArgs(s *podtracev1alpha1.PodTraceSession) []string {
+func buildDiagnoseArgs(s *podtracev1alpha1.PodTraceSession, targetNamespaces []string) []string {
 	args := []string{
 		"--diagnose", s.Spec.Duration.Duration.String(),
 	}
@@ -281,7 +281,12 @@ func buildDiagnoseArgs(s *podtracev1alpha1.PodTraceSession) []string {
 
 	if s.Spec.Selector != nil {
 		args = append(args, "--pod-selector", labelSelectorToFlag(s.Spec.Selector))
-		args = append(args, "--all-in-namespace", "--namespace", s.Namespace)
+		args = append(args, "--all-in-namespace")
+		if len(targetNamespaces) > 0 {
+			args = append(args, "--namespaces", strings.Join(targetNamespaces, ","))
+		} else {
+			args = append(args, "--namespace", s.Namespace)
+		}
 	}
 	if len(s.Spec.PodRefs) > 0 {
 		refs := make([]string, 0, len(s.Spec.PodRefs))

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -33,7 +33,7 @@ func newSession(mod func(*podtracev1alpha1.PodTraceSession)) *podtracev1alpha1.P
 }
 
 func TestBuildDiagnoseArgs_SelectorPath(t *testing.T) {
-	args := buildDiagnoseArgs(newSession(nil))
+	args := buildDiagnoseArgs(newSession(nil), nil)
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "--diagnose 5m0s") {
 		t.Errorf("missing --diagnose: %v", args)
@@ -57,7 +57,7 @@ func TestBuildDiagnoseArgs_PodRefsPath(t *testing.T) {
 			{Namespace: "team-b", Name: "pod-b"}, // explicit ns
 		}
 	})
-	args := buildDiagnoseArgs(s)
+	args := buildDiagnoseArgs(s, nil)
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "--pods default/pod-a,team-b/pod-b") {
 		t.Errorf("pods flag wrong: %v", args)
@@ -77,7 +77,7 @@ func TestBuildDiagnoseArgs_FiltersAndSample(t *testing.T) {
 		s.Spec.SamplePercent = &pct
 		s.Spec.ContainerName = "api"
 	})
-	args := buildDiagnoseArgs(s)
+	args := buildDiagnoseArgs(s, nil)
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "--filter dns,net") {
 		t.Errorf("filter flag wrong: %v", args)
@@ -103,7 +103,7 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 			},
 		},
 	}
-	spec := buildSessionJobSpec(newSession(nil), tc, "node-a")
+	spec := buildSessionJobSpec(newSession(nil), tc, "node-a", nil)
 
 	if spec.BackoffLimit == nil || *spec.BackoffLimit != 0 {
 		t.Errorf("backoffLimit: %v", spec.BackoffLimit)
@@ -170,7 +170,7 @@ func TestBuildSessionJobSpec_SidecarOptedIn(t *testing.T) {
 			ConfigMap: &corev1.LocalObjectReference{Name: "rpt"},
 		}
 	})
-	spec := buildSessionJobSpec(s, tc, "node-a")
+	spec := buildSessionJobSpec(s, tc, "node-a", nil)
 
 	if len(spec.Template.Spec.InitContainers) != 1 {
 		t.Fatalf("sidecar not emitted: %d init containers", len(spec.Template.Spec.InitContainers))
@@ -197,7 +197,7 @@ func TestBuildSessionJobSpec_SidecarSuppressedWithoutReportRef(t *testing.T) {
 			},
 		},
 	}
-	spec := buildSessionJobSpec(newSession(nil), tc, "node-a")
+	spec := buildSessionJobSpec(newSession(nil), tc, "node-a", nil)
 	if len(spec.Template.Spec.InitContainers) != 0 {
 		t.Errorf("sidecar should be suppressed without reportRef: %d", len(spec.Template.Spec.InitContainers))
 	}

--- a/internal/operator/podtracesession_objectstore_test.go
+++ b/internal/operator/podtracesession_objectstore_test.go
@@ -50,7 +50,7 @@ func TestBuildSessionJobSpec_ObjectStoreSidecarWiredWithCredentialsSecret(t *tes
 			},
 		},
 	}
-	spec := buildSessionJobSpec(sessionWithObjectStore("s3-creds"), tc, "node-a")
+	spec := buildSessionJobSpec(sessionWithObjectStore("s3-creds"), tc, "node-a", nil)
 
 	if got := len(spec.Template.Spec.InitContainers); got != 1 {
 		t.Fatalf("init containers = %d, want 1", got)
@@ -123,7 +123,7 @@ func TestBuildSessionJobSpec_ObjectStoreAmbientCreds(t *testing.T) {
 			},
 		},
 	}
-	spec := buildSessionJobSpec(sessionWithObjectStore(""), tc, "node-a")
+	spec := buildSessionJobSpec(sessionWithObjectStore(""), tc, "node-a", nil)
 	if got := len(spec.Template.Spec.InitContainers); got != 1 {
 		t.Fatalf("init containers = %d, want 1 (ambient creds still uses the sidecar)", got)
 	}

--- a/internal/operator/reconcilers_fakeclient_unit_test.go
+++ b/internal/operator/reconcilers_fakeclient_unit_test.go
@@ -269,7 +269,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		},
 	}
 
-	jobs, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"})
+	jobs, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"}, nil)
 	if err != nil {
 		t.Fatalf("ensureJobs: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		}
 	}
 
-	jobs2, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"})
+	jobs2, err := r.ensureJobs(context.Background(), s, nil, []string{"n1", "n2"}, nil)
 	if err != nil {
 		t.Fatalf("second ensureJobs: %v", err)
 	}

--- a/internal/operator/redaction_env_test.go
+++ b/internal/operator/redaction_env_test.go
@@ -82,7 +82,7 @@ func TestBuildSessionJobSpec_Redaction(t *testing.T) {
 			Redaction: &podtracev1alpha1.RedactionSpec{Enabled: true},
 		},
 	}
-	spec := buildSessionJobSpec(newSession(nil), tcfg, "node-a")
+	spec := buildSessionJobSpec(newSession(nil), tcfg, "node-a", nil)
 	var mainEnv []corev1.EnvVar
 	for _, c := range spec.Template.Spec.Containers {
 		if c.Name == "podtrace" {

--- a/internal/operator/session_rbac.go
+++ b/internal/operator/session_rbac.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -34,10 +35,7 @@ func ensureSessionServiceAccount(ctx context.Context, c client.Client, systemNS 
 }
 
 // ensureSessionReportRBAC provisions per-session RBAC in the user
-// namespace. The session SA always needs pods + events read (the CLI
-// resolves pod → container → cgroup on startup); when spec.reportRef
-// is set we additionally grant a resourceNames-scoped get/update/create
-// on the specific ConfigMap or Secret the CLI will patch.
+// namespace.
 func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) error {
 	roleName := SessionReportRoleName(s.UID)
 	bindingName := SessionReportRoleBindingName(s.UID)
@@ -105,6 +103,114 @@ func cleanupSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev
 	return nil
 }
 
+// sessionRBACLabels are the labels every per-session RBAC object carries, so
+// the cross-namespace pod-read grants can be located and cleaned up by label.
+func sessionRBACLabels(s *podtracev1alpha1.PodTraceSession) map[string]string {
+	return map[string]string{
+		LabelManagedBy:   ManagedByValue,
+		LabelComponent:   ComponentSession,
+		LabelSessionName: s.Name,
+		LabelSessionNS:   s.Namespace,
+	}
+}
+
+// sessionPodNamespaces returns the namespaces the in-Job CLI reads pods from
+// BEYOND the session's own namespace: the resolved namespaceSelector allowlist
+// (when spec.selector is set) plus any cross-namespace spec.podRefs.
+func sessionPodNamespaces(s *podtracev1alpha1.PodTraceSession, targetNamespaces []string) []string {
+	set := map[string]struct{}{}
+	if s.Spec.Selector != nil {
+		for _, ns := range targetNamespaces {
+			if ns != "" && ns != s.Namespace {
+				set[ns] = struct{}{}
+			}
+		}
+	}
+	for _, ref := range s.Spec.PodRefs {
+		if ref.Namespace != "" && ref.Namespace != s.Namespace {
+			set[ref.Namespace] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for ns := range set {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ensureSessionPodReadRBAC grants the session SA pods+events read in each
+// extra namespace a cross-namespace session targets.
+func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, namespaces []string, systemNS string) error {
+	for _, ns := range namespaces {
+		role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: SessionPodReadRoleName(s.UID), Namespace: ns}}
+		if _, err := controllerutil.CreateOrUpdate(ctx, c, role, func() error {
+			role.Labels = mergeLabels(role.Labels, sessionRBACLabels(s))
+			role.Rules = []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
+				{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"get", "list", "watch"}},
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("ensure session pod-read Role in %s: %w", ns, err)
+		}
+
+		binding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: SessionPodReadRoleBindingName(s.UID), Namespace: ns}}
+		if _, err := controllerutil.CreateOrUpdate(ctx, c, binding, func() error {
+			binding.Labels = mergeLabels(binding.Labels, sessionRBACLabels(s))
+			binding.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     SessionPodReadRoleName(s.UID),
+			}
+			binding.Subjects = []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      SessionServiceAccountName(),
+				Namespace: systemNS,
+			}}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("ensure session pod-read RoleBinding in %s: %w", ns, err)
+		}
+	}
+	return nil
+}
+
+// cleanupSessionPodReadRBAC deletes the cross-namespace pod-read Role+RoleBinding
+// for a session.
+func cleanupSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession) error {
+	sel := client.MatchingLabels(sessionRBACLabels(s))
+
+	var bindings rbacv1.RoleBindingList
+	if err := c.List(ctx, &bindings, sel); err != nil {
+		return fmt.Errorf("list session pod-read RoleBindings: %w", err)
+	}
+	for i := range bindings.Items {
+		if bindings.Items[i].Name != SessionPodReadRoleBindingName(s.UID) {
+			continue
+		}
+		if err := c.Delete(ctx, &bindings.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete session pod-read RoleBinding %s/%s: %w",
+				bindings.Items[i].Namespace, bindings.Items[i].Name, err)
+		}
+	}
+
+	var roles rbacv1.RoleList
+	if err := c.List(ctx, &roles, sel); err != nil {
+		return fmt.Errorf("list session pod-read Roles: %w", err)
+	}
+	for i := range roles.Items {
+		if roles.Items[i].Name != SessionPodReadRoleName(s.UID) {
+			continue
+		}
+		if err := c.Delete(ctx, &roles.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete session pod-read Role %s/%s: %w",
+				roles.Items[i].Namespace, roles.Items[i].Name, err)
+		}
+	}
+	return nil
+}
+
 func buildSessionReportRules(ref *podtracev1alpha1.ReportReference) []rbacv1.PolicyRule {
 	rules := []rbacv1.PolicyRule{
 		{
@@ -122,10 +228,6 @@ func buildSessionReportRules(ref *podtracev1alpha1.ReportReference) []rbacv1.Pol
 	if resource == "" || name == "" {
 		return rules
 	}
-	// Kubernetes evaluates "create" at the collection level: a
-	// resourceNames-scoped rule does not cover first-time creation,
-	// so the create verb needs a separate unscoped rule on the same
-	// resource kind. Read/update stay narrowed by resourceNames.
 	rules = append(rules,
 		rbacv1.PolicyRule{
 			APIGroups:     []string{""},

--- a/test/chainsaw/tests/dns-capture/assert-report.yaml
+++ b/test/chainsaw/tests/dns-capture/assert-report.yaml
@@ -4,4 +4,4 @@ metadata:
   name: dns-report
   labels:
     podtrace.io/kind: session-report
-(contains(data."report.txt", 'DNS')): true
+(length(values(data)[?contains(@, 'DNS')]) > `0`): true

--- a/test/chainsaw/tests/h2-capture/assert-report.yaml
+++ b/test/chainsaw/tests/h2-capture/assert-report.yaml
@@ -4,4 +4,4 @@ metadata:
   name: h2-report
   labels:
     podtrace.io/kind: session-report
-(contains(data."report.txt", 'HTTP/2')): true
+(length(values(data)[?contains(@, 'HTTP/2')]) > `0`): true

--- a/test/chainsaw/tests/h3-adapter-capture/assert-report.yaml
+++ b/test/chainsaw/tests/h3-adapter-capture/assert-report.yaml
@@ -4,5 +4,5 @@ metadata:
   name: h3-curl-report
   labels:
     podtrace.io/kind: session-report
-(contains(data."report.txt", 'HTTP/3')): true
-(contains(data."report.txt", '-> 200')): true
+(length(values(data)[?contains(@, 'HTTP/3')]) > `0`): true
+(length(values(data)[?contains(@, '-> 200')]) > `0`): true

--- a/test/chainsaw/tests/http-capture/assert-report.yaml
+++ b/test/chainsaw/tests/http-capture/assert-report.yaml
@@ -4,4 +4,4 @@ metadata:
   name: http-report
   labels:
     podtrace.io/kind: session-report
-(contains(data."report.txt", 'HTTP')): true
+(length(values(data)[?contains(@, 'HTTP')]) > `0`): true

--- a/test/chainsaw/tests/session-cr-lifecycle/assert-report.yaml
+++ b/test/chainsaw/tests/session-cr-lifecycle/assert-report.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     podtrace.io/managed-by: podtrace-cli
     podtrace.io/kind: session-report
-(length(data."report.txt") > `0`): true
+(length(values(data)[?length(@) > `0`]) > `0`): true


### PR DESCRIPTION
## Summary

Three related operator/session correctness fixes for continuous PodTraces and multi-node/multi-namespace sessions.

## Sessions now trace every target namespace

A session with a `namespaceSelector` (or cross-namespace `podRefs`) resolved the right target nodes and reported the right namespaces in status, but the per-node Job was pinned to `--all-in-namespace --namespace <session-ns>`, so it only ever traced the session's own namespace, silently returning partial data. The Job now receives `--namespaces <resolved list>`, and the session ServiceAccount is granted pods/events read via a Role+RoleBinding in each target namespace (least privilege; own namespace is already covered). The in-Job CLI now opens one scoped pod informer per target namespace instead of a single cluster-wide one, so that per-namespace RBAC is sufficient (a cluster-wide informer would have required cluster-wide list/watch and failed the cache sync).

## Multi-node session reports no longer overwrite each other

Every per-node Job wrote the same report ConfigMap under a fixed `report.txt` key, so a multi-node session's report was whichever node finished last, and two sessions sharing a sink clobbered each other. Reports are now written under a per-node key (`report-<node>.txt`) using `$NODE_NAME`, and the writers retry on conflict so concurrent per-node updates to the same ConfigMap/Secret don't drop a key.

## Changing systemNamespace no longer strands bundles or leaks credentials

The PodTrace reconciler had no watch on TracerConfig, so changing `spec.systemNamespace` moved the agent fleet but left existing PodTraces' exporter bundles in the old namespace, continuous tracing then exported nothing until each CR was touched, and the credential-bearing bundle Secret in an intermediate namespace was orphaned forever. The reconciler now watches TracerConfig and re-reconciles every PodTrace on a change, and bundle cleanup is label-based across all namespaces.