### PR TITLE
feat: probe every distinct binary in a container for uprobes

### DIFF
--- a/cmd/podtrace/agent.go
+++ b/cmd/podtrace/agent.go
@@ -149,12 +149,16 @@ func (a *ebpfBackendAdapter) SetContainerID(id string) error {
 
 // SetContainerTargets implements the optional pkg/tracer.ContainerUprobeReconciler
 // interface: it hands the eBPF tracer the full set of currently-targeted
-// containers (with per-container PIDs) so it can attach newly-seen containers'
-// uprobes and detach departed ones.
+// containers so it can attach newly-seen containers' uprobes and detach
+// departed ones.
 func (a *ebpfBackendAdapter) SetContainerTargets(targets []tracer.ContainerUprobeTarget) error {
 	conv := make([]ebpf.ContainerProbeTarget, 0, len(targets))
 	for _, t := range targets {
-		conv = append(conv, ebpf.ContainerProbeTarget{ID: t.ContainerID, PID: t.PID})
+		ct := ebpf.ContainerProbeTarget{ID: t.ContainerID}
+		if t.PID != 0 {
+			ct.PIDs = []uint32{t.PID}
+		}
+		conv = append(conv, ct)
 	}
 	return a.tr.SetContainerTargets(conv)
 }

--- a/internal/ebpf/probes/attachedfiles.go
+++ b/internal/ebpf/probes/attachedfiles.go
@@ -1,0 +1,44 @@
+package probes
+
+import (
+	"os"
+	"syscall"
+)
+
+// AttachedFiles tracks library files already claimed for uprobe attachment
+// within one container attach pass.
+type AttachedFiles struct {
+	seen map[attachedFileKey]struct{}
+}
+
+type attachedFileKey struct {
+	family string
+	dev    uint64
+	ino    uint64
+}
+
+func NewAttachedFiles() *AttachedFiles {
+	return &AttachedFiles{seen: map[attachedFileKey]struct{}{}}
+}
+
+// Claim reports whether path is new for this probe family and marks it
+// attached.
+func (a *AttachedFiles) Claim(family, path string) bool {
+	if a == nil {
+		return true
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true
+	}
+	k := attachedFileKey{family: family, dev: uint64(sys.Dev), ino: sys.Ino}
+	if _, dup := a.seen[k]; dup {
+		return false
+	}
+	a.seen[k] = struct{}{}
+	return true
+}

--- a/internal/ebpf/probes/attachedfiles_test.go
+++ b/internal/ebpf/probes/attachedfiles_test.go
@@ -1,0 +1,49 @@
+package probes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAttachedFiles_ClaimDedupesByInode: the same underlying library file is
+// typically reached via different /proc/<pid>/root paths for different PIDs
+// of one container, claims must dedupe on device+inode, not path string.
+func TestAttachedFiles_ClaimDedupesByInode(t *testing.T) {
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "libssl.so.3")
+	if err := os.WriteFile(lib, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(dir, "libssl-alias.so.3")
+	if err := os.Link(lib, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	af := NewAttachedFiles()
+	if !af.Claim("tls", lib) {
+		t.Fatal("first claim must succeed")
+	}
+	if af.Claim("tls", lib) {
+		t.Error("second claim of the same path must be rejected")
+	}
+	if af.Claim("tls", alias) {
+		t.Error("claim via a different path to the same file (same inode) must be rejected")
+	}
+	if !af.Claim("dns", lib) {
+		t.Error("a different probe family must be able to claim the same file")
+	}
+}
+
+func TestAttachedFiles_NilAndUnstatable(t *testing.T) {
+	var af *AttachedFiles
+	if !af.Claim("tls", "/nonexistent") {
+		t.Error("nil AttachedFiles must always claim true")
+	}
+	af = NewAttachedFiles()
+	for i := 0; i < 2; i++ {
+		if !af.Claim("tls", "/nonexistent/path") {
+			t.Errorf("claim %d of an unstatable path = false, want true (attach attempted, never silently skipped)", i+1)
+		}
+	}
+}

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -279,7 +279,7 @@ func AttachProbeGroup(coll *ebpf.Collection, target ProbeGroup) ([]link.Link, er
 }
 
 func AttachDNSProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachDNSProbesWithPID(coll, containerID, 0)
+	return AttachDNSProbesWithPID(coll, containerID, 0, nil)
 }
 
 // packetDNSCaptureEnabled reports whether the libc-independent, packet-based
@@ -391,9 +391,12 @@ func AttachHTTP3Probes(coll *ebpf.Collection, cgroupPaths []string) []link.Link 
 	return links
 }
 
-func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 	libcPath := FindLibcPathWithPID(containerID, pid)
+	if libcPath != "" && !af.Claim("dns", libcPath) {
+		return links
+	}
 	if libcPath != "" {
 		uprobe, err := link.OpenExecutable(libcPath)
 		if err == nil {
@@ -427,13 +430,13 @@ func AttachDNSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 }
 
 func AttachSyncProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachSyncProbesWithPID(coll, containerID, 0)
+	return AttachSyncProbesWithPID(coll, containerID, 0, nil)
 }
 
-func AttachSyncProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachSyncProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 	libcPath := FindLibcPathWithPID(containerID, pid)
-	if libcPath == "" {
+	if libcPath == "" || !af.Claim("sync", libcPath) {
 		return links
 	}
 	uprobe, err := link.OpenExecutable(libcPath)
@@ -461,16 +464,19 @@ func AttachSyncProbesWithPID(coll *ebpf.Collection, containerID string, pid uint
 }
 
 func AttachDBProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachDBProbesWithPID(coll, containerID, 0)
+	return AttachDBProbesWithPID(coll, containerID, 0, nil)
 }
 
-func AttachDBProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachDBProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 
 	libpqPaths := findDBLibsWithPID(containerID, pid, []string{"libpq.so.5", "libpq.so"})
 	for _, path := range libpqPaths {
 		info, err := os.Stat(path)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("db", path) {
 			continue
 		}
 		exe, err := link.OpenExecutable(path)
@@ -495,6 +501,9 @@ func AttachDBProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32
 	for _, path := range mysqlPaths {
 		info, err := os.Stat(path)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("db", path) {
 			continue
 		}
 		exe, err := link.OpenExecutable(path)
@@ -531,10 +540,10 @@ type dbProbeConfig struct {
 }
 
 func AttachPoolProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachPoolProbesWithPID(coll, containerID, 0)
+	return AttachPoolProbesWithPID(coll, containerID, 0, nil)
 }
 
-func AttachPoolProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachPoolProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 
 	var binaryPaths []string
@@ -613,6 +622,9 @@ func AttachPoolProbesWithPID(coll *ebpf.Collection, containerID string, pid uint
 			logger.Debug("Attaching pool probes", zap.String("database", dbConfig.name), zap.String("path", path))
 			info, err := os.Stat(path)
 			if err != nil || info.IsDir() {
+				continue
+			}
+			if !af.Claim("pool/"+dbConfig.name, path) {
 				continue
 			}
 			exe, err := link.OpenExecutable(path)
@@ -849,6 +861,8 @@ func fileInProcMapFiles(pid uint32, addrRange string) string {
 func findContainerProcess(containerID string) uint32 {
 	entries, err := os.ReadDir(config.ProcBasePath)
 	if err != nil {
+		logger.Debug("Container process scan: cannot read proc base",
+			zap.String("proc_base", config.ProcBasePath), zap.Error(err))
 		return 0
 	}
 
@@ -871,6 +885,8 @@ func findContainerProcess(containerID string) uint32 {
 			}
 		}
 	}
+	logger.Debug("Container process scan found no process; library uprobes for this container are silently skipped",
+		zap.String("container_id", containerID))
 	return 0
 }
 
@@ -1896,10 +1912,10 @@ func getArchitectureTLSPaths(libPatterns []string) []string {
 }
 
 func AttachTLSProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachTLSProbesWithPID(coll, containerID, 0)
+	return AttachTLSProbesWithPID(coll, containerID, 0, nil)
 }
 
-func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	links := []link.Link{}
 
 	tlsLibPaths := findTLSLibsWithPID(containerID, pid)
@@ -1921,6 +1937,9 @@ func AttachTLSProbesWithPID(coll *ebpf.Collection, containerID string, pid uint3
 	for _, libPath := range tlsLibPaths {
 		info, err := os.Stat(libPath)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("tls", libPath) {
 			continue
 		}
 		exe, err := link.OpenExecutable(libPath)
@@ -2195,8 +2214,8 @@ func AttachGoHTTP3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
 // AttachNghttp3Probes attaches uprobes on nghttp3's public C ABI
 // (nghttp3_conn_submit_request / nghttp3_conn_submit_response) in libraries
 // mapped by the target process.
-func AttachNghttp3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
-	return attachCLibraryH3Probes(coll, pid, "nghttp3",
+func AttachNghttp3Probes(coll *ebpf.Collection, pid uint32, af *AttachedFiles) []link.Link {
+	return attachCLibraryH3Probes(coll, pid, af, "nghttp3",
 		[]string{"libnghttp3"},
 		map[string][2]string{
 			"nghttp3_conn_submit_request":  {"uprobe_nghttp3_submit_request", ""},
@@ -2207,8 +2226,8 @@ func AttachNghttp3Probes(coll *ebpf.Collection, pid uint32) []link.Link {
 
 // AttachQuicheProbes attaches uprobes on Cloudflare quiche's C FFI
 // (quiche_h3_send_request / quiche_h3_send_response); see bpf/quiche.c.
-func AttachQuicheProbes(coll *ebpf.Collection, pid uint32) []link.Link {
-	return attachCLibraryH3Probes(coll, pid, "quiche",
+func AttachQuicheProbes(coll *ebpf.Collection, pid uint32, af *AttachedFiles) []link.Link {
+	return attachCLibraryH3Probes(coll, pid, af, "quiche",
 		[]string{"libquiche"},
 		map[string][2]string{
 			"quiche_h3_send_request":  {"uprobe_quiche_h3_send_request", "uretprobe_quiche_h3_send_request"},
@@ -2220,7 +2239,7 @@ func AttachQuicheProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 // attachCLibraryH3Probes discovers libraries matching the patterns in the
 // target process's memory maps (including dlopen'd-then-deleted files via
 // map_files) and attaches the given symbol->program uprobes.
-func attachCLibraryH3Probes(coll *ebpf.Collection, pid uint32, adapter string,
+func attachCLibraryH3Probes(coll *ebpf.Collection, pid uint32, af *AttachedFiles, adapter string,
 	libPatterns []string, symbolProgs map[string][2]string) []link.Link {
 	var links []link.Link
 	if pid == 0 {
@@ -2259,6 +2278,9 @@ func attachCLibraryH3Probes(coll *ebpf.Collection, pid uint32, adapter string,
 	}
 
 	for _, libPath := range libPaths {
+		if !af.Claim(adapter, libPath) {
+			continue
+		}
 		exe, err := link.OpenExecutable(libPath)
 		if err != nil {
 			logger.Debug("HTTP/3 adapter: cannot open library",

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -2353,25 +2353,25 @@ func TestFindTLSLibsViaProcessMapsProcRoot_EmptyPatterns(t *testing.T) {
 
 func TestAttachRedisProbesWithPID_NilCollection(t *testing.T) {
 	// nil collection → should return empty without panic
-	links := AttachRedisProbesWithPID(nil, "", 0)
+	links := AttachRedisProbesWithPID(nil, "", 0, nil)
 	_ = links
 }
 
 func TestAttachRedisProbesWithPID_EmptyCollection(t *testing.T) {
 	coll := &ebpf.Collection{Programs: make(map[string]*ebpf.Program)}
-	links := AttachRedisProbesWithPID(coll, "", 0)
+	links := AttachRedisProbesWithPID(coll, "", 0, nil)
 	_ = links
 }
 
 func TestAttachMemcachedProbesWithPID_EmptyCollection(t *testing.T) {
 	coll := &ebpf.Collection{Programs: make(map[string]*ebpf.Program)}
-	links := AttachMemcachedProbesWithPID(coll, "", 0)
+	links := AttachMemcachedProbesWithPID(coll, "", 0, nil)
 	_ = links
 }
 
 func TestAttachKafkaProbesWithPID_EmptyCollection(t *testing.T) {
 	coll := &ebpf.Collection{Programs: make(map[string]*ebpf.Program)}
-	links := AttachKafkaProbesWithPID(coll, "", 0)
+	links := AttachKafkaProbesWithPID(coll, "", 0, nil)
 	_ = links
 }
 

--- a/internal/ebpf/probes/protocols.go
+++ b/internal/ebpf/probes/protocols.go
@@ -41,11 +41,11 @@ func attachUprobeSymbols(exe *link.Executable, coll *ebpf.Collection, libPath st
 
 // AttachRedisProbes attaches hiredis uprobes for EVENT_REDIS_CMD tracing.
 func AttachRedisProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachRedisProbesWithPID(coll, containerID, 0)
+	return AttachRedisProbesWithPID(coll, containerID, 0, nil)
 }
 
 // AttachRedisProbesWithPID attaches hiredis uprobes with process-assisted library resolution.
-func AttachRedisProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachRedisProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 	libNames := []string{"libhiredis.so.1", "libhiredis.so.0.14", "libhiredis.so"}
 	paths := findDBLibsWithPID(containerID, pid, libNames)
@@ -53,6 +53,9 @@ func AttachRedisProbesWithPID(coll *ebpf.Collection, containerID string, pid uin
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("redis", path) {
 			continue
 		}
 		exe, err := link.OpenExecutable(path)
@@ -77,11 +80,11 @@ func AttachRedisProbesWithPID(coll *ebpf.Collection, containerID string, pid uin
 
 // AttachMemcachedProbes attaches libmemcached uprobes for EVENT_MEMCACHED_CMD tracing.
 func AttachMemcachedProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachMemcachedProbesWithPID(coll, containerID, 0)
+	return AttachMemcachedProbesWithPID(coll, containerID, 0, nil)
 }
 
 // AttachMemcachedProbesWithPID attaches libmemcached uprobes with process-assisted library resolution.
-func AttachMemcachedProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachMemcachedProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 	libNames := []string{"libmemcached.so.11", "libmemcached.so.10", "libmemcached.so"}
 	paths := findDBLibsWithPID(containerID, pid, libNames)
@@ -89,6 +92,9 @@ func AttachMemcachedProbesWithPID(coll *ebpf.Collection, containerID string, pid
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("memcached", path) {
 			continue
 		}
 		exe, err := link.OpenExecutable(path)
@@ -114,11 +120,11 @@ func AttachMemcachedProbesWithPID(coll *ebpf.Collection, containerID string, pid
 
 // AttachKafkaProbes attaches librdkafka uprobes for Kafka produce/consume tracing.
 func AttachKafkaProbes(coll *ebpf.Collection, containerID string) []link.Link {
-	return AttachKafkaProbesWithPID(coll, containerID, 0)
+	return AttachKafkaProbesWithPID(coll, containerID, 0, nil)
 }
 
 // AttachKafkaProbesWithPID attaches librdkafka uprobes with process-assisted library resolution.
-func AttachKafkaProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32) []link.Link {
+func AttachKafkaProbesWithPID(coll *ebpf.Collection, containerID string, pid uint32, af *AttachedFiles) []link.Link {
 	var links []link.Link
 	libNames := []string{"librdkafka.so.1", "librdkafka.so"}
 	paths := findDBLibsWithPID(containerID, pid, libNames)
@@ -126,6 +132,9 @@ func AttachKafkaProbesWithPID(coll *ebpf.Collection, containerID string, pid uin
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil || info.IsDir() {
+			continue
+		}
+		if !af.Claim("kafka", path) {
 			continue
 		}
 		exe, err := link.OpenExecutable(path)
@@ -154,7 +163,7 @@ func AttachKafkaProbesWithPID(coll *ebpf.Collection, containerID string, pid uin
 func AttachFastCGIProbes(coll *ebpf.Collection) []link.Link {
 	var links []link.Link
 	kprobeMap := map[string]struct {
-		sym     string
+		sym      string
 		retprobe bool
 	}{
 		"kprobe_unix_stream_recvmsg":    {"unix_stream_recvmsg", false},

--- a/internal/ebpf/probes/protocols_test.go
+++ b/internal/ebpf/probes/protocols_test.go
@@ -36,7 +36,7 @@ func TestAttachRedisProbes_NoLibFound(t *testing.T) {
 }
 
 func TestAttachRedisProbesWithPID_NoMatch(t *testing.T) {
-	if got := AttachRedisProbesWithPID(emptyColl(), "", 0); len(got) != 0 {
+	if got := AttachRedisProbesWithPID(emptyColl(), "", 0, nil); len(got) != 0 {
 		t.Errorf("expected no links, got %d", len(got))
 	}
 }
@@ -51,7 +51,7 @@ func TestAttachMemcachedProbes_NoLibFound(t *testing.T) {
 }
 
 func TestAttachMemcachedProbesWithPID_NoMatch(t *testing.T) {
-	if got := AttachMemcachedProbesWithPID(emptyColl(), "", 0); len(got) != 0 {
+	if got := AttachMemcachedProbesWithPID(emptyColl(), "", 0, nil); len(got) != 0 {
 		t.Errorf("expected no links, got %d", len(got))
 	}
 }
@@ -63,7 +63,7 @@ func TestAttachKafkaProbes_NoLibFound(t *testing.T) {
 }
 
 func TestAttachKafkaProbesWithPID_NoMatch(t *testing.T) {
-	if got := AttachKafkaProbesWithPID(emptyColl(), "", 0); len(got) != 0 {
+	if got := AttachKafkaProbesWithPID(emptyColl(), "", 0, nil); len(got) != 0 {
 		t.Errorf("expected no links, got %d", len(got))
 	}
 }

--- a/internal/ebpf/tracer/multibinary_discovery_test.go
+++ b/internal/ebpf/tracer/multibinary_discovery_test.go
@@ -1,0 +1,147 @@
+package tracer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf/link"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/ebpf/probes"
+	"github.com/podtrace/podtrace/internal/sysfs"
+)
+
+func fakeContainerProc(t *testing.T, containerID string, pids []uint32, exeOf map[uint32]string) string {
+	t.Helper()
+	base := t.TempDir()
+	cgroupBase := filepath.Join(base, "cgroup")
+	procBase := filepath.Join(base, "proc")
+	cgroupDir := filepath.Join(cgroupBase, "kubepods", containerID)
+	if err := os.MkdirAll(cgroupDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(base, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	procsContent := ""
+	for _, pid := range pids {
+		procsContent += fmt.Sprintf("%d\n", pid)
+		name := exeOf[pid]
+		if name == "" {
+			continue
+		}
+		bin := filepath.Join(binDir, name)
+		if _, err := os.Stat(bin); os.IsNotExist(err) {
+			if err := os.WriteFile(bin, []byte(name), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		pidDir := filepath.Join(procBase, fmt.Sprintf("%d", pid))
+		if err := os.MkdirAll(pidDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(bin, filepath.Join(pidDir, "exe")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cgroupDir, "cgroup.procs"), []byte(procsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCgroup, oldProc := config.CgroupBasePath, config.ProcBasePath
+	config.SetCgroupBasePath(cgroupBase)
+	config.SetProcBasePath(procBase)
+	sysfs.ResetForTesting()
+	t.Cleanup(func() {
+		config.SetCgroupBasePath(oldCgroup)
+		config.SetProcBasePath(oldProc)
+		sysfs.ResetForTesting()
+	})
+	return cgroupDir
+}
+
+func TestPidsForContainer_DedupesByExecutableInode(t *testing.T) {
+	const cid = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	cgroupDir := fakeContainerProc(t, cid,
+		[]uint32{101, 102, 103, 104},
+		map[uint32]string{
+			101: "shell",
+			102: "shell",
+			103: "gotls",
+			104: "",
+		})
+
+	tr := &Tracer{cgroupPaths: []string{cgroupDir}}
+	pids := tr.pidsForContainer(cid, nil)
+	if len(pids) != 2 || pids[0] != 101 || pids[1] != 103 {
+		t.Fatalf("pidsForContainer = %v, want [101 103] (one PID per distinct executable)", pids)
+	}
+}
+
+func TestPidsForContainer_CapsDistinctBinaries(t *testing.T) {
+	const cid = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"
+	pids := make([]uint32, 0, maxDistinctBinariesPerContainer+3)
+	exeOf := map[uint32]string{}
+	for i := 0; i < maxDistinctBinariesPerContainer+3; i++ {
+		pid := uint32(200 + i)
+		pids = append(pids, pid)
+		exeOf[pid] = fmt.Sprintf("bin%d", i)
+	}
+	cgroupDir := fakeContainerProc(t, cid, pids, exeOf)
+
+	tr := &Tracer{cgroupPaths: []string{cgroupDir}}
+	got := tr.pidsForContainer(cid, nil)
+	if len(got) != maxDistinctBinariesPerContainer {
+		t.Fatalf("pidsForContainer returned %d PIDs, want cap %d", len(got), maxDistinctBinariesPerContainer)
+	}
+}
+
+func TestSetContainerTargets_ReattachesWhenPIDSetChanges(t *testing.T) {
+	var lastPIDs []uint32
+	attachCalls := 0
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+	old := &fakeLink{}
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
+		if g != probes.GroupTLS {
+			return nil
+		}
+		attachCalls++
+		lastPIDs = append([]uint32(nil), pids...)
+		if attachCalls == 1 {
+			return []link.Link{old}
+		}
+		return []link.Link{&fakeLink{}}
+	}
+
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1}}}); err != nil {
+		t.Fatalf("SetContainerTargets: %v", err)
+	}
+	if attachCalls != 1 || len(lastPIDs) != 1 || lastPIDs[0] != 1 {
+		t.Fatalf("first attach: calls=%d pids=%v, want 1 call with [1]", attachCalls, lastPIDs)
+	}
+
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{2, 1}}}); err != nil {
+		t.Fatalf("SetContainerTargets: %v", err)
+	}
+	if attachCalls != 2 {
+		t.Fatalf("attach calls = %d, want 2 (PID-set change must re-attach)", attachCalls)
+	}
+	if len(lastPIDs) != 2 || lastPIDs[0] != 1 || lastPIDs[1] != 2 {
+		t.Fatalf("second attach pids = %v, want sorted [1 2]", lastPIDs)
+	}
+	if old.closes.Load() != 1 {
+		t.Fatalf("stale link closes = %d, want 1 (old attachment must be detached)", old.closes.Load())
+	}
+
+	// Same set again (any order): no re-attach.
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1, 2}}}); err != nil {
+		t.Fatalf("SetContainerTargets: %v", err)
+	}
+	if attachCalls != 2 {
+		t.Fatalf("attach calls = %d after unchanged set, want 2 (no churn)", attachCalls)
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -84,7 +85,7 @@ type Tracer struct {
 
 	containerUprobes         map[string]*containerUprobeSet
 	globalProtocolAttached   bool
-	attachContainerGroupFn   func(g probes.ProbeGroup, id string, pid uint32) []link.Link
+	attachContainerGroupFn   func(g probes.ProbeGroup, id string, pids []uint32) []link.Link
 	reader                   *ringbuf.Reader
 	h2Reader                 *ringbuf.Reader
 	h2Decoder                *h2decode.Decoder
@@ -144,16 +145,29 @@ func (t *Tracer) linkCount() int {
 }
 
 type ContainerProbeTarget struct {
-	ID  string
-	PID uint32
+	ID   string
+	PIDs []uint32
 }
 
 // containerUprobeSet holds one container's uprobe links keyed by probe group
 // so DisableProbeGroup/EnableProbeGroup can detach and re-attach a group for
 // every targeted container.
 type containerUprobeSet struct {
-	pid   uint32
+	pids  []uint32
 	links map[probes.ProbeGroup][]link.Link
+}
+
+// samePIDSet compares two sorted PID slices.
+func samePIDSet(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *containerUprobeSet) allLinks() []link.Link {
@@ -192,54 +206,56 @@ func (t *Tracer) attachGlobalProtocolProbesOnce() {
 }
 
 // attachContainerGroupUprobes attaches one probe group's container-scoped
-// uprobes for one container (resolved via its own PID) and returns the links,
-// without registering them in the shared probeGroups registry, the
-// per-container lifecycle in SetContainerTargets owns them.
-func (t *Tracer) attachContainerGroupUprobes(g probes.ProbeGroup, id string, pid uint32) []link.Link {
+// uprobes for one container and returns the links, without registering them
+// in the shared probeGroups registry, the per-container lifecycle in
+// SetContainerTargets owns them.
+func (t *Tracer) attachContainerGroupUprobes(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
 	coll := t.collection
-	if coll == nil || id == "" {
+	if coll == nil || id == "" || len(pids) == 0 {
 		return nil
 	}
-	switch g {
-	case probes.GroupTLS:
-		var ls []link.Link
-		ls = append(ls, probes.AttachDNSProbesWithPID(coll, id, pid)...)
-		ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid)...)
-		ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid)...)
-		ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
-		ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
-		ls = append(ls, probes.AttachRustlsProbes(coll, pid)...)
-		ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
-		ls = append(ls, probes.AttachNghttp3Probes(coll, pid)...)
-		ls = append(ls, probes.AttachQuicheProbes(coll, pid)...)
-		ls = append(ls, probes.AttachQuicheRustProbes(coll, pid)...)
-		return ls
-	case probes.GroupDatabase:
-		return probes.AttachDBProbesWithPID(coll, id, pid)
-	case probes.GroupPool:
-		return probes.AttachPoolProbesWithPID(coll, id, pid)
-	case probes.GroupCache:
-		var ls []link.Link
-		ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid)...)
-		ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid)...)
-		return ls
-	case probes.GroupMessaging:
-		return probes.AttachKafkaProbesWithPID(coll, id, pid)
+	af := probes.NewAttachedFiles()
+	var ls []link.Link
+	for _, pid := range pids {
+		switch g {
+		case probes.GroupTLS:
+			ls = append(ls, probes.AttachDNSProbesWithPID(coll, id, pid, af)...)
+			ls = append(ls, probes.AttachSyncProbesWithPID(coll, id, pid, af)...)
+			ls = append(ls, probes.AttachTLSProbesWithPID(coll, id, pid, af)...)
+			ls = append(ls, probes.AttachGoTLSProbes(coll, pid)...)
+			ls = append(ls, probes.AttachGoGRPCProbes(coll, pid)...)
+			ls = append(ls, probes.AttachRustlsProbes(coll, pid)...)
+			ls = append(ls, probes.AttachGoHTTP3Probes(coll, pid)...)
+			ls = append(ls, probes.AttachNghttp3Probes(coll, pid, af)...)
+			ls = append(ls, probes.AttachQuicheProbes(coll, pid, af)...)
+			ls = append(ls, probes.AttachQuicheRustProbes(coll, pid)...)
+		case probes.GroupDatabase:
+			ls = append(ls, probes.AttachDBProbesWithPID(coll, id, pid, af)...)
+		case probes.GroupPool:
+			ls = append(ls, probes.AttachPoolProbesWithPID(coll, id, pid, af)...)
+		case probes.GroupCache:
+			ls = append(ls, probes.AttachRedisProbesWithPID(coll, id, pid, af)...)
+			ls = append(ls, probes.AttachMemcachedProbesWithPID(coll, id, pid, af)...)
+		case probes.GroupMessaging:
+			ls = append(ls, probes.AttachKafkaProbesWithPID(coll, id, pid, af)...)
+		default:
+			return nil
+		}
 	}
-	return nil
+	return ls
 }
 
 // attachContainerGroup dispatches to the test seam when set.
-func (t *Tracer) attachContainerGroup(g probes.ProbeGroup, id string, pid uint32) []link.Link {
+func (t *Tracer) attachContainerGroup(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
 	if t.attachContainerGroupFn != nil {
-		return t.attachContainerGroupFn(g, id, pid)
+		return t.attachContainerGroupFn(g, id, pids)
 	}
-	return t.attachContainerGroupUprobes(g, id, pid)
+	return t.attachContainerGroupUprobes(g, id, pids)
 }
 
 // attachContainerUprobes attaches every currently-enabled container-scoped
 // uprobe group for one container.
-func (t *Tracer) attachContainerUprobes(id string, pid uint32) map[probes.ProbeGroup][]link.Link {
+func (t *Tracer) attachContainerUprobes(id string, pids []uint32) map[probes.ProbeGroup][]link.Link {
 	out := make(map[probes.ProbeGroup][]link.Link, len(containerUprobeGroups))
 	for _, g := range containerUprobeGroups {
 		t.probeGroupsMu.Lock()
@@ -248,7 +264,7 @@ func (t *Tracer) attachContainerUprobes(id string, pid uint32) map[probes.ProbeG
 		if disabled {
 			continue
 		}
-		if ls := t.attachContainerGroup(g, id, pid); len(ls) > 0 {
+		if ls := t.attachContainerGroup(g, id, pids); len(ls) > 0 {
 			out[g] = ls
 		}
 	}
@@ -256,14 +272,17 @@ func (t *Tracer) attachContainerUprobes(id string, pid uint32) map[probes.ProbeG
 }
 
 // SetContainerTargets reconciles container-scoped uprobes against the full set
-// of currently-targeted containers.
+// of currently-targeted containers. Each target's PIDs are expanded to one
+// representative PID per distinct executable in the container (the caller's
+// PIDs act as seeds), so a container is re-attached whenever its binary set
+// changes, not just when a single PID changes.
 func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	t.attachGlobalProtocolProbesOnce()
 
-	want := make(map[string]uint32, len(targets))
+	want := make(map[string][]uint32, len(targets))
 	for _, ct := range targets {
 		if ct.ID != "" {
-			want[ct.ID] = ct.PID
+			want[ct.ID] = t.pidsForContainer(ct.ID, ct.PIDs)
 		}
 	}
 
@@ -273,16 +292,16 @@ func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	}
 	var stale []link.Link
 	for id, set := range t.containerUprobes {
-		if pid, ok := want[id]; ok && pid == set.pid {
+		if pids, ok := want[id]; ok && samePIDSet(pids, set.pids) {
 			continue
 		}
 		stale = append(stale, set.allLinks()...)
 		delete(t.containerUprobes, id)
 	}
 	var toAttach []ContainerProbeTarget
-	for id, pid := range want {
+	for id, pids := range want {
 		if _, ok := t.containerUprobes[id]; !ok {
-			toAttach = append(toAttach, ContainerProbeTarget{ID: id, PID: pid})
+			toAttach = append(toAttach, ContainerProbeTarget{ID: id, PIDs: pids})
 		}
 	}
 	t.probeGroupsMu.Unlock()
@@ -292,9 +311,9 @@ func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	}
 
 	for _, ct := range toAttach {
-		links := t.attachContainerUprobes(ct.ID, ct.PID)
+		links := t.attachContainerUprobes(ct.ID, ct.PIDs)
 		t.probeGroupsMu.Lock()
-		t.containerUprobes[ct.ID] = &containerUprobeSet{pid: ct.PID, links: links}
+		t.containerUprobes[ct.ID] = &containerUprobeSet{pids: ct.PIDs, links: links}
 		t.probeGroupsMu.Unlock()
 	}
 	return nil
@@ -325,26 +344,26 @@ func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
 // uprobes for every currently-targeted container that lost them.
 func (t *Tracer) reattachContainerGroupUprobes(g probes.ProbeGroup) int {
 	type target struct {
-		id  string
-		pid uint32
+		id   string
+		pids []uint32
 	}
 	t.probeGroupsMu.Lock()
 	missing := make([]target, 0, len(t.containerUprobes))
 	for id, set := range t.containerUprobes {
 		if len(set.links[g]) == 0 {
-			missing = append(missing, target{id: id, pid: set.pid})
+			missing = append(missing, target{id: id, pids: set.pids})
 		}
 	}
 	t.probeGroupsMu.Unlock()
 
 	reattached := 0
 	for _, c := range missing {
-		ls := t.attachContainerGroup(g, c.id, c.pid)
+		ls := t.attachContainerGroup(g, c.id, c.pids)
 		if len(ls) == 0 {
 			continue
 		}
 		t.probeGroupsMu.Lock()
-		if set, ok := t.containerUprobes[c.id]; ok && set.pid == c.pid {
+		if set, ok := t.containerUprobes[c.id]; ok && samePIDSet(set.pids, c.pids) {
 			if set.links == nil {
 				set.links = map[probes.ProbeGroup][]link.Link{}
 			}
@@ -1013,15 +1032,18 @@ func (t *Tracer) setCgroupFilterEnabled(enabled bool) error {
 	return flagMap.Update(&zero, &val, ebpf.UpdateAny)
 }
 
-func readFirstPIDFromCgroupProcs(cgroupPath string) uint32 {
+// readPIDsFromCgroupProcs returns every PID listed in the cgroup's
+// cgroup.procs file, in file order.
+func readPIDsFromCgroupProcs(cgroupPath string) []uint32 {
 	rel, ok := sysfs.CgroupRelative(cgroupPath)
 	if !ok {
-		return 0
+		return nil
 	}
 	data, err := sysfs.CgroupReadFile(filepath.Join(rel, "cgroup.procs"))
 	if err != nil {
-		return 0
+		return nil
 	}
+	var pids []uint32
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -1029,8 +1051,15 @@ func readFirstPIDFromCgroupProcs(cgroupPath string) uint32 {
 		}
 		var pid uint32
 		if _, err := fmt.Sscanf(line, "%d", &pid); err == nil && pid > 0 {
-			return pid
+			pids = append(pids, pid)
 		}
+	}
+	return pids
+}
+
+func readFirstPIDFromCgroupProcs(cgroupPath string) uint32 {
+	if pids := readPIDsFromCgroupProcs(cgroupPath); len(pids) > 0 {
+		return pids[0]
 	}
 	return 0
 }
@@ -1073,7 +1102,7 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 			continue
 		}
 		seen[id] = struct{}{}
-		targets = append(targets, ContainerProbeTarget{ID: id, PID: t.pidForContainer(id)})
+		targets = append(targets, ContainerProbeTarget{ID: id})
 	}
 	if len(targets) == 0 {
 		return fmt.Errorf("all container IDs are empty")
@@ -1084,22 +1113,83 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 
 // pidForContainer resolves the PID used to discover a container's binaries
 // for uprobe attachment.
-func (t *Tracer) pidForContainer(id string) uint32 {
+const maxDistinctBinariesPerContainer = 8
+
+// pidsForContainer resolves the PIDs used to discover a container's binaries
+// for uprobe attachment: one representative PID per distinct executable
+// (deduplicated by the exe's device+inode) among all processes in the
+// container's cgroup.
+func (t *Tracer) pidsForContainer(id string, seeds []uint32) []uint32 {
 	short := id
 	if len(short) > 12 {
 		short = short[:12]
 	}
+	var procs []uint32
 	for _, p := range t.cgroupPaths {
 		if strings.Contains(p, id) || (short != "" && strings.Contains(p, short)) {
-			if pid := readFirstPIDFromCgroupProcs(p); pid != 0 {
-				return pid
+			if procs = readPIDsFromCgroupProcs(p); len(procs) > 0 {
+				break
 			}
 		}
 	}
-	logger.Warn("No attached cgroup path matched container ID; uprobe attachment will fall back to scanning /proc for the container",
-		zap.String("container_id", id),
-		zap.Strings("cgroup_paths", t.cgroupPaths))
-	return 0
+	if len(procs) == 0 {
+		out := make([]uint32, 0, len(seeds))
+		seen := map[uint32]struct{}{}
+		for _, s := range seeds {
+			if _, dup := seen[s]; s == 0 || dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+		if len(out) > 0 {
+			sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+			return out
+		}
+		logger.Warn("No attached cgroup path matched container ID; uprobe attachment will fall back to scanning /proc for the container",
+			zap.String("container_id", id),
+			zap.Strings("cgroup_paths", t.cgroupPaths))
+		return []uint32{0}
+	}
+
+	type exeKey struct {
+		dev uint64
+		ino uint64
+	}
+	seenExe := map[exeKey]struct{}{}
+	out := make([]uint32, 0, maxDistinctBinariesPerContainer)
+	dropped := 0
+	for _, pid := range procs {
+		st, err := os.Stat(filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe"))
+		if err != nil {
+			continue
+		}
+		sys, ok := st.Sys().(*syscall.Stat_t)
+		if !ok {
+			continue
+		}
+		k := exeKey{dev: uint64(sys.Dev), ino: sys.Ino}
+		if _, dup := seenExe[k]; dup {
+			continue
+		}
+		seenExe[k] = struct{}{}
+		if len(out) >= maxDistinctBinariesPerContainer {
+			dropped++
+			continue
+		}
+		out = append(out, pid)
+	}
+	if dropped > 0 {
+		logger.Warn("Container has more distinct binaries than the uprobe discovery cap; the extra binaries get no library uprobes",
+			zap.String("container_id", id),
+			zap.Int("cap", maxDistinctBinariesPerContainer),
+			zap.Int("dropped_binaries", dropped))
+	}
+	if len(out) == 0 {
+		out = append(out, procs[0])
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) error {

--- a/internal/ebpf/tracer/uprobe_target_hygiene_test.go
+++ b/internal/ebpf/tracer/uprobe_target_hygiene_test.go
@@ -14,8 +14,15 @@ func TestPidForContainer_NoCgroupMatchReturnsZero(t *testing.T) {
 		containerPID: 42,
 		cgroupPaths:  []string{"/sys/fs/cgroup/kubepods/poduid/othercontainerid"},
 	}
-	if pid := tr.pidForContainer("deadbeefdeadbeef"); pid != 0 {
-		t.Fatalf("pidForContainer = %d, want 0 (must not borrow another container's PID)", pid)
+	if pids := tr.pidsForContainer("deadbeefdeadbeef", nil); len(pids) != 1 || pids[0] != 0 {
+		t.Fatalf("pidsForContainer = %v, want [0] (must not borrow another container's PID)", pids)
+	}
+}
+
+func TestPidsForContainer_SeedsUsedWhenCgroupUnreadable(t *testing.T) {
+	tr := &Tracer{}
+	if pids := tr.pidsForContainer("deadbeefdeadbeef", []uint32{7, 0, 3, 7}); len(pids) != 2 || pids[0] != 3 || pids[1] != 7 {
+		t.Fatalf("pidsForContainer with seeds = %v, want [3 7]", pids)
 	}
 }
 
@@ -23,11 +30,11 @@ func TestDisableProbeGroup_ClosesContainerUprobeLinks(t *testing.T) {
 	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
 	tlsA, tlsB, dbA := &fakeLink{}, &fakeLink{}, &fakeLink{}
 	tr.containerUprobes = map[string]*containerUprobeSet{
-		"containeraaaa": {pid: 1, links: map[probes.ProbeGroup][]link.Link{
+		"containeraaaa": {pids: []uint32{1}, links: map[probes.ProbeGroup][]link.Link{
 			probes.GroupTLS:      {tlsA},
 			probes.GroupDatabase: {dbA},
 		}},
-		"containerbbbb": {pid: 2, links: map[probes.ProbeGroup][]link.Link{
+		"containerbbbb": {pids: []uint32{2}, links: map[probes.ProbeGroup][]link.Link{
 			probes.GroupTLS: {tlsB},
 		}},
 	}
@@ -56,15 +63,15 @@ func TestEnableProbeGroup_ReattachesContainerUprobes(t *testing.T) {
 		probeGroups: map[probes.ProbeGroup][]link.Link{},
 		collection:  &ebpf.Collection{},
 	}
-	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pid uint32) []link.Link {
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
 		attachCalls[string(g)+"/"+id]++
 		return []link.Link{&fakeLink{}}
 	}
 	tr.containerUprobes = map[string]*containerUprobeSet{
-		"containeraaaa": {pid: 1, links: map[probes.ProbeGroup][]link.Link{
+		"containeraaaa": {pids: []uint32{1}, links: map[probes.ProbeGroup][]link.Link{
 			probes.GroupTLS: {&fakeLink{}},
 		}},
-		"containerbbbb": {pid: 2, links: map[probes.ProbeGroup][]link.Link{
+		"containerbbbb": {pids: []uint32{2}, links: map[probes.ProbeGroup][]link.Link{
 			probes.GroupTLS: {&fakeLink{}},
 		}},
 	}
@@ -92,12 +99,12 @@ func TestSetContainerTargets_SkipsIntentionallyDisabledGroups(t *testing.T) {
 		probeGroups:           map[probes.ProbeGroup][]link.Link{},
 		intentionallyDisabled: map[probes.ProbeGroup]struct{}{probes.GroupTLS: {}},
 	}
-	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pid uint32) []link.Link {
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
 		requested[g]++
 		return []link.Link{&fakeLink{}}
 	}
 
-	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PID: 1}}); err != nil {
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1}}}); err != nil {
 		t.Fatalf("SetContainerTargets: %v", err)
 	}
 
@@ -120,7 +127,7 @@ func TestSetEnabledCategories_DisablesContainerOnlyGroups(t *testing.T) {
 	}
 	tlsLink := &fakeLink{}
 	tr.containerUprobes = map[string]*containerUprobeSet{
-		"containeraaaa": {pid: 1, links: map[probes.ProbeGroup][]link.Link{
+		"containeraaaa": {pids: []uint32{1}, links: map[probes.ProbeGroup][]link.Link{
 			probes.GroupTLS: {tlsLink},
 		}},
 	}
@@ -146,11 +153,11 @@ func TestSetEnabledCategories_GatesGroupsBeforeAttach(t *testing.T) {
 	}
 
 	requested := map[probes.ProbeGroup]int{}
-	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pid uint32) []link.Link {
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
 		requested[g]++
 		return []link.Link{&fakeLink{}}
 	}
-	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PID: 1}}); err != nil {
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1}}}); err != nil {
 		t.Fatalf("SetContainerTargets: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Library uprobe discovery previously used a single PID per container (the first entry in `cgroup.procs`), so a shell-wrapper + app container, or a container running two runtimes (e.g. a Go process next to an OpenSSL-linked one), only got the first binary's libraries probed. This PR discovers one representative PID per distinct executable in the container and attaches uprobes for all of them, with file-level deduplication so shared libraries are never attached twice.

## Changes

- **Per-binary PID discovery.** New `pidsForContainer` reads all of `cgroup.procs` and reduces it to one PID per distinct executable (deduplicated by the exe's device+inode; unreadable/zombie entries skipped). Capped at 8 distinct binaries per container with a warning naming what was dropped, no silent truncation. Fallbacks preserve the existing semantics: caller-provided seed PIDs when the cgroup cannot be enumerated, then PID 0 (which routes the library helpers to the /proc container-ID scan).
- **Set-based reconcile.** `ContainerProbeTarget` carries `PIDs []uint32`; `SetContainerTargets` expands each target centrally (callers pass a single seed PID) and re-attaches a container when its full PID set changes, not just when one PID changes. The agent path gains multi-binary coverage with no reconciler changes, and the public engine API is unchanged.
- **File-level attach dedup.** New `probes.AttachedFiles` tracks claimed library files by device+inode, namespaced per probe family: two PIDs reaching the same `libssl.so` via different `/proc/<pid>/root` paths must not attach twice (that would duplicate every event), while the DNS and lock families must both be able to attach the same libc. Threaded through all library-scanning attach entry points; the exe-based Go/Rust helpers need no dedup because discovery already guarantees exe-distinct PIDs.
- **Visibility.** `findContainerProcess` logs at debug level when the /proc scan fails or matches nothing, so silently skipped library uprobes become diagnosable.