### PR TITLE
fix: repair diagnose report math, tracer lifecycle, and validation

### DIFF
--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/logger"
 )
 
 // Metrics registers every Prometheus counter/gauge the agent exposes
@@ -394,6 +397,18 @@ func (o *metricsEngineObserver) OnCgroupsDetached(n int) {
 		return
 	}
 	o.m.CgroupsDetached.Add(float64(n))
+}
+
+// OnTargetError logs a backend target-reconcile failure so an attach problem
+// is visible as an attach problem.
+func (o *metricsEngineObserver) OnTargetError(stage string, err error) {
+	if err == nil {
+		return
+	}
+	logger.Warn("tracer target reconcile failed",
+		zap.String("stage", stage),
+		zap.Error(err),
+	)
 }
 
 // RefreshFromRouter walks the router's rule set + stats table and

--- a/internal/diagnose/analyzer/pool.go
+++ b/internal/diagnose/analyzer/pool.go
@@ -14,7 +14,7 @@ type PoolStats struct {
 	ExhaustedCount  int
 	AvgWaitTime     time.Duration
 	MaxWaitTime     time.Duration
-	ReuseRate       float64
+	ReleaseRatio    float64
 	PeakConnections int
 	AvgConnections  float64
 	P50WaitTime     float64
@@ -30,7 +30,7 @@ func AnalyzePool(acquireEvents, releaseEvents, exhaustedEvents []*events.Event) 
 	}
 
 	if stats.TotalAcquires > 0 {
-		stats.ReuseRate = float64(stats.TotalReleases) / float64(stats.TotalAcquires)
+		stats.ReleaseRatio = float64(stats.TotalReleases) / float64(stats.TotalAcquires)
 	}
 
 	var waitTimes []float64

--- a/internal/diagnose/analyzer/pool_test.go
+++ b/internal/diagnose/analyzer/pool_test.go
@@ -12,26 +12,26 @@ func TestAnalyzePool(t *testing.T) {
 	baseTime := now.UnixNano()
 
 	tests := []struct {
-		name            string
-		acquireEvents   []*events.Event
-		releaseEvents   []*events.Event
-		exhaustedEvents []*events.Event
-		wantAcquires    int
-		wantReleases    int
-		wantExhausted   int
-		wantReuseRate   float64
-		wantPeak        int
+		name             string
+		acquireEvents    []*events.Event
+		releaseEvents    []*events.Event
+		exhaustedEvents  []*events.Event
+		wantAcquires     int
+		wantReleases     int
+		wantExhausted    int
+		wantReleaseRatio float64
+		wantPeak         int
 	}{
 		{
-			name:            "empty events",
-			acquireEvents:   []*events.Event{},
-			releaseEvents:   []*events.Event{},
-			exhaustedEvents: []*events.Event{},
-			wantAcquires:    0,
-			wantReleases:    0,
-			wantExhausted:   0,
-			wantReuseRate:   0,
-			wantPeak:        0,
+			name:             "empty events",
+			acquireEvents:    []*events.Event{},
+			releaseEvents:    []*events.Event{},
+			exhaustedEvents:  []*events.Event{},
+			wantAcquires:     0,
+			wantReleases:     0,
+			wantExhausted:    0,
+			wantReleaseRatio: 0,
+			wantPeak:         0,
 		},
 		{
 			name: "balanced acquire and release",
@@ -43,12 +43,12 @@ func TestAnalyzePool(t *testing.T) {
 				{Timestamp: uint64(baseTime + 5000000), Type: events.EventPoolRelease, Target: "pool1"},
 				{Timestamp: uint64(baseTime + 6000000), Type: events.EventPoolRelease, Target: "pool1"},
 			},
-			exhaustedEvents: []*events.Event{},
-			wantAcquires:    2,
-			wantReleases:    2,
-			wantExhausted:   0,
-			wantReuseRate:   1.0,
-			wantPeak:        2,
+			exhaustedEvents:  []*events.Event{},
+			wantAcquires:     2,
+			wantReleases:     2,
+			wantExhausted:    0,
+			wantReleaseRatio: 1.0,
+			wantPeak:         2,
 		},
 		{
 			name: "pool exhaustion",
@@ -59,11 +59,11 @@ func TestAnalyzePool(t *testing.T) {
 			exhaustedEvents: []*events.Event{
 				{Timestamp: uint64(baseTime + 10000000), Type: events.EventPoolExhausted, Target: "pool1", LatencyNS: 10000000},
 			},
-			wantAcquires:  1,
-			wantReleases:  0,
-			wantExhausted: 1,
-			wantReuseRate: 0,
-			wantPeak:      1,
+			wantAcquires:     1,
+			wantReleases:     0,
+			wantExhausted:    1,
+			wantReleaseRatio: 0,
+			wantPeak:         1,
 		},
 		{
 			name: "multiple pools",
@@ -74,12 +74,12 @@ func TestAnalyzePool(t *testing.T) {
 			releaseEvents: []*events.Event{
 				{Timestamp: uint64(baseTime + 5000000), Type: events.EventPoolRelease, Target: "pool1"},
 			},
-			exhaustedEvents: []*events.Event{},
-			wantAcquires:    2,
-			wantReleases:    1,
-			wantExhausted:   0,
-			wantReuseRate:   0.5,
-			wantPeak:        1,
+			exhaustedEvents:  []*events.Event{},
+			wantAcquires:     2,
+			wantReleases:     1,
+			wantExhausted:    0,
+			wantReleaseRatio: 0.5,
+			wantPeak:         1,
 		},
 	}
 
@@ -96,8 +96,8 @@ func TestAnalyzePool(t *testing.T) {
 			if stats.ExhaustedCount != tt.wantExhausted {
 				t.Errorf("ExhaustedCount = %d, want %d", stats.ExhaustedCount, tt.wantExhausted)
 			}
-			if stats.ReuseRate != tt.wantReuseRate {
-				t.Errorf("ReuseRate = %f, want %f", stats.ReuseRate, tt.wantReuseRate)
+			if stats.ReleaseRatio != tt.wantReleaseRatio {
+				t.Errorf("ReleaseRatio = %f, want %f", stats.ReleaseRatio, tt.wantReleaseRatio)
 			}
 			if stats.PeakConnections != tt.wantPeak {
 				t.Errorf("PeakConnections = %d, want %d", stats.PeakConnections, tt.wantPeak)

--- a/internal/diagnose/correlator/error_correlator.go
+++ b/internal/diagnose/correlator/error_correlator.go
@@ -3,6 +3,7 @@ package correlator
 import (
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/podtrace/podtrace/internal/events"
@@ -28,6 +29,7 @@ type ErrorEvent struct {
 const maxRetainedErrors = 10000
 
 type ErrorCorrelator struct {
+	mu         sync.Mutex
 	errors     []*ErrorEvent
 	chains     []*ErrorChain
 	timeWindow time.Duration
@@ -49,6 +51,9 @@ func (ec *ErrorCorrelator) AddEvent(event *events.Event, k8sContext interface{})
 	if event == nil || !event.IsError() {
 		return
 	}
+
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
 
 	errorEvent := &ErrorEvent{
 		Event:     event,
@@ -99,33 +104,56 @@ func (ec *ErrorCorrelator) buildChains() {
 		return ec.errors[i].Timestamp.Before(ec.errors[j].Timestamp)
 	})
 
-	for i, rootError := range ec.errors {
-		chain := []*ErrorEvent{rootError}
-		rootTime := rootError.Timestamp
-
-		for j := i + 1; j < len(ec.errors); j++ {
-			nextError := ec.errors[j]
-			if nextError.Timestamp.Sub(rootTime) <= ec.timeWindow {
-				if ec.isRelated(rootError, nextError) {
-					chain = append(chain, nextError)
-				}
-			} else {
-				break
-			}
-		}
-
-		if len(chain) > 1 {
-			suggestions := ec.generateSuggestions(chain)
-			severity := ec.calculateSeverity(chain)
-
-			ec.chains = append(ec.chains, &ErrorChain{
-				RootCause:   chain[0],
-				Chain:       chain,
-				Suggestions: suggestions,
-				Severity:    severity,
-			})
-		}
+	type openChain struct {
+		root  time.Time
+		chain []*ErrorEvent
 	}
+	open := map[string]*openChain{}
+	flush := func(oc *openChain) {
+		if oc == nil || len(oc.chain) <= 1 {
+			return
+		}
+		ec.chains = append(ec.chains, &ErrorChain{
+			RootCause:   oc.chain[0],
+			Chain:       oc.chain,
+			Suggestions: ec.generateSuggestions(oc.chain),
+			Severity:    ec.calculateSeverity(oc.chain),
+		})
+	}
+	for _, e := range ec.errors {
+		key := errorChainKey(e)
+		if key == "" {
+			continue
+		}
+		oc := open[key]
+		if oc == nil || e.Timestamp.Sub(oc.root) > ec.timeWindow {
+			flush(oc)
+			open[key] = &openChain{root: e.Timestamp, chain: []*ErrorEvent{e}}
+			continue
+		}
+		oc.chain = append(oc.chain, e)
+	}
+	for _, oc := range open {
+		flush(oc)
+	}
+	sort.Slice(ec.chains, func(i, j int) bool {
+		return ec.chains[i].RootCause.Timestamp.Before(ec.chains[j].RootCause.Timestamp)
+	})
+}
+
+// errorChainKey is the identifier errors are grouped by, most specific first.
+// Errors with no identifier are not chained.
+func errorChainKey(e *ErrorEvent) string {
+	if e.Target != "" {
+		return "t:" + e.Target
+	}
+	if p := e.Context["target_pod"]; p != "" {
+		return "p:" + p
+	}
+	if s := e.Context["target_service"]; s != "" {
+		return "s:" + s
+	}
+	return ""
 }
 
 func (ec *ErrorCorrelator) isRelated(err1, err2 *ErrorEvent) bool {
@@ -204,11 +232,17 @@ func (ec *ErrorCorrelator) calculateSeverity(chain []*ErrorEvent) string {
 }
 
 func (ec *ErrorCorrelator) GetChains() []*ErrorChain {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
 	ec.ensureChains()
-	return ec.chains
+	out := make([]*ErrorChain, len(ec.chains))
+	copy(out, ec.chains)
+	return out
 }
 
 func (ec *ErrorCorrelator) GetErrorSummary() string {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
 	if len(ec.errors) == 0 {
 		return ""
 	}

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -663,9 +663,13 @@ func GenerateIssuesSection(d Diagnostician) string {
 			} else {
 				severity = alerting.SeverityWarning
 			}
+			category := issue
+			if idx := strings.IndexByte(issue, ':'); idx > 0 {
+				category = issue[:idx]
+			}
 			alert := &alerting.Alert{
 				Severity:  severity,
-				Title:     "Diagnostic Issue Detected",
+				Title:     "Diagnostic Issue: " + category,
 				Message:   issue,
 				Timestamp: time.Now(),
 				Source:    "error_detector",
@@ -712,7 +716,7 @@ func GeneratePoolSection(d Diagnostician, duration time.Duration) string {
 	releaseRate := d.CalculateRate(stats.TotalReleases, duration)
 	report += fmt.Sprintf("  Total acquires: %d (%.1f/sec)\n", stats.TotalAcquires, acquireRate)
 	report += fmt.Sprintf("  Total releases: %d (%.1f/sec)\n", stats.TotalReleases, releaseRate)
-	report += fmt.Sprintf("  Reuse rate: %.2f%%\n", stats.ReuseRate*100)
+	report += fmt.Sprintf("  Release ratio: %.2f%% (releases/acquires)\n", stats.ReleaseRatio*100)
 	report += fmt.Sprintf("  Peak connections: %d\n", stats.PeakConnections)
 	report += fmt.Sprintf("  Average connections: %.1f\n", stats.AvgConnections)
 
@@ -741,7 +745,7 @@ func GeneratePoolSection(d Diagnostician, duration time.Duration) string {
 			}
 			report += fmt.Sprintf("    - %s:\n", summary.PoolID)
 			report += fmt.Sprintf("        Acquires: %d, Releases: %d\n", summary.AcquireCount, summary.ReleaseCount)
-			report += fmt.Sprintf("        Reuse rate: %.2f%%\n", summary.ReuseRate*100)
+			report += fmt.Sprintf("        Release ratio: %.2f%% (releases/acquires)\n", summary.ReleaseRatio*100)
 			report += fmt.Sprintf("        Current connections: %d (peak: %d)\n", summary.CurrentConns, summary.MaxConns)
 
 			poolHealthStatus := determinePoolHealthFromSummary(summary)
@@ -764,6 +768,9 @@ func GeneratePoolSection(d Diagnostician, duration time.Duration) string {
 
 func determinePoolHealth(stats analyzer.PoolStats) string {
 	if stats.ExhaustedCount > 0 {
+		if stats.TotalAcquires == 0 {
+			return "CRITICAL - Pool exhausted with no successful acquisitions"
+		}
 		exhaustionRate := float64(stats.ExhaustedCount) / float64(stats.TotalAcquires)
 		if exhaustionRate > 0.1 {
 			return "CRITICAL - High pool exhaustion rate (>10%)"
@@ -772,8 +779,8 @@ func determinePoolHealth(stats analyzer.PoolStats) string {
 		}
 	}
 
-	if stats.ReuseRate < 0.5 {
-		return "WARNING - Low connection reuse rate (<50%)"
+	if stats.ReleaseRatio < 0.5 {
+		return "WARNING - Under half of acquired connections released (<50%, possible leak)"
 	}
 
 	if stats.MaxWaitTime > 1000*time.Millisecond {
@@ -793,8 +800,8 @@ func determinePoolHealthFromSummary(summary tracker.PoolSummary) string {
 		}
 	}
 
-	if summary.ReuseRate < 0.5 {
-		return "WARNING - Low connection reuse rate (<50%)"
+	if summary.ReleaseRatio < 0.5 {
+		return "WARNING - Under half of acquired connections released (<50%, possible leak)"
 	}
 
 	if summary.MaxWaitTime > 1000*time.Millisecond {
@@ -805,7 +812,7 @@ func determinePoolHealthFromSummary(summary tracker.PoolSummary) string {
 }
 
 // GenerateSecuritySection warns when an AF_ALG "aead" socket was bound by an
-// unprivileged process — the CVE-2026-31431 ("Copy-Fail") interface.
+// unprivileged process.
 func GenerateSecuritySection(d Diagnostician) string {
 	victims := map[string]string{} // pod -> "process, uid N"
 	for _, e := range d.FilterEvents(events.EventAFALG) {
@@ -1220,13 +1227,8 @@ func formatFastCGIActivity(d Diagnostician, duration time.Duration) string {
 		})
 	}
 	if len(samples) > 0 {
-		// Newest first.
 		sort.Slice(samples, func(i, j int) bool { return samples[i].ts > samples[j].ts })
 
-		// Render timestamps relative to the oldest sample so they're
-		// human-readable regardless of whether ev.Timestamp came from
-		// CLOCK_MONOTONIC or wall-clock — both clocks advance at the
-		// same rate so the deltas are meaningful either way.
 		oldest := samples[len(samples)-1].ts
 
 		const sampleLimit = 10

--- a/internal/diagnose/report/report_test.go
+++ b/internal/diagnose/report/report_test.go
@@ -77,7 +77,7 @@ func TestGenerateSummarySection(t *testing.T) {
 
 func TestGenerateDNSSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -105,7 +105,7 @@ func TestGenerateDNSSection_WithEvents(t *testing.T) {
 
 func TestGenerateTCPSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -122,9 +122,9 @@ func TestGenerateTCPSection_WithEvents(t *testing.T) {
 			{Type: events.EventTCPSend, LatencyNS: 1000000, Bytes: 1024},
 			{Type: events.EventTCPRecv, LatencyNS: 2000000, Bytes: 2048},
 		},
-		startTime:          time.Now(),
-		endTime:            time.Now().Add(1 * time.Second),
-		rttSpikeThreshold:  100.0,
+		startTime:         time.Now(),
+		endTime:           time.Now().Add(1 * time.Second),
+		rttSpikeThreshold: 100.0,
 	}
 	duration := d.endTime.Sub(d.startTime)
 	result := GenerateTCPSection(d, duration)
@@ -135,7 +135,7 @@ func TestGenerateTCPSection_WithEvents(t *testing.T) {
 
 func TestGenerateConnectionSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -163,7 +163,7 @@ func TestGenerateConnectionSection_WithEvents(t *testing.T) {
 
 func TestGenerateFileSystemSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -180,8 +180,8 @@ func TestGenerateFileSystemSection_WithEvents(t *testing.T) {
 			{Type: events.EventRead, LatencyNS: 2000000, Target: "/tmp/file", Bytes: 4096},
 			{Type: events.EventWrite, LatencyNS: 3000000, Target: "/tmp/file2", Bytes: 2048},
 		},
-		startTime:        time.Now(),
-		endTime:          time.Now().Add(1 * time.Second),
+		startTime:       time.Now(),
+		endTime:         time.Now().Add(1 * time.Second),
 		fsSlowThreshold: 10.0,
 	}
 	duration := d.endTime.Sub(d.startTime)
@@ -193,7 +193,7 @@ func TestGenerateFileSystemSection_WithEvents(t *testing.T) {
 
 func TestGenerateUDPSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -222,7 +222,7 @@ func TestGenerateUDPSection_WithEvents(t *testing.T) {
 
 func TestGenerateHTTPSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -345,7 +345,7 @@ func TestGenerateHTTPSection_PlaintextOmitsBreakdown(t *testing.T) {
 
 func TestGenerateCPUSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -373,7 +373,7 @@ func TestGenerateCPUSection_WithEvents(t *testing.T) {
 
 func TestGenerateTCPStateSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -401,7 +401,7 @@ func TestGenerateTCPStateSection_WithEvents(t *testing.T) {
 
 func TestGenerateMemorySection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -446,7 +446,7 @@ func TestGenerateIssuesSection(t *testing.T) {
 
 func TestGenerateSyscallSection_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -477,7 +477,7 @@ func TestGenerateSyscallSection_WithEvents(t *testing.T) {
 
 func TestGenerateApplicationTracing_Empty(t *testing.T) {
 	d := &mockDiagnostician{
-		events: []*events.Event{},
+		events:    []*events.Event{},
 		startTime: time.Now(),
 		endTime:   time.Now().Add(1 * time.Second),
 	}
@@ -674,10 +674,10 @@ func TestContains(t *testing.T) {
 
 func TestDeterminePoolHealth_OK(t *testing.T) {
 	stats := analyzer.PoolStats{
-		ReuseRate:       0.9,
-		MaxWaitTime:     100 * time.Millisecond,
-		ExhaustedCount:  0,
-		TotalAcquires:   100,
+		ReleaseRatio:   0.9,
+		MaxWaitTime:    100 * time.Millisecond,
+		ExhaustedCount: 0,
+		TotalAcquires:  100,
 	}
 	got := determinePoolHealth(stats)
 	if got != "OK - Pool operating normally" {
@@ -689,7 +689,7 @@ func TestDeterminePoolHealth_CriticalExhaustion(t *testing.T) {
 	stats := analyzer.PoolStats{
 		ExhaustedCount: 20,
 		TotalAcquires:  100,
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 	}
 	got := determinePoolHealth(stats)
 	if !strings.Contains(got, "CRITICAL") {
@@ -701,7 +701,7 @@ func TestDeterminePoolHealth_WarningExhaustion(t *testing.T) {
 	stats := analyzer.PoolStats{
 		ExhaustedCount: 7,
 		TotalAcquires:  100,
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 	}
 	got := determinePoolHealth(stats)
 	if !strings.Contains(got, "WARNING") {
@@ -709,21 +709,21 @@ func TestDeterminePoolHealth_WarningExhaustion(t *testing.T) {
 	}
 }
 
-func TestDeterminePoolHealth_LowReuseRate(t *testing.T) {
+func TestDeterminePoolHealth_LowReleaseRatio(t *testing.T) {
 	stats := analyzer.PoolStats{
 		ExhaustedCount: 0,
-		ReuseRate:      0.3,
+		ReleaseRatio:   0.3,
 	}
 	got := determinePoolHealth(stats)
-	if !strings.Contains(got, "WARNING") || !strings.Contains(got, "reuse rate") {
-		t.Errorf("expected WARNING for low reuse rate, got %q", got)
+	if !strings.Contains(got, "WARNING") || !strings.Contains(got, "possible leak") {
+		t.Errorf("expected WARNING for low release ratio, got %q", got)
 	}
 }
 
 func TestDeterminePoolHealth_HighWaitTime(t *testing.T) {
 	stats := analyzer.PoolStats{
 		ExhaustedCount: 0,
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 		MaxWaitTime:    2000 * time.Millisecond,
 	}
 	got := determinePoolHealth(stats)
@@ -736,7 +736,7 @@ func TestDeterminePoolHealth_HighWaitTime(t *testing.T) {
 
 func TestDeterminePoolHealthFromSummary_OK(t *testing.T) {
 	s := tracker.PoolSummary{
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 		MaxWaitTime:    50 * time.Millisecond,
 		ExhaustedCount: 0,
 	}
@@ -750,7 +750,7 @@ func TestDeterminePoolHealthFromSummary_Critical(t *testing.T) {
 	s := tracker.PoolSummary{
 		ExhaustedCount: 15,
 		AcquireCount:   100,
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 	}
 	got := determinePoolHealthFromSummary(s)
 	if !strings.Contains(got, "CRITICAL") {
@@ -761,7 +761,7 @@ func TestDeterminePoolHealthFromSummary_Critical(t *testing.T) {
 func TestDeterminePoolHealthFromSummary_LowReuse(t *testing.T) {
 	s := tracker.PoolSummary{
 		ExhaustedCount: 0,
-		ReuseRate:      0.2,
+		ReleaseRatio:   0.2,
 	}
 	got := determinePoolHealthFromSummary(s)
 	if !strings.Contains(got, "WARNING") {
@@ -795,7 +795,6 @@ func TestGeneratePoolSection_WithEvents(t *testing.T) {
 	}
 }
 
-
 // TestAnalyzeUDPEvents_NegativeError covers the `if e.Error < 0` branch
 // in analyzeUDPEvents (line 267 of report.go).
 func TestGenerateUDPSection_NegativeError(t *testing.T) {
@@ -815,9 +814,8 @@ func TestGenerateUDPSection_NegativeError(t *testing.T) {
 }
 
 // TestFormatStateDistribution_Break covers the `break` at i >= config.TopStatesLimit
-// in formatStateDistribution. TopStatesLimit defaults to 10, so we need 12 distinct states.
+// in formatStateDistribution.
 func TestGenerateTCPStateSection_ManyStates(t *testing.T) {
-	// TCP states 1-12 are all distinct named states → 12 > TopStatesLimit(10) → triggers break.
 	var evts []*events.Event
 	for state := uint32(1); state <= 12; state++ {
 		evts = append(evts, &events.Event{
@@ -847,7 +845,6 @@ func TestGenerateMemorySection_OOMKillEmptyTarget(t *testing.T) {
 			Type:  events.EventOOMKill,
 			Bytes: 1024 * 1024,
 			PID:   12345,
-			// Target is "" — triggers the "PID N" fallback
 		},
 	}
 	d := &mockDiagnostician{
@@ -865,7 +862,7 @@ func TestGenerateMemorySection_OOMKillEmptyTarget(t *testing.T) {
 }
 
 // TestFormatTopOpenedFiles_EmptyReturn covers the `return ""` branch
-// in formatTopOpenedFiles — reached when all open event targets are "" or "unknown".
+// in formatTopOpenedFiles, reached when all open event targets are "" or "unknown".
 func TestGenerateSyscallSection_OpenedFilesEmptyTargets(t *testing.T) {
 	evts := []*events.Event{
 		{Type: events.EventOpen, Target: ""},        // excluded by buildFileCounts
@@ -879,12 +876,11 @@ func TestGenerateSyscallSection_OpenedFilesEmptyTargets(t *testing.T) {
 		endTime:   time.Now().Add(time.Second),
 	}
 	result := GenerateSyscallSection(d, time.Second)
-	// With only invalid targets, formatTopOpenedFiles returns "" (the uncovered path).
-	_ = result // no panic, uncovered `return ""` is now executed
+	_ = result
 }
 
 // TestCategorizeSyscallEvents_NilEvent covers the `if e == nil { continue }` branch
-// in categorizeSyscallEvents (line 871 of report.go).
+// in categorizeSyscallEvents.
 func TestGenerateSyscallSection_NilEvent(t *testing.T) {
 	evts := []*events.Event{
 		nil,
@@ -897,7 +893,6 @@ func TestGenerateSyscallSection_NilEvent(t *testing.T) {
 		startTime: time.Now(),
 		endTime:   time.Now().Add(time.Second),
 	}
-	// Must not panic; nil events are skipped.
 	result := GenerateSyscallSection(d, time.Second)
 	if result == "" {
 		t.Error("expected non-empty syscall section with exec/open events")
@@ -905,17 +900,13 @@ func TestGenerateSyscallSection_NilEvent(t *testing.T) {
 }
 
 // TestFormatProcessActivity_Break covers the `break` at i >= config.TopProcessesLimit
-// in formatProcessActivity — needs more than 5 distinct PIDs (default TopProcessesLimit=5).
+// in formatProcessActivity, needs more than 5 distinct PIDs (default TopProcessesLimit=5).
 func TestGenerateApplicationTracing_ManyPIDs(t *testing.T) {
-	// Create 8 events each with a distinct PID (1–8) and no ProcessName.
-	// AnalyzeProcessActivity resolves names from /proc; those not found become "unknown".
-	// With 8 distinct PIDs > TopProcessesLimit(5), the break is triggered.
 	var evts []*events.Event
 	for pid := uint32(999990); pid <= 999997; pid++ {
 		evts = append(evts, &events.Event{
 			Type: events.EventDNS,
 			PID:  pid,
-			// ProcessName intentionally empty to force /proc lookup (likely fails → "unknown")
 		})
 	}
 	d := &mockDiagnostician{
@@ -925,7 +916,7 @@ func TestGenerateApplicationTracing_ManyPIDs(t *testing.T) {
 	}
 	duration := time.Second
 	result := GenerateApplicationTracing(d, duration)
-	_ = result // verify no panic; break in loop is now covered
+	_ = result
 }
 
 // ─── GenerateIssuesSection: with detected issues ──────────────────────────────
@@ -953,12 +944,11 @@ func TestGenerateIssuesSection_WithHighErrorRate(t *testing.T) {
 }
 
 func TestGenerateIssuesSection_WithHighRTTSpike(t *testing.T) {
-	// TCP events with very high latency → spike rate > threshold.
 	var evts []*events.Event
 	for i := 0; i < 10; i++ {
 		evts = append(evts, &events.Event{
 			Type:      events.EventTCPSend,
-			LatencyNS: 1_000_000_000, // 1 second latency >> threshold
+			LatencyNS: 1_000_000_000,
 		})
 	}
 	d := &mockDiagnostician{
@@ -975,15 +965,13 @@ func TestGenerateIssuesSection_WithHighRTTSpike(t *testing.T) {
 }
 
 func TestGenerateIssuesSection_WithCriticalIssue(t *testing.T) {
-	// Simulate what happens when issues contain "CRITICAL" keyword.
-	// Create lots of connect errors with 0% threshold.
 	var evts []*events.Event
 	for i := 0; i < 10; i++ {
 		evts = append(evts, &events.Event{Type: events.EventConnect, Error: 1})
 	}
 	d := &mockDiagnostician{
 		events:             evts,
-		errorRateThreshold: 0.0, // 0% threshold → everything is an issue
+		errorRateThreshold: 0.0,
 		rttSpikeThreshold:  0.0,
 	}
 	result := GenerateIssuesSection(d)
@@ -994,9 +982,7 @@ func TestGenerateIssuesSection_WithCriticalIssue(t *testing.T) {
 
 func TestGenerateApplicationTracing_WithBursts(t *testing.T) {
 	startTime := time.Now().Add(-10 * time.Second)
-	// Create a burst: 20 events in the first second, 2 in the rest.
 	var evts []*events.Event
-	// 20 events in first 0.5s window
 	for i := 0; i < 20; i++ {
 		ts := uint64(startTime.Add(500*time.Millisecond).UnixNano()) + uint64(i*1000)
 		evts = append(evts, &events.Event{
@@ -1004,9 +990,8 @@ func TestGenerateApplicationTracing_WithBursts(t *testing.T) {
 			Timestamp: ts,
 		})
 	}
-	// 2 events spread over remaining 9 seconds
 	for i := 1; i <= 2; i++ {
-		ts := uint64(startTime.Add(time.Duration(i)*3*time.Second).UnixNano())
+		ts := uint64(startTime.Add(time.Duration(i) * 3 * time.Second).UnixNano())
 		evts = append(evts, &events.Event{
 			Type:      events.EventDNS,
 			Timestamp: ts,
@@ -1031,7 +1016,7 @@ func TestDeterminePoolHealthFromSummary_ModerateExhaustion(t *testing.T) {
 	s := tracker.PoolSummary{
 		ExhaustedCount: 6,
 		AcquireCount:   100,
-		ReuseRate:      0.9,
+		ReleaseRatio:   0.9,
 	}
 	got := determinePoolHealthFromSummary(s)
 	if !strings.Contains(got, "Moderate") {
@@ -1040,10 +1025,9 @@ func TestDeterminePoolHealthFromSummary_ModerateExhaustion(t *testing.T) {
 }
 
 func TestDeterminePoolHealthFromSummary_HighWaitTime(t *testing.T) {
-	// No exhaustion, good reuse, but very high wait time → "WARNING - High wait times"
 	s := tracker.PoolSummary{
 		ExhaustedCount: 0,
-		ReuseRate:      0.8,
+		ReleaseRatio:   0.8,
 		MaxWaitTime:    2 * time.Second, // > 1000ms threshold
 	}
 	got := determinePoolHealthFromSummary(s)
@@ -1061,7 +1045,6 @@ func TestGenerateSyscallSection_WithFDLeak(t *testing.T) {
 		{Type: events.EventOpen, Target: "/tmp/b.txt"},
 		{Type: events.EventOpen, Target: "/tmp/c.txt"},
 		{Type: events.EventClose},
-		// 3 opens, 1 close → diff=2 > 0 → leak message
 	}
 	d := &mockDiagnostician{
 		events:    evts,
@@ -1090,7 +1073,7 @@ func TestGenerateSyscallSection_WithOpenedFiles(t *testing.T) {
 	}
 	duration := d.endTime.Sub(d.startTime)
 	result := GenerateSyscallSection(d, duration)
-	_ = result // verify no panic; content depends on config.TopFilesLimit
+	_ = result
 }
 
 // ─── GeneratePoolSection: exhausted events path ───────────────────────────────
@@ -1145,7 +1128,6 @@ func TestGenerateIssuesSection_WarningKeyword(t *testing.T) {
 		errorRateThreshold: 0.0,
 		rttSpikeThreshold:  0.0,
 	}
-	// Call with no global alerting manager.
 	result := GenerateIssuesSection(d)
 	_ = result
 }

--- a/internal/diagnose/stacktrace/kallsyms.go
+++ b/internal/diagnose/stacktrace/kallsyms.go
@@ -6,18 +6,14 @@ import (
 	"strings"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/podtrace/podtrace/internal/logger"
 	"github.com/podtrace/podtrace/internal/procfs"
 )
 
 // kallsymsLookup loads /proc/kallsyms once and resolves kernel addresses to
-// symbol names. /proc/kallsyms is sorted by address; we keep the parsed list
-// and binary-search for the largest symbol whose address <= the target.
-//
-// On clusters where kptr_restrict hides addresses (typical default), the file
-// lists all symbols at address 0x0 and resolution returns "" — callers fall
-// back to the raw hex format. Set sysctl kernel.kptr_restrict=0 to get
-// resolution; podtrace doesn't require it.
+// symbol names.
 type kallsymsLookup struct {
 	once    sync.Once
 	syms    []ksym
@@ -54,6 +50,9 @@ func (k *kallsymsLookup) load() {
 		if addr > k.maxAddr {
 			k.maxAddr = addr
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Warn("Kernel symbol table read was truncated; some kernel stack frames may show as raw hex", zap.Error(err))
 	}
 	if !isSorted(k.syms) {
 		sortKsyms(k.syms)

--- a/internal/diagnose/stacktrace/stacktrace.go
+++ b/internal/diagnose/stacktrace/stacktrace.go
@@ -2,10 +2,12 @@ package stacktrace
 
 import (
 	"context"
+	"debug/elf"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/podtrace/podtrace/internal/config"
@@ -27,7 +29,25 @@ type stackSummary struct {
 }
 
 type stackResolver struct {
-	cache map[string]string
+	cache    map[string]string
+	segments map[string][]loadSegment
+	mappings map[string][]exeMapping
+}
+
+// loadSegment is a PT_LOAD program header: the file-offset range it covers and
+// the virtual address it loads at in the ELF's own (unbiased) address space.
+type loadSegment struct {
+	off    uint64
+	vaddr  uint64
+	filesz uint64
+}
+
+// exeMapping is one file-backed line from /proc/<pid>/maps: the runtime address
+// range and the file offset at its start.
+type exeMapping struct {
+	start uint64
+	end   uint64
+	pgoff uint64
 }
 
 func (r *stackResolver) resolve(ctx context.Context, pid uint32, addr uint64) string {
@@ -68,7 +88,11 @@ func (r *stackResolver) resolve(ctx context.Context, pid uint32, addr uint64) st
 		r.cache[key] = v
 		return v
 	}
-	cmd := exec.CommandContext(timeoutCtx, addr2lineBin, "-e", exePath, fmt.Sprintf("%#x", addr)) // #nosec G204 -- LookPath-resolved binary; exePath validated via hostfs.Stat; address is %#x-formatted
+	symAddr := addr
+	if v, ok := r.translateAddr(pid, exePath, addr); ok {
+		symAddr = v
+	}
+	cmd := exec.CommandContext(timeoutCtx, addr2lineBin, "-e", exePath, fmt.Sprintf("%#x", symAddr)) // #nosec G204 -- LookPath-resolved binary; exePath validated via hostfs.Stat; address is %#x-formatted
 	out, err := cmd.Output()
 	if err != nil {
 		v := fmt.Sprintf("%s@0x%x", filepath.Base(exePath), addr)
@@ -83,6 +107,95 @@ func (r *stackResolver) resolve(ctx context.Context, pid uint32, addr uint64) st
 	}
 	r.cache[key] = line
 	return line
+}
+
+// translateAddr converts a runtime instruction pointer into the ELF virtual
+// address addr2line expects.
+func (r *stackResolver) translateAddr(pid uint32, exePath string, addr uint64) (uint64, bool) {
+	mappings := r.exeMappings(pid, exePath)
+	var fileOffset uint64
+	found := false
+	for _, m := range mappings {
+		if addr >= m.start && addr < m.end {
+			fileOffset = addr - m.start + m.pgoff
+			found = true
+			break
+		}
+	}
+	if !found {
+		return 0, false
+	}
+
+	for _, s := range r.loadSegments(exePath) {
+		if fileOffset >= s.off && fileOffset < s.off+s.filesz {
+			return fileOffset - s.off + s.vaddr, true
+		}
+	}
+	return 0, false
+}
+
+// exeMappings returns the file-backed mappings of exePath in process pid,
+// parsed from /proc/<pid>/maps and cached per (pid, exePath).
+func (r *stackResolver) exeMappings(pid uint32, exePath string) []exeMapping {
+	if r.mappings == nil {
+		r.mappings = make(map[string][]exeMapping)
+	}
+	key := fmt.Sprintf("%d|%s", pid, exePath)
+	if m, ok := r.mappings[key]; ok {
+		return m
+	}
+
+	var out []exeMapping
+	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 6 {
+				continue
+			}
+			if strings.Join(fields[5:], " ") != exePath {
+				continue
+			}
+			dash := strings.IndexByte(fields[0], '-')
+			if dash < 0 {
+				continue
+			}
+			start, err1 := strconv.ParseUint(fields[0][:dash], 16, 64)
+			end, err2 := strconv.ParseUint(fields[0][dash+1:], 16, 64)
+			pgoff, err3 := strconv.ParseUint(fields[2], 16, 64)
+			if err1 != nil || err2 != nil || err3 != nil {
+				continue
+			}
+			out = append(out, exeMapping{start: start, end: end, pgoff: pgoff})
+		}
+	}
+	r.mappings[key] = out
+	return out
+}
+
+// loadSegments returns exePath's PT_LOAD program headers, parsing the ELF once
+// and caching the result.
+func (r *stackResolver) loadSegments(exePath string) []loadSegment {
+	if r.segments == nil {
+		r.segments = make(map[string][]loadSegment)
+	}
+	if s, ok := r.segments[exePath]; ok {
+		return s
+	}
+
+	var out []loadSegment
+	if f, err := hostfs.Open(exePath); err == nil {
+		if ef, eerr := elf.NewFile(f); eerr == nil {
+			for _, p := range ef.Progs {
+				if p.Type == elf.PT_LOAD {
+					out = append(out, loadSegment{off: p.Off, vaddr: p.Vaddr, filesz: p.Filesz})
+				}
+			}
+		}
+		_ = f.Close()
+	}
+	r.segments[exePath] = out
+	return out
 }
 
 func GenerateStackTraceSectionWithContext(d Diagnostician, ctx context.Context) string {

--- a/internal/diagnose/stacktrace/stacktrace_pie_test.go
+++ b/internal/diagnose/stacktrace/stacktrace_pie_test.go
@@ -1,0 +1,115 @@
+package stacktrace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/procfs"
+)
+
+func TestTranslateAddr_StripsPIELoadBase(t *testing.T) {
+	tests := []struct {
+		name    string
+		seg     loadSegment
+		mapping exeMapping
+		addr    uint64
+		want    uint64
+	}{
+		{
+			name:    "pie",
+			seg:     loadSegment{off: 0x1000, vaddr: 0x1000, filesz: 0x4000},
+			mapping: exeMapping{start: 0x555555555000, end: 0x555555559000, pgoff: 0x1000},
+			addr:    0x555555555234,
+			want:    0x1234,
+		},
+		{
+			name:    "fixed-load",
+			seg:     loadSegment{off: 0x1000, vaddr: 0x401000, filesz: 0x1000},
+			mapping: exeMapping{start: 0x401000, end: 0x402000, pgoff: 0x1000},
+			addr:    0x401234,
+			want:    0x401234,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &stackResolver{
+				segments: map[string][]loadSegment{"/bin/app": {tc.seg}},
+				mappings: map[string][]exeMapping{"7|/bin/app": {tc.mapping}},
+			}
+			got, ok := r.translateAddr(7, "/bin/app", tc.addr)
+			if !ok {
+				t.Fatalf("translateAddr(%#x) failed, want %#x", tc.addr, tc.want)
+			}
+			if got != tc.want {
+				t.Fatalf("translateAddr(%#x) = %#x, want %#x", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateAddr_MissReturnsFalse(t *testing.T) {
+	r := &stackResolver{
+		segments: map[string][]loadSegment{"/bin/app": {{off: 0x1000, vaddr: 0x1000, filesz: 0x1000}}},
+		mappings: map[string][]exeMapping{"7|/bin/app": {{start: 0x555555555000, end: 0x555555556000, pgoff: 0x1000}}},
+	}
+	if _, ok := r.translateAddr(7, "/bin/app", 0xdeadbeef); ok {
+		t.Fatal("translateAddr for an unmapped address must return ok=false")
+	}
+}
+
+func TestExeMappings_ParsesProcMaps(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "42"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	maps := "" +
+		"555555554000-555555555000 r--p 00000000 08:01 100 /bin/app\n" +
+		"555555555000-555555559000 r-xp 00001000 08:01 100 /bin/app\n" +
+		"7ffff7d00000-7ffff7d22000 r-xp 00000000 08:01 200 /lib/libc.so.6\n" +
+		"7ffffffde000-7ffffffff000 rw-p 00000000 00:00 0 [stack]\n"
+	if err := os.WriteFile(filepath.Join(base, "42", "maps"), []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	original := config.ProcBasePath
+	config.ProcBasePath = base
+	procfs.ResetForTesting()
+	defer func() {
+		config.ProcBasePath = original
+		procfs.ResetForTesting()
+	}()
+
+	r := &stackResolver{}
+	got := r.exeMappings(42, "/bin/app")
+	if len(got) != 2 {
+		t.Fatalf("got %d mappings for /bin/app, want 2: %+v", len(got), got)
+	}
+	exec := got[1]
+	if exec.start != 0x555555555000 || exec.end != 0x555555559000 || exec.pgoff != 0x1000 {
+		t.Fatalf("exec mapping = %+v, want start=0x555555555000 end=0x555555559000 pgoff=0x1000", exec)
+	}
+}
+
+func TestLoadSegments_RealELF(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot resolve test executable: %v", err)
+	}
+	r := &stackResolver{}
+	segs := r.loadSegments(exe)
+	if len(segs) == 0 {
+		t.Fatalf("no PT_LOAD segments parsed from %s", exe)
+	}
+	nonEmpty := false
+	for _, s := range segs {
+		if s.filesz > 0 {
+			nonEmpty = true
+		}
+	}
+	if !nonEmpty {
+		t.Fatal("every PT_LOAD segment reported filesz=0")
+	}
+}

--- a/internal/diagnose/tracker/pool.go
+++ b/internal/diagnose/tracker/pool.go
@@ -91,9 +91,9 @@ func (pt *PoolTracker) GetPoolSummary() []PoolSummary {
 
 	var summaries []PoolSummary
 	for _, pool := range pt.pools {
-		reuseRate := 0.0
+		releaseRatio := 0.0
 		if pool.AcquireCount > 0 {
-			reuseRate = float64(pool.ReleaseCount) / float64(pool.AcquireCount)
+			releaseRatio = float64(pool.ReleaseCount) / float64(pool.AcquireCount)
 		}
 
 		avgWaitTime := time.Duration(0)
@@ -108,7 +108,7 @@ func (pt *PoolTracker) GetPoolSummary() []PoolSummary {
 			AcquireCount:   pool.AcquireCount,
 			ReleaseCount:   pool.ReleaseCount,
 			ExhaustedCount: pool.ExhaustedCount,
-			ReuseRate:      reuseRate,
+			ReleaseRatio:   releaseRatio,
 			AvgWaitTime:    avgWaitTime,
 			MaxWaitTime:    pool.MaxWaitTime,
 			LastAcquire:    pool.LastAcquire,
@@ -131,7 +131,7 @@ type PoolSummary struct {
 	AcquireCount   int
 	ReleaseCount   int
 	ExhaustedCount int
-	ReuseRate      float64
+	ReleaseRatio   float64
 	AvgWaitTime    time.Duration
 	MaxWaitTime    time.Duration
 	LastAcquire    time.Time
@@ -177,7 +177,7 @@ func GeneratePoolCorrelation(events []*events.Event) string {
 		}
 		report += fmt.Sprintf("    - %s:\n", summary.PoolID)
 		report += fmt.Sprintf("        Acquires: %d, Releases: %d\n", summary.AcquireCount, summary.ReleaseCount)
-		report += fmt.Sprintf("        Reuse rate: %.2f%%\n", summary.ReuseRate*100)
+		report += fmt.Sprintf("        Release ratio: %.2f%% (releases/acquires)\n", summary.ReleaseRatio*100)
 		report += fmt.Sprintf("        Current connections: %d (peak: %d)\n", summary.CurrentConns, summary.MaxConns)
 
 		healthStatus := determinePoolHealthFromSummary(summary)
@@ -198,6 +198,9 @@ func GeneratePoolCorrelation(events []*events.Event) string {
 
 func determinePoolHealthFromSummary(summary PoolSummary) string {
 	if summary.ExhaustedCount > 0 {
+		if summary.AcquireCount == 0 {
+			return "CRITICAL - Pool exhausted with no successful acquisitions"
+		}
 		exhaustionRate := float64(summary.ExhaustedCount) / float64(summary.AcquireCount)
 		if exhaustionRate > 0.1 {
 			return "CRITICAL - High pool exhaustion rate (>10%)"
@@ -206,8 +209,8 @@ func determinePoolHealthFromSummary(summary PoolSummary) string {
 		}
 	}
 
-	if summary.ReuseRate < 0.5 {
-		return "WARNING - Low connection reuse rate (<50%)"
+	if summary.ReleaseRatio < 0.5 {
+		return "WARNING - Under half of acquired connections released (<50%, possible leak)"
 	}
 
 	if summary.MaxWaitTime > 1000*time.Millisecond {

--- a/internal/diagnose/tracker/pool_test.go
+++ b/internal/diagnose/tracker/pool_test.go
@@ -80,8 +80,8 @@ func TestPoolTracker_ProcessEvent_Release(t *testing.T) {
 	if summary.CurrentConns != 0 {
 		t.Errorf("CurrentConns = %d, want 0", summary.CurrentConns)
 	}
-	if summary.ReuseRate != 1.0 {
-		t.Errorf("ReuseRate = %f, want 1.0", summary.ReuseRate)
+	if summary.ReleaseRatio != 1.0 {
+		t.Errorf("ReleaseRatio = %f, want 1.0", summary.ReleaseRatio)
 	}
 }
 
@@ -318,7 +318,7 @@ func TestDeterminePoolHealthFromSummary(t *testing.T) {
 				AcquireCount:   100,
 				ReleaseCount:   100,
 				ExhaustedCount: 0,
-				ReuseRate:      1.0,
+				ReleaseRatio:   1.0,
 				MaxWaitTime:    100 * time.Millisecond,
 			},
 			want: "OK - Pool operating normally",
@@ -329,7 +329,7 @@ func TestDeterminePoolHealthFromSummary(t *testing.T) {
 				AcquireCount:   100,
 				ReleaseCount:   90,
 				ExhaustedCount: 15,
-				ReuseRate:      0.9,
+				ReleaseRatio:   0.9,
 			},
 			want: "CRITICAL - High pool exhaustion rate (>10%)",
 		},
@@ -339,7 +339,7 @@ func TestDeterminePoolHealthFromSummary(t *testing.T) {
 				AcquireCount:   100,
 				ReleaseCount:   95,
 				ExhaustedCount: 6,
-				ReuseRate:      0.95,
+				ReleaseRatio:   0.95,
 			},
 			want: "WARNING - Moderate pool exhaustion rate (>5%)",
 		},
@@ -349,9 +349,9 @@ func TestDeterminePoolHealthFromSummary(t *testing.T) {
 				AcquireCount:   100,
 				ReleaseCount:   40,
 				ExhaustedCount: 0,
-				ReuseRate:      0.4,
+				ReleaseRatio:   0.4,
 			},
-			want: "WARNING - Low connection reuse rate (<50%)",
+			want: "WARNING - Under half of acquired connections released (<50%, possible leak)",
 		},
 		{
 			name: "high wait times",
@@ -359,7 +359,7 @@ func TestDeterminePoolHealthFromSummary(t *testing.T) {
 				AcquireCount:   100,
 				ReleaseCount:   100,
 				ExhaustedCount: 0,
-				ReuseRate:      1.0,
+				ReleaseRatio:   1.0,
 				MaxWaitTime:    2000 * time.Millisecond,
 			},
 			want: "WARNING - High wait times detected",

--- a/internal/diagnose/tracker/trace_tracker.go
+++ b/internal/diagnose/tracker/trace_tracker.go
@@ -211,9 +211,8 @@ func (tt *TraceTracker) GetAllTraces() []*Trace {
 	return traces
 }
 
-// SnapshotForExport returns deep copies of traces carrying only the spans
-// that have not been handed to an exporter yet, and advances each trace's
-// watermark.
+// SnapshotForExport returns deep copies of traces carrying only the spans that
+// have not been handed to an exporter yet.
 func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool) []*Trace {
 	tt.mu.RLock()
 	live := make([]*Trace, 0, len(tt.traces))
@@ -235,15 +234,33 @@ func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool) []*T
 			continue
 		}
 		snapshot := cloneTraceLocked(trace, trace.exportedSpans)
-		trace.exportedSpans = len(trace.Spans)
 		trace.mu.Unlock()
 		out = append(out, snapshot)
 	}
 	return out
 }
 
+// CommitExport advances each trace's export watermark by the number of spans
+// that were successfully exported in the matching snapshot.
+func (tt *TraceTracker) CommitExport(exported []*Trace) {
+	tt.mu.RLock()
+	defer tt.mu.RUnlock()
+	for _, snap := range exported {
+		live := tt.traces[snap.TraceID]
+		if live == nil {
+			continue
+		}
+		live.mu.Lock()
+		live.exportedSpans += len(snap.Spans)
+		if live.exportedSpans > len(live.Spans) {
+			live.exportedSpans = len(live.Spans)
+		}
+		live.mu.Unlock()
+	}
+}
+
 // SnapshotAll returns deep copies of every trace (all spans) without touching
-// export watermarks — for read-only consumers like the request-flow graph.
+// export watermarks, for read-only consumers like the request-flow graph.
 func (tt *TraceTracker) SnapshotAll() []*Trace {
 	tt.mu.RLock()
 	live := make([]*Trace, 0, len(tt.traces))
@@ -262,8 +279,7 @@ func (tt *TraceTracker) SnapshotAll() []*Trace {
 }
 
 // cloneTraceLocked deep-copies a trace, including only spans from index
-// fromSpan on. Caller must hold trace.mu. Event pointers are shared — events
-// are not mutated after ProcessEvent — but every slice and map is copied.
+// fromSpan on.
 func cloneTraceLocked(trace *Trace, fromSpan int) *Trace {
 	out := &Trace{
 		TraceID:   trace.TraceID,

--- a/internal/diagnose/tracker/trace_tracker_snapshot_test.go
+++ b/internal/diagnose/tracker/trace_tracker_snapshot_test.go
@@ -29,14 +29,23 @@ func TestSnapshotForExport_ExactlyOnce(t *testing.T) {
 		t.Fatalf("first snapshot = %d traces, want 1 trace with 1 span", len(first))
 	}
 
+	if again := tt.SnapshotForExport(time.Hour, true); len(again) != 1 {
+		t.Fatalf("uncommitted snapshot must re-appear, got %d traces", len(again))
+	}
+
+	tt.CommitExport(first)
 	if second := tt.SnapshotForExport(time.Hour, true); len(second) != 0 {
-		t.Fatalf("second snapshot = %d traces, want 0 (spans must export exactly once)", len(second))
+		t.Fatalf("second snapshot = %d traces, want 0 (spans export exactly once after commit)", len(second))
 	}
 
 	tt.ProcessEvent(snapshotEvent("t1", "s2"), nil)
 	third := tt.SnapshotForExport(time.Hour, true)
 	if len(third) != 1 || len(third[0].Spans) != 1 || third[0].Spans[0].SpanID != "s2" {
 		t.Fatalf("third snapshot must carry only the new span s2, got %+v", third)
+	}
+	tt.CommitExport(third)
+	if fourth := tt.SnapshotForExport(time.Hour, true); len(fourth) != 0 {
+		t.Fatalf("fourth snapshot = %d traces, want 0", len(fourth))
 	}
 }
 
@@ -55,7 +64,7 @@ func TestSnapshotForExport_SettleWindow(t *testing.T) {
 }
 
 // TestSnapshotAll_DeepCopyAndNoWatermark: graph/report consumers get deep
-// copies (mutating them must not touch live state — exporters used to sort
+// copies (mutating them must not touch live state, exporters used to sort
 // and mutate live spans, racing ProcessEvent) and do not consume the export
 // watermark.
 func TestSnapshotAll_DeepCopyAndNoWatermark(t *testing.T) {

--- a/internal/hostfs/hostfs.go
+++ b/internal/hostfs/hostfs.go
@@ -35,6 +35,7 @@ package hostfs
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -44,6 +45,10 @@ import (
 // ErrInvalidPath is returned when the supplied path is not absolute or
 // contains a ".." element.
 var ErrInvalidPath = errors.New("hostfs: path must be absolute and contain no '..' elements")
+
+// ErrUnsafeMode is returned by the write helpers when the requested mode
+// grants write permission to group or other.
+var ErrUnsafeMode = errors.New("hostfs: refusing to write with a group/other-writable mode")
 
 func validate(path string) error {
 	if !filepath.IsAbs(path) {
@@ -88,6 +93,13 @@ func WalkRegular(root string, fn func(path string, info os.FileInfo) error) erro
 	})
 }
 
+func Open(path string) (*os.File, error) {
+	if err := validate(path); err != nil {
+		return nil, err
+	}
+	return os.Open(path) // #nosec G304 -- intentional cross-namespace open; validated absolute path with no ".." segments.
+}
+
 // ReadFile reads a file the operator has explicitly designated via a
 // CLI flag or environment variable.
 func ReadFile(path string) ([]byte, error) {
@@ -103,7 +115,10 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := validate(path); err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, perm) // #nosec G304,G306 -- operator-supplied path validated; perm is caller-controlled and reviewed at the call site.
+	if perm&0o022 != 0 {
+		return fmt.Errorf("%w: %#o (%s)", ErrUnsafeMode, perm, path)
+	}
+	return os.WriteFile(path, data, perm) // #nosec G304,G306 -- path validated absolute/no-"..", mode asserted non-group/other-writable above; 0644 read is intended for sidecar/kubelet handoffs.
 }
 
 // WriteFileAtomic writes data via a temp file + rename so a concurrent reader

--- a/internal/hostfs/hostfs_test.go
+++ b/internal/hostfs/hostfs_test.go
@@ -159,6 +159,35 @@ func TestWriteFile_RejectsTraversal(t *testing.T) {
 	}
 }
 
+// TestWriteFile_ModeGuard locks the invariant behind the G306 suppression:
+// group/other read is allowed (0644 handoffs) but group/other write is
+// rejected, regardless of call site.
+func TestWriteFile_ModeGuard(t *testing.T) {
+	dir := t.TempDir()
+
+	allowed := []os.FileMode{0o600, 0o640, 0o644}
+	for _, perm := range allowed {
+		if err := WriteFile(filepath.Join(dir, "ok"), []byte("x"), perm); err != nil {
+			t.Errorf("WriteFile with safe mode %#o rejected: %v", perm, err)
+		}
+	}
+
+	rejected := []os.FileMode{0o666, 0o622, 0o777, 0o602}
+	for _, perm := range rejected {
+		err := WriteFile(filepath.Join(dir, "bad"), []byte("x"), perm)
+		if !errors.Is(err, ErrUnsafeMode) {
+			t.Errorf("WriteFile with group/other-writable mode %#o: got %v, want ErrUnsafeMode", perm, err)
+		}
+	}
+
+	if err := WriteFileAtomic(filepath.Join(dir, "atomic"), []byte("x"), 0o666); !errors.Is(err, ErrUnsafeMode) {
+		t.Errorf("WriteFileAtomic with 0666: got %v, want ErrUnsafeMode", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "atomic.tmp")); !os.IsNotExist(err) {
+		t.Errorf("rejected atomic write left a .tmp residue")
+	}
+}
+
 // TestWriteFileAtomic verifies the temp+rename write: the final file has the
 // complete content, the correct perm, and no ".tmp" residue is left behind
 // (the sidecar polls the final path and must never observe a partial file).

--- a/internal/profiling/handler.go
+++ b/internal/profiling/handler.go
@@ -51,9 +51,7 @@ func NewHandler(podIP string, ports []int) *Handler {
 
 // Run consumes eventChan, watching for latency spikes that auto-trigger a
 // heap + goroutine profile fetch. It also services on-demand trigger requests.
-// Run is intended to be called in a goroutine; it exits when ctx is cancelled.
 func (h *Handler) Run(ctx context.Context, eventChan <-chan *events.Event) {
-	// Try to discover the pprof endpoint once at startup (non-blocking for caller).
 	discoverCtx, discoverCancel := context.WithTimeout(ctx, 3*time.Second)
 	h.profiler.Discover(discoverCtx)
 	discoverCancel()
@@ -136,33 +134,41 @@ func (h *Handler) doProfile(ctx context.Context, ptype ProfileType, duration tim
 		// CPU profiles don't feed into CorrelatedResult directly — the binary is
 		// stored in cpu.RawBytes for potential file export. Update metadata only.
 		h.mu.Lock()
-		if h.result == nil {
-			h.result = &CorrelatedResult{PageFaultCounts: map[uint32]int{}, PodIP: h.podIP}
-		}
-		h.result.PprofAvailable = cpu.Available
+		next := h.resultCopyLocked()
+		next.PprofAvailable = cpu.Available
+		h.result = next
 		h.mu.Unlock()
 		return
 	}
 
-	// Merge new profile data into the stored result.
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.result == nil {
-		h.result = &CorrelatedResult{PageFaultCounts: map[uint32]int{}, PodIP: h.podIP}
-	}
+	next := h.resultCopyLocked()
 	if heap != nil {
-		h.result.HeapProfile = heap
+		next.HeapProfile = heap
 		if heap.Available {
-			h.result.PprofAvailable = true
+			next.PprofAvailable = true
 		}
 	}
 	if goroutine != nil {
-		h.result.GoroutineProfile = goroutine
+		next.GoroutineProfile = goroutine
 		if goroutine.Available {
-			h.result.PprofAvailable = true
+			next.PprofAvailable = true
 		}
 	}
-	h.result.PodIP = h.podIP
+	next.PodIP = h.podIP
+	h.result = next
+}
+
+// resultCopyLocked returns a shallow copy of the current result (or a fresh
+// one) so the caller can mutate and republish it without touching the struct
+// readers may still be dereferencing. Caller holds h.mu.
+func (h *Handler) resultCopyLocked() *CorrelatedResult {
+	if h.result == nil {
+		return &CorrelatedResult{PageFaultCounts: map[uint32]int{}, PodIP: h.podIP}
+	}
+	cp := *h.result
+	return &cp
 }
 
 // TriggerNow enqueues an on-demand profile request (non-blocking; drops if full).

--- a/internal/tracing/context/context.go
+++ b/internal/tracing/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -70,6 +71,46 @@ func generateSpanID() string {
 	return hex.EncodeToString(b)
 }
 
+// NewTraceContextFromSeed derives a TraceContext whose TraceID is a stable
+// function of seed.
+func NewTraceContextFromSeed(seed string) *TraceContext {
+	sum := sha256.Sum256([]byte(seed))
+	return &TraceContext{
+		TraceID: hex.EncodeToString(sum[:16]),
+		SpanID:  generateSpanID(),
+		Flags:   0x01,
+	}
+}
+
+// isLowerHex reports whether s is non-empty and composed solely of lowercase
+// hexadecimal digits, as the W3C trace-context spec requires for trace-id,
+// parent-id and trace-flags.
+func isLowerHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isDigit := c >= '0' && c <= '9'
+		isHexLower := c >= 'a' && c <= 'f'
+		if !isDigit && !isHexLower {
+			return false
+		}
+	}
+	return true
+}
+
+// isAllZeroHex reports whether s consists entirely of '0'. The all-zero
+// trace-id and parent-id are explicitly invalid per the W3C spec.
+func isAllZeroHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '0' {
+			return false
+		}
+	}
+	return true
+}
+
 func ParseW3CTraceParent(traceParent string) (*TraceContext, error) {
 	if traceParent == "" {
 		return nil, fmt.Errorf("empty traceparent")
@@ -88,14 +129,20 @@ func ParseW3CTraceParent(traceParent string) (*TraceContext, error) {
 	parentID := parts[2]
 	flags := parts[3]
 
-	if len(traceID) != 32 {
-		return nil, fmt.Errorf("invalid trace ID length: %d", len(traceID))
+	if len(traceID) != 32 || !isLowerHex(traceID) {
+		return nil, fmt.Errorf("invalid trace ID: %q", traceID)
 	}
-	if len(parentID) != 16 {
-		return nil, fmt.Errorf("invalid parent ID length: %d", len(parentID))
+	if isAllZeroHex(traceID) {
+		return nil, fmt.Errorf("trace ID must not be all zero")
 	}
-	if len(flags) != 2 {
-		return nil, fmt.Errorf("invalid flags length: %d", len(flags))
+	if len(parentID) != 16 || !isLowerHex(parentID) {
+		return nil, fmt.Errorf("invalid parent ID: %q", parentID)
+	}
+	if isAllZeroHex(parentID) {
+		return nil, fmt.Errorf("parent ID must not be all zero")
+	}
+	if len(flags) != 2 || !isLowerHex(flags) {
+		return nil, fmt.Errorf("invalid flags: %q", flags)
 	}
 
 	var flagsByte uint8

--- a/internal/tracing/context/context_w3c_test.go
+++ b/internal/tracing/context/context_w3c_test.go
@@ -1,0 +1,56 @@
+package context
+
+import "testing"
+
+func TestParseW3CTraceParent_Rejects(t *testing.T) {
+	cases := []struct {
+		name        string
+		traceParent string
+	}{
+		{"non-hex trace id", "00-zzf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+		{"uppercase trace id", "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"},
+		{"non-hex parent id", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902zz-01"},
+		{"all-zero trace id", "00-00000000000000000000000000000000-00f067aa0ba902b7-01"},
+		{"all-zero parent id", "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01"},
+		{"reserved version ff", "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := ParseW3CTraceParent(tc.traceParent); err == nil {
+				t.Fatalf("ParseW3CTraceParent(%q) = %+v, want error", tc.traceParent, got)
+			}
+		})
+	}
+}
+
+func TestParseW3CTraceParent_AcceptsValid(t *testing.T) {
+	tc, err := ParseW3CTraceParent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	if err != nil {
+		t.Fatalf("valid traceparent rejected: %v", err)
+	}
+	if tc.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" || tc.ParentSpanID != "00f067aa0ba902b7" || tc.Flags != 0x01 {
+		t.Fatalf("parsed context = %+v, unexpected fields", tc)
+	}
+}
+
+func TestNewTraceContextFromSeed_Deterministic(t *testing.T) {
+	a := NewTraceContextFromSeed("req-123")
+	b := NewTraceContextFromSeed("req-123")
+	c := NewTraceContextFromSeed("req-999")
+
+	if a.TraceID != b.TraceID {
+		t.Fatalf("same seed produced different trace IDs: %s vs %s", a.TraceID, b.TraceID)
+	}
+	if a.TraceID == c.TraceID {
+		t.Fatalf("distinct seeds collided on trace ID %s", a.TraceID)
+	}
+	if len(a.TraceID) != 32 || !isLowerHex(a.TraceID) {
+		t.Fatalf("derived trace ID %q is not a 32-char lowercase hex string", a.TraceID)
+	}
+	if a.SpanID == b.SpanID {
+		t.Fatalf("span IDs must be unique per event, got %s twice", a.SpanID)
+	}
+	if !a.IsValid() {
+		t.Fatal("derived context must be valid")
+	}
+}

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -171,7 +171,7 @@ func hexToUint64(s string) uint64 {
 func spanType(span *tracker.Span) string {
 	for _, event := range span.Events {
 		switch event.TypeString() {
-		case "HTTP":
+		case "HTTP", "HTTPS", "HTTP/2", "HTTP/3":
 			return "web"
 		case "DB":
 			return "db"

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -161,7 +161,7 @@ func (e *ZipkinExporter) Shutdown(ctx context.Context) error {
 func zipkinKind(span *tracker.Span) string {
 	for _, event := range span.Events {
 		switch event.TypeString() {
-		case "HTTP", "DB", "CACHE", "gRPC":
+		case "HTTP", "HTTPS", "HTTP/2", "HTTP/3", "DB", "CACHE", "gRPC":
 			return "CLIENT"
 		}
 	}

--- a/internal/tracing/extractor/http.go
+++ b/internal/tracing/extractor/http.go
@@ -72,7 +72,7 @@ func (e *HTTPExtractor) ExtractFromHeaders(headers map[string]string) *context.T
 
 	if e.extractSplunk {
 		if requestID, ok := normalized["x-splunk-requestid"]; ok {
-			tc := context.NewTraceContext()
+			tc := context.NewTraceContextFromSeed(requestID)
 			tc.State = requestID
 			return tc
 		}

--- a/internal/tracing/extractor/http_splunk_test.go
+++ b/internal/tracing/extractor/http_splunk_test.go
@@ -1,0 +1,27 @@
+package extractor
+
+import "testing"
+
+func TestExtractSplunk_SameRequestIDCorrelates(t *testing.T) {
+	e := NewHTTPExtractor()
+
+	a := e.ExtractFromHeaders(map[string]string{"x-splunk-requestid": "req-abc"})
+	b := e.ExtractFromHeaders(map[string]string{"x-splunk-requestid": "req-abc"})
+	c := e.ExtractFromHeaders(map[string]string{"x-splunk-requestid": "req-xyz"})
+
+	if a == nil || b == nil || c == nil {
+		t.Fatal("expected a trace context for each x-splunk-requestid header")
+	}
+	if a.TraceID != b.TraceID {
+		t.Fatalf("same request id produced different traces: %s vs %s", a.TraceID, b.TraceID)
+	}
+	if a.TraceID == c.TraceID {
+		t.Fatalf("different request ids collided on trace %s", a.TraceID)
+	}
+	if a.SpanID == b.SpanID {
+		t.Fatal("each event must still get a unique span id")
+	}
+	if a.State != "req-abc" {
+		t.Fatalf("request id must be preserved in State, got %q", a.State)
+	}
+}

--- a/internal/tracing/manager.go
+++ b/internal/tracing/manager.go
@@ -277,11 +277,13 @@ func (m *Manager) exportTraces(force bool) {
 		return
 	}
 
+	allSucceeded := true
 	for _, target := range m.exporterTargets() {
 		err := target.export(traces)
 		if err == nil {
 			continue
 		}
+		allSucceeded = false
 		logger.Warn("Failed to export traces", zap.String("exporter", target.name), zap.Error(err))
 		if target.suppressAlert {
 			continue
@@ -304,6 +306,12 @@ func (m *Manager) exportTraces(force bool) {
 			Recommendations: target.recommendations,
 		})
 	}
+
+	// Advance the per-trace watermark only when every exporter accepted the
+	// spans.
+	if allSucceeded {
+		m.traceTracker.CommitExport(traces)
+	}
 }
 
 func (m *Manager) GetRequestFlowGraph() *graph.RequestFlowGraph {
@@ -311,8 +319,6 @@ func (m *Manager) GetRequestFlowGraph() *graph.RequestFlowGraph {
 		return nil
 	}
 
-	// Deep-copied snapshot: the graph builder sorts spans in place, which
-	// raced ProcessEvent on the live objects.
 	traces := m.traceTracker.SnapshotAll()
 	return m.graphBuilder.BuildFromTraces(traces)
 }

--- a/pkg/exporter/bundle/bundle.go
+++ b/pkg/exporter/bundle/bundle.go
@@ -190,6 +190,9 @@ func FromConfigMapData(data map[string]string) (*Payload, error) {
 			p.TargetNamespaces = strings.Split(raw, ",")
 		}
 	}
+	if err := validatePayload(p); err != nil {
+		return nil, err
+	}
 	return p, nil
 }
 
@@ -370,20 +373,43 @@ func PolicyHash(p *Payload) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// validatePayload enforces the semantic constraints every Payload wire format
+// shares
+func validatePayload(p *Payload) error {
+	if p.Version != "" && p.Version != CurrentVersion {
+		return fmt.Errorf("bundle: unsupported version %q (this build understands %q)", p.Version, CurrentVersion)
+	}
+	if p.Type == "" {
+		return fmt.Errorf("bundle: missing required field 'type'")
+	}
+	if p.Sample != nil && (*p.Sample < 0 || *p.Sample > 1) {
+		return fmt.Errorf("bundle: sample %v out of range 0-1", *p.Sample)
+	}
+	if p.Thresholds != nil {
+		for _, spec := range thresholdFields() {
+			v := spec.get(p.Thresholds)
+			if v == nil {
+				continue
+			}
+			if *v < 0 {
+				return fmt.Errorf("bundle: %s %d must be non-negative", spec.key, *v)
+			}
+			if spec.max > 0 && int(*v) > spec.max {
+				return fmt.Errorf("bundle: %s %d out of range 0-%d", spec.key, *v, spec.max)
+			}
+		}
+	}
+	return nil
+}
+
 // FromYAML parses a Payload from its YAML serialization.
 func FromYAML(raw []byte) (*Payload, error) {
 	var p Payload
 	if err := yaml.Unmarshal(raw, &p); err != nil {
 		return nil, fmt.Errorf("bundle: parse YAML: %w", err)
 	}
-	if p.Version != "" && p.Version != CurrentVersion {
-		return nil, fmt.Errorf("bundle: unsupported version %q (this build understands %q)", p.Version, CurrentVersion)
-	}
-	if p.Type == "" {
-		return nil, fmt.Errorf("bundle: missing required field 'type'")
-	}
-	if p.Sample != nil && (*p.Sample < 0 || *p.Sample > 1) {
-		return nil, fmt.Errorf("bundle: sample %v out of range 0-1", *p.Sample)
+	if err := validatePayload(&p); err != nil {
+		return nil, err
 	}
 	return &p, nil
 }

--- a/pkg/exporter/bundle/validation_parity_test.go
+++ b/pkg/exporter/bundle/validation_parity_test.go
@@ -1,0 +1,54 @@
+package bundle
+
+import "testing"
+
+func TestValidationParity(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		data    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "valid otlp",
+			yaml:    "type: otlp\nendpoint: e\n",
+			data:    map[string]string{"type": "otlp", "endpoint": "e"},
+			wantErr: false,
+		},
+		{
+			name:    "missing type",
+			yaml:    "endpoint: e\n",
+			data:    map[string]string{"endpoint": "e"},
+			wantErr: true,
+		},
+		{
+			name:    "threshold over max",
+			yaml:    "type: otlp\nthresholds:\n  errorRatePercent: 200\n",
+			data:    map[string]string{"type": "otlp", "threshold_error_rate_percent": "200"},
+			wantErr: true,
+		},
+		{
+			name:    "negative threshold",
+			yaml:    "type: otlp\nthresholds:\n  rttSpikeMs: -5\n",
+			data:    map[string]string{"type": "otlp", "threshold_rtt_spike_ms": "-5"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, yErr := FromYAML([]byte(tc.yaml))
+			_, cErr := FromConfigMapData(tc.data)
+
+			if (yErr != nil) != tc.wantErr {
+				t.Errorf("FromYAML error = %v, wantErr %v", yErr, tc.wantErr)
+			}
+			if (cErr != nil) != tc.wantErr {
+				t.Errorf("FromConfigMapData error = %v, wantErr %v", cErr, tc.wantErr)
+			}
+			if (yErr != nil) != (cErr != nil) {
+				t.Errorf("validation drift: FromYAML err=%v but FromConfigMapData err=%v", yErr, cErr)
+			}
+		})
+	}
+}

--- a/pkg/tracer/engine.go
+++ b/pkg/tracer/engine.go
@@ -32,18 +32,24 @@ type EngineStats struct {
 	EventsDropped   int64
 	ActiveTargets   int
 	ExporterFailure int64
+	AttachFailure   int64
 	CgroupsAttached int64
 	CgroupsDetached int64
 }
 
 // Engine orchestrates a TracerBackend + Exporters over a stream of
-// TargetSet snapshots. One instance serves one trace intent end-to-end:
-// CLI invocations, agent DaemonSet processes, and session Jobs each
-// construct an Engine with mode-appropriate backend/exporters/stream.
+// TargetSet snapshots.
 type Engine interface {
 	Run(ctx context.Context, targets <-chan TargetSet) error
 
 	Stats() EngineStats
+}
+
+// cgroupState is the engine's remembered identity for an attached cgroup
+// path.
+type cgroupState struct {
+	containerID  string
+	containerPID uint32
 }
 
 type engine struct {
@@ -52,13 +58,22 @@ type engine struct {
 	cfg       Config
 
 	mu              sync.RWMutex
-	activeCgroups   map[string]struct{}
+	activeCgroups   map[string]cgroupState
 	eventsReceived  int64
 	eventsExported  int64
 	eventsDropped   int64
 	exporterFailure int64
+	attachFailure   int64
 	cgroupsAttached int64
 	cgroupsDetached int64
+}
+
+// attachError pairs a backend reconcile stage with the error it produced, so
+// the engine can report both to a TargetErrorObserver after releasing its
+// lock.
+type attachError struct {
+	stage string
+	err   error
 }
 
 // NewEngine composes a backend and a set of exporters into a runnable
@@ -83,7 +98,7 @@ func NewEngine(backend TracerBackend, exporters []Exporter, cfg Config) (Engine,
 		backend:       backend,
 		exporters:     exporters,
 		cfg:           cfg,
-		activeCgroups: make(map[string]struct{}),
+		activeCgroups: make(map[string]cgroupState),
 	}, nil
 }
 
@@ -92,7 +107,7 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 		return errors.New("tracer: targets channel is required")
 	}
 
-	dispatchCtx, cancelDispatch := context.WithCancel(ctx)
+	dispatchCtx, cancelDispatch := context.WithCancel(context.WithoutCancel(ctx))
 
 	eventCh := make(chan *events.Event, e.cfg.EventBufferSize)
 	if err := e.backend.Start(ctx, eventCh); err != nil {
@@ -123,11 +138,7 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 				shutdown()
 				return nil
 			}
-			if err := e.applyTargets(set); err != nil {
-				e.mu.Lock()
-				e.exporterFailure++
-				e.mu.Unlock()
-			}
+			_ = e.applyTargets(set)
 		}
 	}
 }
@@ -153,10 +164,15 @@ func (e *engine) applyTargets(set TargetSet) error {
 
 	e.mu.Lock()
 
-	added, removed := 0, 0
-	for path := range desired {
-		if _, ok := e.activeCgroups[path]; !ok {
+	added, removed, changed := 0, 0, 0
+	for path, t := range desired {
+		prev, ok := e.activeCgroups[path]
+		if !ok {
 			added++
+			continue
+		}
+		if prev.containerID != t.ContainerID || prev.containerPID != t.ContainerPID {
+			changed++
 		}
 	}
 	for path := range e.activeCgroups {
@@ -165,13 +181,17 @@ func (e *engine) applyTargets(set TargetSet) error {
 		}
 	}
 
-	if added == 0 && removed == 0 {
+	if added == 0 && removed == 0 && changed == 0 {
 		e.mu.Unlock()
 		return nil
 	}
 
+	var attachErrs []attachError
+
 	if err := e.backend.SetCgroups(snapshot); err != nil {
+		e.attachFailure++
 		e.mu.Unlock()
+		e.reportAttachErrors([]attachError{{stage: "set_cgroups", err: err}})
 		return err
 	}
 
@@ -189,34 +209,34 @@ func (e *engine) applyTargets(set TargetSet) error {
 			cts = append(cts, ContainerUprobeTarget{ContainerID: t.ContainerID, PID: t.ContainerPID})
 		}
 		if err := rec.SetContainerTargets(cts); err != nil {
-			e.exporterFailure++
+			e.attachFailure++
+			attachErrs = append(attachErrs, attachError{stage: "set_container_targets", err: err})
 		}
 	} else {
 		for path, t := range desired {
 			if t.ContainerID == "" {
 				continue
 			}
-			if _, alreadyActive := e.activeCgroups[path]; alreadyActive {
+			if prev, alreadyActive := e.activeCgroups[path]; alreadyActive && prev.containerID == t.ContainerID {
 				continue
 			}
 			if err := e.backend.SetContainerID(t.ContainerID); err != nil {
-				e.exporterFailure++
+				e.attachFailure++
+				attachErrs = append(attachErrs, attachError{stage: "set_container_id", err: err})
 			}
 		}
 	}
 
-	next := make(map[string]struct{}, len(desired))
-	for path := range desired {
-		next[path] = struct{}{}
+	next := make(map[string]cgroupState, len(desired))
+	for path, t := range desired {
+		next[path] = cgroupState{containerID: t.ContainerID, containerPID: t.ContainerPID}
 	}
 	e.activeCgroups = next
 	e.cgroupsAttached += int64(added)
 	e.cgroupsDetached += int64(removed)
 	e.mu.Unlock()
 
-	// Observer callbacks run OUTSIDE the engine lock: an observer calling
-	// back into Stats() (which takes a read lock) deadlocked, and a slow
-	// observer stalled every target reconcile.
+	e.reportAttachErrors(attachErrs)
 	if obs := e.cfg.Observer; obs != nil {
 		if added > 0 {
 			obs.OnCgroupsAttached(added)
@@ -226,6 +246,21 @@ func (e *engine) applyTargets(set TargetSet) error {
 		}
 	}
 	return nil
+}
+
+// reportAttachErrors forwards each attach failure to the Observer if it
+// implements TargetErrorObserver.
+func (e *engine) reportAttachErrors(errs []attachError) {
+	if len(errs) == 0 {
+		return
+	}
+	teo, ok := e.cfg.Observer.(TargetErrorObserver)
+	if !ok {
+		return
+	}
+	for _, ae := range errs {
+		teo.OnTargetError(ae.stage, ae.err)
+	}
 }
 
 func (e *engine) dispatchLoop(ctx context.Context, eventCh <-chan *events.Event) {
@@ -248,26 +283,16 @@ func (e *engine) dispatchLoop(ctx context.Context, eventCh <-chan *events.Event)
 		if delivered {
 			e.eventsExported += int64(len(batch))
 		} else {
-			// No exporter accepted the batch: these events are gone.
-			// EventsDropped used to stay permanently 0, which read as
-			// "nothing was ever lost" even when every export failed.
 			e.eventsDropped += int64(len(batch))
 		}
 		e.mu.Unlock()
 		batch = batch[:0]
 	}
 
-	// shutdownFlush gives the FINAL batch a context that survives the
-	// engine's cancellation: flushing with the already-cancelled run
-	// context made every ctx-honoring exporter drop the tail batch of
-	// every run.
 	shutdownFlush := func() {
 		flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), e.cfg.ShutdownFlushTimeout)
 		defer cancel()
 
-		// Drain events still buffered in eventCh (the backend has been
-		// stopped or the channel closed): they were captured and counted
-		// nowhere before.
 	drain:
 		for {
 			select {
@@ -327,6 +352,7 @@ func (e *engine) Stats() EngineStats {
 		EventsDropped:   e.eventsDropped,
 		ActiveTargets:   len(e.activeCgroups),
 		ExporterFailure: e.exporterFailure,
+		AttachFailure:   e.attachFailure,
 		CgroupsAttached: e.cgroupsAttached,
 		CgroupsDetached: e.cgroupsDetached,
 	}

--- a/pkg/tracer/engine_attach_error_test.go
+++ b/pkg/tracer/engine_attach_error_test.go
@@ -1,0 +1,81 @@
+package tracer_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+// targetErrObserver records OnTargetError notifications.
+type targetErrObserver struct {
+	mu     sync.Mutex
+	stages []string
+	errs   []error
+}
+
+func (o *targetErrObserver) OnCgroupsAttached(int) {}
+func (o *targetErrObserver) OnCgroupsDetached(int) {}
+
+func (o *targetErrObserver) OnTargetError(stage string, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.stages = append(o.stages, stage)
+	o.errs = append(o.errs, err)
+}
+
+func (o *targetErrObserver) snapshot() ([]string, []error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.stages...), append([]error(nil), o.errs...)
+}
+
+// TestEngine_AttachFailureNotCountedAsExporter is the regression test for the
+// misattributed-failure bug.
+func TestEngine_AttachFailureNotCountedAsExporter(t *testing.T) {
+	attachErr := errors.New("cgroup attach broken")
+	backend := &mockBackend{setCgroupsErr: attachErr}
+	obs := &targetErrObserver{}
+	eng, err := tracer.NewEngine(
+		backend,
+		[]tracer.Exporter{&recordingExporter{name: "x"}},
+		tracer.Config{Observer: obs},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 1)
+	targets <- tracer.TargetSet{{CgroupPath: "/will/fail", ContainerID: "c1"}}
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().AttachFailure > 0 })
+
+	s := eng.Stats()
+	if s.ExporterFailure != 0 {
+		t.Errorf("attach failure leaked into ExporterFailure=%d, want 0", s.ExporterFailure)
+	}
+
+	stages, errs := obs.snapshot()
+	if len(stages) == 0 {
+		t.Fatal("TargetErrorObserver was never notified of the attach failure")
+	}
+	if stages[0] != "set_cgroups" {
+		t.Errorf("reported stage = %q, want set_cgroups", stages[0])
+	}
+	if !errors.Is(errs[0], attachErr) {
+		t.Errorf("reported error = %v, want %v", errs[0], attachErr)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}

--- a/pkg/tracer/engine_drain_test.go
+++ b/pkg/tracer/engine_drain_test.go
@@ -1,0 +1,53 @@
+package tracer_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+type stopEmittingBackend struct {
+	*mockBackend
+}
+
+func (b *stopEmittingBackend) Stop() error {
+	b.mu.Lock()
+	ch := b.eventCh
+	b.mu.Unlock()
+	if ch != nil {
+		ch <- &events.Event{Type: events.EventDNS}
+	}
+	return b.mockBackend.Stop()
+}
+
+func TestEngine_DrainsEventsEmittedDuringStop(t *testing.T) {
+	backend := &stopEmittingBackend{mockBackend: &mockBackend{}}
+	exp := &recordingExporter{name: "rec"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{EventBufferSize: 16, ExportBatchSize: 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	targets := make(chan tracer.TargetSet, 1)
+	targets <- tracer.TargetSet{{CgroupPath: "/c"}}
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	waitUntil(t, 2*time.Second, func() bool { return len(backend.activePaths()) == 1 })
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := exp.totalEvents(); got != 1 {
+		t.Fatalf("event emitted during Stop() was lost: exporter saw %d events, want 1", got)
+	}
+	if s := eng.Stats(); s.EventsExported != 1 {
+		t.Fatalf("EventsExported=%d, want 1 (final event must be flushed)", s.EventsExported)
+	}
+}

--- a/pkg/tracer/engine_h2_test.go
+++ b/pkg/tracer/engine_h2_test.go
@@ -1,0 +1,92 @@
+package tracer_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/pkg/tracer"
+)
+
+func (r *reconcilerBackend) callCount() int {
+	r.rmu.Lock()
+	defer r.rmu.Unlock()
+	return r.calls
+}
+
+func TestEngine_ContainerIdentityChangeReconciles(t *testing.T) {
+	backend := &reconcilerBackend{mockBackend: &mockBackend{}}
+	exporter := &recordingExporter{name: "rec"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exporter}, tracer.Config{EventBufferSize: 16, ExportBatchSize: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	targets := make(chan tracer.TargetSet, 4)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 0},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		_, ok := backend.targetsByID()["a"]
+		return ok
+	})
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 111},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		return backend.targetsByID()["a"] == 111
+	})
+
+	targets <- tracer.TargetSet{
+		{CgroupPath: "/cg/a", ContainerID: "a2", ContainerPID: 222},
+	}
+	waitUntil(t, 2*time.Second, func() bool {
+		return backend.targetsByID()["a2"] == 222
+	})
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}
+
+func TestEngine_IdenticalUpdateDoesNotReconcile(t *testing.T) {
+	backend := &reconcilerBackend{mockBackend: &mockBackend{}}
+	exporter := &recordingExporter{name: "rec"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exporter}, tracer.Config{EventBufferSize: 16, ExportBatchSize: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	targets := make(chan tracer.TargetSet, 4)
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	set := tracer.TargetSet{{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 111}}
+	targets <- set
+	waitUntil(t, 2*time.Second, func() bool {
+		return backend.targetsByID()["a"] == 111
+	})
+	afterFirst := backend.callCount()
+
+	targets <- tracer.TargetSet{{CgroupPath: "/cg/a", ContainerID: "a", ContainerPID: 111}}
+	waitUntil(t, 2*time.Second, func() bool { return backend.callCount() >= afterFirst })
+	time.Sleep(50 * time.Millisecond)
+
+	if got := backend.callCount(); got != afterFirst {
+		t.Fatalf("identical update triggered %d extra reconcile(s), want 0", got-afterFirst)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}

--- a/pkg/tracer/engine_test.go
+++ b/pkg/tracer/engine_test.go
@@ -522,7 +522,7 @@ func TestEngine_AttachErrorDoesNotAbortRun(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(ctx, targets) }()
 
-	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ExporterFailure > 0 })
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().AttachFailure > 0 })
 	backend.mu.Lock()
 	backend.setCgroupsErr = nil
 	backend.mu.Unlock()
@@ -805,7 +805,7 @@ func TestEngine_ObserverNotifiedOnChurn(t *testing.T) {
 
 // TestEngine_BackendSetCgroupsErrorPreservesActiveSet asserts that when
 // SetCgroups fails, the engine does NOT clobber its previous active set
-// — the next snapshot retry can still converge.
+// the next snapshot retry can still converge.
 func TestEngine_BackendSetCgroupsErrorPreservesActiveSet(t *testing.T) {
 	backend := &mockBackend{}
 	eng, err := tracer.NewEngine(backend, []tracer.Exporter{&recordingExporter{name: "x"}}, tracer.Config{})
@@ -828,10 +828,8 @@ func TestEngine_BackendSetCgroupsErrorPreservesActiveSet(t *testing.T) {
 	backend.mu.Unlock()
 
 	targets <- tracer.TargetSet{{CgroupPath: "/c/c"}}
-	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().ExporterFailure > 0 })
+	waitUntil(t, 2*time.Second, func() bool { return eng.Stats().AttachFailure > 0 })
 
-	// Active set must still be {a, b} — failed replace did not poison
-	// engine state.
 	if s := eng.Stats(); s.ActiveTargets != 2 {
 		t.Errorf("ActiveTargets=%d after failed replace, want 2", s.ActiveTargets)
 	}

--- a/pkg/tracer/errors.go
+++ b/pkg/tracer/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"syscall"
+
+	"github.com/cilium/ebpf"
 )
 
 // Backend startup error classes. These short, stable strings appear in:
@@ -25,16 +27,21 @@ const (
 )
 
 // ClassifyBackendError maps a backend startup error to one of the
-// BackendErr* constants. Returns the empty string for a nil error and
-// BackendErrUnknown when no class matches.
+// BackendErr* constants.
 func ClassifyBackendError(err error) string {
 	if err == nil {
 		return ""
 	}
+	msg := strings.ToLower(err.Error())
+	var verifierErr *ebpf.VerifierError
+	if errors.As(err, &verifierErr) ||
+		strings.Contains(msg, "verifier rejected") ||
+		strings.Contains(msg, "verifier error") {
+		return BackendErrVerifierRejected
+	}
 	if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM) {
 		return BackendErrPermission
 	}
-	msg := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(msg, "permission denied"),
 		strings.Contains(msg, "operation not permitted"):
@@ -44,14 +51,6 @@ func ClassifyBackendError(err error) string {
 		return BackendErrTracefsUnmounted
 	case strings.Contains(msg, "btf"):
 		return BackendErrBTFUnavailable
-	case strings.Contains(msg, "verifier rejected"),
-		strings.Contains(msg, "verifier error"):
-		// A verifier rejection is NOT evidence of an old kernel: on
-		// modern kernels it usually means the verifier got stricter (or
-		// the program grew past a limit). Classifying it as
-		// kernel_too_old sent operators chasing upgrades that would make
-		// the problem worse, not better.
-		return BackendErrVerifierRejected
 	case strings.Contains(msg, "ring buffer"),
 		strings.Contains(msg, "ringbuf"):
 		return BackendErrRingBuffer

--- a/pkg/tracer/errors_test.go
+++ b/pkg/tracer/errors_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"syscall"
 	"testing"
+
+	"github.com/cilium/ebpf"
 )
 
 func TestClassifyBackendError(t *testing.T) {
@@ -25,6 +27,9 @@ func TestClassifyBackendError(t *testing.T) {
 		{"btf lower", errors.New("btf unsupported on this kernel"), BackendErrBTFUnavailable},
 		{"verifier rejected", errors.New("program load: verifier rejected program: invalid stack access"), BackendErrVerifierRejected},
 		{"verifier error", errors.New("verifier error: too many instructions"), BackendErrVerifierRejected},
+		{"verifier error type wrapping eacces", &ebpf.VerifierError{Cause: syscall.EACCES}, BackendErrVerifierRejected},
+		{"verifier error type wrapping eperm", &ebpf.VerifierError{Cause: syscall.EPERM}, BackendErrVerifierRejected},
+		{"wrapped verifier error type", fmt.Errorf("load collection: %w", &ebpf.VerifierError{Cause: syscall.EACCES}), BackendErrVerifierRejected},
 		{"ringbuf", errors.New("ringbuf reader: bad fd"), BackendErrRingBuffer},
 		{"ring buffer phrase", errors.New("create ring buffer: ENOMEM"), BackendErrRingBuffer},
 		{"map lookup", errors.New("lookup map filter_cgroups: ENOENT"), BackendErrMapLookup},

--- a/pkg/tracer/types.go
+++ b/pkg/tracer/types.go
@@ -9,10 +9,7 @@ import (
 	"github.com/podtrace/podtrace/internal/events"
 )
 
-// Target describes one pod whose traffic the tracer should observe. Each
-// field is populated by the producer of the target stream (CLI target
-// registry, CR-backed agent, or session Job) and is otherwise opaque to
-// the Engine.
+// Target describes one pod whose traffic the tracer should observe.
 type Target struct {
 	PodName   string
 	Namespace string
@@ -72,6 +69,12 @@ type TracerBackend interface {
 type EngineObserver interface {
 	OnCgroupsAttached(n int)
 	OnCgroupsDetached(n int)
+}
+
+// TargetErrorObserver is an optional capability an EngineObserver may also
+// implement.
+type TargetErrorObserver interface {
+	OnTargetError(stage string, err error)
 }
 
 // CategoryGateable is an optional capability a TracerBackend can


### PR DESCRIPTION
## Summary
Fixes a batch of correctness, concurrency, and lifecycle findings across the diagnose/report pipeline and the `pkg/tracer` engine, each with a regression test. Verified end-to-end on a cluster.

## Changes
**Diagnose / report**
- Advance the export watermark only after a successful export (`CommitExport`), so a transient collector outage no longer silently drops spans.
- Serialize `ErrorCorrelator` and rebuild error chains in O(n) via canonical keys instead of O(n²) per tick.
- Copy-on-write the shared profiling result to remove a data race.
- Give each diagnostic issue category its own alert dedup key.
- Classify HTTPS/HTTP2/HTTP3 spans as web/CLIENT (Datadog + Zipkin), not just literal `HTTP`.
- Report a connection pool's release ratio (guarded against ÷0 → +Inf CRITICAL) instead of a meaningless "reuse rate".
- Translate PIE runtime IPs to ELF virtual addresses before `addr2line`.
- Reject non-hex / all-zero / reserved-version W3C traceparents, and derive the Splunk fallback trace ID from `x-splunk-requestid` so events correlate.

**pkg/tracer & config**
- Detect `*ebpf.VerifierError` before the EACCES/EPERM check so verifier rejections stop being misreported as `permission_denied`.
- Reconcile on ContainerID/ContainerPID changes even when the cgroup-path set is unchanged, so container uprobes attach after a startup race.
- Decouple the dispatch context from the run context so the shutdown drain runs after `backend.Stop()` instead of racing it.
- Count attach failures under a distinct `AttachFailure` and surface them via an optional `TargetErrorObserver`.
- Unify `bundle.FromYAML` / `FromConfigMapData` validation behind one validator.