### PR TITLE
feat: trace every container of a targeted pod by default

### DIFF
--- a/api/v1alpha1/podtrace_types.go
+++ b/api/v1alpha1/podtrace_types.go
@@ -22,6 +22,9 @@ type PodTraceSpec struct {
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 
+	// ContainerName narrows tracing to one named container of each matched
+	// pod. Empty means every running container (including restartable-init
+	// sidecars and ephemeral containers) is traced.
 	// +optional
 	ContainerName string `json:"containerName,omitempty"`
 

--- a/api/v1alpha1/podtracesession_types.go
+++ b/api/v1alpha1/podtracesession_types.go
@@ -34,9 +34,6 @@ const (
 
 // PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
 // reconciles this into one privileged Job per node hosting matched pods.
-// The CEL one-of mirrors PodTraceSpec: without it, installs that disable
-// the validating webhook (the chart default) accepted sessions with no
-// target selection at all, or with conflicting ones.
 // +kubebuilder:validation:XValidation:rule="[has(self.selector), has(self.podRefs)].filter(x, x).size() == 1",message="exactly one of spec.selector or spec.podRefs must be set"
 type PodTraceSessionSpec struct {
 	// +optional

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -138,7 +138,7 @@ func main() {
 	rootCmd.Flags().BoolVar(&enableMetrics, "metrics", false, "Enable Prometheus metrics server")
 	rootCmd.Flags().StringVar(&exportFormat, "export", "", "Export format for diagnose report (json, csv)")
 	rootCmd.Flags().StringVar(&eventFilter, "filter", "", "Filter events by type (dns,net,fs,cpu,proc,crypto)")
-	rootCmd.Flags().StringVar(&containerName, "container", "", "Container name to trace (default: first container)")
+	rootCmd.Flags().StringVar(&containerName, "container", "", "Container name to trace (default: all containers of the pod)")
 	rootCmd.Flags().Float64Var(&errorRateThreshold, "error-threshold", config.DefaultErrorRateThreshold, "Error rate threshold percentage for issue detection")
 	rootCmd.Flags().Float64Var(&rttSpikeThreshold, "rtt-threshold", config.DefaultRTTThreshold, "RTT spike threshold in milliseconds")
 	rootCmd.Flags().Float64Var(&fsSlowThreshold, "fs-threshold", config.DefaultFSSlowThreshold, "File system slow operation threshold in milliseconds")
@@ -476,26 +476,32 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		logger.Info("Resolved target pod",
 			zap.String("namespace", p.Namespace),
 			zap.String("pod", p.PodName),
+			zap.Int("containers", len(podContainerTargets(p))),
 			zap.String("container_id", p.ContainerID),
 			zap.String("cgroup_path", p.CgroupPath))
-		if os.Getenv("PODTRACE_ALLOW_BROAD_CGROUP") == "1" || p.CgroupPath == "" {
+		if os.Getenv("PODTRACE_ALLOW_BROAD_CGROUP") == "1" {
 			continue
 		}
-		short := p.ContainerID
-		if len(short) > 12 {
-			short = short[:12]
-		}
-		if !strings.Contains(p.CgroupPath, p.ContainerID) && (short == "" || !strings.Contains(p.CgroupPath, short)) {
-			return fmt.Errorf(
-				"resolved cgroup path %q does not contain container id %q; refusing to run.\n\n"+
-					"This safety check prevents accidentally tracing the wrong container.\n\n"+
-					"Common causes and fixes:\n"+
-					"  • OpenShift/OKD: CRI-O may use a cgroup path that omits the container ID.\n"+
-					"  • Talos Linux: custom cgroup layout may not embed the container ID.\n"+
-					"  • Custom kubelet --cgroup-parent may produce parent-level slice paths.\n\n"+
-					"To bypass this check: set PODTRACE_ALLOW_BROAD_CGROUP=1\n"+
-					"To inspect the path:  ls /sys/fs/cgroup/**/*%s* 2>/dev/null || true",
-				p.CgroupPath, short, short)
+		for _, c := range podContainerTargets(p) {
+			if c.CgroupPath == "" {
+				continue
+			}
+			short := c.ID
+			if len(short) > 12 {
+				short = short[:12]
+			}
+			if !strings.Contains(c.CgroupPath, c.ID) && (short == "" || !strings.Contains(c.CgroupPath, short)) {
+				return fmt.Errorf(
+					"resolved cgroup path %q does not contain container id %q; refusing to run.\n\n"+
+						"This safety check prevents accidentally tracing the wrong container.\n\n"+
+						"Common causes and fixes:\n"+
+						"  • OpenShift/OKD: CRI-O may use a cgroup path that omits the container ID.\n"+
+						"  • Talos Linux: custom cgroup layout may not embed the container ID.\n"+
+						"  • Custom kubelet --cgroup-parent may produce parent-level slice paths.\n\n"+
+						"To bypass this check: set PODTRACE_ALLOW_BROAD_CGROUP=1\n"+
+						"To inspect the path:  ls /sys/fs/cgroup/**/*%s* 2>/dev/null || true",
+					c.CgroupPath, short, short)
+			}
 		}
 	}
 
@@ -513,12 +519,7 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = tracer.Stop() }()
 
-	cgroupPaths := make([]string, 0, len(targetInfos))
-	containerIDs := make([]string, 0, len(targetInfos))
-	for _, target := range targetInfos {
-		cgroupPaths = append(cgroupPaths, target.CgroupPath)
-		containerIDs = append(containerIDs, target.ContainerID)
-	}
+	cgroupPaths, containerIDs := targetAttachSets(targetInfos)
 	if err := attachTracerToCgroups(tracer, cgroupPaths); err != nil {
 		return fmt.Errorf("failed to attach to cgroups: %w", err)
 	}
@@ -536,16 +537,18 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 						logger.Warn("Target registry currently empty; retaining previous cgroup filters")
 						continue
 					}
-					nextCgroups := make([]string, 0, len(snapshot))
-					for _, s := range snapshot {
-						nextCgroups = append(nextCgroups, s.CgroupPath)
-					}
+					nextCgroups, nextContainerIDs := targetAttachSets(snapshot)
 					if err := attachTracerToCgroups(tracer, nextCgroups); err != nil {
 						logger.Warn("Failed to apply dynamic cgroup target update", zap.Error(err))
 						continue
 					}
+					if err := setTracerContainerIDs(tracer, nextContainerIDs); err != nil {
+						logger.Warn("Failed to apply dynamic container uprobe target update", zap.Error(err))
+					}
 					sourceIndex.Replace(snapshot)
-					logger.Info("Updated dynamic target set", zap.Int("pods", len(snapshot)))
+					logger.Info("Updated dynamic target set",
+						zap.Int("pods", len(snapshot)),
+						zap.Int("containers", len(nextContainerIDs)))
 				}
 			}
 		}()
@@ -963,6 +966,34 @@ func exportReport(_ string, format string, d *diagnose.Diagnostician) error {
 	}
 }
 
+// podContainerTargets returns the pod's traced containers, synthesizing a
+// single-entry list from the legacy singular fields when the list is empty.
+func podContainerTargets(p *kubernetes.PodInfo) []kubernetes.ContainerTarget {
+	if p == nil {
+		return nil
+	}
+	if len(p.Containers) > 0 {
+		return p.Containers
+	}
+	return []kubernetes.ContainerTarget{{Name: p.ContainerName, ID: p.ContainerID, CgroupPath: p.CgroupPath}}
+}
+
+// targetAttachSets flattens every traced container of every target pod into
+// the cgroup-path and container-ID attach lists.
+func targetAttachSets(infos []*kubernetes.PodInfo) (cgroupPaths, containerIDs []string) {
+	for _, p := range infos {
+		for _, c := range podContainerTargets(p) {
+			if c.CgroupPath != "" {
+				cgroupPaths = append(cgroupPaths, c.CgroupPath)
+			}
+			if c.ID != "" {
+				containerIDs = append(containerIDs, c.ID)
+			}
+		}
+	}
+	return cgroupPaths, containerIDs
+}
+
 type sourcePodIndex struct {
 	mu    sync.RWMutex
 	byCG  map[uint64]*kubernetes.PodInfo
@@ -987,8 +1018,19 @@ func (s *sourcePodIndex) Replace(targets []*kubernetes.PodInfo) {
 		}
 		cp := *t
 		nextByNSP[t.Namespace+"/"+t.PodName] = &cp
-		if cgid, err := cgroupIDFromPath(t.CgroupPath); err == nil && cgid != 0 {
-			nextByCG[cgid] = &cp
+		for _, c := range podContainerTargets(t) {
+			if c.CgroupPath == "" {
+				continue
+			}
+			cgid, err := cgroupIDFromPath(c.CgroupPath)
+			if err != nil || cgid == 0 {
+				continue
+			}
+			cc := *t
+			cc.ContainerName = c.Name
+			cc.ContainerID = c.ID
+			cc.CgroupPath = c.CgroupPath
+			nextByCG[cgid] = &cc
 		}
 	}
 	s.mu.Lock()

--- a/cmd/podtrace/multicontainer_wiring_test.go
+++ b/cmd/podtrace/multicontainer_wiring_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func TestTargetAttachSets_FansOutAllContainers(t *testing.T) {
+	d1, d2 := t.TempDir(), t.TempDir()
+	infos := []*kubernetes.PodInfo{{
+		PodName: "web", Namespace: "default",
+		Containers: []kubernetes.ContainerTarget{
+			{Name: "app", ID: "aaa", CgroupPath: d1},
+			{Name: "sidecar", ID: "bbb", CgroupPath: d2},
+		},
+		ContainerID: "aaa", CgroupPath: d1, ContainerName: "app",
+	}}
+	paths, ids := targetAttachSets(infos)
+	if len(paths) != 2 || len(ids) != 2 {
+		t.Fatalf("attach sets = %d paths / %d ids, want 2/2", len(paths), len(ids))
+	}
+	if ids[0] != "aaa" || ids[1] != "bbb" {
+		t.Errorf("container IDs = %v, want [aaa bbb]", ids)
+	}
+}
+
+func TestTargetAttachSets_LegacySingularFallback(t *testing.T) {
+	infos := []*kubernetes.PodInfo{{
+		PodName: "old", Namespace: "ns",
+		ContainerID: "ccc", CgroupPath: "/sys/fs/cgroup/x", ContainerName: "app",
+	}}
+	paths, ids := targetAttachSets(infos)
+	if len(paths) != 1 || len(ids) != 1 || ids[0] != "ccc" {
+		t.Fatalf("legacy fallback = %v / %v, want single entry from singular fields", paths, ids)
+	}
+}
+
+func TestSourcePodIndex_PerContainerAttribution(t *testing.T) {
+	d1, d2 := t.TempDir(), t.TempDir()
+	info := &kubernetes.PodInfo{
+		PodName: "web", Namespace: "default",
+		Containers: []kubernetes.ContainerTarget{
+			{Name: "app", ID: "aaa", CgroupPath: d1},
+			{Name: "sidecar", ID: "bbb", CgroupPath: d2},
+		},
+		ContainerID: "aaa", CgroupPath: d1, ContainerName: "app",
+	}
+	idx := newSourcePodIndex([]*kubernetes.PodInfo{info})
+
+	cg1, err := cgroupIDFromPath(d1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cg2, err := cgroupIDFromPath(d2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := idx.Resolve(&events.Event{CgroupID: cg1}); got == nil || got.ContainerName != "app" {
+		t.Errorf("cgroup1 attribution = %+v, want container app", got)
+	}
+	if got := idx.Resolve(&events.Event{CgroupID: cg2}); got == nil || got.ContainerName != "sidecar" {
+		t.Errorf("cgroup2 attribution = %+v, want container sidecar", got)
+	}
+}

--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -210,8 +210,8 @@ func newChildArgsBuilder(cmd *cobra.Command, passMetrics bool) func(string, []no
 			args = append(args, "--"+f.Name+"="+f.Value.String())
 		})
 		for _, p := range pods {
-			if p.ContainerID != "" {
-				args = append(args, "--preresolved-pod="+p.PreResolved())
+			for _, ref := range p.PreResolved() {
+				args = append(args, "--preresolved-pod="+ref)
 			}
 		}
 		return args

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraces.yaml
@@ -127,6 +127,10 @@ spec:
                 - matchSelectors
                 type: object
               containerName:
+                description: |-
+                  ContainerName narrows tracing to one named container of each matched
+                  pod. Empty means every running container (including restartable-init
+                  sidecars and ephemeral containers) is traced.
                 type: string
               exporterRef:
                 description: LocalObjectReference references an object in the same

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
@@ -118,9 +118,6 @@ spec:
                     description: |-
                       PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
                       reconciles this into one privileged Job per node hosting matched pods.
-                      The CEL one-of mirrors PodTraceSpec: without it, installs that disable
-                      the validating webhook (the chart default) accepted sessions with no
-                      target selection at all, or with conflicting ones.
                     properties:
                       containerName:
                         type: string

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -67,9 +67,6 @@ spec:
             description: |-
               PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
               reconciles this into one privileged Job per node hosting matched pods.
-              The CEL one-of mirrors PodTraceSpec: without it, installs that disable
-              the validating webhook (the chart default) accepted sessions with no
-              target selection at all, or with conflicting ones.
             properties:
               containerName:
                 type: string

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ Flags:
       --metrics                 Enable Prometheus metrics server
       --export string           Export format for diagnose report (json, csv)
       --filter string           Filter events by type (dns,net,fs,cpu,proc,crypto)
-      --container string        Container name to trace (default: first container)
+      --container string        Container name to trace (default: all containers of the pod)
       --error-threshold float   Error rate threshold percentage for issue detection (default: 10.0)
       --rtt-threshold float     RTT spike threshold in milliseconds (default: 100.0)
       --fs-threshold float      File system slow operation threshold in milliseconds (default: 10.0)
@@ -254,7 +254,9 @@ Review:
 
 ## Limitations
 
-- By default traces the first container per selected pod (override with `--container`)
+- By default traces every running container of each selected pod, including
+  sidecars — event volume grows accordingly for sidecar-heavy pods (e.g.
+  service meshes); narrow to one container with `--container`
 - Requires kernel **5.8+** with BTF support (BPF ring buffer + CO-RE). Full L7
   protocol tracing (HTTP/1.1, HTTP/2, HTTP/3, gRPC) additionally needs the
   `bpf_loop` helper — mainline **5.17+**, or a distribution that backports it

--- a/internal/kubernetes/multicontainer_resolve_test.go
+++ b/internal/kubernetes/multicontainer_resolve_test.go
@@ -1,0 +1,134 @@
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func fakeCgroupBase(t *testing.T, containerIDs ...string) map[string]string {
+	t.Helper()
+	base := t.TempDir()
+	if err := os.WriteFile(filepath.Join(base, "cgroup.controllers"), []byte("cpu memory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirs := map[string]string{}
+	for _, id := range containerIDs {
+		d := filepath.Join(base, "kubepods.slice", "container-"+id)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "cgroup.procs"), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dirs[id] = d
+	}
+	origBase := config.CgroupBasePath
+	config.CgroupBasePath = base
+	t.Setenv("PODTRACE_CRI_RESOLVE", "false")
+	t.Cleanup(func() { config.CgroupBasePath = origBase })
+	return dirs
+}
+
+func multiContainerRunningPod(ns, name string, containers map[string]string) *corev1.Pod {
+	running := corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Status:     corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	for _, cname := range []string{"sidecar", "app"} {
+		id, ok := containers[cname]
+		if !ok {
+			continue
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: cname})
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+			Name: cname, ContainerID: "containerd://" + id, State: running,
+		})
+	}
+	return pod
+}
+
+func TestResolvePod_MultiContainer(t *testing.T) {
+	idSidecar := strings.Repeat("a", 64)
+	idApp := strings.Repeat("b", 64)
+	dirs := fakeCgroupBase(t, idSidecar, idApp)
+	pod := multiContainerRunningPod("default", "web", map[string]string{"sidecar": idSidecar, "app": idApp})
+
+	resolver := NewPodResolverForTesting(fake.NewSimpleClientset(pod))
+	info, err := resolver.ResolvePod(context.Background(), "web", "default", "")
+	if err != nil {
+		t.Fatalf("ResolvePod: %v", err)
+	}
+	if len(info.Containers) != 2 {
+		t.Fatalf("Containers = %d, want 2 (whole pod must be targeted)", len(info.Containers))
+	}
+	byName := map[string]ContainerTarget{}
+	for _, c := range info.Containers {
+		byName[c.Name] = c
+	}
+	if byName["sidecar"].ID != idSidecar || byName["sidecar"].CgroupPath != dirs[idSidecar] {
+		t.Errorf("sidecar target = %+v, want id/cgroup resolved", byName["sidecar"])
+	}
+	if byName["app"].ID != idApp || byName["app"].CgroupPath != dirs[idApp] {
+		t.Errorf("app target = %+v, want id/cgroup resolved", byName["app"])
+	}
+	if info.ContainerID != info.Containers[0].ID || info.CgroupPath != info.Containers[0].CgroupPath {
+		t.Errorf("singular fields must mirror the first container entry")
+	}
+}
+
+func TestResolvePod_NamedContainerNarrows(t *testing.T) {
+	idSidecar := strings.Repeat("c", 64)
+	idApp := strings.Repeat("d", 64)
+	fakeCgroupBase(t, idSidecar, idApp)
+	pod := multiContainerRunningPod("default", "web", map[string]string{"sidecar": idSidecar, "app": idApp})
+
+	resolver := NewPodResolverForTesting(fake.NewSimpleClientset(pod))
+	info, err := resolver.ResolvePod(context.Background(), "web", "default", "app")
+	if err != nil {
+		t.Fatalf("ResolvePod: %v", err)
+	}
+	if len(info.Containers) != 1 || info.Containers[0].Name != "app" || info.Containers[0].ID != idApp {
+		t.Fatalf("Containers = %+v, want exactly the app container", info.Containers)
+	}
+}
+
+func TestResolvePod_PartialCgroupFailure(t *testing.T) {
+	idSidecar := strings.Repeat("e", 64)
+	idApp := strings.Repeat("f", 64)
+	fakeCgroupBase(t, idApp) // sidecar's cgroup deliberately absent
+	pod := multiContainerRunningPod("default", "web", map[string]string{"sidecar": idSidecar, "app": idApp})
+
+	resolver := NewPodResolverForTesting(fake.NewSimpleClientset(pod))
+	info, err := resolver.ResolvePod(context.Background(), "web", "default", "")
+	if err != nil {
+		t.Fatalf("ResolvePod: %v", err)
+	}
+	if len(info.Containers) != 1 || info.Containers[0].Name != "app" {
+		t.Fatalf("Containers = %+v, want the resolvable app container only", info.Containers)
+	}
+}
+
+func TestResolvePodInfoFromObject_MultiContainer(t *testing.T) {
+	idSidecar := strings.Repeat("1", 64)
+	idApp := strings.Repeat("2", 64)
+	fakeCgroupBase(t, idSidecar, idApp)
+	pod := multiContainerRunningPod("prod", "api-0", map[string]string{"sidecar": idSidecar, "app": idApp})
+
+	info, err := resolvePodInfoFromObject(context.Background(), pod, "")
+	if err != nil {
+		t.Fatalf("resolvePodInfoFromObject: %v", err)
+	}
+	if len(info.Containers) != 2 {
+		t.Fatalf("Containers = %d, want 2", len(info.Containers))
+	}
+}

--- a/internal/kubernetes/nodespawn/container_selection_test.go
+++ b/internal/kubernetes/nodespawn/container_selection_test.go
@@ -64,15 +64,15 @@ func TestResolveTargetNodes_MissingContainerNameFails(t *testing.T) {
 	}
 }
 
-func TestPickRunningContainer_ByName(t *testing.T) {
+func TestPickRunningContainers_ByName(t *testing.T) {
 	pod := multiContainerPod()
-	if cs := pickRunningContainer(pod, "app"); cs == nil || cs.Name != "app" {
-		t.Errorf("pickRunningContainer(pod, app) = %+v, want the app container", cs)
+	if got := pickRunningContainers(pod, "app"); len(got) != 1 || got[0].Name != "app" {
+		t.Errorf("pickRunningContainers(pod, app) = %+v, want exactly the app container", got)
 	}
-	if cs := pickRunningContainer(pod, ""); cs == nil || cs.Name != "sidecar" {
-		t.Errorf("pickRunningContainer(pod, \"\") = %+v, want first running (sidecar)", cs)
+	if got := pickRunningContainers(pod, ""); len(got) != 2 || got[0].Name != "sidecar" || got[1].Name != "app" {
+		t.Errorf("pickRunningContainers(pod, \"\") = %+v, want all running containers", got)
 	}
-	if cs := pickRunningContainer(pod, "ghost"); cs != nil {
-		t.Errorf("pickRunningContainer(pod, ghost) = %+v, want nil", cs)
+	if got := pickRunningContainers(pod, "ghost"); len(got) != 0 {
+		t.Errorf("pickRunningContainers(pod, ghost) = %+v, want empty", got)
 	}
 }

--- a/internal/kubernetes/nodespawn/pure_helpers_test.go
+++ b/internal/kubernetes/nodespawn/pure_helpers_test.go
@@ -9,14 +9,22 @@ func TestPodRef_PreResolved(t *testing.T) {
 		ContainerID:   "deadbeef",
 		ContainerName: "app",
 	}
-	want := "ns1/cart-abc/deadbeef/app"
-	if got := r.PreResolved(); got != want {
-		t.Errorf("PreResolved() = %q, want %q", got, want)
+	if got := r.PreResolved(); len(got) != 1 || got[0] != "ns1/cart-abc/deadbeef/app" {
+		t.Errorf("PreResolved() = %v, want [ns1/cart-abc/deadbeef/app] (legacy singular fields)", got)
 	}
 
 	r2 := PodRef{Namespace: "ns", Name: "p"}
-	if got, want := r2.PreResolved(), "ns/p//"; got != want {
-		t.Errorf("PreResolved() = %q, want %q", got, want)
+	if got := r2.PreResolved(); len(got) != 0 {
+		t.Errorf("PreResolved() with no containers = %v, want empty", got)
+	}
+
+	multi := PodRef{
+		Namespace: "ns1", Name: "cart-abc",
+		Containers: []ContainerRef{{ID: "aaa", Name: "app"}, {ID: "bbb", Name: "sidecar"}},
+	}
+	got := multi.PreResolved()
+	if len(got) != 2 || got[0] != "ns1/cart-abc/aaa/app" || got[1] != "ns1/cart-abc/bbb/sidecar" {
+		t.Errorf("PreResolved() multi-container = %v, want one ref per container", got)
 	}
 }
 

--- a/internal/kubernetes/nodespawn/target_nodes.go
+++ b/internal/kubernetes/nodespawn/target_nodes.go
@@ -15,6 +15,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// ContainerRef identifies one running container of a pre-resolved pod.
+type ContainerRef struct {
+	ID   string
+	Name string
+}
+
 // PodRef holds everything the workstation pre-resolves about a target pod so
 // the spawned binary can build its PodInfo without a single K8s API call.
 type PodRef struct {
@@ -22,6 +28,7 @@ type PodRef struct {
 	Name          string
 	ContainerID   string
 	ContainerName string
+	Containers    []ContainerRef
 }
 
 // String returns the "namespace/name" form ResolvePod accepts.
@@ -29,10 +36,21 @@ func (r PodRef) String() string {
 	return r.Namespace + "/" + r.Name
 }
 
-// PreResolved returns the "ns/name/containerID/containerName" form the spawn
-// pod accepts via --preresolved-pod (single string keeps the argv compact).
-func (r PodRef) PreResolved() string {
-	return r.Namespace + "/" + r.Name + "/" + r.ContainerID + "/" + r.ContainerName
+// PreResolved returns one "ns/name/containerID/containerName" string per
+// traced container, each accepted by --preresolved-pod.
+func (r PodRef) PreResolved() []string {
+	containers := r.Containers
+	if len(containers) == 0 && r.ContainerID != "" {
+		containers = []ContainerRef{{ID: r.ContainerID, Name: r.ContainerName}}
+	}
+	out := make([]string, 0, len(containers))
+	for _, c := range containers {
+		if c.ID == "" {
+			continue
+		}
+		out = append(out, r.Namespace+"/"+r.Name+"/"+c.ID+"/"+c.Name)
+	}
+	return out
 }
 
 // NodeTargets groups the resolved target pods by the node they run on.
@@ -71,16 +89,21 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 			unscheduled = append(unscheduled, ref)
 			return
 		}
-		cs := pickRunningContainer(pod, sel.ContainerName)
-		if sel.ContainerName != "" && cs == nil {
+		statuses := pickRunningContainers(pod, sel.ContainerName)
+		if sel.ContainerName != "" && len(statuses) == 0 {
 			missingContainer = append(missingContainer, ref)
 			return
 		}
-		if cs != nil {
-			ref.ContainerName = cs.Name
-			if idx := indexAfterScheme(cs.ContainerID); idx >= 0 {
-				ref.ContainerID = cs.ContainerID[idx:]
+		if len(statuses) > 0 {
+			for _, cs := range statuses {
+				if idx := indexAfterScheme(cs.ContainerID); idx >= 0 && cs.ContainerID[idx:] != "" {
+					ref.Containers = append(ref.Containers, ContainerRef{ID: cs.ContainerID[idx:], Name: cs.Name})
+				}
 			}
+		}
+		if len(ref.Containers) > 0 {
+			ref.ContainerID = ref.Containers[0].ID
+			ref.ContainerName = ref.Containers[0].Name
 		} else {
 			routedWithoutID = append(routedWithoutID, ref)
 		}
@@ -168,23 +191,30 @@ func ResolveTargetNodes(ctx context.Context, clientset kubernetes.Interface, sel
 	return out, nil
 }
 
-// pickRunningContainer returns the running container matching name, or the
-// first running container when name is empty.
-func pickRunningContainer(pod *corev1.Pod, name string) *corev1.ContainerStatus {
+// pickRunningContainers returns every running container with a container ID,
+// regular, restartable-init (sidecar), and ephemeral, when name is empty,
+// or exactly the named one.
+func pickRunningContainers(pod *corev1.Pod, name string) []corev1.ContainerStatus {
 	if pod == nil {
 		return nil
 	}
-	for i := range pod.Status.ContainerStatuses {
-		cs := &pod.Status.ContainerStatuses[i]
-		if cs.State.Running == nil || cs.ContainerID == "" {
-			continue
+	var out []corev1.ContainerStatus
+	add := func(list []corev1.ContainerStatus) {
+		for i := range list {
+			cs := list[i]
+			if cs.State.Running == nil || cs.ContainerID == "" {
+				continue
+			}
+			if name != "" && cs.Name != name {
+				continue
+			}
+			out = append(out, cs)
 		}
-		if name != "" && cs.Name != name {
-			continue
-		}
-		return cs
 	}
-	return nil
+	add(pod.Status.ContainerStatuses)
+	add(pod.Status.InitContainerStatuses)
+	add(pod.Status.EphemeralContainerStatuses)
+	return out
 }
 
 // indexAfterScheme returns the offset right after "://" in a containerID like

--- a/internal/kubernetes/nodespawn/target_nodes_test.go
+++ b/internal/kubernetes/nodespawn/target_nodes_test.go
@@ -174,25 +174,35 @@ func podWithContainer(ns, name, node, cName, cID string, state corev1.ContainerS
 	}
 }
 
-func TestPickRunningContainer_PrefersRunning(t *testing.T) {
-	p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-		{Name: "a", ContainerID: "containerd://aaa", State: corev1.ContainerState{
-			Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
-		}},
-		{Name: "b", ContainerID: "containerd://bbb", State: corev1.ContainerState{
-			Running: &corev1.ContainerStateRunning{},
-		}},
-		{Name: "c", ContainerID: "containerd://ccc", State: corev1.ContainerState{
-			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
-		}},
-	}}}
-	cs := pickRunningContainer(p, "")
-	if cs == nil || cs.Name != "b" {
-		t.Fatalf("expected to pick the Running container, got %+v", cs)
+func TestPickRunningContainers_SelectsAllRunning(t *testing.T) {
+	p := &corev1.Pod{Status: corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{
+			{Name: "a", ContainerID: "containerd://aaa", State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+			}},
+			{Name: "b", ContainerID: "containerd://bbb", State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{},
+			}},
+			{Name: "c", ContainerID: "containerd://ccc", State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+			}},
+		},
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{Name: "mesh", ContainerID: "containerd://mmm", State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{},
+			}},
+		},
+	}}
+	got := pickRunningContainers(p, "")
+	if len(got) != 2 || got[0].Name != "b" || got[1].Name != "mesh" {
+		t.Fatalf("expected all Running containers [b mesh], got %+v", got)
+	}
+	if named := pickRunningContainers(p, "b"); len(named) != 1 || named[0].Name != "b" {
+		t.Fatalf("named pick = %+v, want exactly b", named)
 	}
 }
 
-func TestPickRunningContainer_RejectsAllNonRunning(t *testing.T) {
+func TestPickRunningContainers_RejectsAllNonRunning(t *testing.T) {
 	cases := map[string]corev1.ContainerState{
 		"Waiting":    {Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
 		"Terminated": {Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}},
@@ -202,14 +212,14 @@ func TestPickRunningContainer_RejectsAllNonRunning(t *testing.T) {
 			p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
 				{Name: "x", ContainerID: "containerd://xxx", State: st},
 			}}}
-			if cs := pickRunningContainer(p, ""); cs != nil {
-				t.Errorf("must not pick a %s container, got %+v", name, cs)
+			if got := pickRunningContainers(p, ""); len(got) != 0 {
+				t.Errorf("must not pick a %s container, got %+v", name, got)
 			}
 		})
 	}
 }
 
-func TestPickRunningContainer_RejectsRunningWithEmptyID(t *testing.T) {
+func TestPickRunningContainers_RejectsRunningWithEmptyID(t *testing.T) {
 	// A Pod can momentarily be in Status.Running with ContainerID="" right
 	// at startup. We must NOT hand the spawn pod an empty containerID.
 	p := &corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
@@ -217,8 +227,8 @@ func TestPickRunningContainer_RejectsRunningWithEmptyID(t *testing.T) {
 			Running: &corev1.ContainerStateRunning{},
 		}},
 	}}}
-	if cs := pickRunningContainer(p, ""); cs != nil {
-		t.Errorf("Running container with empty ID must be rejected, got %+v", cs)
+	if got := pickRunningContainers(p, ""); len(got) != 0 {
+		t.Errorf("Running container with empty ID must be rejected, got %+v", got)
 	}
 }
 
@@ -280,8 +290,8 @@ func TestResolveTargetNodes_DedupesNameAndSelectorMatch(t *testing.T) {
 	sel := pkgkube.TargetSelection{
 		DefaultNamespace: "ns1",
 		Namespaces:       []string{"ns1"},
-		Pods:             []string{"dup"},  // explicit match
-		PodSelector:      "app=api",        // selector match too
+		Pods:             []string{"dup"}, // explicit match
+		PodSelector:      "app=api",       // selector match too
 	}
 	got, err := ResolveTargetNodes(context.Background(), cs, sel)
 	if err != nil {

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -131,8 +131,8 @@ func (r *PodResolver) ResolvePod(ctx context.Context, podName, namespace, contai
 		return nil, NewNoContainersError()
 	}
 
-	containerStatus, containerSpec := pickContainer(pod, containerName)
-	if containerStatus == nil {
+	statuses := pickContainers(pod, containerName)
+	if len(statuses) == 0 {
 		name := containerName
 		if name == "" && len(pod.Spec.Containers) > 0 {
 			name = pod.Spec.Containers[0].Name
@@ -140,36 +140,13 @@ func (r *PodResolver) ResolvePod(ctx context.Context, podName, namespace, contai
 		return nil, NewContainerNotFoundError(name)
 	}
 
-	containerID := containerStatus.ContainerID
-
-	parts := strings.Split(containerID, "://")
-	if len(parts) != 2 {
-		return nil, NewInvalidContainerIDError("invalid container ID format")
-	}
-	shortID := parts[1]
-
-	if !validation.ValidateContainerID(shortID) {
-		return nil, NewInvalidContainerIDError("validation failed")
-	}
-
-	cgroupPath, err := resolveCgroupPathCRI(ctx, shortID)
-	if err != nil || cgroupPath == "" {
-		logger.Debug("CRI cgroup resolution failed, trying filesystem scan", zap.Error(err), zap.String("container_id", shortID))
-		cgroupPath, err = findCgroupPath(shortID)
+	targets := resolveContainerTargets(ctx, pod, statuses)
+	if len(targets) == 0 {
+		shortID, err := shortContainerID(statuses[0].ContainerID)
 		if err != nil {
-			logger.Debug("Filesystem cgroup scan failed, trying /proc fallback", zap.Error(err), zap.String("container_id", shortID))
-			cgroupPathFromProc, procErr := findCgroupPathFromProc(shortID)
-			if procErr == nil && cgroupPathFromProc != "" {
-				cgroupPath = cgroupPathFromProc
-				logger.Debug("Found cgroup path via /proc fallback", zap.String("cgroup_path", cgroupPath))
-			} else {
-				return nil, NewCgroupNotFoundError(shortID)
-			}
-		} else {
-			logger.Debug("Found cgroup path via filesystem scan", zap.String("cgroup_path", cgroupPath))
+			return nil, err
 		}
-	} else {
-		logger.Debug("Found cgroup path via CRI", zap.String("cgroup_path", cgroupPath))
+		return nil, NewCgroupNotFoundError(shortID)
 	}
 
 	labels := make(map[string]string)
@@ -188,14 +165,81 @@ func (r *PodResolver) ResolvePod(ctx context.Context, podName, namespace, contai
 	return &PodInfo{
 		PodName:       podName,
 		Namespace:     namespace,
-		ContainerID:   shortID,
-		CgroupPath:    cgroupPath,
-		ContainerName: containerSpec.Name,
+		Containers:    targets,
+		ContainerID:   targets[0].ID,
+		CgroupPath:    targets[0].CgroupPath,
+		ContainerName: targets[0].Name,
 		Labels:        labels,
 		PodIP:         pod.Status.PodIP,
 		OwnerKind:     ownerKind,
 		OwnerName:     ownerName,
 	}, nil
+}
+
+// resolveContainerTargets turns picked container statuses into ContainerTargets
+// with resolved cgroup paths. Containers whose ID or cgroup cannot be resolved
+// are skipped with a warning; the caller decides whether an empty result is
+// fatal.
+func resolveContainerTargets(ctx context.Context, pod *corev1.Pod, statuses []corev1.ContainerStatus) []ContainerTarget {
+	targets := make([]ContainerTarget, 0, len(statuses))
+	for _, cs := range statuses {
+		shortID, err := shortContainerID(cs.ContainerID)
+		if err != nil {
+			logger.Warn("Skipping container with unusable container ID",
+				zap.String("pod", pod.Namespace+"/"+pod.Name),
+				zap.String("container", cs.Name),
+				zap.Error(err))
+			continue
+		}
+		cgroupPath, err := resolveContainerCgroup(ctx, shortID)
+		if err != nil {
+			logger.Warn("Skipping container whose cgroup could not be resolved",
+				zap.String("pod", pod.Namespace+"/"+pod.Name),
+				zap.String("container", cs.Name),
+				zap.String("container_id", shortID),
+				zap.Error(err))
+			continue
+		}
+		targets = append(targets, ContainerTarget{Name: cs.Name, ID: shortID, CgroupPath: cgroupPath})
+	}
+	return targets
+}
+
+// shortContainerID strips the runtime scheme from a status ContainerID and
+// validates the remainder.
+func shortContainerID(containerID string) (string, error) {
+	parts := strings.Split(containerID, "://")
+	if len(parts) != 2 {
+		return "", NewInvalidContainerIDError("invalid container ID format")
+	}
+	shortID := parts[1]
+	if !validation.ValidateContainerID(shortID) {
+		return "", NewInvalidContainerIDError("validation failed")
+	}
+	return shortID, nil
+}
+
+// resolveContainerCgroup resolves one container's cgroup path via the
+// CRI -> filesystem-scan -> /proc fallback chain.
+func resolveContainerCgroup(ctx context.Context, shortID string) (string, error) {
+	cgroupPath, err := resolveCgroupPathCRI(ctx, shortID)
+	if err == nil && cgroupPath != "" {
+		logger.Debug("Found cgroup path via CRI", zap.String("cgroup_path", cgroupPath))
+		return cgroupPath, nil
+	}
+	logger.Debug("CRI cgroup resolution failed, trying filesystem scan", zap.Error(err), zap.String("container_id", shortID))
+	cgroupPath, err = findCgroupPath(shortID)
+	if err == nil && cgroupPath != "" {
+		logger.Debug("Found cgroup path via filesystem scan", zap.String("cgroup_path", cgroupPath))
+		return cgroupPath, nil
+	}
+	logger.Debug("Filesystem cgroup scan failed, trying /proc fallback", zap.Error(err), zap.String("container_id", shortID))
+	cgroupPath, err = findCgroupPathFromProc(shortID)
+	if err == nil && cgroupPath != "" {
+		logger.Debug("Found cgroup path via /proc fallback", zap.String("cgroup_path", cgroupPath))
+		return cgroupPath, nil
+	}
+	return "", NewCgroupNotFoundError(shortID)
 }
 
 // cgroupRootCandidates returns base paths to search when resolving cgroup paths.
@@ -395,32 +439,41 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 	return "", errors.New("podtrace: CRI cgroup path not found on filesystem")
 }
 
-// pickContainer selects the container to trace: the named one, or the
-// pod's first spec container when no name is given.
-func pickContainer(pod *corev1.Pod, containerName string) (*corev1.ContainerStatus, *corev1.Container) {
-	name := containerName
-	if name == "" && len(pod.Spec.Containers) > 0 {
-		name = pod.Spec.Containers[0].Name
+// pickContainers selects the containers to trace: every running container
+// with a container ID, regular, restartable-init (sidecar), and ephemeral,
+// matching the agent's containerStatusIndex enumeration so both planes agree,
+// when no name is given, or exactly the named one.
+func pickContainers(pod *corev1.Pod, containerName string) []corev1.ContainerStatus {
+	var out []corev1.ContainerStatus
+	add := func(list []corev1.ContainerStatus) {
+		for i := range list {
+			cs := list[i]
+			if cs.ContainerID == "" || cs.State.Running == nil {
+				continue
+			}
+			if containerName != "" && cs.Name != containerName {
+				continue
+			}
+			out = append(out, cs)
+		}
 	}
+	add(pod.Status.ContainerStatuses)
+	add(pod.Status.InitContainerStatuses)
+	add(pod.Status.EphemeralContainerStatuses)
+	return out
+}
 
-	var spec *corev1.Container
-	for j := range pod.Spec.Containers {
-		if pod.Spec.Containers[j].Name == name {
-			spec = &pod.Spec.Containers[j]
-			break
-		}
-	}
-	for i := range pod.Status.ContainerStatuses {
-		if pod.Status.ContainerStatuses[i].Name == name {
-			return &pod.Status.ContainerStatuses[i], spec
-		}
-	}
-	return nil, spec
+// ContainerTarget identifies one traced container of a resolved pod.
+type ContainerTarget struct {
+	Name       string
+	ID         string
+	CgroupPath string
 }
 
 type PodInfo struct {
 	PodName       string
 	Namespace     string
+	Containers    []ContainerTarget
 	ContainerID   string
 	CgroupPath    string
 	ContainerName string

--- a/internal/kubernetes/pod_test.go
+++ b/internal/kubernetes/pod_test.go
@@ -215,6 +215,7 @@ func TestResolvePod_Success_WithoutContainerName(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: containerID,
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -280,10 +281,12 @@ func TestResolvePod_Success_WithContainerName(t *testing.T) {
 				{
 					Name:        "first-container",
 					ContainerID: "containerd://1111111111111111111111111111111111111111",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 				{
 					Name:        "second-container",
 					ContainerID: containerID,
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -363,6 +366,7 @@ func TestResolvePod_ContainerNotFound(t *testing.T) {
 				{
 					Name:        "existing-container",
 					ContainerID: "containerd://abcdef1234567890abcdef1234567890abcdef12",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -398,6 +402,7 @@ func TestResolvePod_InvalidContainerIDFormat(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: "invalid-format",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -438,6 +443,7 @@ func TestResolvePod_InvalidContainerID(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: "containerd://invalid",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -478,6 +484,7 @@ func TestResolvePod_CgroupPathNotFound(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: "containerd://abcdef1234567890abcdef1234567890abcdef12",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -829,6 +836,7 @@ func TestResolvePod_ContainerID_EmptyString(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: "",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -841,8 +849,8 @@ func TestResolvePod_ContainerID_EmptyString(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty container ID")
 	}
-	if !strings.Contains(err.Error(), "invalid container ID format") {
-		t.Errorf("expected error about invalid container ID format, got: %v", err)
+	if !strings.Contains(err.Error(), "not found in pod") {
+		t.Errorf("expected container-not-found error, got: %v", err)
 	}
 }
 
@@ -864,6 +872,7 @@ func TestResolvePod_ContainerID_NoSeparator(t *testing.T) {
 				{
 					Name:        "test-container",
 					ContainerID: "no-separator-here",
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				},
 			},
 		},
@@ -884,7 +893,7 @@ func TestResolvePod_ContainerID_NoSeparator(t *testing.T) {
 func TestPodResolver_GetClientset(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	resolver := NewPodResolverForTesting(clientset)
-	
+
 	result := resolver.GetClientset()
 	if result != clientset {
 		t.Error("GetClientset() should return the same clientset")
@@ -893,7 +902,7 @@ func TestPodResolver_GetClientset(t *testing.T) {
 
 func TestFindCgroupPathFromProc_Success(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -902,14 +911,14 @@ func TestFindCgroupPathFromProc_Success(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "abcdef1234567890"
 	pid := "12345"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupPath := filepath.Join(tmpDir, "kubepods", "pod_"+containerID)
 	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
 		t.Fatalf("failed to create cgroup path: %v", err)
@@ -918,13 +927,13 @@ func TestFindCgroupPathFromProc_Success(t *testing.T) {
 	if err := os.WriteFile(cgroupProcsPath, []byte(""), 0644); err != nil {
 		t.Fatalf("failed to create cgroup.procs: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := fmt.Sprintf("0::/kubepods/pod_%s\n", containerID)
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	path, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (may be expected): %v", err)
@@ -936,7 +945,7 @@ func TestFindCgroupPathFromProc_Success(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithShortID(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -945,7 +954,7 @@ func TestFindCgroupPathFromProc_WithShortID(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	fullID := "abcdef1234567890abcdef1234567890abcdef12"
 	shortID := fullID[:12]
 	pid := "12346"
@@ -953,7 +962,7 @@ func TestFindCgroupPathFromProc_WithShortID(t *testing.T) {
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupPath := filepath.Join(tmpDir, "kubepods", "pod_"+shortID)
 	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
 		t.Fatalf("failed to create cgroup path: %v", err)
@@ -962,13 +971,13 @@ func TestFindCgroupPathFromProc_WithShortID(t *testing.T) {
 	if err := os.WriteFile(cgroupProcsPath, []byte(""), 0644); err != nil {
 		t.Fatalf("failed to create cgroup.procs: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := fmt.Sprintf("0::/kubepods/pod_%s\n", shortID)
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	path, err := findCgroupPathFromProc(fullID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (may be expected): %v", err)
@@ -980,7 +989,7 @@ func TestFindCgroupPathFromProc_WithShortID(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithV1Format(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -989,25 +998,25 @@ func TestFindCgroupPathFromProc_WithV1Format(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "test123"
 	pid := "12347"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupPath := filepath.Join(tmpDir, "kubepods", "pod_"+containerID)
 	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
 		t.Fatalf("failed to create cgroup path: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := fmt.Sprintf("1:cpu:/kubepods/pod_%s\n", containerID)
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	path, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (may be expected): %v", err)
@@ -1019,7 +1028,7 @@ func TestFindCgroupPathFromProc_WithV1Format(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithRootPath(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -1028,25 +1037,25 @@ func TestFindCgroupPathFromProc_WithRootPath(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "test456"
 	pid := "12348"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupProcsPath := filepath.Join(tmpDir, "cgroup.procs")
 	if err := os.WriteFile(cgroupProcsPath, []byte(""), 0644); err != nil {
 		t.Fatalf("failed to create cgroup.procs: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := "0::/\n"
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	path, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (may be expected): %v", err)
@@ -1058,11 +1067,11 @@ func TestFindCgroupPathFromProc_WithRootPath(t *testing.T) {
 
 func TestFindCgroupPathFromProc_ReadDirError(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	config.SetProcBasePath(filepath.Join(tmpDir, "nonexistent"))
 	defer func() { config.SetProcBasePath(origProcBase) }()
-	
+
 	_, err := findCgroupPathFromProc("test123")
 	if err == nil {
 		t.Error("Expected error when proc path doesn't exist")
@@ -1071,16 +1080,16 @@ func TestFindCgroupPathFromProc_ReadDirError(t *testing.T) {
 
 func TestFindCgroupPathFromProc_NonNumericPID(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	config.SetProcBasePath(tmpDir)
 	defer func() { config.SetProcBasePath(origProcBase) }()
-	
+
 	nonNumericDir := filepath.Join(tmpDir, "not-a-pid")
 	if err := os.MkdirAll(nonNumericDir, 0755); err != nil {
 		t.Fatalf("failed to create non-numeric dir: %v", err)
 	}
-	
+
 	_, err := findCgroupPathFromProc("test123")
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (expected): %v", err)
@@ -1089,11 +1098,11 @@ func TestFindCgroupPathFromProc_NonNumericPID(t *testing.T) {
 
 func TestFindCgroupPathV2_NotFound(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origCgroupBase := config.CgroupBasePath
 	config.SetCgroupBasePath(tmpDir)
 	defer func() { config.SetCgroupBasePath(origCgroupBase) }()
-	
+
 	_, err := findCgroupPathV2("nonexistent-container")
 	if err == nil {
 		t.Error("Expected error for nonexistent container")
@@ -1102,11 +1111,11 @@ func TestFindCgroupPathV2_NotFound(t *testing.T) {
 
 func TestFindCgroupPathV2_FoundInKubepods(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origCgroupBase := config.CgroupBasePath
 	config.SetCgroupBasePath(tmpDir)
 	defer func() { config.SetCgroupBasePath(origCgroupBase) }()
-	
+
 	containerID := "test789"
 	kubepodsPath := filepath.Join(tmpDir, "kubepods", "pod_"+containerID)
 	if err := os.MkdirAll(kubepodsPath, 0755); err != nil {
@@ -1116,7 +1125,7 @@ func TestFindCgroupPathV2_FoundInKubepods(t *testing.T) {
 	if err := os.WriteFile(cgroupProcsPath, []byte(""), 0644); err != nil {
 		t.Fatalf("failed to create cgroup.procs: %v", err)
 	}
-	
+
 	path, err := findCgroupPathV2(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathV2 returned error (may be expected): %v", err)
@@ -1128,11 +1137,11 @@ func TestFindCgroupPathV2_FoundInKubepods(t *testing.T) {
 
 func TestFindCgroupPathV2_WithShortID(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origCgroupBase := config.CgroupBasePath
 	config.SetCgroupBasePath(tmpDir)
 	defer func() { config.SetCgroupBasePath(origCgroupBase) }()
-	
+
 	fullID := "abcdef1234567890abcdef1234567890abcdef12"
 	shortID := fullID[:12]
 	kubepodsPath := filepath.Join(tmpDir, "kubepods.slice", "pod_"+shortID)
@@ -1143,7 +1152,7 @@ func TestFindCgroupPathV2_WithShortID(t *testing.T) {
 	if err := os.WriteFile(cgroupProcsPath, []byte(""), 0644); err != nil {
 		t.Fatalf("failed to create cgroup.procs: %v", err)
 	}
-	
+
 	path, err := findCgroupPathV2(fullID)
 	if err != nil {
 		t.Logf("findCgroupPathV2 returned error (may be expected): %v", err)
@@ -1155,7 +1164,7 @@ func TestFindCgroupPathV2_WithShortID(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithV1Format_PartsLessThan3(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -1164,20 +1173,20 @@ func TestFindCgroupPathFromProc_WithV1Format_PartsLessThan3(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "test123"
 	pid := "12349"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := "1:cpu:\n"
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	_, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (expected): %v", err)
@@ -1186,7 +1195,7 @@ func TestFindCgroupPathFromProc_WithV1Format_PartsLessThan3(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithV1Format_EmptyCgroupPath(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -1195,20 +1204,20 @@ func TestFindCgroupPathFromProc_WithV1Format_EmptyCgroupPath(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "test123"
 	pid := "12350"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := "1:cpu:/\n"
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	_, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (expected): %v", err)
@@ -1217,7 +1226,7 @@ func TestFindCgroupPathFromProc_WithV1Format_EmptyCgroupPath(t *testing.T) {
 
 func TestFindCgroupPathFromProc_WithV1Format_EmptyLine(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origProcBase := config.ProcBasePath
 	origCgroupBase := config.CgroupBasePath
 	config.SetProcBasePath(tmpDir)
@@ -1226,25 +1235,25 @@ func TestFindCgroupPathFromProc_WithV1Format_EmptyLine(t *testing.T) {
 		config.SetProcBasePath(origProcBase)
 		config.SetCgroupBasePath(origCgroupBase)
 	}()
-	
+
 	containerID := "test123"
 	pid := "12351"
 	procDir := filepath.Join(tmpDir, pid)
 	if err := os.MkdirAll(procDir, 0755); err != nil {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
-	
+
 	cgroupFile := filepath.Join(procDir, "cgroup")
 	cgroupContent := fmt.Sprintf("   \n1:cpu:/kubepods/pod_%s\n", containerID)
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0644); err != nil {
 		t.Fatalf("failed to create cgroup file: %v", err)
 	}
-	
+
 	cgroupPath := filepath.Join(tmpDir, "kubepods", "pod_"+containerID)
 	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
 		t.Fatalf("failed to create cgroup path: %v", err)
 	}
-	
+
 	path, err := findCgroupPathFromProc(containerID)
 	if err != nil {
 		t.Logf("findCgroupPathFromProc returned error (may be expected): %v", err)
@@ -1256,11 +1265,11 @@ func TestFindCgroupPathFromProc_WithV1Format_EmptyLine(t *testing.T) {
 
 func TestFindCgroupPathV2_WalkError(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	origCgroupBase := config.CgroupBasePath
 	config.SetCgroupBasePath(tmpDir)
 	defer func() { config.SetCgroupBasePath(origCgroupBase) }()
-	
+
 	kubepodsPath := filepath.Join(tmpDir, "kubepods")
 	if err := os.MkdirAll(kubepodsPath, 0755); err != nil {
 		t.Fatalf("failed to create kubepods path: %v", err)
@@ -1271,7 +1280,7 @@ func TestFindCgroupPathV2_WalkError(t *testing.T) {
 	defer func() {
 		_ = os.Chmod(kubepodsPath, 0755)
 	}()
-	
+
 	_, err := findCgroupPathV2("test123")
 	if err != nil {
 		t.Logf("findCgroupPathV2 returned error (expected): %v", err)
@@ -1455,7 +1464,6 @@ func TestCgroupRootCandidates_WithSystemd(t *testing.T) {
 		t.Errorf("expected systemd dir %q in candidates %v", systemdDir, candidates)
 	}
 }
-
 
 // ─── cgroupRootCandidates ────────────────────────────────────────────────────
 

--- a/internal/kubernetes/preresolved.go
+++ b/internal/kubernetes/preresolved.go
@@ -15,8 +15,8 @@ type PreResolvedRef struct {
 }
 
 // ParsePreResolvedRef parses the "namespace/podName/containerID/containerName"
-// form. Empty containerName is allowed (the spawned binary defaults to the
-// first container's name during its own resolution).
+// form. Each ref names exactly one container; a multi-container pod arrives
+// as one ref per container. Empty containerName is allowed.
 func ParsePreResolvedRef(s string) (PreResolvedRef, error) {
 	parts := strings.SplitN(s, "/", 4)
 	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
@@ -53,8 +53,11 @@ func BuildPodInfoFromPreResolved(ref PreResolvedRef) (*PodInfo, error) {
 		cgroupPath = fromProc
 	}
 	return &PodInfo{
-		PodName:       ref.PodName,
-		Namespace:     ref.Namespace,
+		PodName:   ref.PodName,
+		Namespace: ref.Namespace,
+		Containers: []ContainerTarget{
+			{Name: ref.ContainerName, ID: ref.ContainerID, CgroupPath: cgroupPath},
+		},
 		ContainerID:   ref.ContainerID,
 		ContainerName: ref.ContainerName,
 		CgroupPath:    cgroupPath,
@@ -94,10 +97,10 @@ type PreResolvedSkip struct {
 // strings and returns:
 //   - infos:    the successfully-resolved targets
 //   - skipped:  per-ref failures with their reason (parse error, empty container,
-//               cgroup not found on THIS node) — caller decides whether to warn
-//               and continue, or hard-fail
+//     cgroup not found on THIS node) — caller decides whether to warn
+//     and continue, or hard-fail
 //   - parseErr: the first malformed-input error, if any (returned alongside the
-//               other slices so the caller can surface it deterministically)
+//     other slices so the caller can surface it deterministically)
 func BuildPodInfosFromPreResolved(refs []string) (infos []*PodInfo, skipped []PreResolvedSkip, parseErr error) {
 	for _, raw := range refs {
 		ref, err := ParsePreResolvedRef(raw)

--- a/internal/kubernetes/robustness_regression_test.go
+++ b/internal/kubernetes/robustness_regression_test.go
@@ -38,35 +38,51 @@ func TestParseTarget_BracketedIPv6WithoutPort(t *testing.T) {
 	}
 }
 
-// TestPickContainer_StatusOrderIndependent: ContainerStatuses is not
-// guaranteed to share Spec.Containers' order; positional pairing returned
-// the wrong container's ID and cgroup.
-func TestPickContainer_StatusOrderIndependent(t *testing.T) {
+func TestPickContainers_DefaultIsAllContainers(t *testing.T) {
+	running := corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}
 	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{Name: "app"}, {Name: "sidecar"},
 		}},
-		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
-			{Name: "sidecar", ContainerID: "containerd://side"},
-			{Name: "app", ContainerID: "containerd://app1"},
-		}},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar", ContainerID: "containerd://side", State: running},
+				{Name: "app", ContainerID: "containerd://app1", State: running},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "mesh-init", ContainerID: "containerd://mesh", State: running},
+				{Name: "done-init", ContainerID: "containerd://done", State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+				}},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", ContainerID: "containerd://dbg", State: running},
+			},
+		},
 	}
 
-	status, spec := pickContainer(pod, "")
-	if status == nil || spec == nil {
-		t.Fatal("expected the first spec container to resolve")
+	got := pickContainers(pod, "")
+	names := make([]string, 0, len(got))
+	for _, cs := range got {
+		names = append(names, cs.Name)
 	}
-	if status.Name != "app" || status.ContainerID != "containerd://app1" || spec.Name != "app" {
-		t.Errorf("default pick = status %q/%s spec %q, want the app container", status.Name, status.ContainerID, spec.Name)
+	want := []string{"sidecar", "app", "mesh-init", "debugger"}
+	if len(got) != len(want) {
+		t.Fatalf("default pick = %v, want all running containers %v", names, want)
+	}
+	for i, name := range want {
+		if names[i] != name {
+			t.Errorf("default pick[%d] = %q, want %q", i, names[i], name)
+		}
 	}
 
-	status, spec = pickContainer(pod, "sidecar")
-	if status == nil || status.ContainerID != "containerd://side" || spec == nil || spec.Name != "sidecar" {
-		t.Errorf("named pick mismatched: status %+v spec %+v", status, spec)
+	named := pickContainers(pod, "sidecar")
+	if len(named) != 1 || named[0].ContainerID != "containerd://side" {
+		t.Errorf("named pick = %+v, want exactly the sidecar", named)
 	}
 
-	if status, _ := pickContainer(pod, "missing"); status != nil {
-		t.Errorf("unknown container name must return nil status, got %+v", status)
+	if got := pickContainers(pod, "missing"); len(got) != 0 {
+		t.Errorf("unknown container name must select nothing, got %+v", got)
 	}
 }
 

--- a/internal/kubernetes/target_registry.go
+++ b/internal/kubernetes/target_registry.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/podtrace/podtrace/internal/logger"
-	"github.com/podtrace/podtrace/internal/validation"
 	"go.uber.org/zap"
 )
 
@@ -345,32 +344,27 @@ func resolvePodInfoFromObject(ctx context.Context, pod *corev1.Pod, containerNam
 		return nil, fmt.Errorf("pod %s/%s has no container statuses", pod.Namespace, pod.Name)
 	}
 
-	containerStatus, containerSpec := pickContainer(pod, containerName)
-	if containerStatus == nil {
-		return nil, fmt.Errorf("container %q has no status yet in pod %s/%s", containerName, pod.Namespace, pod.Name)
-	}
-
-	containerID := containerStatus.ContainerID
-	parts := strings.Split(containerID, "://")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid container id format for %s/%s: %q", pod.Namespace, pod.Name, containerID)
-	}
-	shortID := parts[1]
-	if !validation.ValidateContainerID(shortID) {
-		return nil, fmt.Errorf("container id validation failed for %s/%s", pod.Namespace, pod.Name)
+	statuses := pickContainers(pod, containerName)
+	if len(statuses) == 0 {
+		return nil, fmt.Errorf("no running container matching %q in pod %s/%s", containerName, pod.Namespace, pod.Name)
 	}
 
 	resolveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	cgroupPath, err := resolveCgroupPathCRI(resolveCtx, shortID)
-	if err != nil || cgroupPath == "" {
-		cgroupPath, err = findCgroupPath(shortID)
-		if err != nil || cgroupPath == "" {
-			cgroupPath, err = findCgroupPathFromProc(shortID)
+	targets := resolveContainerTargets(resolveCtx, pod, statuses)
+	if len(targets) == 0 {
+		for _, cs := range statuses {
+			shortID, err := shortContainerID(cs.ContainerID)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve cgroup path for %s/%s: %w", pod.Namespace, pod.Name, err)
+				continue
 			}
+			targets = append(targets, ContainerTarget{Name: cs.Name, ID: shortID})
 		}
+		if len(targets) == 0 {
+			return nil, fmt.Errorf("no usable container in pod %s/%s", pod.Namespace, pod.Name)
+		}
+		logger.Debug("No container cgroup resolved; keeping target with container IDs only",
+			zap.String("pod", pod.Namespace+"/"+pod.Name))
 	}
 
 	labels := make(map[string]string, len(pod.Labels))
@@ -383,16 +377,13 @@ func resolvePodInfoFromObject(ctx context.Context, pod *corev1.Pod, containerNam
 		ownerName = pod.OwnerReferences[0].Name
 	}
 
-	name := ""
-	if containerSpec != nil {
-		name = containerSpec.Name
-	}
 	return &PodInfo{
 		PodName:       pod.Name,
 		Namespace:     pod.Namespace,
-		ContainerID:   shortID,
-		CgroupPath:    cgroupPath,
-		ContainerName: name,
+		Containers:    targets,
+		ContainerID:   targets[0].ID,
+		CgroupPath:    targets[0].CgroupPath,
+		ContainerName: targets[0].Name,
 		Labels:        labels,
 		PodIP:         pod.Status.PodIP,
 		OwnerKind:     ownerKind,

--- a/internal/kubernetes/target_registry_unit_test.go
+++ b/internal/kubernetes/target_registry_unit_test.go
@@ -63,7 +63,8 @@ func runningPod(uid, ns, name, containerName, containerID string) *corev1.Pod {
 		Status: corev1.PodStatus{
 			PodIP: "10.1.2.3",
 			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: containerName, ContainerID: "containerd://" + containerID},
+				{Name: containerName, ContainerID: "containerd://" + containerID,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
 			},
 		},
 	}
@@ -119,8 +120,10 @@ func TestResolvePodInfoFromObject_NamedContainerSelected(t *testing.T) {
 		},
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "sidecar", ContainerID: "containerd://" + hex64()},
-				{Name: "main", ContainerID: "containerd://" + cid},
+				{Name: "sidecar", ContainerID: "containerd://" + hex64(),
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				{Name: "main", ContainerID: "containerd://" + cid,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
 			},
 		},
 	}
@@ -148,7 +151,8 @@ func TestResolvePodInfoFromObject_MissingOptionalFields(t *testing.T) {
 		},
 		Status: corev1.PodStatus{
 			ContainerStatuses: []corev1.ContainerStatus{
-				{Name: "c0", ContainerID: "containerd://" + cid},
+				{Name: "c0", ContainerID: "containerd://" + cid,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Targeting a pod by name, label selector, or CR, previously traced only one container (the `--container` one, or silently the first spec container), so sidecars and secondary containers were invisible. This PR makes pod targeting mean the whole pod: every running container is traced by default, including restartable-init sidecars and ephemeral containers, matching the agent plane's enumeration so both planes agree. `--container` (CLI) and `spec.containerName` (PodTrace/PodTraceSession/PodTraceSchedule) remain as the narrowing filter for a single named container.

## Changes

- **Resolver.** `pickContainer` becomes `pickContainers`: all running containers with a container ID (regular + restartable-init + ephemeral) when no name is given, exactly the named one otherwise. `PodInfo` gains `Containers []ContainerTarget{Name, ID, CgroupPath}`; the singular fields mirror the first entry so existing call sites keep working. Both resolvers (`ResolvePod` and the target registry) resolve the cgroup per container through the existing CRI → filesystem-scan → /proc chain, warn and skip on per-container failure, and fail only when nothing resolves. The registry path stays lenient when no cgroup resolves at all (container IDs alone still enable process-scan uprobe attachment, and the next registry update re-resolves).
- **CLI wiring.** The cgroup and container-ID attach lists, and the wrong-container safety check, fan out over every container of every target pod. `sourcePodIndex` keeps one entry per container cgroup carrying that container's identity, so events are attributed to the specific container, while the diagnose report's pod-level partitioning is unchanged.
- **Dynamic-update fix.** The target-registry snapshot goroutine only refreshed cgroup filters; uprobe targets were never refreshed on pod churn. It now re-applies both, in startup order (cgroups first so per-container PID discovery sees the new paths).
- **Node-spawn path.** `PodRef` carries a container list and the workstation emits one `--preresolved-pod=ns/name/containerID/containerName` flag per container. The per-ref format is unchanged, so older and newer spawn binaries interoperate with no encoding version.
- **CRDs and docs.** `containerName` is documented as "empty = every running container" (manifests regenerated); `--container` help and usage docs updated. Release-note callout: pod targeting now covers the whole pod, so event volume grows accordingly for sidecar-heavy pods.