### PR TITLE
feat: attribute cgroup_skb events to owning process at ingest

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,6 +38,8 @@ All metrics are exported per process and per event type.
 | `podtrace_grpc_latency_seconds` | Distribution of gRPC method call latencies |
 | `podtrace_kafka_latency_seconds` | Distribution of Kafka produce/consume latencies |
 | `podtrace_kafka_bytes_total` | Total bytes in Kafka produce/consume operations |
+| `podtrace_attribution_total` | Process-identity attribution outcome per event, labeled `source` (`event_comm`/`correlator`/`proc_fallback`/`none`) and `event` (`dns`/`quic`/`other`) |
+| `podtrace_attribution_pid_reuse_suspected_total` | Attribution lookups rejected on a cgroup mismatch (suspected pid reuse) |
 
 ## Enabling Metrics
 

--- a/internal/attribution/attribution.go
+++ b/internal/attribution/attribution.go
@@ -1,0 +1,125 @@
+// Package attribution maintains a short-lived map from host PID to the
+// process identity (comm, cgroup) most recently captured in kernel
+// context, so events produced by BPF program types that cannot call
+// bpf_get_current_comm — the cgroup_skb DNS and QUIC probes, can be
+// attributed at ingest while the owning process is still alive, instead
+// of through a deferred /proc lookup that races process exit and pid
+// recycling.
+package attribution
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// DefaultTTL bounds how long a captured identity may attribute later
+// events.
+const DefaultTTL = 30 * time.Second
+
+// DefaultMaxEntries caps the table..
+const DefaultMaxEntries = 8192
+
+type entry struct {
+	pid      uint32
+	comm     string
+	cgroupID uint64
+	seenAt   time.Time
+}
+
+// Table is a concurrency-safe pid, identity map with TTL expiry and
+// LRU eviction.
+type Table struct {
+	mu         sync.Mutex
+	entries    map[uint32]*list.Element
+	order      *list.List
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+}
+
+// New returns an empty table.
+func New(ttl time.Duration, maxEntries int) *Table {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+	return &Table{
+		entries:    make(map[uint32]*list.Element, 256),
+		order:      list.New(),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        time.Now,
+	}
+}
+
+// Record stores (comm, cgroupID) as the identity of pid, replacing any
+// previous identity (last-writer-wins: on pid reuse the newest owner is
+// the correct one).
+func (t *Table) Record(pid uint32, cgroupID uint64, comm string) {
+	if t == nil || pid == 0 || comm == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	if el, ok := t.entries[pid]; ok {
+		e := el.Value.(*entry)
+		e.comm = comm
+		e.cgroupID = cgroupID
+		e.seenAt = now
+		t.order.MoveToFront(el)
+		return
+	}
+	if t.order.Len() >= t.maxEntries {
+		oldest := t.order.Back()
+		if oldest != nil {
+			t.order.Remove(oldest)
+			delete(t.entries, oldest.Value.(*entry).pid)
+		}
+	}
+	t.entries[pid] = t.order.PushFront(&entry{
+		pid:      pid,
+		comm:     comm,
+		cgroupID: cgroupID,
+		seenAt:   now,
+	})
+}
+
+// Lookup returns the comm recorded for pid, if it is still within TTL
+// and its cgroup is consistent with the event being attributed.
+func (t *Table) Lookup(pid uint32, cgroupID uint64) (comm string, ok bool, reuseSuspected bool) {
+	if t == nil || pid == 0 {
+		return "", false, false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	el, found := t.entries[pid]
+	if !found {
+		return "", false, false
+	}
+	e := el.Value.(*entry)
+	if t.now().Sub(e.seenAt) > t.ttl {
+		t.order.Remove(el)
+		delete(t.entries, pid)
+		return "", false, false
+	}
+	if cgroupID != 0 && e.cgroupID != 0 && e.cgroupID != cgroupID {
+		t.order.Remove(el)
+		delete(t.entries, pid)
+		return "", false, true
+	}
+	return e.comm, true, false
+}
+
+// Len returns the number of live entries.
+func (t *Table) Len() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.order.Len()
+}

--- a/internal/attribution/attribution_test.go
+++ b/internal/attribution/attribution_test.go
@@ -1,0 +1,187 @@
+package attribution
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fixedClock struct {
+	mu  sync.Mutex
+	t   time.Time
+}
+
+func (c *fixedClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fixedClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestTable(ttl time.Duration, maxEntries int) (*Table, *fixedClock) {
+	clock := &fixedClock{t: time.Unix(1_000_000, 0)}
+	table := New(ttl, maxEntries)
+	table.now = clock.now
+	return table, clock
+}
+
+func TestRecordAndLookupHit(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	table.Record(42, 100, "nslookup")
+
+	comm, ok, reuse := table.Lookup(42, 100)
+	if !ok || reuse {
+		t.Fatalf("Lookup(42,100) = (%q,%v,%v), want hit without reuse", comm, ok, reuse)
+	}
+	if comm != "nslookup" {
+		t.Fatalf("comm = %q, want nslookup", comm)
+	}
+}
+
+func TestLookupMiss(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	if _, ok, reuse := table.Lookup(7, 100); ok || reuse {
+		t.Fatalf("Lookup on empty table = hit=%v reuse=%v, want miss", ok, reuse)
+	}
+}
+
+func TestTTLEviction(t *testing.T) {
+	table, clock := newTestTable(10*time.Second, 16)
+	table.Record(42, 100, "curl")
+
+	clock.advance(9 * time.Second)
+	if _, ok, _ := table.Lookup(42, 100); !ok {
+		t.Fatal("entry expired before TTL")
+	}
+
+	clock.advance(2 * time.Second)
+	if _, ok, _ := table.Lookup(42, 100); ok {
+		t.Fatal("entry survived past TTL")
+	}
+	if table.Len() != 0 {
+		t.Fatalf("expired entry not evicted, Len = %d", table.Len())
+	}
+}
+
+func TestLastWriterWins(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	table.Record(42, 100, "old-owner")
+	table.Record(42, 100, "new-owner")
+
+	comm, ok, _ := table.Lookup(42, 100)
+	if !ok || comm != "new-owner" {
+		t.Fatalf("Lookup = (%q,%v), want new-owner hit", comm, ok)
+	}
+	if table.Len() != 1 {
+		t.Fatalf("rewrite duplicated the entry, Len = %d", table.Len())
+	}
+}
+
+func TestCgroupMismatchSuspectsPidReuse(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	table.Record(42, 100, "victim")
+
+	comm, ok, reuse := table.Lookup(42, 200)
+	if ok || comm != "" {
+		t.Fatalf("cross-cgroup lookup returned %q, want miss", comm)
+	}
+	if !reuse {
+		t.Fatal("cross-cgroup lookup did not flag pid reuse")
+	}
+	if _, ok, reuse := table.Lookup(42, 200); ok || reuse {
+		t.Fatalf("stale entry survived reuse eviction: hit=%v reuse=%v", ok, reuse)
+	}
+}
+
+func TestZeroCgroupSkipsReuseCheck(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	table.Record(42, 0, "no-cgroup-producer")
+	if _, ok, reuse := table.Lookup(42, 200); !ok || reuse {
+		t.Fatalf("zero recorded cgroup must not trigger reuse: hit=%v reuse=%v", ok, reuse)
+	}
+
+	table.Record(43, 100, "curl")
+	if _, ok, reuse := table.Lookup(43, 0); !ok || reuse {
+		t.Fatalf("zero lookup cgroup must not trigger reuse: hit=%v reuse=%v", ok, reuse)
+	}
+}
+
+func TestLRUCapEviction(t *testing.T) {
+	const cap = 8
+	table, _ := newTestTable(time.Minute, cap)
+	for pid := uint32(1); pid <= cap+3; pid++ {
+		table.Record(pid, 100, fmt.Sprintf("proc-%d", pid))
+	}
+	if table.Len() != cap {
+		t.Fatalf("Len = %d, want %d", table.Len(), cap)
+	}
+	for pid := uint32(1); pid <= 3; pid++ {
+		if _, ok, _ := table.Lookup(pid, 100); ok {
+			t.Fatalf("pid %d survived cap eviction", pid)
+		}
+	}
+	if _, ok, _ := table.Lookup(cap+3, 100); !ok {
+		t.Fatal("most recent entry missing after cap eviction")
+	}
+}
+
+func TestRewriteRefreshesLRUPosition(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 2)
+	table.Record(1, 100, "a")
+	table.Record(2, 100, "b")
+	table.Record(1, 100, "a2")
+	table.Record(3, 100, "c")
+
+	if _, ok, _ := table.Lookup(2, 100); ok {
+		t.Fatal("refreshed entry was evicted instead of the stale one")
+	}
+	if comm, ok, _ := table.Lookup(1, 100); !ok || comm != "a2" {
+		t.Fatalf("Lookup(1) = (%q,%v), want a2 hit", comm, ok)
+	}
+}
+
+func TestIgnoresPidZeroAndEmptyComm(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 16)
+	table.Record(0, 100, "kernel")
+	table.Record(42, 100, "")
+	if table.Len() != 0 {
+		t.Fatalf("invalid records were stored, Len = %d", table.Len())
+	}
+	if _, ok, _ := table.Lookup(0, 100); ok {
+		t.Fatal("Lookup(0) must miss")
+	}
+}
+
+func TestNilTableIsSafe(t *testing.T) {
+	var table *Table
+	table.Record(42, 100, "curl")
+	if _, ok, reuse := table.Lookup(42, 100); ok || reuse {
+		t.Fatal("nil table must always miss")
+	}
+	if table.Len() != 0 {
+		t.Fatal("nil table Len must be 0")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	table, _ := newTestTable(time.Minute, 128)
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				pid := uint32(w*1000 + i%64 + 1)
+				table.Record(pid, uint64(w+1), "worker")
+				table.Lookup(pid, uint64(w+1))
+			}
+		}(w)
+	}
+	wg.Wait()
+}

--- a/internal/ebpf/tracer/attribution.go
+++ b/internal/ebpf/tracer/attribution.go
@@ -1,0 +1,62 @@
+package tracer
+
+import (
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/metricsexporter"
+)
+
+// Attribution sources reported to podtrace_attribution_total.
+const (
+	attributionSourceEventComm    = "event_comm"
+	attributionSourceCorrelator   = "correlator"
+	attributionSourceProcFallback = "proc_fallback"
+	attributionSourceNone         = "none"
+)
+
+// attributeProcessName fills event.ProcessName for events that arrived
+// without a kernel-captured comm, the cgroup_skb producers (DNS, QUIC),
+// which cannot call bpf_get_current_comm — and reports where the name
+// came from.
+func (t *Tracer) attributeProcessName(event *events.Event) string {
+	if event.ProcessName != "" {
+		return attributionSourceEventComm
+	}
+	if !t.attributionCorrelatorDisabled {
+		name, ok, reuseSuspected := t.attributionTable.Lookup(event.PID, event.CgroupID)
+		if ok {
+			event.ProcessName = name
+			return attributionSourceCorrelator
+		}
+		if reuseSuspected {
+			metricsexporter.RecordAttributionPidReuseSuspected()
+		}
+	}
+	event.ProcessName = t.getProcessNameQuick(event.PID)
+	if event.ProcessName != "" {
+		return attributionSourceProcFallback
+	}
+	return attributionSourceNone
+}
+
+// recordAttributionOutcome feeds the attribution table and the metrics
+// from one dispatched event.
+func (t *Tracer) recordAttributionOutcome(event *events.Event, source string) {
+	if source == attributionSourceEventComm && event.ProcessName != "" {
+		t.attributionTable.Record(event.PID, event.CgroupID, event.ProcessName)
+	}
+	metricsexporter.RecordAttribution(source, attributionEventKind(event.Type))
+}
+
+// attributionEventKind buckets event types for the attribution metric:
+// dns and quic are the cgroup_skb-sourced kinds the attribution work
+// targets, everything else is the baseline.
+func attributionEventKind(t events.EventType) string {
+	switch t {
+	case events.EventDNS, events.EventDNSQuery:
+		return "dns"
+	case events.EventHTTP3:
+		return "quic"
+	default:
+		return "other"
+	}
+}

--- a/internal/ebpf/tracer/attribution_test.go
+++ b/internal/ebpf/tracer/attribution_test.go
@@ -1,0 +1,125 @@
+package tracer
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/attribution"
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/ebpf/cache"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func newAttributionTestTracer() *Tracer {
+	ttl := time.Duration(config.CacheTTLSeconds) * time.Second
+	return &Tracer{
+		processNameCache: cache.NewLRUCache(config.CacheMaxSize, ttl),
+		attributionTable: attribution.New(time.Minute, 64),
+	}
+}
+
+func TestAttributeProcessName_EventCommWins(t *testing.T) {
+	tracer := newAttributionTestTracer()
+	ev := &events.Event{PID: 42, CgroupID: 7, ProcessName: "curl"}
+	if source := tracer.attributeProcessName(ev); source != attributionSourceEventComm {
+		t.Fatalf("source = %q, want event_comm", source)
+	}
+	if ev.ProcessName != "curl" {
+		t.Fatalf("ProcessName mutated to %q", ev.ProcessName)
+	}
+}
+
+func TestAttributeProcessName_CorrelatorFillsEmptyComm(t *testing.T) {
+	tracer := newAttributionTestTracer()
+
+	feeder := &events.Event{PID: 4194200, CgroupID: 7, ProcessName: "nslookup", Type: events.EventUDPSend}
+	tracer.recordAttributionOutcome(feeder, tracer.attributeProcessName(feeder))
+
+	dns := &events.Event{PID: 4194200, CgroupID: 7, Type: events.EventDNSQuery}
+	if source := tracer.attributeProcessName(dns); source != attributionSourceCorrelator {
+		t.Fatalf("source = %q, want correlator", source)
+	}
+	if dns.ProcessName != "nslookup" {
+		t.Fatalf("ProcessName = %q, want nslookup", dns.ProcessName)
+	}
+}
+
+func TestAttributeProcessName_ProcFallbackForUnknownPid(t *testing.T) {
+	tracer := newAttributionTestTracer()
+	self := &events.Event{PID: uint32(os.Getpid()), CgroupID: 7, Type: events.EventDNSQuery}
+	source := tracer.attributeProcessName(self)
+	if source != attributionSourceProcFallback {
+		t.Fatalf("source = %q, want proc_fallback", source)
+	}
+	if self.ProcessName == "" {
+		t.Fatal("proc fallback produced no name for a live pid")
+	}
+}
+
+func TestAttributeProcessName_NoneForDeadPid(t *testing.T) {
+	tracer := newAttributionTestTracer()
+	dead := &events.Event{PID: 4194303, CgroupID: 7, Type: events.EventDNSQuery}
+	if source := tracer.attributeProcessName(dead); source != attributionSourceNone {
+		t.Fatalf("source = %q, want none", source)
+	}
+	if dead.ProcessName != "" {
+		t.Fatalf("ProcessName = %q, want empty", dead.ProcessName)
+	}
+}
+
+func TestAttributeProcessName_CgroupMismatchMisses(t *testing.T) {
+	tracer := newAttributionTestTracer()
+	feeder := &events.Event{PID: 4194201, CgroupID: 7, ProcessName: "victim", Type: events.EventUDPSend}
+	tracer.recordAttributionOutcome(feeder, tracer.attributeProcessName(feeder))
+
+	otherPod := &events.Event{PID: 4194201, CgroupID: 99, Type: events.EventDNSQuery}
+	if source := tracer.attributeProcessName(otherPod); source == attributionSourceCorrelator {
+		t.Fatal("correlator attributed across cgroups (pid reuse hazard)")
+	}
+	if otherPod.ProcessName == "victim" {
+		t.Fatal("stale identity leaked across cgroups")
+	}
+}
+
+func TestRecordAttributionOutcome_DoesNotFeedFromCorrelatorOrProc(t *testing.T) {
+	tracer := newAttributionTestTracer()
+
+	ev := &events.Event{PID: 4194202, CgroupID: 7, ProcessName: "from-proc"}
+	tracer.recordAttributionOutcome(ev, attributionSourceProcFallback)
+	if _, ok, _ := tracer.attributionTable.Lookup(4194202, 7); ok {
+		t.Fatal("proc-derived name was recorded into the attribution table")
+	}
+
+	ev2 := &events.Event{PID: 4194203, CgroupID: 7, ProcessName: "from-table"}
+	tracer.recordAttributionOutcome(ev2, attributionSourceCorrelator)
+	if _, ok, _ := tracer.attributionTable.Lookup(4194203, 7); ok {
+		t.Fatal("correlator-derived name was recorded into the attribution table")
+	}
+}
+
+func TestAttributionEventKind(t *testing.T) {
+	cases := []struct {
+		typ  events.EventType
+		want string
+	}{
+		{events.EventDNS, "dns"},
+		{events.EventDNSQuery, "dns"},
+		{events.EventHTTP3, "quic"},
+		{events.EventConnect, "other"},
+		{events.EventExec, "other"},
+	}
+	for _, c := range cases {
+		if got := attributionEventKind(c.typ); got != c.want {
+			t.Errorf("attributionEventKind(%v) = %q, want %q", c.typ, got, c.want)
+		}
+	}
+}
+
+func TestHaveSkStorageCrossContext(t *testing.T) {
+	first := HaveSkStorageCrossContext()
+	second := HaveSkStorageCrossContext()
+	if first != second {
+		t.Fatalf("probe not stable: first=%v second=%v", first, second)
+	}
+}

--- a/internal/ebpf/tracer/ingest_attribution_test.go
+++ b/internal/ebpf/tracer/ingest_attribution_test.go
@@ -1,0 +1,210 @@
+package tracer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/podtrace/podtrace/internal/attribution"
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/ebpf/cache"
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+// deadPID is a syntactically valid pid that is overwhelmingly unlikely to
+// exist, so the /proc fallback yields nothing and only the correlator can
+// attribute an event carrying it.
+const deadPID = uint32(4194301)
+
+// newDispatchTestTracer builds a Tracer wired for a processAndDispatch
+// call: an empty target-cgroup set (so loadCgroupIDs is non-nil-safe) and
+// a fresh attribution table.
+func newDispatchTestTracer() *Tracer {
+	ttl := time.Duration(config.CacheTTLSeconds) * time.Second
+	t := &Tracer{
+		processNameCache: cache.NewLRUCache(config.CacheMaxSize, ttl),
+		attributionTable: attribution.New(time.Minute, 64),
+	}
+	t.storeCgroupIDs(map[uint64]struct{}{})
+	return t
+}
+
+// dispatchOne pushes one event through the real ingest entry point with
+// cgroup filtering disabled (allow-all) and returns the event as the
+// downstream consumer would receive it.
+func dispatchOne(t *testing.T, tr *Tracer, ev *events.Event) *events.Event {
+	t.Helper()
+	ch := make(chan *events.Event, 1)
+	var collected, filtered, parsed atomic.Int64
+	var filteringDisabled atomic.Bool
+	filteringDisabled.Store(true)
+	ec := &eventCounters{
+		collected:         &collected,
+		filtered:          &filtered,
+		parsed:            &parsed,
+		filteringDisabled: &filteringDisabled,
+	}
+	tr.processAndDispatch(context.Background(), ev, ch, nil, ec, time.Now())
+	select {
+	case got := <-ch:
+		return got
+	default:
+		t.Fatal("event was not dispatched to the channel")
+		return nil
+	}
+}
+
+// attrCounter reads podtrace_attribution_total{source,event} from the
+// default registry (metricsexporter registers there) so the test asserts
+// the real cross-package metric the ingest path emits, not a stub.
+func attrCounter(t *testing.T, source, event string) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "podtrace_attribution_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var gotSource, gotEvent string
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "source":
+					gotSource = l.GetValue()
+				case "event":
+					gotEvent = l.GetValue()
+				}
+			}
+			if gotSource == source && gotEvent == event {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// TestIngest_CorrelatorBeatsProcForDeadDNSPid is the end-to-end-shaped
+// proof the kind run could not give: a DNS event carrying a pid that is
+// NOT in /proc still gets the right process name, and it can only have
+// come from the correlator. This is exactly the short-lived-client case
+// the whole feature exists for.
+func TestIngest_CorrelatorBeatsProcForDeadDNSPid(t *testing.T) {
+	tr := newDispatchTestTracer()
+	const cgroup = uint64(7)
+
+	// A live-context UDP send from the same pid+cgroup seeds the table
+	// (this is what a kprobe producer with a real comm would do).
+	seed := dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, ProcessName: "nslookup", Type: events.EventUDPSend,
+	})
+	if seed.ProcessName != "nslookup" {
+		t.Fatalf("seed event comm mutated to %q", seed.ProcessName)
+	}
+
+	before := attrCounter(t, "correlator", "dns")
+
+	// The cgroup_skb DNS query arrives later with a zeroed comm and a pid
+	// that /proc can no longer resolve.
+	dns := dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, Type: events.EventDNSQuery,
+	})
+	if dns.ProcessName != "nslookup" {
+		t.Fatalf("dead-pid DNS event ProcessName = %q, want nslookup (correlator)", dns.ProcessName)
+	}
+	if delta := attrCounter(t, "correlator", "dns") - before; delta != 1 {
+		t.Fatalf("attribution_total{correlator,dns} delta = %v, want 1", delta)
+	}
+}
+
+// TestIngest_QUICAttributedAtIngest covers the QUIC/HTTP3 path the plan
+// called out: an EventHTTP3 with a zeroed comm (as bpf/http3.c ships it)
+// is attributed at ingest and counted under event="quic".
+func TestIngest_QUICAttributedAtIngest(t *testing.T) {
+	tr := newDispatchTestTracer()
+	const cgroup = uint64(11)
+
+	dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, ProcessName: "curl", Type: events.EventUDPSend,
+	})
+
+	before := attrCounter(t, "correlator", "quic")
+	quic := dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, Type: events.EventHTTP3,
+	})
+	if quic.ProcessName != "curl" {
+		t.Fatalf("HTTP/3 event ProcessName = %q, want curl (correlator)", quic.ProcessName)
+	}
+	if delta := attrCounter(t, "correlator", "quic") - before; delta != 1 {
+		t.Fatalf("attribution_total{correlator,quic} delta = %v, want 1", delta)
+	}
+}
+
+// TestIngest_DeadPidNoTableIsNone proves the honest negative: with no
+// correlator entry and a dead pid, /proc cannot save it and the event is
+// counted as unattributed rather than mislabeled.
+func TestIngest_DeadPidNoTableIsNone(t *testing.T) {
+	tr := newDispatchTestTracer()
+	before := attrCounter(t, "none", "dns")
+	ev := dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: 99, Type: events.EventDNSQuery,
+	})
+	if ev.ProcessName != "" {
+		t.Fatalf("dead-pid unattributed event ProcessName = %q, want empty", ev.ProcessName)
+	}
+	if delta := attrCounter(t, "none", "dns") - before; delta != 1 {
+		t.Fatalf("attribution_total{none,dns} delta = %v, want 1", delta)
+	}
+}
+
+// TestIngest_CorrelatorDisabledFallsBackToProc proves the kill-switch
+// reproduces the pre-correlator behavior: with the correlator off, a DNS
+// event whose pid the table knows is NOT attributed from the table, it
+// falls to /proc, and a dead pid yields none.
+func TestIngest_CorrelatorDisabledFallsBackToProc(t *testing.T) {
+	tr := newDispatchTestTracer()
+	tr.attributionCorrelatorDisabled = true
+	const cgroup = uint64(7)
+
+	// Seed the table exactly as the enabled path would.
+	dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, ProcessName: "nslookup", Type: events.EventUDPSend,
+	})
+
+	beforeCorr := attrCounter(t, "correlator", "dns")
+	beforeNone := attrCounter(t, "none", "dns")
+
+	dns := dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: cgroup, Type: events.EventDNSQuery,
+	})
+	if dns.ProcessName != "" {
+		t.Fatalf("correlator-disabled dead-pid DNS ProcessName = %q, want empty (proc only)", dns.ProcessName)
+	}
+	if delta := attrCounter(t, "correlator", "dns") - beforeCorr; delta != 0 {
+		t.Fatalf("correlator counted while disabled: delta = %v", delta)
+	}
+	if delta := attrCounter(t, "none", "dns") - beforeNone; delta != 1 {
+		t.Fatalf("attribution_total{none,dns} delta = %v, want 1", delta)
+	}
+}
+
+// TestIngest_KernelCommCountedAndFeedsTable proves the common path emits
+// source=event_comm and that this is what seeds the correlator (not the
+// later correlator/proc reads).
+func TestIngest_KernelCommCountedAndFeedsTable(t *testing.T) {
+	tr := newDispatchTestTracer()
+	before := attrCounter(t, "event_comm", "other")
+	dispatchOne(t, tr, &events.Event{
+		PID: deadPID, CgroupID: 5, ProcessName: "wget", Type: events.EventUDPSend,
+	})
+	if delta := attrCounter(t, "event_comm", "other") - before; delta != 1 {
+		t.Fatalf("attribution_total{event_comm,other} delta = %v, want 1", delta)
+	}
+	if name, ok, _ := tr.attributionTable.Lookup(deadPID, 5); !ok || name != "wget" {
+		t.Fatalf("kernel-comm event did not seed the table: name=%q ok=%v", name, ok)
+	}
+}

--- a/internal/ebpf/tracer/skstorage_probe.go
+++ b/internal/ebpf/tracer/skstorage_probe.go
@@ -1,0 +1,66 @@
+package tracer
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+	"go.uber.org/zap"
+
+	"github.com/podtrace/podtrace/internal/logger"
+)
+
+// skStorageCrossContextResult holds the outcome of the one-shot
+// HaveSkStorageCrossContext capability probe.
+type skStorageCrossContextResult struct {
+	mapType        bool
+	cgroupSkbRead  bool
+	kprobeWrite    bool
+}
+
+var (
+	skStorageProbeOnce   sync.Once
+	skStorageProbeResult skStorageCrossContextResult
+)
+
+// viable reports whether every capability required for the cross-context
+// sk_storage design holds on this kernel.
+func (r skStorageCrossContextResult) viable() bool {
+	return r.mapType && r.cgroupSkbRead && r.kprobeWrite
+}
+
+// HaveSkStorageCrossContext reports whether the running kernel can share a
+// BPF_MAP_TYPE_SK_STORAGE map between a socket-layer kprobe producer
+// (process context, where bpf_get_current_comm is valid) and a cgroup_skb
+// consumer.
+func HaveSkStorageCrossContext() bool {
+	skStorageProbeOnce.Do(func() {
+		skStorageProbeResult = skStorageCrossContextResult{
+			mapType:       probeSupported(features.HaveMapType(ebpf.SkStorage), "map_type_sk_storage"),
+			cgroupSkbRead: probeSupported(features.HaveProgramHelper(ebpf.CGroupSKB, asm.FnSkStorageGet), "cgroup_skb_sk_storage_get"),
+			kprobeWrite:   probeSupported(features.HaveProgramHelper(ebpf.Kprobe, asm.FnSkStorageGet), "kprobe_sk_storage_get"),
+		}
+		logger.Info("sk_storage cross-context capability probe (attribution GATE A)",
+			zap.Bool("viable", skStorageProbeResult.viable()),
+			zap.Bool("map_type_sk_storage", skStorageProbeResult.mapType),
+			zap.Bool("cgroup_skb_sk_storage_get", skStorageProbeResult.cgroupSkbRead),
+			zap.Bool("kprobe_sk_storage_get", skStorageProbeResult.kprobeWrite),
+		)
+	})
+	return skStorageProbeResult.viable()
+}
+
+// probeSupported collapses a features probe error into a boolean,
+// logging inconclusive results.
+func probeSupported(err error, leg string) bool {
+	if err == nil {
+		return true
+	}
+	if !errors.Is(err, ebpf.ErrNotSupported) {
+		logger.Warn("sk_storage capability probe inconclusive; treating as unsupported",
+			zap.String("leg", leg), zap.Error(err))
+	}
+	return false
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/podtrace/podtrace/internal/analysis/criticalpath"
+	"github.com/podtrace/podtrace/internal/attribution"
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/ebpf/cache"
 	"github.com/podtrace/podtrace/internal/ebpf/filter"
@@ -83,37 +84,39 @@ type Tracer struct {
 	intentionallyDisabled map[probes.ProbeGroup]struct{}
 	detachWarned          map[probes.ProbeGroup]struct{}
 
-	containerUprobes         map[string]*containerUprobeSet
-	globalProtocolAttached   bool
-	attachContainerGroupFn   func(g probes.ProbeGroup, id string, pids []uint32) []link.Link
-	reader                   *ringbuf.Reader
-	h2Reader                 *ringbuf.Reader
-	h2Decoder                *h2decode.Decoder
-	h3Reader                 *ringbuf.Reader
-	h3Decoder                *h3decode.Decoder
-	h3ChunkReader            *ringbuf.Reader
-	h3Assembler              *h3stream.Assembler
-	h3SectionStash           *h3stream.SectionStash
-	h3ParkedMu               sync.Mutex
-	h3Parked                 []h3ParkedTxn
-	quicReader               *ringbuf.Reader
-	filter                   *filter.CgroupFilter
-	containerID              string
-	containerPID             uint32
-	processNameCache         *cache.LRUCache
-	pathCache                *cache.PathCache
-	resourceMgr              *resourceMonitorManager
-	cgroupPath               string
-	lastDNSDrops             uint64
-	cgroupPaths              []string
-	useUserspaceCgroupFilter atomic.Bool
-	denyWhenNoTargets        atomic.Bool
-	targetCgroupIDs          atomic.Pointer[map[uint64]struct{}]
-	cgroupCapacityWarned     atomic.Int64
-	cgroupWriteMu            sync.Mutex
-	cpAnalyzer               *criticalpath.Analyzer
-	piiRedactor              *redactor.Redactor
-	profilingCtrl            ProfilingController
+	containerUprobes              map[string]*containerUprobeSet
+	globalProtocolAttached        bool
+	attachContainerGroupFn        func(g probes.ProbeGroup, id string, pids []uint32) []link.Link
+	reader                        *ringbuf.Reader
+	h2Reader                      *ringbuf.Reader
+	h2Decoder                     *h2decode.Decoder
+	h3Reader                      *ringbuf.Reader
+	h3Decoder                     *h3decode.Decoder
+	h3ChunkReader                 *ringbuf.Reader
+	h3Assembler                   *h3stream.Assembler
+	h3SectionStash                *h3stream.SectionStash
+	h3ParkedMu                    sync.Mutex
+	h3Parked                      []h3ParkedTxn
+	quicReader                    *ringbuf.Reader
+	filter                        *filter.CgroupFilter
+	containerID                   string
+	containerPID                  uint32
+	processNameCache              *cache.LRUCache
+	attributionTable              *attribution.Table
+	attributionCorrelatorDisabled bool
+	pathCache                     *cache.PathCache
+	resourceMgr                   *resourceMonitorManager
+	cgroupPath                    string
+	lastDNSDrops                  uint64
+	cgroupPaths                   []string
+	useUserspaceCgroupFilter      atomic.Bool
+	denyWhenNoTargets             atomic.Bool
+	targetCgroupIDs               atomic.Pointer[map[uint64]struct{}]
+	cgroupCapacityWarned          atomic.Int64
+	cgroupWriteMu                 sync.Mutex
+	cpAnalyzer                    *criticalpath.Analyzer
+	piiRedactor                   *redactor.Redactor
+	profilingCtrl                 ProfilingController
 }
 
 // registerGroupLinks records freshly attached links under their probe group
@@ -606,6 +609,8 @@ func NewTracer() (*Tracer, error) {
 
 	pruneL7ProbesIfNoBPFLoop(spec)
 
+	HaveSkStorageCrossContext()
+
 	coll, err := ebpf.NewCollectionWithOptions(spec, opts)
 	if err != nil {
 		logVerifierFailure(err)
@@ -706,23 +711,25 @@ func NewTracer() (*Tracer, error) {
 	processCache := cache.NewLRUCache(config.CacheMaxSize, ttl)
 
 	t := &Tracer{
-		collection:            coll,
-		links:                 links,
-		probeGroups:           probeGroups,
-		intentionallyDisabled: map[probes.ProbeGroup]struct{}{},
-		reader:                rd,
-		h2Reader:              h2rd,
-		h2Decoder:             h2dec,
-		h3Reader:              h3rd,
-		h3Decoder:             h3decode.NewDecoder(captureHeaders),
-		h3ChunkReader:         h3chunkrd,
-		h3Assembler:           h3asm,
-		h3SectionStash:        h3stash,
-		quicReader:            quicrd,
-		filter:                filter.NewCgroupFilter(),
-		processNameCache:      processCache,
-		pathCache:             cache.NewPathCache(),
-		resourceMgr:           newResourceMonitorManager(),
+		collection:                    coll,
+		links:                         links,
+		probeGroups:                   probeGroups,
+		intentionallyDisabled:         map[probes.ProbeGroup]struct{}{},
+		reader:                        rd,
+		h2Reader:                      h2rd,
+		h2Decoder:                     h2dec,
+		h3Reader:                      h3rd,
+		h3Decoder:                     h3decode.NewDecoder(captureHeaders),
+		h3ChunkReader:                 h3chunkrd,
+		h3Assembler:                   h3asm,
+		h3SectionStash:                h3stash,
+		quicReader:                    quicrd,
+		filter:                        filter.NewCgroupFilter(),
+		processNameCache:              processCache,
+		attributionTable:              attribution.New(0, 0),
+		attributionCorrelatorDisabled: os.Getenv("PODTRACE_DISABLE_ATTRIBUTION_CORRELATOR") == "1",
+		pathCache:                     cache.NewPathCache(),
+		resourceMgr:                   newResourceMonitorManager(),
 	}
 	t.useUserspaceCgroupFilter.Store(true)
 	t.storeCgroupIDs(map[uint64]struct{}{})
@@ -1449,9 +1456,7 @@ func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 	processingStart time.Time) {
 	ec.parsed.Add(1)
 	resolveAndConsumeStack(stackMap, event)
-	if event.ProcessName == "" {
-		event.ProcessName = t.getProcessNameQuick(event.PID)
-	}
+	attributionSource := t.attributeProcessName(event)
 	event.ProcessName = validation.SanitizeProcessName(event.ProcessName)
 
 	if isLikelyTransientComm(event.ProcessName) {
@@ -1467,6 +1472,8 @@ func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 			event.ProcessName = "runc-bootstrap[" + event.ProcessName + "]"
 		}
 	}
+
+	t.recordAttributionOutcome(event, attributionSource)
 
 	cache.SnapshotCPUTime(event.PID)
 

--- a/internal/metricsexporter/attribution_metrics_test.go
+++ b/internal/metricsexporter/attribution_metrics_test.go
@@ -1,0 +1,39 @@
+package metricsexporter
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestRecordAttribution_IncrementsLabeledCounter guards the exact label
+// values the ingest path passes: a fat-fingered source or event label
+// would land on a different (or invalid) series and this would catch it.
+func TestRecordAttribution_IncrementsLabeledCounter(t *testing.T) {
+	cases := []struct{ source, event string }{
+		{"event_comm", "other"},
+		{"correlator", "dns"},
+		{"proc_fallback", "dns"},
+		{"correlator", "quic"},
+		{"none", "quic"},
+	}
+	for _, c := range cases {
+		before := testutil.ToFloat64(attributionCounter.WithLabelValues(c.source, c.event))
+		RecordAttribution(c.source, c.event)
+		after := testutil.ToFloat64(attributionCounter.WithLabelValues(c.source, c.event))
+		if after-before != 1 {
+			t.Errorf("attribution_total{source=%q,event=%q} delta = %v, want 1",
+				c.source, c.event, after-before)
+		}
+	}
+}
+
+func TestRecordAttributionPidReuseSuspected_Increments(t *testing.T) {
+	before := testutil.ToFloat64(attributionPidReuseCounter)
+	RecordAttributionPidReuseSuspected()
+	RecordAttributionPidReuseSuspected()
+	after := testutil.ToFloat64(attributionPidReuseCounter)
+	if after-before != 2 {
+		t.Errorf("pid_reuse_suspected delta = %v, want 2", after-before)
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -186,6 +186,28 @@ var (
 		[]string{"event_type", "error_code"},
 	)
 
+	attributionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "podtrace_attribution_total",
+			Help: "Process-identity attribution outcomes at event ingest, per source. " +
+				"event_comm = comm arrived in the kernel event (kprobe/uprobe producers); " +
+				"correlator = filled from the pid→comm table fed by kernel-context events; " +
+				"proc_fallback = resolved by reading /proc at ingest (racy for short-lived processes); " +
+				"none = unattributed. The event label buckets dns/quic (cgroup_skb producers, " +
+				"the attribution gap) against everything else.",
+		},
+		[]string{"source", "event"},
+	)
+
+	attributionPidReuseCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "podtrace_attribution_pid_reuse_suspected_total",
+			Help: "Attribution lookups rejected because the pid's cached identity " +
+				"belonged to a different cgroup — the strongest observable signal " +
+				"that the pid was recycled between capture and ingest.",
+		},
+	)
+
 	tlsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "podtrace_tls_handshake_latency_latest_seconds",
@@ -410,6 +432,8 @@ func init() {
 	prometheus.MustRegister(pidCacheMissesCounter)
 	prometheus.MustRegister(eventProcessingLatencyHistogram)
 	prometheus.MustRegister(errorRateCounter)
+	prometheus.MustRegister(attributionCounter)
+	prometheus.MustRegister(attributionPidReuseCounter)
 	prometheus.MustRegister(tlsGauge)
 	prometheus.MustRegister(tlsHistogram)
 	prometheus.MustRegister(tlsHandshakesCounter)
@@ -760,6 +784,18 @@ func RecordEventProcessingLatency(duration time.Duration) {
 
 func RecordError(eventType string, errorCode int32) {
 	errorRateCounter.WithLabelValues(eventType, fmt.Sprintf("%d", errorCode)).Inc()
+}
+
+// RecordAttribution counts one process-identity attribution outcome at
+// event ingest.
+func RecordAttribution(source, eventKind string) {
+	attributionCounter.WithLabelValues(source, eventKind).Inc()
+}
+
+// RecordAttributionPidReuseSuspected counts one attribution lookup that
+// was rejected on a cgroup mismatch.
+func RecordAttributionPidReuseSuspected() {
+	attributionPidReuseCounter.Inc()
 }
 
 func RecordChannelDepths(eventLen, filteredLen int) {


### PR DESCRIPTION
## Summary

DNS and QUIC/HTTP3 events come from `cgroup_skb` BPF programs, which cannot call `bpf_get_current_comm`, so they shipped with a zeroed comm and a best-effort pid resolved later from `/proc`, racy for short-lived clients. This attributes them at ingest from identity captured while the process is alive.

## Changes

- Add `internal/attribution`: a pid (comm, cgroup, ts) table with TTL + LRU, fed from events that carry a kernel-stamped comm, consulted at ingest before the `/proc` fallback. A cgroup mismatch is treated as pid reuse, the stale entry is evicted and the lookup misses instead of returning a wrong name.
- Add the `HaveSkStorageCrossContext()` capability probe. On kernel 7.0 it reports not viable (the kprobe `bpf_sk_storage_get` leg is unsupported), so any future in-kernel accelerator must use a flow-tuple `LRU_HASH`, not sk-local storage.
- Add attribution metrics: `podtrace_attribution_total{source,event}` and `podtrace_attribution_pid_reuse_suspected_total`.
- Wire the correlator into the ingest path; no event-ABI change, no minimum-kernel change.