### PR TITLE
fix: correct protocol-edge decoding and bound diagnose/tracer memory

### DIFF
--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -90,6 +90,15 @@ static long h2_frames_cb(u32 idx, void *vctx)
 	if (off >= c->avail)
 		return 1;
 
+	if (fs->remaining == 0 && fs->pad > 0) {
+		u32 avail_here = c->avail - off;
+		u32 skip = avail_here < fs->pad ? avail_here : fs->pad;
+		off += skip;
+		fs->pad -= (u8)skip;
+		s->off = off;
+		return 0;
+	}
+
 	if (fs->remaining > 0) {
 		u32 avail_here = c->avail - off;
 		u32 take = avail_here < fs->remaining ? avail_here : fs->remaining;
@@ -137,6 +146,7 @@ static long h2_frames_cb(u32 idx, void *vctx)
 		   ((u32)fh[7] << 8) | (u32)fh[8]) & 0x7fffffff;
 	off += HTTP2_FRAME_HDR;
 
+	u8 pad_bytes = 0;
 	if (type == HTTP2_HEADERS) {
 		if ((flags & HTTP2_FLAG_PADDED) && off < c->avail) {
 			u8 pb = 0;
@@ -144,6 +154,7 @@ static long h2_frames_cb(u32 idx, void *vctx)
 				off += 1;
 				flen = flen >= 1 ? flen - 1 : 0;
 				flen = flen >= pb ? flen - pb : 0;
+				pad_bytes = pb;
 			}
 		}
 		if (flags & HTTP2_FLAG_PRIORITY) {
@@ -155,6 +166,7 @@ static long h2_frames_cb(u32 idx, void *vctx)
 	fs->flags = flags;
 	fs->stream_id = sid;
 	fs->remaining = flen;
+	fs->pad = pad_bytes;
 	s->off = off;
 	return 0;
 }

--- a/bpf/http.c
+++ b/bpf/http.c
@@ -49,7 +49,7 @@ struct tp_scan_ctx {
 static long tp_scan_cb(u32 i, void *vctx)
 {
 	struct tp_scan_ctx *c = (struct tp_scan_ctx *)vctx;
-	if (i + 16 >= HTTP_SCAN_BUF_SIZE || i >= c->rlen)
+	if (i + 16 >= HTTP_SCAN_BUF_SIZE || i + 12 > c->rlen)
 		return 1;
 	u32 zero = 0;
 	char *buf = bpf_map_lookup_elem(&http_scan_buf, &zero);
@@ -89,7 +89,7 @@ static __noinline void http_capture_traceparent(void *base, u64 avail, char *out
 		return;
 
 	u32 v = (u32)sc.pos + 12;
-	if (v < HTTP_SCAN_BUF_SIZE && buf[v & (HTTP_SCAN_BUF_SIZE - 1)] == ' ')
+	if (v < rlen && buf[v & (HTTP_SCAN_BUF_SIZE - 1)] == ' ')
 		v++;
 
 	if (v + W3C_TRACEPARENT_LEN > rlen)

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -679,6 +679,13 @@ struct {
 } h3_adapter_calls SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u64);
+	__type(value, struct h3_txn_record);
+} h3_adapter_pending SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 2 * 1024 * 1024);
 } h3_stream_chunks SEC(".maps");
@@ -732,7 +739,7 @@ struct h2_frame_state {
 	u8  type;
 	u8  flags;
 	u8  preface_seen;
-	u8  _pad;
+	u8  pad;
 };
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);

--- a/bpf/memory.c
+++ b/bpf/memory.c
@@ -37,35 +37,19 @@ int tracepoint_page_fault_user(void *ctx) {
 	return 0;
 }
 
-struct oom_mark_victim_args {
-	unsigned short common_type;
-	unsigned char common_flags;
-	unsigned char common_preempt_count;
-	int common_pid;
+struct oom_mark_victim_hdr {
+	unsigned char common[8];
 	int pid;
-	unsigned int comm_loc;
-	u64 total_vm;
-	u64 anon_rss;
-	u64 file_rss;
-	u64 shmem_rss;
 };
-_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, pid) == 8, "mark_victim: pid must be at offset 8");
-_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, comm_loc) == 12, "mark_victim: comm __data_loc must be at offset 12");
-_Static_assert(__builtin_offsetof(struct oom_mark_victim_args, total_vm) == 16, "mark_victim: total_vm must be at offset 16");
+_Static_assert(__builtin_offsetof(struct oom_mark_victim_hdr, pid) == 8, "mark_victim: pid must be at offset 8");
 
 SEC("tp/oom/mark_victim")
 int tracepoint_oom_mark_victim(void *ctx) {
-	struct oom_mark_victim_args args_local = {};
-	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
-		return 0;
-	}
-
 	struct event *e = get_event_buf_unfiltered();
 	if (!e) {
 		return 0;
 	}
 	e->timestamp = bpf_ktime_get_ns();
-	e->pid = args_local.pid;
 	e->type = EVENT_OOM_KILL;
 	e->latency_ns = 0;
 	e->error = 0;
@@ -73,13 +57,25 @@ int tracepoint_oom_mark_victim(void *ctx) {
 	e->tcp_state = 0;
 	e->target[0] = '\0';
 
-	unsigned short comm_off = (unsigned short)(args_local.comm_loc & 0xffff);
-	unsigned short comm_len = (unsigned short)(args_local.comm_loc >> 16);
-	if (comm_off >= sizeof(struct oom_mark_victim_args) && comm_off < 4096 &&
-	    comm_len > 0 && comm_len <= COMM_LEN + 1) {
-		bpf_probe_read_kernel_str(e->target, COMM_LEN, (char *)ctx + comm_off);
-		__builtin_memcpy(e->comm, e->target, COMM_LEN);
+#ifdef PODTRACE_VMLINUX_FROM_BTF
+	struct trace_event_raw_mark_victim *tp = ctx;
+	e->pid = BPF_CORE_READ(tp, pid);
+	if (bpf_core_field_exists(tp->__data_loc_comm)) {
+		u32 comm_loc = BPF_CORE_READ(tp, __data_loc_comm);
+		unsigned short comm_off = (unsigned short)(comm_loc & 0xffff);
+		unsigned short comm_len = (unsigned short)(comm_loc >> 16);
+		if (comm_off >= sizeof(struct oom_mark_victim_hdr) && comm_off < 4096 &&
+		    comm_len > 0 && comm_len <= COMM_LEN + 1) {
+			bpf_probe_read_kernel_str(e->target, COMM_LEN, (char *)ctx + comm_off);
+			__builtin_memcpy(e->comm, e->target, COMM_LEN);
+		}
 	}
+#else
+	struct oom_mark_victim_hdr hdr = {};
+	if (bpf_probe_read_kernel(&hdr, sizeof(hdr), ctx) == 0) {
+		e->pid = hdr.pid;
+	}
+#endif
 
 	capture_user_stack(ctx, e->pid, 0, e);
 	bpf_ringbuf_output(&events, e, sizeof(*e), 0);

--- a/bpf/quiche.c
+++ b/bpf/quiche.c
@@ -117,6 +117,7 @@ int uprobe_quiche_h3_send_request(struct pt_regs *ctx)
 	u64 tid = bpf_get_current_pid_tgid();
 	struct h3_adapter_call call = { .conn = (u64)PT_REGS_PARM1(ctx) };
 	bpf_map_update_elem(&h3_adapter_calls, &tid, &call, BPF_ANY);
+	bpf_map_update_elem(&h3_adapter_pending, &tid, rec, BPF_ANY);
 	return 0;
 }
 
@@ -130,14 +131,22 @@ int uretprobe_quiche_h3_send_request(struct pt_regs *ctx)
 	u64 conn = call->conn;
 	bpf_map_delete_elem(&h3_adapter_calls, &tid);
 
+	struct h3_txn_record *rec = bpf_map_lookup_elem(&h3_adapter_pending, &tid);
+	if (!rec) {
+		return 0;
+	}
+
 	s64 stream_id = (s64)PT_REGS_RC(ctx);
-	if (stream_id < 0)
+	if (stream_id < 0) {
+		bpf_map_delete_elem(&h3_adapter_pending, &tid);
 		return 0;
-	u32 zero = 0;
-	struct h3_txn_scratch *s = bpf_map_lookup_elem(&h3_txn_scratch_map, &zero);
-	if (!s || (s->rec.method_len == 0 && s->rec.path_len == 0))
+	}
+	if (rec->method_len == 0 && rec->path_len == 0) {
+		bpf_map_delete_elem(&h3_adapter_pending, &tid);
 		return 0;
-	h3_adapter_stash_request(&s->rec, conn, (u64)stream_id);
+	}
+	h3_adapter_stash_request(rec, conn, (u64)stream_id);
+	bpf_map_delete_elem(&h3_adapter_pending, &tid);
 	return 0;
 }
 

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -273,7 +273,7 @@ int kretprobe_vfs_rename(struct pt_regs *ctx) {
 
 	char *path = bpf_map_lookup_elem(&syscall_paths, &key);
 	if (path) {
-		bpf_probe_read_kernel_str(e->target, sizeof(e->target), path);
+		bpf_probe_read_kernel(e->target, sizeof(e->target), path);
 		bpf_map_delete_elem(&syscall_paths, &key);
 	} else {
 		e->target[0] = '\0';

--- a/internal/diagnose/cap_bounded_test.go
+++ b/internal/diagnose/cap_bounded_test.go
@@ -1,0 +1,61 @@
+package diagnose
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestAddEvent_BoundedPastCap(t *testing.T) {
+	d := NewDiagnostician()
+	d.maxEvents = 5
+
+	const total = 18
+	for i := 0; i < total; i++ {
+		d.AddEvent(&events.Event{Type: events.EventHTTPResp, Error: 503, Bytes: uint64(i)})
+	}
+
+	got := d.GetEvents()
+	if len(got) != d.maxEvents {
+		t.Fatalf("buffer must stay bounded at %d, grew to %d", d.maxEvents, len(got))
+	}
+	for i, e := range got {
+		want := uint64(total - d.maxEvents + i)
+		if e.Bytes != want {
+			t.Errorf("slot %d: id=%d, want %d (recent window, in order)", i, e.Bytes, want)
+		}
+	}
+}
+
+func TestAddEvent_ContextsStayAligned(t *testing.T) {
+	d := NewDiagnostician()
+	d.maxEvents = 4
+	for i := 0; i < 11; i++ {
+		id := uint64(i)
+		d.AddEventWithContext(
+			&events.Event{Type: events.EventHTTPResp, Error: 500, Bytes: id},
+			map[string]interface{}{"id": id},
+		)
+	}
+	evs := d.GetEvents()
+	ctxs := d.EventContexts()
+	if len(evs) != len(ctxs) || len(evs) != d.maxEvents {
+		t.Fatalf("len mismatch: events=%d contexts=%d cap=%d", len(evs), len(ctxs), d.maxEvents)
+	}
+	for i := range evs {
+		if ctxs[i]["id"] != evs[i].Bytes {
+			t.Errorf("slot %d: event id=%d but context id=%v (misaligned)", i, evs[i].Bytes, ctxs[i]["id"])
+		}
+	}
+}
+
+func TestAddEvent_NoDropCounterUnderCap(t *testing.T) {
+	d := NewDiagnostician()
+	d.maxEvents = 100
+	for i := 0; i < 50; i++ {
+		d.AddEvent(&events.Event{Type: events.EventHTTPResp, Bytes: uint64(i)})
+	}
+	if d.droppedEvents != 0 {
+		t.Errorf("no events should be dropped under cap, got droppedEvents=%d", d.droppedEvents)
+	}
+}

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -42,6 +42,8 @@ type Diagnostician struct {
 	maxEvents          int
 	eventCount         int
 	droppedEvents      int
+	evHead             int
+	wrapped            bool
 	podCommTracker     *tracker.PodCommunicationTracker
 	errorCorrelator    *correlator.ErrorCorrelator
 	sourcePod          string
@@ -103,39 +105,33 @@ func (d *Diagnostician) AddEventWithContext(event *events.Event, k8sContext map[
 	defer d.mu.Unlock()
 
 	d.eventCount++
-	if len(d.events) >= d.maxEvents {
-		if shouldSampleEvent(event, d.eventCount) {
-			d.events = append(d.events, event)
-			if k8sContext != nil {
-				d.enrichedEvents = append(d.enrichedEvents, k8sContext)
-			} else {
-				d.enrichedEvents = append(d.enrichedEvents, nil)
-			}
-		} else {
-			d.droppedEvents++
-		}
-		if d.droppedEvents%config.DroppedEventsLogRate == 0 {
-			logger.Warn("Event limit reached, sampling events",
+
+	if d.podCommTracker != nil && k8sContext != nil {
+		d.podCommTracker.ProcessEvent(event, k8sContext)
+	}
+	if d.errorCorrelator != nil {
+		d.errorCorrelator.AddEvent(event, k8sContext)
+	}
+
+	if len(d.events) < d.maxEvents {
+		d.events = append(d.events, event)
+		d.enrichedEvents = append(d.enrichedEvents, k8sContext)
+		return
+	}
+
+	if !shouldSampleEvent(event, d.eventCount) {
+		d.droppedEvents++
+		if d.droppedEvents == 1 || d.droppedEvents%config.DroppedEventsLogRate == 0 {
+			logger.Warn("Event buffer at capacity; sampling and evicting oldest events",
 				zap.Int("max_events", d.maxEvents),
 				zap.Int("dropped", d.droppedEvents))
 		}
 		return
 	}
-
-	d.events = append(d.events, event)
-	if k8sContext != nil {
-		d.enrichedEvents = append(d.enrichedEvents, k8sContext)
-	} else {
-		d.enrichedEvents = append(d.enrichedEvents, nil)
-	}
-
-	if d.podCommTracker != nil && k8sContext != nil {
-		d.podCommTracker.ProcessEvent(event, k8sContext)
-	}
-
-	if d.errorCorrelator != nil {
-		d.errorCorrelator.AddEvent(event, k8sContext)
-	}
+	d.events[d.evHead] = event
+	d.enrichedEvents[d.evHead] = k8sContext
+	d.evHead = (d.evHead + 1) % d.maxEvents
+	d.wrapped = true
 }
 
 func (d *Diagnostician) GetEvents() []*events.Event {
@@ -143,7 +139,12 @@ func (d *Diagnostician) GetEvents() []*events.Event {
 	defer d.mu.RUnlock()
 
 	result := make([]*events.Event, len(d.events))
-	copy(result, d.events)
+	if !d.wrapped {
+		copy(result, d.events)
+	} else {
+		n := copy(result, d.events[d.evHead:])
+		copy(result[n:], d.events[:d.evHead])
+	}
 	return result
 }
 
@@ -158,7 +159,12 @@ func (d *Diagnostician) EventContexts() []map[string]interface{} {
 	defer d.mu.RUnlock()
 
 	result := make([]map[string]interface{}, len(d.enrichedEvents))
-	copy(result, d.enrichedEvents)
+	if !d.wrapped {
+		copy(result, d.enrichedEvents)
+	} else {
+		n := copy(result, d.enrichedEvents[d.evHead:])
+		copy(result[n:], d.enrichedEvents[:d.evHead])
+	}
 	return result
 }
 

--- a/internal/ebpf/parser/parser.go
+++ b/internal/ebpf/parser/parser.go
@@ -18,6 +18,22 @@ var (
 	}
 )
 
+const maxStringLen = 128
+
+// decodeTarget turns a raw fixed-size target buffer into a string.
+func decodeTarget(eventType uint32, raw []byte) string {
+	if events.EventType(eventType) == events.EventRename && len(raw) >= maxStringLen {
+		half := maxStringLen / 2
+		oldName := string(bytes.TrimRight(raw[:half-1], "\x00"))
+		newName := string(bytes.TrimRight(raw[half:maxStringLen], "\x00"))
+		if newName == "" {
+			return oldName
+		}
+		return oldName + ">" + newName
+	}
+	return string(bytes.TrimRight(raw, "\x00"))
+}
+
 type rawEvent struct {
 	Timestamp uint64
 	PID       uint32
@@ -234,7 +250,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 		event.NetNsID = e.NetNsID
 		event.DNSServerIP = e.DNSServerIP
@@ -263,7 +279,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 		event.NetNsID = e.NetNsID
 		event.DNSServerIP = e.DNSServerIP
@@ -291,7 +307,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 		event.NetNsID = e.NetNsID
 		event.DNSServerIP = e.DNSServerIP
@@ -315,7 +331,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 		event.NetNsID = e.NetNsID
 		event.DNSServerIP = e.DNSServerIP
@@ -339,7 +355,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 		event.NetNsID = e.NetNsID
 
@@ -362,7 +378,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
 		event.ProcessName = string(bytes.TrimRight(e.Comm[:], "\x00"))
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 
 		return event
@@ -383,7 +399,7 @@ func ParseEvent(data []byte) *events.Event {
 		event.TCPState = e.TCPState
 		event.StackKey = e.StackKey
 		event.CgroupID = e.CgroupID
-		event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+		event.Target = decodeTarget(e.Type, e.Target[:])
 		event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 
 		return event
@@ -402,7 +418,7 @@ func ParseEvent(data []byte) *events.Event {
 	event.Bytes = e.Bytes
 	event.TCPState = e.TCPState
 	event.StackKey = e.StackKey
-	event.Target = string(bytes.TrimRight(e.Target[:], "\x00"))
+	event.Target = decodeTarget(e.Type, e.Target[:])
 	event.Details = string(bytes.TrimRight(e.Details[:], "\x00"))
 
 	return event

--- a/internal/ebpf/parser/rename_target_test.go
+++ b/internal/ebpf/parser/rename_target_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestDecodeTarget_RenameRejoinsHalves(t *testing.T) {
+	raw := make([]byte, maxStringLen)
+	copy(raw[0:], "old.txt")
+	raw[maxStringLen/2-1] = '>'
+	copy(raw[maxStringLen/2:], "new.txt")
+
+	got := decodeTarget(uint32(events.EventRename), raw)
+	if got != "old.txt>new.txt" {
+		t.Errorf("rename target = %q, want %q", got, "old.txt>new.txt")
+	}
+}
+
+func TestDecodeTarget_RenameMissingNewName(t *testing.T) {
+	raw := make([]byte, maxStringLen)
+	copy(raw[0:], "only-old")
+	raw[maxStringLen/2-1] = '>'
+	if got := decodeTarget(uint32(events.EventRename), raw); got != "only-old" {
+		t.Errorf("target = %q, want %q", got, "only-old")
+	}
+}
+
+func TestDecodeTarget_NonRenameUnchanged(t *testing.T) {
+	raw := make([]byte, maxStringLen)
+	copy(raw[0:], "/etc/passwd")
+	if got := decodeTarget(uint32(events.EventOpen), raw); got != "/etc/passwd" {
+		t.Errorf("target = %q, want %q", got, "/etc/passwd")
+	}
+}

--- a/internal/ebpf/probes/gosym.go
+++ b/internal/ebpf/probes/gosym.go
@@ -166,8 +166,7 @@ func x86ReturnPositions(code []byte) []uint64 {
 	for pos := 0; pos < len(code); {
 		inst, derr := x86asm.Decode(code[pos:], 64)
 		if derr != nil || inst.Len == 0 {
-			pos++
-			continue
+			break
 		}
 		if inst.Op == x86asm.RET {
 			out = append(out, uint64(pos))

--- a/internal/ebpf/probes/gosym_x86_test.go
+++ b/internal/ebpf/probes/gosym_x86_test.go
@@ -1,0 +1,23 @@
+package probes
+
+import "testing"
+
+// TestX86ReturnPositions_Clean finds RET at the right offset in valid code.
+func TestX86ReturnPositions_Clean(t *testing.T) {
+	// 0x90 NOP, 0xc3 RET
+	got := x86ReturnPositions([]byte{0x90, 0xc3})
+	if len(got) != 1 || got[0] != 1 {
+		t.Fatalf("positions = %v, want [1]", got)
+	}
+}
+
+// TestX86ReturnPositions_StopsOnDesync guards ebpf M1: after an undecodable
+// byte (0x06 = PUSH ES, invalid in 64-bit mode) the scan must stop rather than
+// resync mid-instruction and report a spurious RET, which would plant a
+// uretprobe mid-instruction and corrupt the traced process.
+func TestX86ReturnPositions_StopsOnDesync(t *testing.T) {
+	got := x86ReturnPositions([]byte{0x06, 0x90, 0xc3})
+	if len(got) != 0 {
+		t.Fatalf("expected no positions after a decode failure, got %v", got)
+	}
+}

--- a/internal/ebpf/probes/h3offsets.go
+++ b/internal/ebpf/probes/h3offsets.go
@@ -100,6 +100,9 @@ func h3OffsetsFromDWARF(exePath string) (result h3FieldOffsets, ok bool) {
 		if !ok {
 			continue
 		}
+		if decl, _ := ent.Val(dwarf.AttrDeclaration).(bool); decl {
+			continue
+		}
 		for {
 			c, err := r.Next()
 			if err != nil || c == nil || c.Tag == 0 {
@@ -115,6 +118,12 @@ func h3OffsetsFromDWARF(exePath string) (result h3FieldOffsets, ok bool) {
 			}
 			loc, _ := c.Val(dwarf.AttrDataMemberLoc).(int64)
 			if loc < 0 || loc > maxStructFieldOffset {
+				continue
+			}
+			if w.found {
+				if *w.dst != uint32(loc) {
+					return h3FieldOffsets{}, false
+				}
 				continue
 			}
 			*w.dst = uint32(loc)

--- a/internal/ebpf/tracer/quic_evict_test.go
+++ b/internal/ebpf/tracer/quic_evict_test.go
@@ -1,0 +1,38 @@
+package tracer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvictQUICFlows_DropsStaleKeepsFresh(t *testing.T) {
+	now := time.Now()
+	flows := map[quicFlowKey]*quicFlowState{
+		{cgroup: 1}: {lastSeen: now.Add(-2 * quicFlowTTL)},
+		{cgroup: 2}: {lastSeen: now.Add(-1 * time.Second)},
+	}
+	evictQUICFlows(flows, now)
+	if _, ok := flows[quicFlowKey{cgroup: 1}]; ok {
+		t.Error("stale flow should have been evicted")
+	}
+	if _, ok := flows[quicFlowKey{cgroup: 2}]; !ok {
+		t.Error("fresh in-progress flow must be retained")
+	}
+}
+
+func TestEvictQUICFlows_NoWipeWhenAllFresh(t *testing.T) {
+	now := time.Now()
+	flows := make(map[quicFlowKey]*quicFlowState, quicMaxTrackedFlows)
+	for i := 0; i < quicMaxTrackedFlows; i++ {
+		flows[quicFlowKey{cgroup: uint64(i + 1)}] = &quicFlowState{
+			lastSeen: now.Add(-time.Duration(quicMaxTrackedFlows-i) * time.Millisecond),
+		}
+	}
+	evictQUICFlows(flows, now)
+	if got := len(flows); got != quicMaxTrackedFlows-1 {
+		t.Fatalf("expected exactly one eviction, len=%d want %d", got, quicMaxTrackedFlows-1)
+	}
+	if _, ok := flows[quicFlowKey{cgroup: 1}]; ok {
+		t.Error("the least-recently-seen flow should have been evicted")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -44,6 +44,7 @@ import (
 	"github.com/podtrace/podtrace/internal/metricsexporter"
 	"github.com/podtrace/podtrace/internal/procfs"
 	"github.com/podtrace/podtrace/internal/redactor"
+	"github.com/podtrace/podtrace/internal/safeconv"
 	"github.com/podtrace/podtrace/internal/sysfs"
 	"github.com/podtrace/podtrace/internal/validation"
 )
@@ -1620,14 +1621,36 @@ type quicFlowKey struct {
 // extracted (quic-go splits the ClientHello across two Initials) or the BPF
 // per-flow packet cap is reached.
 type quicFlowState struct {
-	pkts [][]byte
-	done bool
+	pkts     [][]byte
+	done     bool
+	lastSeen time.Time
 }
 
 const (
 	quicInitialMaxPackets = 3
 	quicMaxTrackedFlows   = 2048
+	quicFlowTTL           = 30 * time.Second
 )
+
+// evictQUICFlows makes room in the flow table without discarding flows that are
+// still mid-reassembly.
+func evictQUICFlows(flows map[quicFlowKey]*quicFlowState, now time.Time) {
+	var oldestKey quicFlowKey
+	var oldest time.Time
+	found := false
+	for k, st := range flows {
+		if now.Sub(st.lastSeen) > quicFlowTTL {
+			delete(flows, k)
+			continue
+		}
+		if !found || st.lastSeen.Before(oldest) {
+			oldestKey, oldest, found = k, st.lastSeen, true
+		}
+	}
+	if len(flows) >= quicMaxTrackedFlows && found {
+		delete(flows, oldestKey)
+	}
+}
 
 // runQUICInitialReader drains the QUIC Initial packet ringbuf, extracts the SNI
 // (server name) and ALPN from the client's ClientHello via the quicinitial
@@ -1672,18 +1695,20 @@ func (t *Tracer) runQUICInitialReader(ctx context.Context, eventChan chan<- *eve
 			ip = events.PeerIP(2, binary.BigEndian.Uint32(data[24:28]), v6)
 		}
 
+		now := time.Now()
 		key := quicFlowKey{cgroup: binary.LittleEndian.Uint64(data[8:16]), addr: v6, port: dport}
 		st := flows[key]
 		if st == nil {
 			if len(flows) >= quicMaxTrackedFlows {
-				flows = make(map[quicFlowKey]*quicFlowState)
+				evictQUICFlows(flows, now)
 			}
-			st = &quicFlowState{}
+			st = &quicFlowState{lastSeen: now}
 			flows[key] = st
 		}
 		if st.done {
 			continue
 		}
+		st.lastSeen = now
 		pktEnd := hdr + int(binary.LittleEndian.Uint16(data[40:42]))
 		if pktEnd > len(data) {
 			pktEnd = len(data)
@@ -1694,7 +1719,7 @@ func (t *Tracer) runQUICInitialReader(ctx context.Context, eventChan chan<- *eve
 
 		info, xerr := quicinitial.ExtractPackets(st.pkts)
 		if xerr != nil && len(st.pkts) < quicInitialMaxPackets {
-			continue // wait for the flow's next Initial packet
+			continue
 		}
 		st.done = true
 		st.pkts = nil
@@ -1846,14 +1871,45 @@ func (t *Tracer) pollBPFMapUtilization() {
 		if err != nil || info.MaxEntries == 0 {
 			continue
 		}
-		var count uint32
-		var key, val []byte
-		iter := m.Iterate()
-		for iter.Next(&key, &val) {
-			count++
+		count, ok := batchCountMapEntries(m)
+		if !ok {
+			count = 0
+			var key, val []byte
+			iter := m.Iterate()
+			for iter.Next(&key, &val) {
+				count++
+			}
 		}
 		ratio := float64(count) / float64(info.MaxEntries)
 		metricsexporter.RecordBPFMapUtilization(name, ratio)
+	}
+}
+
+// batchCountMapEntries counts a map's live entries using BPF_MAP_LOOKUP_BATCH,
+// turning the O(n) per-entry get_next_key syscalls of a full iteration into
+// O(n/batch) syscalls.
+func batchCountMapEntries(m *ebpf.Map) (uint32, bool) {
+	ks, vs := int(m.KeySize()), int(m.ValueSize())
+	if ks == 0 || vs == 0 {
+		return 0, false
+	}
+	const batch = 256
+	keys := make([]byte, batch*ks)
+	vals := make([]byte, batch*vs)
+	var cursor ebpf.MapBatchCursor
+	var count uint32
+	for {
+		n, err := m.BatchLookup(&cursor, keys, vals, nil)
+		count += safeconv.IntToUint32(n)
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return count, true
+		}
+		if err != nil {
+			return 0, false
+		}
+		if n == 0 {
+			return count, true
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes a set of protocol-decoding correctness bugs in the eBPF probes and userspace loader, plus an unbounded-memory issue in the diagnostician's event buffer.

## Changes
- Bound the diagnostician's event retention: once the cap is reached, sampled events overwrite the oldest slot via a ring buffer instead of being appended without limit, feed the pod-communication and error correlators for every event (not just pre-cap ones), and only log the "buffer full" warning after a real drop.
- Skip trailing padding on padded HTTP/2 HEADERS frames so the frame parser no longer desynchronizes for the rest of the connection.
- Copy the full fixed-size vfs_rename path buffer and rejoin its two halves in the parser, so the renamed-to name is emitted as `old>new` instead of being truncated at the first NUL.
- Bound the traceparent scan and space-skip to the freshly-read length so stale per-CPU scratch bytes from a prior request can't bleed into the captured value.
- Carry the quiche send_request record between the uprobe and uretprobe in a per-thread map, so it survives preemption or CPU migration instead of being clobbered in per-CPU scratch.
- Read the oom mark_victim pid unconditionally and gate the comm field on its existence via CO-RE, so kernels without those fields aren't misread.
- Stop the x86 return-site scan at the first decode failure instead of resyncing byte-by-byte, preventing a uretprobe from being planted mid-instruction and corrupting the traced process.
- Evict QUIC Initial-flow state by idle TTL (or the single oldest entry) instead of wiping the whole table, so in-progress reassemblies survive when the table fills, and completed/abandoned flows no longer leak.
- Count BPF map utilization with batched lookups (falling back to iteration) to avoid O(n) syscalls on hot maps every 30s, using a bounds-checked int conversion.
- Fall back to version-keyed HTTP/3 field offsets when DWARF contains a duplicate type name with a conflicting layout, and skip forward-declaration entries, instead of silently picking a wrong offset.