### PR TITLE
fix: bound process_name label cardinality in all metric exporters

### DIFF
--- a/internal/metricsexporter/process_name_cardinality_test.go
+++ b/internal/metricsexporter/process_name_cardinality_test.go
@@ -1,0 +1,102 @@
+package metricsexporter
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestProcessNameCardinalityBounded(t *testing.T) {
+	const limit = 2
+	const distinctNames = 8
+	const prefix = "cardguard-proc-"
+
+	saved := processCardinality
+	processCardinality = newLabelCardinalityLimiter(limit)
+	t.Cleanup(func() { processCardinality = saved })
+
+	drive := func(e *events.Event) {
+		ExportRTTMetricWithContext(e, "ns", "pod", "svc")
+		ExportTCPMetricWithContext(e, "ns", "pod", "svc")
+		ExportDNSMetricWithContext(e, "ns")
+		ExportFileSystemMetricWithContext(e, "ns")
+		ExportSchedSwitchMetricWithContext(e, "ns")
+		ExportTLSMetricWithContext(e, "ns")
+		ExportNetworkBandwidthMetricWithContext(e, "send", "ns", "pod", "svc")
+		ExportFilesystemBandwidthMetricWithContext(e, "write", "ns")
+	}
+
+	switchTypes := []events.EventType{
+		events.EventRedisCmd,
+		events.EventMemcachedCmd,
+		events.EventFastCGIResp,
+		events.EventGRPCMethod,
+		events.EventKafkaProduce,
+		events.EventKafkaFetch,
+	}
+
+	for i := 0; i < distinctNames; i++ {
+		name := prefix + strconv.Itoa(i)
+		drive(&events.Event{
+			Type:        events.EventDNS,
+			ProcessName: name,
+			LatencyNS:   1000,
+			Bytes:       10,
+		})
+		for _, et := range switchTypes {
+			HandleEventWithContext(&events.Event{
+				Type:        et,
+				ProcessName: name,
+				Details:     "op",
+				Target:      "tgt",
+				LatencyNS:   1000,
+				Bytes:       10,
+			}, nil)
+		}
+	}
+
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	sawOther := false
+	total := map[string]struct{}{}
+	for _, mf := range mfs {
+		perFamily := map[string]struct{}{}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() != "process_name" {
+					continue
+				}
+				v := lp.GetValue()
+				if v == "other" {
+					sawOther = true
+					continue
+				}
+				if strings.HasPrefix(v, prefix) {
+					perFamily[v] = struct{}{}
+					total[v] = struct{}{}
+				}
+			}
+		}
+		if len(perFamily) > limit {
+			t.Errorf("family %q has %d distinct test process_name values (limit %d) — exporter is not bounding process_name",
+				mf.GetName(), len(perFamily), limit)
+		}
+	}
+
+	if len(total) > limit {
+		t.Fatalf("across all families, %d distinct test process_name values admitted; limit is %d — process_name cardinality is unbounded", len(total), limit)
+	}
+	if len(total) == 0 {
+		t.Fatal("no test process_name series produced — exporters did not run")
+	}
+	if !sawOther {
+		t.Errorf("fed %d distinct names past a limit of %d but no \"other\" bucket appeared — overflow was not collapsed", distinctNames, limit)
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -615,7 +615,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if cmd == "" {
 			cmd = "unknown"
 		}
-		redisLatencyHistogram.WithLabelValues(cmd, e.ProcessName, namespace).Observe(latSec)
+		redisLatencyHistogram.WithLabelValues(cmd, boundProcessName(e), namespace).Observe(latSec)
 
 	case events.EventMemcachedCmd:
 		latSec := float64(e.LatencyNS) / 1e9
@@ -623,7 +623,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if op == "" {
 			op = "unknown"
 		}
-		memcachedLatencyHistogram.WithLabelValues(op, e.ProcessName, namespace).Observe(latSec)
+		memcachedLatencyHistogram.WithLabelValues(op, boundProcessName(e), namespace).Observe(latSec)
 
 	case events.EventFastCGIResp:
 		latSec := float64(e.LatencyNS) / 1e9
@@ -631,7 +631,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if method == "" {
 			method = "unknown"
 		}
-		fastcgiLatencyHistogram.WithLabelValues(method, e.ProcessName, namespace).Observe(latSec)
+		fastcgiLatencyHistogram.WithLabelValues(method, boundProcessName(e), namespace).Observe(latSec)
 
 	case events.EventGRPCMethod:
 		latSec := float64(e.LatencyNS) / 1e9
@@ -639,7 +639,7 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if method == "" {
 			method = "unknown"
 		}
-		grpcLatencyHistogram.WithLabelValues(method, e.ProcessName, namespace).Observe(latSec)
+		grpcLatencyHistogram.WithLabelValues(method, boundProcessName(e), namespace).Observe(latSec)
 
 	case events.EventKafkaProduce:
 		latSec := float64(e.LatencyNS) / 1e9
@@ -647,9 +647,10 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if topic == "" {
 			topic = "unknown"
 		}
-		kafkaLatencyHistogram.WithLabelValues("produce", topic, e.ProcessName, namespace).Observe(latSec)
+		procName := boundProcessName(e)
+		kafkaLatencyHistogram.WithLabelValues("produce", topic, procName, namespace).Observe(latSec)
 		if e.Bytes > 0 {
-			kafkaBytesCounter.WithLabelValues("produce", topic, e.ProcessName, namespace).Add(float64(e.Bytes))
+			kafkaBytesCounter.WithLabelValues("produce", topic, procName, namespace).Add(float64(e.Bytes))
 		}
 
 	case events.EventKafkaFetch:
@@ -658,9 +659,10 @@ func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) 
 		if topic == "" {
 			topic = "unknown"
 		}
-		kafkaLatencyHistogram.WithLabelValues("fetch", topic, e.ProcessName, namespace).Observe(latSec)
+		procName := boundProcessName(e)
+		kafkaLatencyHistogram.WithLabelValues("fetch", topic, procName, namespace).Observe(latSec)
 		if e.Bytes > 0 {
-			kafkaBytesCounter.WithLabelValues("fetch", topic, e.ProcessName, namespace).Add(float64(e.Bytes))
+			kafkaBytesCounter.WithLabelValues("fetch", topic, procName, namespace).Add(float64(e.Bytes))
 		}
 	}
 }
@@ -681,8 +683,9 @@ func ExportRTTMetric(e *events.Event) {
 
 func ExportRTTMetricWithContext(e *events.Event, namespace, targetPod, targetService string) {
 	rttSec := float64(e.LatencyNS) / 1e9
-	rttHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace, targetPod, targetService).Observe(rttSec)
-	rttGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace, targetPod, targetService).Set(rttSec)
+	procName := boundProcessName(e)
+	rttHistogram.WithLabelValues(e.TypeString(), procName, namespace, targetPod, targetService).Observe(rttSec)
+	rttGauge.WithLabelValues(e.TypeString(), procName, namespace, targetPod, targetService).Set(rttSec)
 }
 
 func ExportTCPMetric(e *events.Event) {
@@ -691,8 +694,9 @@ func ExportTCPMetric(e *events.Event) {
 
 func ExportTCPMetricWithContext(e *events.Event, namespace, targetPod, targetService string) {
 	latencySec := float64(e.LatencyNS) / 1e9
-	latencyHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace, targetPod, targetService).Observe(latencySec)
-	latencyGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace, targetPod, targetService).Set(latencySec)
+	procName := boundProcessName(e)
+	latencyHistogram.WithLabelValues(e.TypeString(), procName, namespace, targetPod, targetService).Observe(latencySec)
+	latencyGauge.WithLabelValues(e.TypeString(), procName, namespace, targetPod, targetService).Set(latencySec)
 }
 
 func ExportDNSMetric(e *events.Event) {
@@ -701,8 +705,9 @@ func ExportDNSMetric(e *events.Event) {
 
 func ExportDNSMetricWithContext(e *events.Event, namespace string) {
 	latencySec := float64(e.LatencyNS) / 1e9
-	dnsGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Set(latencySec)
-	dnsHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Observe(latencySec)
+	procName := boundProcessName(e)
+	dnsGauge.WithLabelValues(e.TypeString(), procName, namespace).Set(latencySec)
+	dnsHistogram.WithLabelValues(e.TypeString(), procName, namespace).Observe(latencySec)
 }
 
 func ExportFileSystemMetric(e *events.Event) {
@@ -711,8 +716,9 @@ func ExportFileSystemMetric(e *events.Event) {
 
 func ExportFileSystemMetricWithContext(e *events.Event, namespace string) {
 	latencySec := float64(e.LatencyNS) / 1e9
-	fsGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Set(latencySec)
-	fsHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Observe(latencySec)
+	procName := boundProcessName(e)
+	fsGauge.WithLabelValues(e.TypeString(), procName, namespace).Set(latencySec)
+	fsHistogram.WithLabelValues(e.TypeString(), procName, namespace).Observe(latencySec)
 }
 
 func ExportSchedSwitchMetric(e *events.Event) {
@@ -721,8 +727,9 @@ func ExportSchedSwitchMetric(e *events.Event) {
 
 func ExportSchedSwitchMetricWithContext(e *events.Event, namespace string) {
 	blockSec := float64(e.LatencyNS) / 1e9
-	cpuGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Set(blockSec)
-	cpuHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Observe(blockSec)
+	procName := boundProcessName(e)
+	cpuGauge.WithLabelValues(e.TypeString(), procName, namespace).Set(blockSec)
+	cpuHistogram.WithLabelValues(e.TypeString(), procName, namespace).Observe(blockSec)
 }
 
 func ExportNetworkBandwidthMetric(e *events.Event, direction string) {
@@ -731,7 +738,7 @@ func ExportNetworkBandwidthMetric(e *events.Event, direction string) {
 
 func ExportNetworkBandwidthMetricWithContext(e *events.Event, direction, namespace, targetPod, targetService string) {
 	if e.Bytes > 0 {
-		networkBytesCounter.WithLabelValues(e.TypeString(), e.ProcessName, direction, namespace, targetPod, targetService).Add(float64(e.Bytes))
+		networkBytesCounter.WithLabelValues(e.TypeString(), boundProcessName(e), direction, namespace, targetPod, targetService).Add(float64(e.Bytes))
 	}
 }
 
@@ -741,7 +748,7 @@ func ExportFilesystemBandwidthMetric(e *events.Event, operation string) {
 
 func ExportFilesystemBandwidthMetricWithContext(e *events.Event, operation, namespace string) {
 	if e.Bytes > 0 {
-		filesystemBytesCounter.WithLabelValues(e.TypeString(), e.ProcessName, operation, namespace).Add(float64(e.Bytes))
+		filesystemBytesCounter.WithLabelValues(e.TypeString(), boundProcessName(e), operation, namespace).Add(float64(e.Bytes))
 	}
 }
 
@@ -928,9 +935,10 @@ func ExportTLSMetric(e *events.Event) {
 
 func ExportTLSMetricWithContext(e *events.Event, namespace string) {
 	latencySec := float64(e.LatencyNS) / 1e9
-	tlsGauge.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Set(latencySec)
-	tlsHistogram.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Observe(latencySec)
-	tlsHandshakesCounter.WithLabelValues(e.TypeString(), e.ProcessName, namespace).Inc()
+	procName := boundProcessName(e)
+	tlsGauge.WithLabelValues(e.TypeString(), procName, namespace).Set(latencySec)
+	tlsHistogram.WithLabelValues(e.TypeString(), procName, namespace).Observe(latencySec)
+	tlsHandshakesCounter.WithLabelValues(e.TypeString(), procName, namespace).Inc()
 }
 
 func ExportResourceLimitMetric(e *events.Event) {
@@ -997,6 +1005,11 @@ func ExportResourceMetrics(resourceType string, namespace string, limitBytes, us
 	resourceAlertLevelGauge.WithLabelValues(resourceType, namespace).Set(float64(alertLevel))
 }
 
+// boundProcessName caps process_name label cardinality.
+func boundProcessName(e *events.Event) string {
+	return processCardinality.bound(e.ProcessName)
+}
+
 // poolLabels resolves the (bounded) pool_id and process_name label values so
 // arbitrary pool identifiers and process names cannot grow series without
 // bound, matching how every other traffic-derived label is capped.
@@ -1005,7 +1018,7 @@ func poolLabels(e *events.Event) (poolID, processName string) {
 	if poolID == "" {
 		poolID = "default"
 	}
-	return poolCardinality.bound(poolID), processCardinality.bound(e.ProcessName)
+	return poolCardinality.bound(poolID), boundProcessName(e)
 }
 
 func ExportPoolAcquireMetricWithContext(e *events.Event, namespace string) {


### PR DESCRIPTION
## Summary

Bounds the `process_name` label cardinality across all Prometheus metric exporters to prevent an agent OOM. A `processCardinality` limiter already existed (cap = `config.MetricsLabelLimit`, default 200) but was applied only in `poolLabels`, every other hot-path exporter passed `e.ProcessName` raw.

## The bug

`process_name` is comm/argv-derived and workload-controllable, and nothing ever calls `DeleteLabelValues`, so series are permanent. All ~15 exporters (rtt/tcp, dns, fs, cpu, tls, redis/memcached/fastcgi/grpc/kafka, and the network/filesystem byte counters) minted one permanent series per distinct process name × 20 histogram buckets. A pod spawning varied-named processes could grow series without bound and OOM the privileged DaemonSet.

## The fix

Added a single chokepoint `boundProcessName(e)` next to `poolLabels` and routed every callsite through it, resolving `procName` once per exporter and reusing it across the histogram/gauge/counter calls. Refactored `poolLabels` to call the same helper, so there is exactly one place `process_name` cardinality is capped. No signature changes, this follows the existing local-resolution precedent already used for `pool_id`, `command`, `method`, `topic`, `target_pod`, and `target_service`.