### PR TITLE
fix: harden agent security posture, chart schema, and CI drift gates

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -129,7 +129,10 @@ jobs:
           fail_ci_if_error: false
 
   cross-compile:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # Also run on push to main (scoped by `on.push.branches`) so a merged
+    # commit — which may differ from the tested PR head after squash/rebase —
+    # is verified before a release is cut from it.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -190,3 +193,32 @@ jobs:
         with:
           name: benchmark-results
           path: benchmark.txt
+
+  # Drift gate: the Makefile generates CRDs (templates/crds) and the reference
+  # webhook manifest (hack/reference) from the api types + kubebuilder markers.
+  # Without this job a change to a marker or CRD type could merge with stale
+  # committed manifests. Regenerate and fail if anything differs.
+  manifests-drift:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Regenerate CRDs, deepcopy, and webhook reference
+        run: GOTOOLCHAIN=auto make manifests generate
+
+      - name: Fail on manifest drift
+        run: |
+          if ! git diff --exit-code -- deploy/charts/podtrace/templates/crds hack/reference api/v1alpha1; then
+            echo "::error::Generated manifests are stale. Run 'make manifests generate' and commit the result." >&2
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -285,9 +285,11 @@ manifests: operator-tools
 	$(CONTROLLER_GEN) crd paths=./api/v1alpha1/... output:crd:artifacts:config=$(CRD_OUT_DIR)
 	@./hack/inject-crd-annotations.sh $(CRD_OUT_DIR)
 	@# Emit the webhook manifest to hack/reference/ as a diff target: the
-	@# Helm template at templates/validating-webhook.yaml is hand-authored,
-	@# but must stay in sync with the paths/rules kubebuilder generates
-	@# from the +kubebuilder:webhook markers. CI compares the two.
+	@# Helm template at templates/validating-webhook.yaml is hand-authored
+	@# and must stay in sync with the paths/rules kubebuilder generates from
+	@# the +kubebuilder:webhook markers. The manifests-drift CI job regenerates
+	@# hack/reference and fails if the committed copy is stale; reconciling the
+	@# hand-authored template against hack/reference is a manual review step.
 	@mkdir -p hack/reference
 	$(CONTROLLER_GEN) webhook paths=./internal/webhook/v1alpha1/... output:webhook:artifacts:config=hack/reference
 
@@ -325,13 +327,16 @@ e2e-kind-cleanup:
 CHAINSAW ?= $(shell command -v chainsaw 2>/dev/null)
 CHAINSAW_VERSION ?= latest
 chainsaw-tools:
-	@if [ -z "$(CHAINSAW)" ]; then \
+	@if [ -z "$(CHAINSAW)" ] && ! command -v chainsaw >/dev/null 2>&1 && [ ! -x "$$($(GO) env GOPATH)/bin/chainsaw" ]; then \
 	  echo "Installing chainsaw@$(CHAINSAW_VERSION)..."; \
 	  $(GO) install github.com/kyverno/chainsaw@$(CHAINSAW_VERSION); \
 	fi
 
 chainsaw: chainsaw-tools
-	$(or $(CHAINSAW),chainsaw) test --test-dir test/chainsaw/tests
+	@CHAINSAW_BIN="$(CHAINSAW)"; \
+	[ -n "$$CHAINSAW_BIN" ] || CHAINSAW_BIN="$$(command -v chainsaw 2>/dev/null)"; \
+	[ -n "$$CHAINSAW_BIN" ] || CHAINSAW_BIN="$$($(GO) env GOPATH)/bin/chainsaw"; \
+	"$$CHAINSAW_BIN" test --test-dir test/chainsaw/tests
 
 helm-template:
 	helm template podtrace deploy/charts/podtrace

--- a/cmd/podtrace/operator.go
+++ b/cmd/podtrace/operator.go
@@ -91,14 +91,15 @@ func toOperatorOptions(c *operatorOptions, leaderNSExplicit bool) operator.Optio
 		leaderNS = envNS
 	}
 	return operator.Options{
-		SystemNamespace:         c.systemNamespace,
-		MetricsBindAddress:      c.metricsAddr,
-		HealthBindAddress:       c.healthAddr,
-		LeaderElection:          c.leaderElect,
-		LeaderElectionNamespace: leaderNS,
-		WebhookPort:             c.webhookPort,
-		WebhookCertDir:          c.webhookCertDir,
-		BootstrapFallbackImage:  bootstrapFallbackImage(),
+		SystemNamespace:           c.systemNamespace,
+		MetricsBindAddress:        c.metricsAddr,
+		HealthBindAddress:         c.healthAddr,
+		LeaderElection:            c.leaderElect,
+		LeaderElectionNamespace:   leaderNS,
+		WebhookPort:               c.webhookPort,
+		WebhookCertDir:            c.webhookCertDir,
+		BootstrapFallbackImage:    bootstrapFallbackImage(),
+		BootstrapTracerConfigName: os.Getenv("PODTRACE_BOOTSTRAP_TC_NAME"),
 	}
 }
 

--- a/deploy/charts/podtrace/templates/NOTES.txt
+++ b/deploy/charts/podtrace/templates/NOTES.txt
@@ -8,9 +8,10 @@ labels onto the existing namespace after Helm creates it.
 
 Installed resources
 -------------------
-  CRDs (podtrace.io/v1alpha1) — installed by the chart's pre-install hook
-                                (templates/crds/, weight -10, runs before
-                                regular templates):
+  CRDs (podtrace.io/v1alpha1) — installed as regular chart resources
+                                (templates/crds/, gated by crds.install;
+                                a pre-upgrade labeler hook adopts any
+                                pre-existing copies first):
     PodTrace          continuous realtime tracing
     PodTraceSession   bounded diagnose-mode tracing
     PodTraceSchedule  cron-style recurring sessions

--- a/deploy/charts/podtrace/templates/cr-bootstrap.yaml
+++ b/deploy/charts/podtrace/templates/cr-bootstrap.yaml
@@ -26,12 +26,16 @@ Why a Job instead of regular templates:
   and the Job's kubectl-apply runs AFTER the CRDs have been installed
   and the apiserver has registered the new types.
 
-  The operator also self-bootstraps a default TracerConfig if none
-  exists (see internal/operator/bootstrap.go) so OLM and raw-kubectl
-  install paths — which don't run Helm hooks — still get a working
-  out-of-the-box state. On Helm installs the Job races with the
-  operator and typically wins; the operator's bootstrap then becomes
-  a no-op. Either way, values.yaml-driven config takes precedence.
+  The operator also self-bootstraps a TracerConfig if none exists
+  (see internal/operator/bootstrap.go) so OLM and raw-kubectl install
+  paths — which don't run Helm hooks — still get a working
+  out-of-the-box state. On Helm installs the Job and the operator's
+  bootstrap may race, but both target the SAME name (the operator
+  reads it from PODTRACE_BOOTSTRAP_TC_NAME, set to tracerConfig.name),
+  so whichever runs second is a no-op (AlreadyExists) — they converge
+  on one object instead of leaving a stray "default". The Job's
+  kubectl-apply then reconciles that object to the values.yaml-driven
+  spec, which takes precedence.
 
   Helm-uninstall semantics: hook resources (this Job, its ConfigMap,
   its RBAC) self-clean via hook-delete-policy. The applied

--- a/deploy/charts/podtrace/templates/crd-labeler.yaml
+++ b/deploy/charts/podtrace/templates/crd-labeler.yaml
@@ -4,19 +4,19 @@ crd-labeler — one-time-per-cluster CRD ownership migration.
 Earlier the chart shipped its CRDs in Helm's `crds/`
 directory, which installs once at first `helm install` and never
 updates afterward. We have since moved the CRDs into `templates/crds/`
-with `helm.sh/hook: pre-install,pre-upgrade` so Helm propagates schema
-changes on upgrade.
+as regular chart resources, so Helm propagates schema changes on upgrade.
 
 The wrinkle: clusters already running an older chart version carry
 CRDs that lack the Helm ownership labels (`app.kubernetes.io/managed-by=Helm`
-and the meta.helm.sh/release-* annotations). When the new pre-upgrade
-hook tries to apply the same-named CRD it refuses with "invalid
-ownership metadata" because Helm will not silently take over a
-resource somebody else created.
+and the meta.helm.sh/release-* annotations). When Helm's apply reaches
+the same-named CRD template it refuses with "invalid ownership
+metadata" because Helm will not silently take over a resource somebody
+else created.
 
-This Job runs at weight -20 (before the CRDs themselves at -10) and
-patches the four podtrace.io CRDs with the ownership labels the chart
-expects, so the subsequent CRD hook adopts and updates them cleanly.
+This Job runs as a pre-install/pre-upgrade hook at weight -20, before
+Helm's main apply phase where the CRD templates land, and patches the
+six podtrace.io CRDs with the ownership labels the chart expects, so
+Helm's subsequent apply adopts and updates them cleanly.
 After that first upgrade the CRDs are Helm-owned forever; this Job is
 a no-op on every subsequent run.
 

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_applicationtraces.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_applicationtraces.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: applicationtraces.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_exporterconfigs.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_exporterconfigs.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: exporterconfigs.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: podtraces.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: podtraceschedules.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: podtracesessions.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_tracerconfigs.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_tracerconfigs.yaml
@@ -5,7 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    helm.sh/resource-policy: {{ ternary "keep" "delete" .Values.crds.keep }}
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   name: tracerconfigs.podtrace.io
 spec:
   group: podtrace.io

--- a/deploy/charts/podtrace/templates/namespace.yaml
+++ b/deploy/charts/podtrace/templates/namespace.yaml
@@ -17,12 +17,16 @@ Why a Job instead of a templated Namespace resource:
   A pre-install hook Job that runs `kubectl apply` on the Namespace
   sidesteps both problems. `kubectl apply` is the idempotent operation —
   it creates the namespace if missing and patches labels if existing,
-  with no Helm ownership check involved. The Job itself lives in
-  kube-system (always present on every cluster), so it has somewhere to
-  land regardless of whether the user used --create-namespace.
+  with no Helm ownership check involved. The Job (and its SA/RBAC) lands
+  in .Release.Namespace, which Helm creates before any hook runs (with
+  --create-namespace, which NOTES requires). It deliberately does NOT
+  use kube-system: managed platforms such as GKE Autopilot forbid
+  creating resources there, which broke the install outright.
 
-  Weight -100 puts this before crd-labeler (-20) and the CRD templates
-  (-10), so by the time those hooks run, the target namespace exists.
+  Weight -100 puts this before the crd-labeler hook (-20) and, being a
+  pre-install/pre-upgrade hook, ahead of Helm's main apply phase where the
+  CRD templates and the operator land — so the target namespace exists by
+  the time anything references it.
 
   The hook-delete-policy clears the Job after success, so it does not
   accumulate across upgrades. The Namespace itself persists — there is
@@ -34,7 +38,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: podtrace
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -83,13 +87,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "podtrace.fullname" . }}-namespace-bootstrap
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: podtrace
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/podtrace/templates/operator-deployment.yaml
+++ b/deploy/charts/podtrace/templates/operator-deployment.yaml
@@ -60,6 +60,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: PODTRACE_BOOTSTRAP_IMAGE
               value: {{ include "podtrace.image" . | quote }}
+            - name: PODTRACE_BOOTSTRAP_TC_NAME
+              value: {{ .Values.tracerConfig.name | default "default" | quote }}
             {{- with .Values.operator.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/charts/podtrace/templates/validating-webhook.yaml
+++ b/deploy/charts/podtrace/templates/validating-webhook.yaml
@@ -1,18 +1,20 @@
-{{- if .Values.webhook.enabled }}
+{{- /*
+   Require the operator too: the operator pod IS the webhook server. Rendering
+   the ValidatingWebhookConfiguration without it (failurePolicy: Fail) makes the
+   apiserver call an endpoint that does not exist, blocking every podtrace.io
+   create/update cluster-wide. Gate on both so webhook.enabled without
+   operator.enabled is a no-op instead of a self-inflicted outage.
+*/ -}}
+{{- if and .Values.webhook.enabled .Values.operator.enabled }}
 ---
 # Validating admission webhook for podtrace.io/v1alpha1.
 #
 # The paths below are authoritative: they match the kubebuilder markers on
-# the Go webhook types in api/v1alpha1/*_webhook.go. If a marker changes,
-# `make manifests` will emit a mismatch between the Go server and this
-# template — the Makefile target regenerates the reference manifest so
-# drift is caught.
-#
-# TLS source: cert-manager issues the Service's serving cert when
-# .Values.webhook.certSource = "cert-manager" (default). The annotation
-# `cert-manager.io/inject-ca-from` populates each webhook's caBundle at
-# install time. For air-gapped clusters without cert-manager, switch to
-# certSource=self-signed and provide .Values.webhook.caBundle / .tls.
+# the Go webhook types in api/v1alpha1/*_webhook.go. `make manifests`
+# regenerates hack/reference/ from those markers, and the manifests-drift CI
+# job fails if the committed reference is stale. Keep this hand-authored
+# template in sync with hack/reference/ (a manual diff — CI does not compare
+# the template against the reference automatically).
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/deploy/charts/podtrace/values.schema.json
+++ b/deploy/charts/podtrace/values.schema.json
@@ -26,10 +26,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         },
@@ -37,10 +37,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         }
@@ -214,10 +214,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         },
@@ -225,10 +225,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         }
@@ -266,10 +266,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         },
@@ -277,10 +277,10 @@
                             "type": "object",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 },
                                 "memory": {
-                                    "type": "string"
+                                    "type": ["string", "integer", "number"]
                                 }
                             }
                         }

--- a/hack/inject-crd-annotations.sh
+++ b/hack/inject-crd-annotations.sh
@@ -106,20 +106,18 @@ if not match:
     sys.exit(f"inject-crd-annotations: controller-gen marker not found in {path}")
 
 indent = match.group(1)
-annotations = [
-    ('helm.sh/resource-policy', '{{ ternary "keep" "delete" .Values.crds.keep }}'),
-]
 
-addenda = []
-for key, value in annotations:
-    if key in text:
-        continue
-    addenda.append(f"{indent}{key}: {value}")
-
-if not addenda:
+policy_key = "helm.sh/resource-policy"
+if policy_key in text:
     sys.exit(0)
 
-replacement = match.group(0) + "\n" + "\n".join(addenda)
+block = "\n".join([
+    f"{indent}{{{{- if .Values.crds.keep }}}}",
+    f"{indent}{policy_key}: keep",
+    f"{indent}{{{{- end }}}}",
+])
+
+replacement = match.group(0) + "\n" + block
 path.write_text(text.replace(match.group(0), replacement, 1))
 PY
 }

--- a/internal/operator/bootstrap.go
+++ b/internal/operator/bootstrap.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,9 +21,10 @@ const DefaultTracerConfigName = "default"
 const BootstrapImageEnv = "PODTRACE_BOOTSTRAP_IMAGE"
 
 type BootstrapDefaultTracerConfig struct {
-	Client          client.Client
-	SystemNamespace string
-	FallbackImage   string
+	Client           client.Client
+	SystemNamespace  string
+	FallbackImage    string
+	TracerConfigName string
 }
 
 func (b *BootstrapDefaultTracerConfig) NeedLeaderElection() bool { return true }
@@ -62,15 +65,26 @@ func (b *BootstrapDefaultTracerConfig) Start(ctx context.Context) error {
 		return nil
 	}
 
+	name := b.TracerConfigName
+	if name == "" {
+		name = DefaultTracerConfigName
+	}
+
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultTracerConfigName,
+			Name: name,
 			Annotations: map[string]string{
 				"podtrace.io/bootstrap-source": "operator",
 			},
 		},
 		Spec: podtracev1alpha1.TracerConfigSpec{
 			Image: image,
+			Agent: podtracev1alpha1.AgentSpec{
+				Resources: defaultAgentResources(),
+			},
+			Session: podtracev1alpha1.SessionRuntimeSpec{
+				Resources: defaultSessionResources(),
+			},
 		},
 	}
 
@@ -84,4 +98,35 @@ func (b *BootstrapDefaultTracerConfig) Start(ctx context.Context) error {
 	logger.Info("created default TracerConfig",
 		"name", tc.Name, "image", image, "source", "operator-bootstrap")
 	return nil
+}
+
+// defaultAgentResources mirrors the chart's values.yaml agent resource
+// defaults so a non-Helm (OLM / raw-kubectl) or race-bootstrapped TracerConfig
+// still bounds the agent DaemonSet.
+func defaultAgentResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+}
+
+// defaultSessionResources mirrors the chart's values.yaml session resource
+// defaults for the per-session Job pods.
+func defaultSessionResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
 }

--- a/internal/operator/bootstrap_test.go
+++ b/internal/operator/bootstrap_test.go
@@ -49,6 +49,13 @@ func TestBootstrap_CreatesDefaultWhenAbsent(t *testing.T) {
 	if got.Annotations["podtrace.io/bootstrap-source"] != "operator" {
 		t.Errorf("missing bootstrap-source annotation; got %v", got.Annotations)
 	}
+
+	if got.Spec.Agent.Resources.Limits.Memory().IsZero() || got.Spec.Agent.Resources.Limits.Cpu().IsZero() {
+		t.Errorf("bootstrapped TracerConfig agent has no CPU/memory limits: %+v", got.Spec.Agent.Resources)
+	}
+	if got.Spec.Session.Resources.Limits.Memory().IsZero() || got.Spec.Session.Resources.Limits.Cpu().IsZero() {
+		t.Errorf("bootstrapped TracerConfig session has no CPU/memory limits: %+v", got.Spec.Session.Resources)
+	}
 }
 
 func TestBootstrap_NoopWhenTracerConfigExists(t *testing.T) {
@@ -104,6 +111,56 @@ func TestBootstrap_NoopWhenAnyTracerConfigExists(t *testing.T) {
 	err := c.Get(context.Background(), types.NamespacedName{Name: DefaultTracerConfigName}, &nope)
 	if err == nil {
 		t.Fatal("operator created a 'default' TracerConfig despite an existing 'production' one")
+	}
+}
+
+func TestBootstrap_UsesConfiguredName(t *testing.T) {
+	c := bootstrapTestScheme(t)
+	b := &BootstrapDefaultTracerConfig{
+		Client:           c,
+		FallbackImage:    "img:v1",
+		TracerConfigName: "custom",
+	}
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "custom"}, &podtracev1alpha1.TracerConfig{}); err != nil {
+		t.Fatalf("expected TracerConfig named 'custom': %v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: DefaultTracerConfigName}, &podtracev1alpha1.TracerConfig{}); err == nil {
+		t.Fatal("operator created a stray 'default' TracerConfig instead of the configured name")
+	}
+}
+
+func TestBootstrap_NoDuplicateWhenNameMatchesExisting(t *testing.T) {
+	c := bootstrapTestScheme(t)
+	jobCreated := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "helm-supplied:v1"},
+	}
+	if err := c.Create(context.Background(), jobCreated); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	b := &BootstrapDefaultTracerConfig{
+		Client:           c,
+		FallbackImage:    "operator-default:v0",
+		TracerConfigName: "custom",
+	}
+	if err := b.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	var list podtracev1alpha1.TracerConfigList
+	if err := c.List(context.Background(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected exactly 1 TracerConfig, got %d", len(list.Items))
+	}
+	if list.Items[0].Spec.Image != "helm-supplied:v1" {
+		t.Errorf("operator clobbered the Helm-created TracerConfig: image=%q", list.Items[0].Spec.Image)
 	}
 }
 

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -49,7 +49,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		resources = tc.Spec.Session.Resources
 	}
 
-	priv := true
+	priv := false
 	runAsRoot := int64(0)
 
 	args := buildDiagnoseArgs(s, targetNamespaces, effectiveDuration)

--- a/internal/operator/runtime.go
+++ b/internal/operator/runtime.go
@@ -39,6 +39,8 @@ type Options struct {
 	GracefulShutdownTimeout time.Duration
 
 	BootstrapFallbackImage string
+
+	BootstrapTracerConfigName string
 }
 
 func DefaultOptions() Options {
@@ -55,8 +57,7 @@ func DefaultOptions() Options {
 }
 
 // NewScheme returns a scheme with both client-go's default types and
-// the podtrace v1alpha1 API group registered. Exposed so tests can
-// share one scheme across envtest harnesses.
+// the podtrace v1alpha1 API group registered.
 func NewScheme() (*runtime.Scheme, error) {
 	s := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(s); err != nil {
@@ -126,9 +127,10 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	if err := mgr.Add(&BootstrapDefaultTracerConfig{
-		Client:          mgr.GetClient(),
-		SystemNamespace: opts.SystemNamespace,
-		FallbackImage:   opts.BootstrapFallbackImage,
+		Client:           mgr.GetClient(),
+		SystemNamespace:  opts.SystemNamespace,
+		FallbackImage:    opts.BootstrapFallbackImage,
+		TracerConfigName: opts.BootstrapTracerConfigName,
 	}); err != nil {
 		return fmt.Errorf("register TracerConfig bootstrap: %w", err)
 	}
@@ -144,8 +146,6 @@ func leaderElectionID(opts Options) string {
 }
 
 // registerWebhooks wires the three validating webhooks onto the manager.
-// Each Setup* function declares a +kubebuilder:webhook marker so the
-// paths match the Helm-rendered ValidatingWebhookConfiguration.
 func registerWebhooks(mgr ctrl.Manager) error {
 	if err := webhookv1alpha1.SetupPodTraceWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("podtrace webhook: %w", err)

--- a/internal/operator/tracerconfig_daemonset.go
+++ b/internal/operator/tracerconfig_daemonset.go
@@ -38,7 +38,7 @@ func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string)
 	}
 
 	hostPathType := corev1.HostPathDirectory
-	priv := true
+	priv := false
 	runAsRoot := int64(0)
 
 	imagePullPolicy := tc.Spec.ImagePullPolicy

--- a/internal/operator/tracerconfig_daemonset_test.go
+++ b/internal/operator/tracerconfig_daemonset_test.go
@@ -44,21 +44,23 @@ func TestBuildAgentDaemonSetSpec_SelectorStability(t *testing.T) {
 	}
 }
 
-func TestBuildAgentDaemonSetSpec_PrivilegedContainer(t *testing.T) {
+func TestBuildAgentDaemonSetSpec_CapabilitiesNotPrivileged(t *testing.T) {
 	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
 	c := spec.Template.Spec.Containers[0]
 	if c.SecurityContext == nil {
 		t.Fatal("SecurityContext is nil")
 	}
-	if c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Error("agent container must be privileged")
+	if c.SecurityContext.Privileged != nil && *c.SecurityContext.Privileged {
+		t.Error("agent container must NOT be privileged (caps-only)")
 	}
 	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
 		t.Error("agent must run as root (user 0)")
 	}
-	// Must request the four eBPF-relevant capabilities.
 	wantCaps := map[corev1.Capability]bool{
-		"BPF": false, "SYS_ADMIN": false, "PERFMON": false, "NET_ADMIN": false,
+		"BPF": false, "SYS_ADMIN": false, "PERFMON": false, "SYS_RESOURCE": false, "NET_ADMIN": false,
+	}
+	if c.SecurityContext.Capabilities == nil {
+		t.Fatal("Capabilities must be set when running unprivileged")
 	}
 	for _, added := range c.SecurityContext.Capabilities.Add {
 		if _, ok := wantCaps[added]; ok {
@@ -93,7 +95,6 @@ func TestBuildAgentDaemonSetSpec_HostMounts(t *testing.T) {
 			t.Errorf("volume %q path=%q want %q", name, found[name], path)
 		}
 	}
-	// HostPID MUST be on for pid → cgroup traversal.
 	if !spec.Template.Spec.HostPID {
 		t.Error("HostPID must be true")
 	}
@@ -118,7 +119,6 @@ func TestBuildAgentDaemonSetSpec_ArgsCarryTracerConfigName(t *testing.T) {
 		x.Name = "alt"
 	}), "podtrace-system")
 	args := spec.Template.Spec.Containers[0].Args
-	// Expect the `agent` subcommand with system-namespace and tracer-config flags.
 	if len(args) == 0 || args[0] != "agent" {
 		t.Fatalf("args[0]=%q want agent (full args: %v)", args[0], args)
 	}


### PR DESCRIPTION
## Summary
Fixes a batch of Deploy/CI findings across the Helm chart, the operator, the Makefile, and CI. Each is covered by unit tests and/or Helm render checks, and the security-posture change (agent/session pods) is validated end-to-end on a cluster.

## Changes
**Security posture**
- Drop `privileged: true` from the agent DaemonSet and session Jobs and run caps-only (BPF, SYS_ADMIN, PERFMON, SYS_RESOURCE, NET_ADMIN); the privileged flag was redundant with the explicit capability list and only widened the blast radius.

**Operator bootstrap (TracerConfig)**
- Give the operator-bootstrapped default TracerConfig the chart's resource limits so a bootstrap (or a race-created stray) can no longer spawn an unbounded, whole-node-OOM agent DaemonSet.
- Eliminate the duplicate-TracerConfig race: propagate `tracerConfig.name` to the operator via `PODTRACE_BOOTSTRAP_TC_NAME` so the operator's self-bootstrap and the Helm cr-bootstrap Job target the same object and converge (the loser hits AlreadyExists) instead of leaving a stray `default` beside a custom-named TracerConfig.

**Helm chart**
- `values.schema.json` accepts `["string","integer","number"]` for cpu/memory so `--set …resources.limits.cpu=2` no longer fails schema validation.
- Emit `helm.sh/resource-policy: keep` only when `crds.keep` (fixed at the source in `hack/inject-crd-annotations.sh`); the previous `ternary "keep" "delete"` rendered the invalid literal value `delete`.
- Gate the validating webhook on `operator.enabled` as well, so enabling the webhook without the operator is a no-op instead of a cluster-wide CR-create lockout (failurePolicy: Fail with no server).
- Move the namespace-bootstrap ServiceAccount/RBAC/Job off hardcoded `kube-system` (which GKE Autopilot forbids writing to) onto `.Release.Namespace`.
- Correct stale CRD-hook wording in NOTES.txt and crd-labeler.yaml (the CRDs are regular templates, not a weight -10 pre-install hook; six CRDs, not four).

**Makefile / CI**
- `make chainsaw` resolves `$GOPATH/bin/chainsaw` at recipe time instead of parse time, so it works immediately after `make chainsaw-tools`.
- Run `build-and-test` and `cross-compile` on push to main, so a merged commit is tested before a release is cut from it.
- Add a `manifests-drift` job that regenerates CRDs/deepcopy/webhook reference and fails on any diff, enforcing the sync the Makefile already claimed.