### PR TITLE
feat: graceful L7 degradation via bpf_loop probe and low-severity fixes

### DIFF
--- a/bpf/database.c
+++ b/bpf/database.c
@@ -78,10 +78,11 @@ static inline void handle_pool_release(u32 pid, u32 tid, u64 key) {
 	u32 db = db_type ? *db_type : DB_TYPE_SQLITE;
 	
 	if (state->in_use == 1) {
-		state->in_use = 0;
-		bpf_map_update_elem(&pool_states, &key, state, BPF_ANY);
 		emit_pool_event(pid, EVENT_POOL_RELEASE, 0, db);
 	}
+	bpf_map_delete_elem(&pool_states, &key);
+	bpf_map_delete_elem(&pool_db_types, &key);
+	bpf_map_delete_elem(&pool_acquire_times, &key);
 }
 
 static inline void handle_pool_exhaustion(u32 pid, u32 tid, u64 key, u64 now) {

--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -74,6 +74,11 @@ static __always_inline int l4_offset(struct __sk_buff *skb, u8 *is_v6, u8 *proto
 			if (bpf_skb_load_bytes(skb, off, &nh, 1) < 0)
 				return -1;
 			if (nexthdr == IP6_FRAGMENT) {
+				__u16 fragoff = 0;
+				if (bpf_skb_load_bytes(skb, off + 2, &fragoff, sizeof(fragoff)) < 0)
+					return -1;
+				if (bpf_ntohs(fragoff) & 0xFFF8)
+					return -1;
 				off += 8;
 			} else {
 				__u8 hlen = 0;

--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -18,14 +18,14 @@ static __always_inline u32 h2_next_seq(u64 conn_id, u32 dir)
 {
 	struct h2_seq_key k = { .conn_id = conn_id, .dir = dir, ._pad = 0 };
 	u64 *cur = bpf_map_lookup_elem(&h2_seq, &k);
-	if (cur) {
-		u32 seq = (u32)*cur;
-		*cur = *cur + 1;
-		return seq;
+	if (!cur) {
+		u64 zero = 0;
+		bpf_map_update_elem(&h2_seq, &k, &zero, BPF_NOEXIST);
+		cur = bpf_map_lookup_elem(&h2_seq, &k);
+		if (!cur)
+			return 0;
 	}
-	u64 one = 1;
-	bpf_map_update_elem(&h2_seq, &k, &one, BPF_ANY);
-	return 0;
+	return (u32)__sync_fetch_and_add(cur, 1);
 }
 
 struct h2_raw_ctx {

--- a/bpf/http.c
+++ b/bpf/http.c
@@ -197,11 +197,11 @@ static __noinline void http_emit_response(void *ctx, void *base, u64 len,
 			break;
 		status[si++] = c;
 	}
-	if (si == 0)
+	if (si != 3)
 		return;
 	status[si] = '\0';
 
-	if (si == 3 && status[0] == '1')
+	if (status[0] == '1')
 		return;
 
 	u32 pid = bpf_get_current_pid_tgid() >> 32;

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -127,13 +127,6 @@ struct {
 } socket_conns SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
-	__type(key, u64);
-	__type(value, u64);
-} tcp_sockets SEC(".maps");
-
-struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 2048);
 	__type(key, u64);
@@ -218,13 +211,6 @@ struct {
 	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } syscall_paths SEC(".maps");
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
-	__type(key, u64);
-	__type(value, u64);
-} tls_handshakes SEC(".maps");
 
 struct resource_limit {
 	u64 limit_bytes;
@@ -344,21 +330,21 @@ struct pool_state {
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
 	__type(value, struct pool_state);
 } pool_states SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
 	__type(value, u64);
 } pool_acquire_times SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 1024);
 	__type(key, u64);
 	__type(value, u32);
@@ -749,7 +735,7 @@ struct {
 } h2_frame_state SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 256);
 	__type(key, u64);
 	__type(value, char[MAX_STRING_LEN]);

--- a/cmd/podtrace/watch.go
+++ b/cmd/podtrace/watch.go
@@ -88,10 +88,6 @@ exits. Events flow to the referenced ExporterConfig, not to this terminal.`,
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			if !cmd.Flags().Changed("namespace") {
-				// Resolve the default namespace from the SAME kubeconfig
-				// the client uses; reading the default loading rules while
-				// the client honors --kubeconfig mixed namespaces across
-				// clusters.
 				if ctxNamespace, ok := kubernetes.NamespaceFromKubeconfig(watchKubeconfig); ok {
 					namespace = ctxNamespace
 				}
@@ -102,12 +98,11 @@ exits. Events flow to the referenced ExporterConfig, not to this terminal.`,
 	registerTargetFlags(cmd.Flags())
 	registerWatchOnlyFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", config.DefaultNamespace, "Namespace to create the PodTrace in (its ExporterConfig must live here too; defaults to the current kubeconfig context's namespace)")
-	cmd.Flags().StringVar(&eventFilter, "filter", "", "Event categories to capture (dns,net,fs,cpu,proc); empty = all")
+	cmd.Flags().StringVar(&eventFilter, "filter", "", "Event categories to capture (dns,net,fs,cpu,proc,crypto); empty = all")
 	return cmd
 }
 
-// watchOptions is the resolved input to runWatch/buildPodTrace. Splitting it
-// from the flag vars keeps buildPodTrace a pure, unit-testable function.
+// watchOptions is the resolved input to runWatch/buildPodTrace.
 type watchOptions struct {
 	AppName           string
 	Labels            []string

--- a/deploy/charts/podtrace/templates/cr-bootstrap.yaml
+++ b/deploy/charts/podtrace/templates/cr-bootstrap.yaml
@@ -229,7 +229,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubectl
-          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4" }}
+          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4@sha256:129291af93e2b5df392f619cee8564cac4b377d66ff45f52f165af87688b68b9" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/charts/podtrace/templates/crd-labeler.yaml
+++ b/deploy/charts/podtrace/templates/crd-labeler.yaml
@@ -112,7 +112,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubectl
-          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4" }}
+          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4@sha256:129291af93e2b5df392f619cee8564cac4b377d66ff45f52f165af87688b68b9" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/charts/podtrace/templates/namespace.yaml
+++ b/deploy/charts/podtrace/templates/namespace.yaml
@@ -122,7 +122,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kubectl
-          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4" }}
+          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.30.4@sha256:129291af93e2b5df392f619cee8564cac4b377d66ff45f52f165af87688b68b9" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -23,6 +23,10 @@ crds:
 
   adopt: true
 
+  # Image for the CRD-labeler / namespace / cr-bootstrap hook Jobs (kubectl).
+  # Empty uses a digest-pinned alpine/k8s default so these cluster-critical
+  # hooks are reproducible and cannot silently change when the upstream tag
+  # moves. Override with your own (ideally digest-pinned) mirror if needed.
   labelerImage: ""
 
   keep: true

--- a/docs/crd-applicationtrace.md
+++ b/docs/crd-applicationtrace.md
@@ -57,7 +57,7 @@ podtrace watch --application --name checkout \
 | `selectors` | `[]LabelSelector` | yes (≥1) | The application's workloads. A pod matching **any** selector is traced (union). Become `PodTrace.spec.appSelector.matchSelectors`. |
 | `namespaceSelector` | LabelSelector | optional | Widen across namespaces. Empty (set) = every namespace; nil = the application's own namespace. |
 | `exporterRef.name` | string | yes | Names an `ExporterConfig` in the same namespace; inherited by the generated `PodTrace`. |
-| `filters` | `[dns,net,fs,cpu,proc]` | optional | Empty = all categories. |
+| `filters` | `[dns,net,fs,cpu,proc,crypto]` | optional | Empty = all categories. |
 | `samplePercent` | int 0-100 | optional | Sampling intent, passed through. |
 | `thresholds` | object | optional | Passed through to the generated `PodTrace`. |
 | `paused` | bool | optional | Stop tracing without deleting; propagated to the child. |

--- a/docs/crd-podtrace.md
+++ b/docs/crd-podtrace.md
@@ -49,7 +49,7 @@ spec:
 | `podRefs` | `[{namespace, name}]` | one of selector/podRefs/appSelector | Explicit pod list. Cross-namespace allowed. |
 | `appSelector` | `{matchSelectors: []LabelSelector}` | one of selector/podRefs/appSelector | Application of several workloads: a pod matching **any** selector is traced (union, de-duplicated). Exactly-one-of is enforced by CEL + webhook. |
 | `namespaceSelector` | LabelSelector | optional | Widens `selector` across namespaces. Field's expressions are not yet evaluated; presence alone enables cluster-wide search. |
-| `filters` | `[dns,net,fs,cpu,proc]` | optional | Empty = all categories. Agents enforce the set per-event in userspace and only the listed categories reach the configured exporter. |
+| `filters` | `[dns,net,fs,cpu,proc,crypto]` | optional | Empty = all categories. Agents enforce the set per-event in userspace and only the listed categories reach the configured exporter. |
 | `exporterRef.name` | string | required | Names an `ExporterConfig` in the same namespace. |
 | `paused` | bool | optional | Stop emitting events without deleting the CR. |
 | `samplePercent` | int 0-100 | optional | Workload-owner sampling intent. The operator combines this with `ExporterConfig.spec.samplePercent` (platform-owner cap) and writes the **minimum** of the two to the bundle — that minimum is what every exporter applies. Unset on either side is treated as 100%. The resolved value is echoed at `status.policy.effectiveSampleRate`. |

--- a/docs/crd-podtracesession.md
+++ b/docs/crd-podtracesession.md
@@ -51,7 +51,7 @@ spec:
 | `namespaceSelector` | LabelSelector | optional | Widens `selector` across namespaces. |
 | `containerName` | string | optional | Restrict to one container per pod. |
 | `duration` | Go duration string | required | Wall-clock run time, e.g. `"30s"`, `"5m"`. Webhook rejects `0s` and bounded by `TracerConfig.spec.session.maxDuration`. |
-| `filters` | `[dns,net,fs,cpu,proc]` | optional | Event categories to record. |
+| `filters` | `[dns,net,fs,cpu,proc,crypto]` | optional | Event categories to record. |
 | `exporterRef.name` | string | required | Names an `ExporterConfig` in the same namespace. |
 | `samplePercent` | int 0-100 | optional | Workload-owner sampling intent. The operator combines this with `ExporterConfig.spec.samplePercent` (platform-owner cap) and writes the **minimum** of the two to the session bundle. Unset on either side is treated as 100%. The resolved value is echoed at `status.policy.effectiveSampleRate`. |
 | `reportRef` | object | optional | Persistent artifact sink — see "Report sinks" below. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,7 +49,8 @@ podtrace/
 - Go 1.26+ (or any earlier 1.x with `GOTOOLCHAIN=auto`, which downloads
   the toolchain version declared in `go.mod` automatically)
 - Clang and LLVM
-- Linux kernel 5.8+ with BTF
+- Linux kernel 5.8+ with BTF (full L7 tracing needs the `bpf_loop` helper,
+  mainline 5.17+ or a backporting distro; older kernels auto-run core L4 only)
 
 ### Build Commands
 

--- a/docs/openshift.md
+++ b/docs/openshift.md
@@ -46,7 +46,7 @@ mode by default on all RHEL-based OpenShift nodes.
 | cgroup driver | systemd |
 | cgroup version | v1 (≤4.13) / v2 (≥4.14) |
 | SELinux | Enforcing |
-| Kernel | 4.18+ (RHEL 8), 5.14+ (RHEL 9) |
+| Kernel | RHEL 9 (5.14) ✅ full L7 (backports `bpf_loop`); RHEL 8 (4.18) ❌ below the 5.8 floor. Mainline `bpf_loop` = 5.17+; older kernels auto-run core L4 only |
 | BTF | ✅ (RHEL 9 kernel), partial (RHEL 8) |
 
 ## Prerequisites
@@ -249,9 +249,12 @@ PODTRACE_CRI_CGROUP_FIELDS=linux.cgroupsPath,cgroupDirectory
 
 ## Known issues
 
-- **RHEL 8 kernels** (4.18) are below the 5.8 requirement for BPF ring buffers.
-  OpenShift 4.14+ on RHEL 9 uses kernel 5.14+ which fully supports podtrace.
-  On older RHEL 8 nodes, BPF perf buffer fallback is not yet implemented.
+- **RHEL 8 kernels** (4.18) are below the 5.8 floor for BPF ring buffers.
+  OpenShift 4.14+ on RHEL 9 uses kernel 5.14, which gets full L7 tracing because
+  RHEL backports the `bpf_loop` helper (mainline 5.17+); podtrace detects the
+  helper at load time, so a kernel without it keeps core L4 tracing and only the
+  L7 probes are disabled. On older RHEL 8 nodes, BPF perf buffer fallback is not
+  yet implemented.
 - **BTF on RHEL 8**: not available by default; install `kernel-devel` and use
   `PODTRACE_BTF_FILE` to point to a matching BTF file.
 - **Cross-node tracing**: podtrace traces processes on the node where it runs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,7 +69,7 @@ Flags:
       --diagnose string         Run in diagnose mode for the specified duration (e.g., 10s, 5m)
       --metrics                 Enable Prometheus metrics server
       --export string           Export format for diagnose report (json, csv)
-      --filter string           Filter events by type (dns,net,fs,cpu,proc)
+      --filter string           Filter events by type (dns,net,fs,cpu,proc,crypto)
       --container string        Container name to trace (default: first container)
       --error-threshold float   Error rate threshold percentage for issue detection (default: 10.0)
       --rtt-threshold float     RTT spike threshold in milliseconds (default: 100.0)
@@ -255,8 +255,14 @@ Review:
 ## Limitations
 
 - By default traces the first container per selected pod (override with `--container`)
-- Requires kernel 5.8+ with BTF support
-- File path tracking uses inode-based correlation and works on all kernels (5.8+)
+- Requires kernel **5.8+** with BTF support (BPF ring buffer + CO-RE). Full L7
+  protocol tracing (HTTP/1.1, HTTP/2, HTTP/3, gRPC) additionally needs the
+  `bpf_loop` helper — mainline **5.17+**, or a distribution that backports it
+  (e.g. RHEL 9's 5.14). podtrace probes for `bpf_loop` at load time (a real
+  capability check, not a version guess), and on kernels without it it
+  automatically disables just the L7 probes and continues with core L4 tracing
+  (network, DNS, filesystem, CPU, syscalls) rather than failing.
+- File path tracking uses inode-based correlation (once the backend has loaded)
 - DNS tracking may be unavailable if libc path cannot be determined
 - CPU scheduling tracking requires tracepoint permissions
 - Stack trace symbol resolution requires `addr2line` tool and debug symbols

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -694,7 +694,7 @@ func bundlePolicyGeneration(b *BundlePayload) int64 {
 }
 
 // unionCategoriesFromRules returns the sorted, deduplicated union of
-// CRD-filter category strings (dns/net/fs/cpu/proc) across every active
+// CRD-filter category strings (dns/net/fs/cpu/proc/crypto) across every active
 // CRRule.
 func unionCategoriesFromRules(rules []CRRule) []string {
 	seen := make(map[string]struct{}, len(rules))

--- a/internal/diagnose/analyzer/analyzer_test.go
+++ b/internal/diagnose/analyzer/analyzer_test.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"math"
 	"sort"
 	"testing"
 
@@ -17,11 +18,13 @@ func TestPercentile(t *testing.T) {
 		{"empty slice", []float64{}, 50, 0},
 		{"single value p50", []float64{10}, 50, 10},
 		{"single value p95", []float64{10}, 95, 10},
-		{"two values p50", []float64{10, 20}, 50, 10},
-		{"two values p95", []float64{10, 20}, 95, 10},
-		{"ten values p50", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 50, 5},
-		{"ten values p95", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 95, 9},
-		{"ten values p99", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 99, 9},
+		{"two values p50", []float64{10, 20}, 50, 15},
+		{"two values p95", []float64{10, 20}, 95, 19.5},
+		{"ten values p50", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 50, 5.5},
+		{"ten values p95", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 95, 9.55},
+		{"ten values p99", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 99, 9.91},
+		{"ten values p100", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 100, 10},
+		{"ten values p0", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0, 1},
 		{"unsorted", []float64{5, 1, 9, 3, 7}, 50, 5},
 	}
 
@@ -31,7 +34,7 @@ func TestPercentile(t *testing.T) {
 			copy(sorted, tt.data)
 			sort.Float64s(sorted)
 			result := Percentile(sorted, tt.percentile)
-			if result != tt.expected {
+			if math.Abs(result-tt.expected) > 1e-9 {
 				t.Errorf("Percentile() = %v, want %v", result, tt.expected)
 			}
 		})

--- a/internal/diagnose/analyzer/common.go
+++ b/internal/diagnose/analyzer/common.go
@@ -6,12 +6,28 @@ import (
 	"github.com/podtrace/podtrace/internal/config"
 )
 
+// Percentile returns the p-th percentile (0-100) of an ascending-sorted slice
+// using linear interpolation between closest ranks (method R-7, as used by
+// NumPy/Excel). Plain integer indexing floored the rank and systematically
+// under-reported P95/P99.
 func Percentile(sorted []float64, p float64) float64 {
-	if len(sorted) == 0 {
+	n := len(sorted)
+	if n == 0 {
 		return 0
 	}
-	index := int(float64(len(sorted)-1) * p / 100)
-	return sorted[index]
+	if n == 1 || p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[n-1]
+	}
+	rank := (p / 100) * float64(n-1)
+	lo := int(rank)
+	if lo+1 >= n {
+		return sorted[n-1]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
 }
 
 func FormatBytes(bytes uint64) string {

--- a/internal/diagnose/analyzer/tls_test.go
+++ b/internal/diagnose/analyzer/tls_test.go
@@ -69,8 +69,8 @@ func TestAnalyzeTLS(t *testing.T) {
 			wantMaxLatency: 200.0,
 			wantErrors:     1,
 			wantP50:        150.0,
-			wantP95:        150.0,
-			wantP99:        150.0,
+			wantP95:        195.0,
+			wantP99:        199.0,
 		},
 	}
 
@@ -116,4 +116,3 @@ func TestAnalyzeTLS(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -1120,14 +1120,24 @@ func formatFastCGIActivity(d Diagnostician, duration time.Duration) string {
 	}
 
 	pctMs := func(sorted []uint64, p int) float64 {
-		if len(sorted) == 0 {
+		n := len(sorted)
+		if n == 0 {
 			return 0
 		}
-		idx := (len(sorted) * p) / 100
-		if idx >= len(sorted) {
-			idx = len(sorted) - 1
+		if n == 1 || p <= 0 {
+			return float64(sorted[0]) / 1e6
 		}
-		return float64(sorted[idx]) / 1e6
+		if p >= 100 {
+			return float64(sorted[n-1]) / 1e6
+		}
+		rank := (float64(p) / 100) * float64(n-1)
+		lo := int(rank)
+		if lo+1 >= n {
+			return float64(sorted[n-1]) / 1e6
+		}
+		frac := rank - float64(lo)
+		val := float64(sorted[lo]) + frac*(float64(sorted[lo+1])-float64(sorted[lo]))
+		return val / 1e6
 	}
 
 	stats := make([]*uriStat, 0, len(byURI))

--- a/internal/ebpf/tracer/prune_l7_test.go
+++ b/internal/ebpf/tracer/prune_l7_test.go
@@ -1,0 +1,72 @@
+package tracer
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+func TestPruneL7ProbesIfNoBPFLoop(t *testing.T) {
+	t.Setenv("PODTRACE_FORCE_DISABLE_L7", "1")
+
+	spec := &ebpf.CollectionSpec{
+		Programs: map[string]*ebpf.ProgramSpec{
+			"uprobe_h3_parse_headers": {
+				Name: "uprobe_h3_parse_headers",
+				Type: ebpf.Kprobe,
+				Instructions: asm.Instructions{
+					asm.Mov.Imm(asm.R1, 0),
+					asm.FnLoop.Call(),
+					asm.Return(),
+				},
+			},
+			"kprobe_h2_tcp_recvmsg": {
+				Name: "kprobe_h2_tcp_recvmsg",
+				Type: ebpf.Kprobe,
+				Instructions: asm.Instructions{
+					asm.FnLoop.Call(),
+					asm.Return(),
+				},
+			},
+			"kprobe_tcp_connect": {
+				Name: "kprobe_tcp_connect",
+				Type: ebpf.Kprobe,
+				Instructions: asm.Instructions{
+					asm.Mov.Imm(asm.R0, 0),
+					asm.Return(),
+				},
+			},
+		},
+	}
+
+	pruneL7ProbesIfNoBPFLoop(spec)
+
+	for _, gone := range []string{"uprobe_h3_parse_headers", "kprobe_h2_tcp_recvmsg"} {
+		if _, ok := spec.Programs[gone]; ok {
+			t.Errorf("program %q calls bpf_loop and must be pruned when the helper is absent", gone)
+		}
+	}
+	if _, ok := spec.Programs["kprobe_tcp_connect"]; !ok {
+		t.Error("core program kprobe_tcp_connect must be retained (no bpf_loop)")
+	}
+}
+
+func TestPruneL7ProbesIfNoBPFLoop_NoOpWhenAvailable(t *testing.T) {
+	if !bpfLoopAvailable() {
+		t.Skip("bpf_loop not available on this host; prune-skip path not exercisable")
+	}
+	spec := &ebpf.CollectionSpec{
+		Programs: map[string]*ebpf.ProgramSpec{
+			"uprobe_h3_parse_headers": {
+				Name:         "uprobe_h3_parse_headers",
+				Type:         ebpf.Kprobe,
+				Instructions: asm.Instructions{asm.FnLoop.Call(), asm.Return()},
+			},
+		},
+	}
+	pruneL7ProbesIfNoBPFLoop(spec)
+	if _, ok := spec.Programs["uprobe_h3_parse_headers"]; !ok {
+		t.Error("L7 program must be retained when bpf_loop is available")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -21,7 +21,9 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/cilium/ebpf/rlimit"
@@ -425,6 +427,48 @@ func roundUpPow2(n uint32) uint32 {
 
 var _ TracerInterface = (*Tracer)(nil)
 
+// bpfLoopAvailable reports whether the running kernel supports the bpf_loop
+// helper.
+func bpfLoopAvailable() bool {
+	if os.Getenv("PODTRACE_FORCE_DISABLE_L7") == "1" {
+		return false
+	}
+	err := features.HaveProgramHelper(ebpf.Kprobe, asm.FnLoop)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, ebpf.ErrNotSupported) {
+		return false
+	}
+	logger.Warn("bpf_loop capability probe inconclusive; assuming available", zap.Error(err))
+	return true
+}
+
+// pruneL7ProbesIfNoBPFLoop removes the L7 protocol programs (identified by an
+// actual bpf_loop call in their instruction stream, no hardcoded list) from
+// the collection spec when the kernel lacks bpf_loop.
+func pruneL7ProbesIfNoBPFLoop(spec *ebpf.CollectionSpec) {
+	if bpfLoopAvailable() {
+		return
+	}
+	var pruned []string
+	for name, ps := range spec.Programs {
+		for i := range ps.Instructions {
+			ins := ps.Instructions[i]
+			if ins.IsBuiltinCall() && ins.Constant == int64(asm.FnLoop) {
+				delete(spec.Programs, name)
+				pruned = append(pruned, name)
+				break
+			}
+		}
+	}
+	if len(pruned) > 0 {
+		logger.Warn("Kernel lacks the bpf_loop helper (needs mainline 5.17+ or a distro that backports it); "+
+			"disabling L7 protocol tracing (HTTP/2, HTTP/3, gRPC, HTTP header capture) and continuing with core L4 tracing",
+			zap.Int("pruned_programs", len(pruned)))
+	}
+}
+
 func NewTracer() (*Tracer, error) {
 	if err := setDumpable(); err != nil {
 		logger.Warn("Failed to set dumpable flag", zap.Error(err))
@@ -487,6 +531,8 @@ func NewTracer() (*Tracer, error) {
 		}
 	}
 	applyVerifierLogOptions(&opts)
+
+	pruneL7ProbesIfNoBPFLoop(spec)
 
 	coll, err := ebpf.NewCollectionWithOptions(spec, opts)
 	if err != nil {

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -89,6 +89,9 @@ func (r *Redactor) Redact(e *events.Event) {
 		switch e.Type {
 		case events.EventDNS, events.EventDNSQuery:
 			e.Target = "[redacted]"
+			if e.Details != "" {
+				e.Details = "[redacted]"
+			}
 		case events.EventConnect:
 			if e.Details != "" {
 				e.Details = "[redacted]"

--- a/internal/redactor/redactor_test.go
+++ b/internal/redactor/redactor_test.go
@@ -146,4 +146,10 @@ func TestRedact_DNSNameBypasses(t *testing.T) {
 	if connect.Target != "10.0.0.8:00443" {
 		t.Errorf("EventConnect target must keep the ip:port, got %q", connect.Target)
 	}
+
+	answer := &events.Event{Type: events.EventDNS, Target: "secret-internal.example.com", Details: "192.0.2.7"}
+	r.Redact(answer)
+	if answer.Details != "[redacted]" {
+		t.Errorf("EventDNS answer IP left in Details = %q, want [redacted]", answer.Details)
+	}
 }

--- a/internal/system/checks.go
+++ b/internal/system/checks.go
@@ -40,7 +40,6 @@ func (v KernelVersion) AtLeast(major, minor int) bool {
 func CheckRequirements() error {
 	kv, err := parseKernelVersion()
 	if err != nil {
-		// Best-effort: if we cannot parse, warn and continue rather than block.
 		logger.Warn("Could not parse kernel version; proceeding anyway",
 			zap.Error(err))
 		return nil
@@ -75,8 +74,6 @@ func CheckRequirements() error {
 }
 
 // CheckSELinux checks if SELinux is in Enforcing mode and warns if so.
-// It does not block execution — only the kernel can prevent BPF operations,
-// and we want a clear warning before the cryptic EACCES from the kernel.
 func CheckSELinux() {
 	enforcing, how := selinuxEnforcing()
 	if !enforcing {
@@ -188,7 +185,6 @@ func parseKernelVersion() (KernelVersion, error) {
 }
 
 func parseVersionString(s string) (KernelVersion, error) {
-	// Strip anything after '-' (distro suffix) or '+' (local build suffix).
 	for _, sep := range []string{"-", "+"} {
 		if idx := strings.Index(s, sep); idx >= 0 {
 			s = s[:idx]
@@ -226,7 +222,6 @@ func selinuxEnforcing() (bool, string) {
 		return false, ""
 	}
 
-	// Method 1: /sys/fs/selinux/enforce contains "1" when enforcing.
 	if data, err := os.ReadFile("/sys/fs/selinux/enforce"); err == nil {
 		if strings.TrimSpace(string(data)) == "1" {
 			return true, "/sys/fs/selinux/enforce"
@@ -234,12 +229,10 @@ func selinuxEnforcing() (bool, string) {
 		return false, ""
 	}
 
-	// Method 2: /sys/fs/selinux exists but enforce is unreadable — still present.
 	if _, err := os.Stat("/sys/fs/selinux"); err == nil {
 		return true, "/sys/fs/selinux (enforce unreadable)"
 	}
 
-	// Method 3: check /proc/cmdline for selinux=1 or security=selinux.
 	if data, err := os.ReadFile("/proc/cmdline"); err == nil {
 		cmdline := string(data)
 		if strings.Contains(cmdline, "security=selinux") || strings.Contains(cmdline, "selinux=1") {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -172,18 +172,31 @@ func ValidatePath(path string, basePath string) error {
 	}
 	cleanPath := filepath.Clean(path)
 	cleanBase := filepath.Clean(basePath)
-	// The prefix check must stop at a path-separator boundary: a bare
-	// HasPrefix accepted "/base-evil" as being inside "/base".
-	inside := cleanPath == cleanBase ||
-		cleanBase == string(filepath.Separator) && strings.HasPrefix(cleanPath, cleanBase) ||
-		strings.HasPrefix(cleanPath, cleanBase+string(filepath.Separator))
-	if !inside {
+	if !pathInside(cleanPath, cleanBase) {
 		return fmt.Errorf("path %s is outside base path %s", cleanPath, cleanBase)
 	}
-	if strings.Contains(cleanPath, "..") {
-		return fmt.Errorf("path contains traversal sequence")
+	for _, seg := range strings.Split(cleanPath, string(filepath.Separator)) {
+		if seg == ".." {
+			return fmt.Errorf("path contains traversal sequence")
+		}
+	}
+	if resolved, err := filepath.EvalSymlinks(cleanPath); err == nil {
+		resolvedBase := cleanBase
+		if rb, err := filepath.EvalSymlinks(cleanBase); err == nil {
+			resolvedBase = rb
+		}
+		if !pathInside(resolved, resolvedBase) {
+			return fmt.Errorf("path %s resolves outside base path %s via symlink", cleanPath, resolvedBase)
+		}
 	}
 	return nil
+}
+
+// pathInside reports whether cleanPath equals or is nested under cleanBase.
+func pathInside(cleanPath, cleanBase string) bool {
+	return cleanPath == cleanBase ||
+		(cleanBase == string(filepath.Separator) && strings.HasPrefix(cleanPath, cleanBase)) ||
+		strings.HasPrefix(cleanPath, cleanBase+string(filepath.Separator))
 }
 
 func ValidateContainerPath(path string, containerID string) error {
@@ -193,8 +206,6 @@ func ValidateContainerPath(path string, containerID string) error {
 	if strings.ContainsRune(path, 0) {
 		return fmt.Errorf("path contains null byte")
 	}
-	// filepath.Clean resolves ".." sequences before checking, preventing
-	// traversal attacks like "foo/../../etc/passwd" from bypassing the check.
 	clean := filepath.Clean(path)
 	if strings.Contains(clean, "..") || strings.ContainsRune(clean, '/') {
 		return fmt.Errorf("path contains invalid characters")

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -351,6 +353,12 @@ func TestValidatePath(t *testing.T) {
 			basePath: "/base",
 			wantErr:  false,
 		},
+		{
+			name:     "filename containing dot-dot is not traversal",
+			path:     "/base/release-1..2/file",
+			basePath: "/base",
+			wantErr:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -359,6 +367,39 @@ func TestValidatePath(t *testing.T) {
 				t.Errorf("ValidatePath() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestValidatePath_SymlinkEscape: a symlink that is lexically inside basePath
+// but resolves outside must be rejected; a symlink that stays inside is fine.
+func TestValidatePath_SymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	outside := filepath.Join(root, "outside")
+	for _, d := range []string{base, outside} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	escape := filepath.Join(base, "escape")
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := ValidatePath(escape, base); err == nil {
+		t.Error("symlink escaping basePath must be rejected")
+	}
+
+	inside := filepath.Join(base, "sub")
+	if err := os.MkdirAll(inside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "inlink")
+	if err := os.Symlink(inside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := ValidatePath(link, base); err != nil {
+		t.Errorf("symlink staying inside basePath must be accepted, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds runtime `bpf_loop` capability detection so podtrace degrades gracefully on kernels without it, and clears a batch of low-severity robustness, correctness, and doc findings. Validated end-to-end.

## Feature: graceful L7 degradation
- The L7 protocol probes (HTTP/1.1, HTTP/2, HTTP/3, gRPC) use the `bpf_loop` helper (mainline kernel 5.17+), and the eBPF collection loads all-or-nothing, so on a kernel without it the whole backend previously dropped to noop.
- podtrace now probes for `bpf_loop` at load time, a real capability check via `features.HaveProgramHelper`, not a kernel-version guess, so it is correct on distros that backport the helper onto an older version number (e.g. RHEL 9's 5.14).
- When the helper is genuinely absent, it prunes exactly the programs that call `bpf_loop` (detected from the instruction stream, no hardcoded list) and continues with core L4 tracing (network, DNS, filesystem, CPU, syscalls) instead of failing. `PODTRACE_FORCE_DISABLE_L7=1` forces this path for testing.
- Kernel-support docs rewritten to the graceful-degradation; the runtime version gate stays at the true 5.8 floor rather than a risky bump that would wrongly block backport distros.

## Fixes
- redactor: DNS-name redaction now also redacts the answer IP in `Details`, which was reverse-DNS resolvable and defeated the redaction.
- validation: `ValidatePath` rejects `..` only as a path component (no more false positives on names like `release-1..2`) and resolves symlinks to catch escapes out of the base path.
- diagnose: unified `analyzer.Percentile` and the report's `pctMs` on R-7 linear interpolation; they diverged and both floored the rank, under-reporting P95/P99.
- bpf/http.c: only emit a response when exactly three status digits were parsed (was `si == 0`), eliminating negative/bogus status codes from short reads.
- bpf/h2.c: the HPACK sequence counter now uses an atomic `__sync_fetch_and_add` (a genuine `BPF_ATOMIC|BPF_FETCH` at `-mcpu=v2`) so concurrent CPUs on one connection can no longer hand out the same seq.
- bpf/dns.c: reject non-first IPv6 fragments (fragment-offset guard), matching the existing IPv4 guard, so a non-first fragment is not parsed as an L4/DNS header.
- bpf maps: db-pool tracking now deletes its `(pid,tid)` entries on release and uses `LRU_HASH` as a backstop; `kafka_topic_names` uses `LRU_HASH`; the genuinely-dead `tcp_sockets` and `tls_handshakes` maps are removed (the loader-referenced `cgroup_limits` is kept).
- Helm: the CRD-labeler / namespace / cr-bootstrap hook Jobs pin `alpine/k8s` by digest so these cluster-critical hooks are reproducible.