### PR TITLE
fix: harden session lifecycle and exporter endpoint validation

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -80,5 +80,50 @@ func ValidateExporterConfigVariant(spec ExporterConfigSpec) error {
 			return fmt.Errorf("at most one headers[].valueFrom is supported (the bundle carries a single credential); move additional secret-backed headers into spec.otlp.headersFromSecret")
 		}
 	}
+	if err := validateExporterEndpoint(spec); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateExporterEndpoint enforces the endpoint scheme allowlist on the
+// populated exporter variant.
+func validateExporterEndpoint(spec ExporterConfigSpec) error {
+	switch {
+	case spec.OTLP != nil:
+		return validateEndpointScheme("spec.otlp.endpoint", spec.OTLP.Endpoint)
+	case spec.Jaeger != nil:
+		return validateEndpointScheme("spec.jaeger.endpoint", spec.Jaeger.Endpoint)
+	case spec.Zipkin != nil:
+		return validateEndpointScheme("spec.zipkin.endpoint", spec.Zipkin.Endpoint)
+	case spec.Splunk != nil:
+		return validateEndpointScheme("spec.splunk.endpoint", spec.Splunk.Endpoint)
+	case spec.DataDog != nil:
+		return validateEndpointScheme("spec.datadog.endpoint", spec.DataDog.Endpoint)
+	}
+	return nil
+}
+
+// validateEndpointScheme mirrors the exporter constructors' normalization:
+// a bare host:port is treated as http:// (allowed); an explicit scheme must
+// be http or https.
+func validateEndpointScheme(field, endpoint string) error {
+	raw := strings.TrimSpace(endpoint)
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s: parse %q: %w", field, raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		if _, err := url.Parse("http://" + raw); err != nil {
+			return fmt.Errorf("%s: parse %q: %w", field, raw, err)
+		}
+		return nil
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s: endpoint scheme must be http or https, got %q", field, u.Scheme)
+	}
 	return nil
 }

--- a/api/v1alpha1/validation_pure_test.go
+++ b/api/v1alpha1/validation_pure_test.go
@@ -172,3 +172,37 @@ func TestValidateExporterConfigVariant_MultiSecretHeaders(t *testing.T) {
 		t.Errorf("one valueFrom header must be accepted: %v", err)
 	}
 }
+
+// TestValidateExporterConfigVariant_EndpointScheme is the admission-side
+// regression for the exporter SSRF/cleartext finding: an explicit
+// non-http(s) scheme must be rejected; bare host:port and http/https are
+// accepted (the cleartext-to-non-loopback refusal lives in the exporter
+// constructors, which know the runtime insecure override).
+func TestValidateExporterConfigVariant_EndpointScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    ExporterConfigSpec
+		wantErr string
+	}{
+		{"otlp bare host:port ok", ExporterConfigSpec{Type: ExporterTypeOTLP, OTLP: &OTLPExporter{Endpoint: "otel-collector:4318"}}, ""},
+		{"otlp https ok", ExporterConfigSpec{Type: ExporterTypeOTLP, OTLP: &OTLPExporter{Endpoint: "https://otel:4318"}}, ""},
+		{"datadog gopher rejected", ExporterConfigSpec{Type: ExporterTypeDataDog, DataDog: &DataDogExporter{Endpoint: "gopher://evil.internal:70/x"}}, "scheme must be http or https"},
+		{"splunk ftp rejected", ExporterConfigSpec{Type: ExporterTypeSplunk, Splunk: &SplunkExporter{Endpoint: "ftp://evil.internal/x"}}, "scheme must be http or https"},
+		{"zipkin http ok", ExporterConfigSpec{Type: ExporterTypeZipkin, Zipkin: &ZipkinExporter{Endpoint: "http://zipkin:9411/api/v2/spans"}}, ""},
+		{"jaeger dict rejected", ExporterConfigSpec{Type: ExporterTypeJaeger, Jaeger: &JaegerExporter{Endpoint: "dict://evil.internal:2628/x"}}, "scheme must be http or https"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExporterConfigVariant(tt.spec)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("got %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -502,6 +502,10 @@ func OTLPAllowInsecureNonLoopback() bool {
 	return getBoolEnvOrDefault("PODTRACE_OTLP_INSECURE", false)
 }
 
+func ExporterAllowInsecureNonLoopback() bool {
+	return getBoolEnvOrDefault("PODTRACE_EXPORTER_INSECURE", false)
+}
+
 func MetricsEnablePprof() bool {
 	return getBoolEnvOrDefault("PODTRACE_METRICS_ENABLE_PPROF", false) || ProfilingEnabled
 }
@@ -518,17 +522,10 @@ func AllowCgroupFilterAutoDisable() bool {
 	return getBoolEnvOrDefault("PODTRACE_ALLOW_CGROUP_FILTER_DISABLE", false)
 }
 
-// MaxCaptureHeaders bounds the header-capture allowlist; mirrors H3_HDR_SLOTS
-// in bpf/events.h.
 const MaxCaptureHeaders = 4
 
-// MaxCaptureHeaderNameLen bounds a captured header name; mirrors
-// H3_HDR_NAME_MAX in bpf/events.h.
 const MaxCaptureHeaderNameLen = 32
 
-// CaptureHeaderList parses PODTRACE_CAPTURE_HEADERS (comma-separated HTTP
-// header names) into the normalized lowercase allowlist applied to HTTP/2 and
-// HTTP/3 events.
 func CaptureHeaderList() []string {
 	return ParseCaptureHeaders(CaptureHeaders)
 }

--- a/internal/operator/finalizer.go
+++ b/internal/operator/finalizer.go
@@ -3,12 +3,14 @@ package operator
 import (
 	"context"
 	"fmt"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -41,12 +43,23 @@ func removeFinalizer(obj client.Object) bool {
 	return controllerutil.RemoveFinalizer(obj, FinalizerCleanup)
 }
 
+// finalizerUpdateOutcome classifies the error from a set/clear-finalizer
+// Update.
+func finalizerUpdateOutcome(err error) (ctrl.Result, bool) {
+	switch {
+	case apierrors.IsNotFound(err):
+		return ctrl.Result{}, true
+	case apierrors.IsConflict(err):
+		return ctrl.Result{RequeueAfter: time.Second}, true
+	default:
+		return ctrl.Result{}, false
+	}
+}
+
 // cleanupPodTraceChildren deletes the bundle ConfigMap + Secret this
 // PodTrace owns across namespaces. Called on CR deletion.
 func cleanupPodTraceChildren(ctx context.Context, c client.Client, pt *podtracev1alpha1.PodTrace, systemNS string) error {
 	bundleName := ExporterBundleName(pt.UID)
-	// Delete ConfigMap + Secret with matching name. Ignore NotFound so
-	// repeated cleanups are idempotent.
 	for _, obj := range []client.Object{
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: bundleName, Namespace: systemNS}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: bundleName, Namespace: systemNS}},
@@ -156,6 +169,9 @@ func cleanupPodTraceSessionChildren(ctx context.Context, c client.Client, s *pod
 		return err
 	}
 	if err := cleanupSessionPodReadRBAC(ctx, c, s); err != nil {
+		return err
+	}
+	if err := cleanupSessionServiceAccount(ctx, c, s, systemNS); err != nil {
 		return err
 	}
 	return nil

--- a/internal/operator/finalizer_notfound_test.go
+++ b/internal/operator/finalizer_notfound_test.go
@@ -1,0 +1,73 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestFinalizerUpdateOutcome(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "podtrace.io", Resource: "podtraces"}, "x")
+	conflict := apierrors.NewConflict(schema.GroupResource{Group: "podtrace.io", Resource: "podtraces"}, "x", errors.New("boom"))
+	other := errors.New("real failure")
+
+	if res, handled := finalizerUpdateOutcome(notFound); !handled || res.RequeueAfter != 0 {
+		t.Errorf("NotFound: got (%v, %v), want ({}, true)", res, handled)
+	}
+	if res, handled := finalizerUpdateOutcome(conflict); !handled || res.RequeueAfter != time.Second {
+		t.Errorf("Conflict: got (%v, %v), want (requeue 1s, true)", res, handled)
+	}
+	if _, handled := finalizerUpdateOutcome(other); handled {
+		t.Errorf("real error must not be swallowed")
+	}
+}
+
+func TestSessionReconcile_FinalizerClearNotFoundIsClean(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	now := metav1.Now()
+	session := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "dying",
+			Namespace:         "team-a",
+			UID:               "u-dying-000",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerCleanup},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(session).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*podtracev1alpha1.PodTraceSession); ok {
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: "podtrace.io", Resource: "podtracesessions"}, obj.GetName())
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Namespace: "team-a", Name: "dying"},
+	})
+	if err != nil {
+		t.Fatalf("finalizer-clear NotFound must not surface as a reconcile error, got: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue on a completed deletion, got %v", res.RequeueAfter)
+	}
+}

--- a/internal/operator/naming.go
+++ b/internal/operator/naming.go
@@ -56,7 +56,9 @@ func AgentDaemonSetName() string { return "podtrace-agent" }
 // AgentServiceAccountName is the ServiceAccount the agent DaemonSet runs as.
 func AgentServiceAccountName() string { return "podtrace-agent" }
 
-func SessionServiceAccountName() string { return "podtrace-session" }
+func SessionServiceAccountName(sessionUID types.UID) string {
+	return "podtrace-session-" + shortUID(sessionUID)
+}
 
 func SessionReportRoleName(sessionUID types.UID) string {
 	return "podtrace-session-report-" + shortUID(sessionUID)

--- a/internal/operator/operator_regression_test.go
+++ b/internal/operator/operator_regression_test.go
@@ -107,7 +107,7 @@ func TestEnsureSessionPodReadRBAC(t *testing.T) {
 		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: SessionPodReadRoleBindingName(s.UID)}, &rb); err != nil {
 			t.Fatalf("pod-read RoleBinding missing in %s: %v", ns, err)
 		}
-		if len(rb.Subjects) != 1 || rb.Subjects[0].Namespace != systemNS || rb.Subjects[0].Name != SessionServiceAccountName() {
+		if len(rb.Subjects) != 1 || rb.Subjects[0].Namespace != systemNS || rb.Subjects[0].Name != SessionServiceAccountName(s.UID) {
 			t.Errorf("RoleBinding in %s bound to wrong subject: %+v", ns, rb.Subjects)
 		}
 	}

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -63,8 +63,8 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		if removeFinalizer(&pt) {
 			if err := r.Update(ctx, &pt); err != nil {
-				if apierrors.IsConflict(err) {
-					return ctrl.Result{RequeueAfter: time.Second}, nil
+				if res, handled := finalizerUpdateOutcome(err); handled {
+					return res, nil
 				}
 				return ctrl.Result{}, fmt.Errorf("clear finalizer: %w", err)
 			}
@@ -73,8 +73,8 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	if ensureFinalizer(&pt) {
 		if err := r.Update(ctx, &pt); err != nil {
-			if apierrors.IsConflict(err) {
-				return ctrl.Result{RequeueAfter: time.Second}, nil
+			if res, handled := finalizerUpdateOutcome(err); handled {
+				return res, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("set finalizer: %w", err)
 		}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -70,8 +71,8 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		forgetReportObservations(session.Namespace, session.Name)
 		if removeFinalizer(&session) {
 			if err := r.Update(ctx, &session); err != nil {
-				if apierrors.IsConflict(err) {
-					return ctrl.Result{RequeueAfter: time.Second}, nil
+				if res, handled := finalizerUpdateOutcome(err); handled {
+					return res, nil
 				}
 				return ctrl.Result{}, fmt.Errorf("clear finalizer: %w", err)
 			}
@@ -80,8 +81,8 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	if ensureFinalizer(&session) {
 		if err := r.Update(ctx, &session); err != nil {
-			if apierrors.IsConflict(err) {
-				return ctrl.Result{RequeueAfter: time.Second}, nil
+			if res, handled := finalizerUpdateOutcome(err); handled {
+				return res, nil
 			}
 			return ctrl.Result{}, fmt.Errorf("set finalizer: %w", err)
 		}
@@ -150,17 +151,21 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 	}
 
-	if err := ensureSessionServiceAccount(ctx, r.Client, systemNS); err != nil {
+	if err := ensureSessionServiceAccount(ctx, r.Client, &session, systemNS); err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionSA", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	if err := ensureSessionReportRBAC(ctx, r.Client, &session, systemNS); err != nil {
+	if err := ensureSessionReportObject(ctx, r.Client, &session); err != nil {
+		var conflict *reportObjectConflictError
+		if errors.As(err, &conflict) {
+			return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "ReportObjectConflict", err.Error())
+		}
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	if err := ensureSessionReportObject(ctx, r.Client, &session); err != nil {
+	if err := ensureSessionReportRBAC(ctx, r.Client, &session, systemNS); err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
@@ -186,15 +191,16 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	jobs, err := r.ensureJobs(ctx, &session, tc, targets)
+	completedNodes := completedSessionNodes(session.Status.Jobs)
+	jobs, err := r.ensureJobs(ctx, &session, tc, targets, completedNodes)
 	if err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "EnsureJobs", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
 
-	session.Status.Jobs = makeSessionJobRefs(jobs)
-	session.Status.State = computeSessionState(jobs, len(targets.Nodes))
+	session.Status.Jobs = mergeSessionJobRefs(jobs, session.Status.Jobs)
+	session.Status.State = computeSessionState(session.Status.Jobs, jobs, len(targets.Nodes))
 	session.Status.ObservedGeneration = session.Generation
 
 	if err := populateSessionSummaries(ctx, r.Client, &session, jobs); err != nil {
@@ -524,10 +530,13 @@ func effectiveMaxConcurrentSessionsPerNode(tc *podtracev1alpha1.TracerConfig) in
 
 // ensureJobs creates-or-updates one Job per target node, owner-ref'd to
 // the session.
-func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, targets sessionTargets) ([]batchv1.Job, error) {
+func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, targets sessionTargets, completedNodes map[string]struct{}) ([]batchv1.Job, error) {
 	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
 
 	for _, node := range targets.Nodes {
+		if _, done := completedNodes[node]; done {
+			continue
+		}
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      SessionJobName(s.UID, node),

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -174,7 +175,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 			},
 			Spec: corev1.PodSpec{
 				RestartPolicy:      corev1.RestartPolicyNever,
-				ServiceAccountName: SessionServiceAccountName(),
+				ServiceAccountName: SessionServiceAccountName(s.UID),
 				NodeSelector: map[string]string{
 					"kubernetes.io/hostname": node,
 				},
@@ -343,6 +344,8 @@ func priorityClassNameFrom(tc *podtracev1alpha1.TracerConfig) string {
 
 // makeSessionJobRefs rolls up a list of child Jobs into the slim status
 // representation carried on PodTraceSession.
+const sessionJobFailedMessage = "Job failed"
+
 func makeSessionJobRefs(jobs []batchv1.Job) []podtracev1alpha1.SessionJobRef {
 	refs := make([]podtracev1alpha1.SessionJobRef, 0, len(jobs))
 	for _, j := range jobs {
@@ -359,11 +362,46 @@ func makeSessionJobRefs(jobs []batchv1.Job) []podtracev1alpha1.SessionJobRef {
 			ref.CompletionTime = j.Status.CompletionTime
 		}
 		if jobFailed(&j) && !jobSucceeded(&j) {
-			ref.Message = "Job failed"
+			ref.Message = sessionJobFailedMessage
 		}
 		refs = append(refs, ref)
 	}
 	return refs
+}
+
+// mergeSessionJobRefs unions the live Job list with the previously recorded
+// per-node refs, carrying forward any node whose Job already completed but
+// has since been TTL-garbage-collected.
+func mergeSessionJobRefs(live []batchv1.Job, prior []podtracev1alpha1.SessionJobRef) []podtracev1alpha1.SessionJobRef {
+	refs := makeSessionJobRefs(live)
+	seen := make(map[string]struct{}, len(refs))
+	for i := range refs {
+		seen[refs[i].Node] = struct{}{}
+	}
+	for i := range prior {
+		p := prior[i]
+		if p.Completed && p.Node != "" {
+			if _, ok := seen[p.Node]; !ok {
+				refs = append(refs, p)
+				seen[p.Node] = struct{}{}
+			}
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Node < refs[j].Node })
+	return refs
+}
+
+// completedSessionNodes returns the set of nodes with a recorded terminal
+// Job outcome, so the reconciler never recreates a Job for a node that has
+// already finished this session.
+func completedSessionNodes(refs []podtracev1alpha1.SessionJobRef) map[string]struct{} {
+	done := make(map[string]struct{})
+	for i := range refs {
+		if refs[i].Completed && refs[i].Node != "" {
+			done[refs[i].Node] = struct{}{}
+		}
+	}
+	return done
 }
 
 func jobBackoffLimit(j *batchv1.Job) int32 {
@@ -400,54 +438,33 @@ func jobFailed(j *batchv1.Job) bool {
 //   - Any failed past limit → Failed
 //   - Any running           → Running
 //   - Otherwise             → Pending
-//
-// computeSessionState rolls Job conditions up into a session state.
-// expectedJobs is the number of target nodes this reconcile fanned out to:
-// the Job List comes from the informer cache, which may not yet contain a
-// Job created moments ago — without the guard a freshly grown target set
-// could read as "all (visible) Jobs succeeded" and terminate the session
-// early, orphaning the invisible Job's results.
-func computeSessionState(jobs []batchv1.Job, expectedJobs int) podtracev1alpha1.SessionState {
-	if len(jobs) == 0 {
+func computeSessionState(refs []podtracev1alpha1.SessionJobRef, liveJobs []batchv1.Job, expectedNodes int) podtracev1alpha1.SessionState {
+	if len(refs) == 0 || expectedNodes == 0 {
 		return podtracev1alpha1.SessionStatePending
 	}
-	if len(jobs) < expectedJobs {
-		for i := range jobs {
-			if jobs[i].Status.Active > 0 {
-				return podtracev1alpha1.SessionStateRunning
-			}
+	completed := 0
+	anyFailed := false
+	for i := range refs {
+		if !refs[i].Completed {
+			continue
 		}
-		return podtracev1alpha1.SessionStatePending
-	}
-	allSucceeded := true
-	anyRunning := false
-	anyFailedFatal := false
-	for i := range jobs {
-		j := &jobs[i]
-		succeeded := jobSucceeded(j)
-		failed := jobFailed(j)
-		running := j.Status.Active > 0
-
-		if !succeeded {
-			allSucceeded = false
-		}
-		if failed {
-			anyFailedFatal = true
-		}
-		if running {
-			anyRunning = true
+		completed++
+		if refs[i].Message == sessionJobFailedMessage {
+			anyFailed = true
 		}
 	}
 	switch {
-	case allSucceeded:
-		return podtracev1alpha1.SessionStateCompleted
-	case anyFailedFatal:
+	case anyFailed:
 		return podtracev1alpha1.SessionStateFailed
-	case anyRunning:
-		return podtracev1alpha1.SessionStateRunning
-	default:
-		return podtracev1alpha1.SessionStatePending
+	case completed >= expectedNodes:
+		return podtracev1alpha1.SessionStateCompleted
 	}
+	for i := range liveJobs {
+		if liveJobs[i].Status.Active > 0 {
+			return podtracev1alpha1.SessionStateRunning
+		}
+	}
+	return podtracev1alpha1.SessionStatePending
 }
 
 func isTerminal(p podtracev1alpha1.SessionState) bool {

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -124,8 +124,8 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	if spec.Template.Spec.Containers[0].Image != "ghcr.io/gma1k/podtrace:test" {
 		t.Errorf("image: %q", spec.Template.Spec.Containers[0].Image)
 	}
-	if spec.Template.Spec.ServiceAccountName != SessionServiceAccountName() {
-		t.Errorf("SA=%q want %q", spec.Template.Spec.ServiceAccountName, SessionServiceAccountName())
+	if spec.Template.Spec.ServiceAccountName != SessionServiceAccountName("u-sess") {
+		t.Errorf("SA=%q want %q", spec.Template.Spec.ServiceAccountName, SessionServiceAccountName("u-sess"))
 	}
 	args := strings.Join(spec.Template.Spec.Containers[0].Args, " ")
 	if !slices.Contains(spec.Template.Spec.Containers[0].Args, "--tracing") {
@@ -224,7 +224,7 @@ func TestComputeSessionPhase_Transitions(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if got := computeSessionState(tc.jobs, len(tc.jobs)); got != tc.want {
+			if got := computeSessionState(makeSessionJobRefs(tc.jobs), tc.jobs, len(tc.jobs)); got != tc.want {
 				t.Errorf("got %q want %q", got, tc.want)
 			}
 		})

--- a/internal/operator/reconcile_robustness_test.go
+++ b/internal/operator/reconcile_robustness_test.go
@@ -16,10 +16,6 @@ import (
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
 
-// TestLabelSelectorToFlag_MatchExpressions is a regression test: only
-// MatchLabels were serialized, so an expression-only selector became an
-// empty string — which combined with --all-in-namespace traced every pod in
-// the namespace.
 func TestLabelSelectorToFlag_MatchExpressions(t *testing.T) {
 	flag := labelSelectorToFlag(&metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": "api"},
@@ -41,23 +37,17 @@ func TestLabelSelectorToFlag_MatchExpressions(t *testing.T) {
 	}
 }
 
-// TestComputeSessionState_UndercountedJobsNotTerminal: the Job List comes
-// from the informer cache and may not yet contain a just-created Job — fewer
-// Jobs than target nodes must never read as Completed.
 func TestComputeSessionState_UndercountedJobsNotTerminal(t *testing.T) {
 	succeeded := batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}
-	state := computeSessionState([]batchv1.Job{succeeded}, 2)
+	state := computeSessionState(makeSessionJobRefs([]batchv1.Job{succeeded}), []batchv1.Job{succeeded}, 2)
 	if state == podtracev1alpha1.SessionStateCompleted || state == podtracev1alpha1.SessionStateFailed {
 		t.Errorf("state = %s with 1 of 2 expected Jobs visible, must not be terminal", state)
 	}
-	if state := computeSessionState([]batchv1.Job{succeeded}, 1); state != podtracev1alpha1.SessionStateCompleted {
+	if state := computeSessionState(makeSessionJobRefs([]batchv1.Job{succeeded}), []batchv1.Job{succeeded}, 1); state != podtracev1alpha1.SessionStateCompleted {
 		t.Errorf("state = %s with all expected Jobs succeeded, want Completed", state)
 	}
 }
 
-// TestComputeSessionState_DeadlineExceededIsTerminal regression: a
-// Job killed by ActiveDeadlineSeconds carries a JobFailed condition (reason
-// DeadlineExceeded) but its .status.Failed count does not exceed backoffLimit.
 func TestComputeSessionState_DeadlineExceededIsTerminal(t *testing.T) {
 	backoff := int32(6)
 	deadlineKilled := batchv1.Job{
@@ -71,21 +61,18 @@ func TestComputeSessionState_DeadlineExceededIsTerminal(t *testing.T) {
 			}},
 		},
 	}
-	if state := computeSessionState([]batchv1.Job{deadlineKilled}, 1); state != podtracev1alpha1.SessionStateFailed {
+	if state := computeSessionState(makeSessionJobRefs([]batchv1.Job{deadlineKilled}), []batchv1.Job{deadlineKilled}, 1); state != podtracev1alpha1.SessionStateFailed {
 		t.Errorf("deadline-exceeded Job: state = %s, want Failed (else the session re-runs forever)", state)
 	}
 
 	complete := batchv1.Job{Status: batchv1.JobStatus{
 		Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
 	}}
-	if state := computeSessionState([]batchv1.Job{complete}, 1); state != podtracev1alpha1.SessionStateCompleted {
+	if state := computeSessionState(makeSessionJobRefs([]batchv1.Job{complete}), []batchv1.Job{complete}, 1); state != podtracev1alpha1.SessionStateCompleted {
 		t.Errorf("JobComplete condition: state = %s, want Completed", state)
 	}
 }
 
-// TestSessionValidationFailureIsTerminalAndGCable: validation failures used
-// to set Failed without a CompletionTime (never TTL-collected) and returned
-// an error on a permanently failed object (infinite backoff).
 func TestSessionValidationFailureIsTerminalAndGCable(t *testing.T) {
 	scheme := newOperatorScheme(t)
 	session := &podtracev1alpha1.PodTraceSession{
@@ -129,9 +116,6 @@ func TestSessionValidationFailureIsTerminalAndGCable(t *testing.T) {
 	}
 }
 
-// TestNonDefaultTracerConfigIsInert: the agent DaemonSet has one fixed name,
-// so a second TracerConfig used to fight the first over owner references and
-// the immutable selector, failing its reconcile forever.
 func TestNonDefaultTracerConfigIsInert(t *testing.T) {
 	scheme := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
@@ -164,9 +148,6 @@ func TestNonDefaultTracerConfigIsInert(t *testing.T) {
 	}
 }
 
-// TestScheduleSkipsBacklogPastMissedRunBound: without startingDeadlineSeconds
-// every missed tick used to replay serially — a month-long suspension at a
-// minutely cron meant tens of thousands of stale sessions.
 func TestScheduleSkipsBacklogPastMissedRunBound(t *testing.T) {
 	scheme := newOperatorScheme(t)
 	sch := &podtracev1alpha1.PodTraceSchedule{
@@ -212,9 +193,6 @@ func TestScheduleSkipsBacklogPastMissedRunBound(t *testing.T) {
 	}
 }
 
-// TestApplicationTraceRefusesAdoption: a pre-existing user PodTrace with the
-// same name used to be silently adopted — its spec overwritten and an
-// ownerReference added that garbage-collects it with the ApplicationTrace.
 func TestApplicationTraceRefusesAdoption(t *testing.T) {
 	scheme := newOperatorScheme(t)
 	app := mkApp()

--- a/internal/operator/reconcilers_fakeclient_unit_test.go
+++ b/internal/operator/reconcilers_fakeclient_unit_test.go
@@ -269,7 +269,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		},
 	}
 
-	jobs, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}})
+	jobs, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
 	if err != nil {
 		t.Fatalf("ensureJobs: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		}
 	}
 
-	jobs2, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}})
+	jobs2, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
 	if err != nil {
 		t.Fatalf("second ensureJobs: %v", err)
 	}

--- a/internal/operator/reconcilers_unit_test.go
+++ b/internal/operator/reconcilers_unit_test.go
@@ -51,7 +51,7 @@ func TestNamingHelpers(t *testing.T) {
 		{"AgentBundleRoleBindingName", AgentBundleRoleBindingName(), "podtrace-agent-bundles"},
 		{"AgentServiceAccountName", AgentServiceAccountName(), "podtrace-agent"},
 		{"OperatorWebhookServiceName", OperatorWebhookServiceName(), "podtrace-webhook"},
-		{"SessionServiceAccountName", SessionServiceAccountName(), "podtrace-session"},
+		{"SessionServiceAccountName", SessionServiceAccountName("abcdef012345xyz"), "podtrace-session-abcdef012345"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/internal/operator/session_hardening_test.go
+++ b/internal/operator/session_hardening_test.go
@@ -1,0 +1,134 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func sessionWithConfigMapReport(name, namespace, uid, cmName string) *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(uid)},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ConfigMap: &corev1.LocalObjectReference{Name: cmName},
+			},
+		},
+	}
+}
+
+func TestEnsureSessionReportObject_RefusesForeignObject(t *testing.T) {
+	scheme := newRBACScheme(t)
+	ctx := context.Background()
+
+	t.Run("refuses-preexisting-user-object", func(t *testing.T) {
+		userCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "app-config", Namespace: "team-a",
+			Labels: map[string]string{"app": "billing"},
+		}, Data: map[string]string{"secret": "keepme"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(userCM).Build()
+
+		s := sessionWithConfigMapReport("diag", "team-a", "u1", "app-config")
+		err := ensureSessionReportObject(ctx, c, s)
+		var conflict *reportObjectConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("expected reportObjectConflictError, got %v", err)
+		}
+
+		var got corev1.ConfigMap
+		if err := c.Get(ctx, types.NamespacedName{Name: "app-config", Namespace: "team-a"}, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Data["secret"] != "keepme" {
+			t.Errorf("user ConfigMap was mutated: %+v", got.Data)
+		}
+	})
+
+	t.Run("refuses-other-sessions-object", func(t *testing.T) {
+		other := sessionWithConfigMapReport("other", "team-a", "u-other", "shared-report")
+		labels := sessionRBACLabels(other)
+		labels[reportManagedBy] = reportManagedVal
+		labels[labelReportKind] = reportKindValue
+		otherCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "shared-report", Namespace: "team-a", Labels: labels,
+		}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(otherCM).Build()
+
+		s := sessionWithConfigMapReport("diag", "team-a", "u1", "shared-report")
+		if err := ensureSessionReportObject(ctx, c, s); err == nil {
+			t.Fatal("expected conflict adopting another session's report object")
+		}
+	})
+
+	t.Run("creates-when-absent", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		s := sessionWithConfigMapReport("diag", "team-a", "u1", "fresh-report")
+		if err := ensureSessionReportObject(ctx, c, s); err != nil {
+			t.Fatalf("create fresh report object: %v", err)
+		}
+		var cm corev1.ConfigMap
+		if err := c.Get(ctx, types.NamespacedName{Name: "fresh-report", Namespace: "team-a"}, &cm); err != nil {
+			t.Fatalf("report object not created: %v", err)
+		}
+		if !reportObjectOwnedBySession(cm.Labels, s) {
+			t.Errorf("created object missing ownership labels: %+v", cm.Labels)
+		}
+	})
+
+	t.Run("adopts-own-object-idempotently", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		s := sessionWithConfigMapReport("diag", "team-a", "u1", "my-report")
+		if err := ensureSessionReportObject(ctx, c, s); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureSessionReportObject(ctx, c, s); err != nil {
+			t.Fatalf("re-reconcile must adopt own object: %v", err)
+		}
+	})
+}
+
+func TestSessionServiceAccount_IsPerSession(t *testing.T) {
+	if SessionServiceAccountName("aaaa11112222") == SessionServiceAccountName("bbbb33334444") {
+		t.Fatal("two sessions must not share a ServiceAccount name")
+	}
+	scheme := newRBACScheme(t)
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	s1 := &podtracev1alpha1.PodTraceSession{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "team-a", UID: "uid-one-000"}}
+	s2 := &podtracev1alpha1.PodTraceSession{ObjectMeta: metav1.ObjectMeta{Name: "s2", Namespace: "team-b", UID: "uid-two-000"}}
+	for _, s := range []*podtracev1alpha1.PodTraceSession{s1, s2} {
+		if err := ensureSessionServiceAccount(ctx, c, s, "podtrace-system"); err != nil {
+			t.Fatalf("ensure SA %s: %v", s.Name, err)
+		}
+	}
+
+	var sa1, sa2 corev1.ServiceAccount
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(s1.UID), Namespace: "podtrace-system"}, &sa1); err != nil {
+		t.Fatalf("SA for s1 missing: %v", err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(s2.UID), Namespace: "podtrace-system"}, &sa2); err != nil {
+		t.Fatalf("SA for s2 missing: %v", err)
+	}
+	if sa1.Labels[LabelSessionName] != "s1" || sa2.Labels[LabelSessionName] != "s2" {
+		t.Errorf("per-session SAs must carry their own session labels: %v / %v", sa1.Labels, sa2.Labels)
+	}
+
+	if err := cleanupSessionServiceAccount(ctx, c, s1, "podtrace-system"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(s1.UID), Namespace: "podtrace-system"}, &sa1); !apierrors.IsNotFound(err) {
+		t.Errorf("s1 SA should be deleted, got %v", err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(s2.UID), Namespace: "podtrace-system"}, &sa2); err != nil {
+		t.Errorf("s2 SA must survive s1 cleanup: %v", err)
+	}
+}

--- a/internal/operator/session_job_completion_test.go
+++ b/internal/operator/session_job_completion_test.go
@@ -1,0 +1,95 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestMergeSessionJobRefs_CarriesForwardGCdNode(t *testing.T) {
+	prior := []podtracev1alpha1.SessionJobRef{
+		{Node: "node-a", Name: "pts-a", Completed: true},
+	}
+	live := []batchv1.Job{{
+		ObjectMeta: metav1.ObjectMeta{Name: "pts-b", Labels: map[string]string{LabelNodeName: "node-b"}},
+		Status:     batchv1.JobStatus{Active: 1},
+	}}
+	merged := mergeSessionJobRefs(live, prior)
+	byNode := map[string]podtracev1alpha1.SessionJobRef{}
+	for _, r := range merged {
+		byNode[r.Node] = r
+	}
+	if _, ok := byNode["node-a"]; !ok {
+		t.Fatalf("completed GC'd node-a dropped from merged refs: %+v", merged)
+	}
+	if !byNode["node-a"].Completed {
+		t.Errorf("carried-forward node-a must stay Completed")
+	}
+	if byNode["node-b"].Completed {
+		t.Errorf("running node-b must not be Completed")
+	}
+}
+
+func TestComputeSessionState_CompletesViaCarriedRefs(t *testing.T) {
+	refsRunning := []podtracev1alpha1.SessionJobRef{
+		{Node: "node-a", Completed: true},
+		{Node: "node-b", Completed: false},
+	}
+	liveRunning := []batchv1.Job{{Status: batchv1.JobStatus{Active: 1}}}
+	if got := computeSessionState(refsRunning, liveRunning, 2); got != podtracev1alpha1.SessionStateRunning {
+		t.Errorf("with one node still running, want Running, got %s", got)
+	}
+
+	refsDone := []podtracev1alpha1.SessionJobRef{
+		{Node: "node-a", Completed: true},
+		{Node: "node-b", Completed: true},
+	}
+	if got := computeSessionState(refsDone, nil, 2); got != podtracev1alpha1.SessionStateCompleted {
+		t.Errorf("both nodes completed (node-a carried), want Completed, got %s", got)
+	}
+
+	refsFailed := []podtracev1alpha1.SessionJobRef{
+		{Node: "node-a", Completed: true, Message: sessionJobFailedMessage},
+		{Node: "node-b", Completed: true},
+	}
+	if got := computeSessionState(refsFailed, nil, 2); got != podtracev1alpha1.SessionStateFailed {
+		t.Errorf("a failed node must yield Failed, got %s", got)
+	}
+}
+
+func TestEnsureJobs_SkipsCompletedNode(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "u-skip-000"},
+		Spec:       podtracev1alpha1.PodTraceSessionSpec{Duration: metav1.Duration{Duration: 1e9}},
+	}
+	targets := sessionTargets{Nodes: []string{"node-a", "node-b"}}
+	completed := map[string]struct{}{"node-a": {}}
+
+	if _, err := r.ensureJobs(context.Background(), s, nil, targets, completed); err != nil {
+		t.Fatalf("ensureJobs: %v", err)
+	}
+
+	var jobs batchv1.JobList
+	if err := c.List(context.Background(), &jobs, client.InNamespace("podtrace-system")); err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]bool{}
+	for i := range jobs.Items {
+		nodes[jobs.Items[i].Labels[LabelNodeName]] = true
+	}
+	if nodes["node-a"] {
+		t.Error("node-a Job was (re)created despite being recorded complete — duplicate capture")
+	}
+	if !nodes["node-b"] {
+		t.Error("node-b Job should have been created")
+	}
+}

--- a/internal/operator/session_rbac.go
+++ b/internal/operator/session_rbac.go
@@ -15,21 +15,30 @@ import (
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
 )
 
-func ensureSessionServiceAccount(ctx context.Context, c client.Client, systemNS string) error {
+func ensureSessionServiceAccount(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) error {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      SessionServiceAccountName(),
+			Name:      SessionServiceAccountName(s.UID),
 			Namespace: systemNS,
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, func() error {
-		sa.Labels = mergeLabels(sa.Labels, map[string]string{
-			LabelManagedBy: ManagedByValue,
-			LabelComponent: ComponentSession,
-		})
+		sa.Labels = mergeLabels(sa.Labels, sessionRBACLabels(s))
 		return nil
 	}); err != nil {
 		return fmt.Errorf("ensure session SA: %w", err)
+	}
+	return nil
+}
+
+// cleanupSessionServiceAccount deletes the per-session ServiceAccount in
+// the system namespace.
+func cleanupSessionServiceAccount(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) error {
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: SessionServiceAccountName(s.UID), Namespace: systemNS,
+	}}
+	if err := c.Delete(ctx, sa); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete session SA %s/%s: %w", systemNS, sa.Name, err)
 	}
 	return nil
 }
@@ -73,7 +82,7 @@ func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1
 		}
 		binding.Subjects = []rbacv1.Subject{{
 			Kind:      rbacv1.ServiceAccountKind,
-			Name:      SessionServiceAccountName(),
+			Name:      SessionServiceAccountName(s.UID),
 			Namespace: systemNS,
 		}}
 		return nil
@@ -84,8 +93,7 @@ func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1
 }
 
 // cleanupSessionReportRBAC deletes the per-session Role+RoleBinding in
-// the user namespace. Called from the session finalizer path. NotFound
-// is non-fatal — the session may have been created without a reportRef.
+// the user namespace.
 func cleanupSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession) error {
 	objects := []client.Object{
 		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{
@@ -165,7 +173,7 @@ func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev
 			}
 			binding.Subjects = []rbacv1.Subject{{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      SessionServiceAccountName(),
+				Name:      SessionServiceAccountName(s.UID),
 				Namespace: systemNS,
 			}}
 			return nil
@@ -239,6 +247,26 @@ func buildSessionReportRules(ref *podtracev1alpha1.ReportReference) []rbacv1.Pol
 	return rules
 }
 
+const (
+	labelReportKind  = "podtrace.io/kind"
+	reportKindValue  = "session-report"
+	reportManagedBy  = "podtrace.io/managed-by"
+	reportManagedVal = "podtrace-cli"
+)
+
+// reportObjectConflictError signals that spec.reportRef names a
+// pre-existing ConfigMap/Secret the session did not create.
+type reportObjectConflictError struct {
+	namespace string
+	name      string
+	resource  string
+}
+
+func (e *reportObjectConflictError) Error() string {
+	return fmt.Sprintf("spec.reportRef names %s %s/%s which already exists and was not created by this session; "+
+		"pick a name that does not collide with an existing object", e.resource, e.namespace, e.name)
+}
+
 // ensureSessionReportObject pre-creates an empty report ConfigMap/Secret in the
 // session namespace so the Job's ServiceAccount needs only scoped get/update.
 func ensureSessionReportObject(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession) error {
@@ -247,8 +275,8 @@ func ensureSessionReportObject(ctx context.Context, c client.Client, s *podtrace
 		return nil
 	}
 	labels := sessionRBACLabels(s)
-	labels["podtrace.io/managed-by"] = "podtrace-cli"
-	labels["podtrace.io/kind"] = "session-report"
+	labels[reportManagedBy] = reportManagedVal
+	labels[labelReportKind] = reportKindValue
 	var obj client.Object
 	switch resource {
 	case "configmaps":
@@ -258,15 +286,35 @@ func ensureSessionReportObject(ctx context.Context, c client.Client, s *podtrace
 	default:
 		return nil
 	}
-	if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+	err := c.Create(ctx, obj)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("pre-create session report %s/%s: %w", s.Namespace, name, err)
+	}
+
+	existing := obj.DeepCopyObject().(client.Object)
+	if getErr := c.Get(ctx, client.ObjectKey{Namespace: s.Namespace, Name: name}, existing); getErr != nil {
+		return fmt.Errorf("inspect existing session report %s/%s: %w", s.Namespace, name, getErr)
+	}
+	if !reportObjectOwnedBySession(existing.GetLabels(), s) {
+		return &reportObjectConflictError{namespace: s.Namespace, name: name, resource: resource}
 	}
 	return nil
 }
 
+// reportObjectOwnedBySession reports whether a pre-existing report object
+// carries the labels this session stamps on the objects it creates.
+func reportObjectOwnedBySession(labels map[string]string, s *podtracev1alpha1.PodTraceSession) bool {
+	return labels[labelReportKind] == reportKindValue &&
+		labels[reportManagedBy] == reportManagedVal &&
+		labels[LabelSessionName] == s.Name &&
+		labels[LabelSessionNS] == s.Namespace
+}
+
 // reportRefResource decodes spec.reportRef into the (resource, name)
-// tuple the RBAC grant needs. Returns empty strings when no supported
-// sink is set (including ObjectStore, which the webhook rejects today).
+// tuple the RBAC grant needs.
 func reportRefResource(ref *podtracev1alpha1.ReportReference) (string, string) {
 	switch {
 	case ref == nil:

--- a/internal/operator/session_rbac_test.go
+++ b/internal/operator/session_rbac_test.go
@@ -28,13 +28,14 @@ func TestEnsureSessionServiceAccount_IsIdempotent(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	ctx := context.Background()
 
+	s := &podtracev1alpha1.PodTraceSession{ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "u-sa-idem"}}
 	for i := 0; i < 2; i++ {
-		if err := ensureSessionServiceAccount(ctx, c, "podtrace-system"); err != nil {
+		if err := ensureSessionServiceAccount(ctx, c, s, "podtrace-system"); err != nil {
 			t.Fatalf("call %d: %v", i, err)
 		}
 	}
 	var sa corev1.ServiceAccount
-	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(), Namespace: "podtrace-system"}, &sa); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionServiceAccountName(s.UID), Namespace: "podtrace-system"}, &sa); err != nil {
 		t.Fatalf("expected SA: %v", err)
 	}
 	if sa.Labels[LabelManagedBy] != ManagedByValue {
@@ -75,10 +76,6 @@ func TestEnsureSessionReportRBAC_CreatesNarrowRole(t *testing.T) {
 	if !foundResourceNamed {
 		t.Errorf("role should scope to resourceNames=[smoke-report]: %+v", role.Rules)
 	}
-	// The sink resource (configmaps/secrets) MUST NOT grant
-	// list/watch/delete — those are footguns for a session-scoped SA.
-	// Pod and event reads DO need list/watch (the CLI uses informers);
-	// this guard scopes the check to the report sink only.
 	for _, rule := range role.Rules {
 		isSinkRule := false
 		for _, res := range rule.Resources {
@@ -105,16 +102,13 @@ func TestEnsureSessionReportRBAC_CreatesNarrowRole(t *testing.T) {
 		t.Errorf("binding.roleRef wrong: %+v", binding.RoleRef)
 	}
 	if len(binding.Subjects) != 1 ||
-		binding.Subjects[0].Name != SessionServiceAccountName() ||
+		binding.Subjects[0].Name != SessionServiceAccountName(s.UID) ||
 		binding.Subjects[0].Namespace != "podtrace-system" {
 		t.Errorf("binding subject wrong: %+v", binding.Subjects)
 	}
 }
 
 func TestEnsureSessionReportRBAC_NoSinkStillGrantsPodRead(t *testing.T) {
-	// Sessions without a reportRef still need pod reads in the user
-	// namespace so the CLI can resolve spec.podRefs / spec.selector.
-	// A Role must be created for every session, even without reportRef.
 	scheme := newRBACScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	ctx := context.Background()

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -38,8 +38,9 @@ type datadogSpan struct {
 }
 
 func NewDataDogExporter(endpoint, apiKey string, sampleRate float64) (*DataDogExporter, error) {
-	if endpoint == "" {
-		endpoint = config.DefaultDataDogEndpoint
+	endpoint, err := validateExporterEndpoint(endpoint, config.DefaultDataDogEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("datadog: %w", err)
 	}
 
 	return &DataDogExporter{

--- a/internal/tracing/exporter/endpoint.go
+++ b/internal/tracing/exporter/endpoint.go
@@ -1,0 +1,35 @@
+package exporter
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func validateExporterEndpoint(endpoint, defaultEndpoint string) (string, error) {
+	raw := strings.TrimSpace(endpoint)
+	if raw == "" {
+		raw = defaultEndpoint
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse exporter endpoint %q: %w", raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		u, err = url.Parse("http://" + raw)
+		if err != nil {
+			return "", fmt.Errorf("parse exporter endpoint %q: %w", raw, err)
+		}
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("exporter endpoint scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) && !config.ExporterAllowInsecureNonLoopback() {
+		return "", fmt.Errorf(
+			"refusing cleartext http to non-loopback host %q: it would leak exporter credentials on the wire; use https:// or set PODTRACE_EXPORTER_INSECURE=1",
+			u.Hostname())
+	}
+	return u.String(), nil
+}

--- a/internal/tracing/exporter/endpoint_test.go
+++ b/internal/tracing/exporter/endpoint_test.go
@@ -1,0 +1,64 @@
+package exporter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExporterEndpoint(t *testing.T) {
+	const def = "http://localhost:8126/v0.4/traces"
+	cases := []struct {
+		name     string
+		endpoint string
+		wantErr  string
+	}{
+		{"empty-uses-loopback-default", "", ""},
+		{"https-allowed", "https://intake.example.com/api", ""},
+		{"http-loopback-allowed", "http://127.0.0.1:8126/x", ""},
+		{"http-localhost-allowed", "http://localhost:8088/services/collector", ""},
+		{"bare-hostport-defaults-http-loopback", "localhost:8126", ""},
+		{"http-nonloopback-refused", "http://intake.datadoghq.com/api", "cleartext http"},
+		{"http-internal-ip-refused", "http://10.0.0.5:8126/x", "cleartext http"},
+		{"file-scheme-rewritten-then-refused", "file:///etc/shadow", "cleartext http"}, // becomes http://file/... (host "file", not a file read) → refused as cleartext non-loopback
+		{"gopher-scheme-refused", "gopher://evil.internal:70/x", "scheme must be http or https"},
+		{"ftp-scheme-refused", "ftp://evil.internal/x", "scheme must be http or https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateExporterEndpoint(tc.endpoint, def)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got == "" {
+					t.Fatal("expected a normalized endpoint, got empty")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil (normalized=%q)", tc.wantErr, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExporterConstructorsRejectCleartextCredentials(t *testing.T) {
+	if _, err := NewDataDogExporter("http://intake.datadoghq.com/api", "secret-key", 1.0); err == nil {
+		t.Error("DataDog: expected rejection of cleartext non-loopback endpoint")
+	}
+	if _, err := NewSplunkExporter("http://splunk.example.com:8088", "hec-token", 1.0); err == nil {
+		t.Error("Splunk: expected rejection of cleartext non-loopback endpoint")
+	}
+	if _, err := NewZipkinExporter("gopher://evil.internal/x", 1.0); err == nil {
+		t.Error("Zipkin: expected rejection of non-http scheme")
+	}
+	if _, err := NewDataDogExporter("", "secret-key", 1.0); err != nil {
+		t.Errorf("DataDog with default loopback endpoint should construct: %v", err)
+	}
+	if _, err := NewSplunkExporter("https://splunk.example.com:8088", "hec-token", 1.0); err != nil {
+		t.Errorf("Splunk with https should construct: %v", err)
+	}
+}

--- a/internal/tracing/exporter/splunk.go
+++ b/internal/tracing/exporter/splunk.go
@@ -29,8 +29,9 @@ type SplunkEvent struct {
 }
 
 func NewSplunkExporter(endpoint, token string, sampleRate float64) (*SplunkExporter, error) {
-	if endpoint == "" {
-		endpoint = config.DefaultSplunkEndpoint
+	endpoint, err := validateExporterEndpoint(endpoint, config.DefaultSplunkEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("splunk: %w", err)
 	}
 
 	return &SplunkExporter{

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -43,8 +43,9 @@ type zipkinAnnotation struct {
 }
 
 func NewZipkinExporter(endpoint string, sampleRate float64) (*ZipkinExporter, error) {
-	if endpoint == "" {
-		endpoint = config.DefaultZipkinEndpoint
+	endpoint, err := validateExporterEndpoint(endpoint, config.DefaultZipkinEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("zipkin: %w", err)
 	}
 
 	return &ZipkinExporter{


### PR DESCRIPTION
## Summary

Fixes five operator/exporter security and robustness issues found, all on the session/exporter surface. Each ships with regression tests, and the batch was verified end-to-end.

## Fixes

- **In-namespace report object overwrite (integrity escalation).** `ensureSessionReportObject` ignored `AlreadyExists` and adopted any pre-existing ConfigMap/Secret named in `spec.reportRef`, and the operator then granted the session ServiceAccount `get,update` on it, so a user who can create PodTraceSessions but lacks `update` on that object could have the Job overwrite it. Now the session adopts a pre-existing report object only if it carries this session's own labels; any other collision returns a terminal `ReportObjectConflict` and the object-ownership check runs before the update grant is minted (reordered in the reconciler).
- **Exporter endpoint SSRF / cleartext credential leak.** `datadog`/`splunk` POST their API key / HEC token to a raw endpoint with no scheme check (only `otlp` guarded it). Added a shared endpoint validator applied in the DataDog/Splunk/Zipkin constructors, require http/https, refuse cleartext http to a non-loopback host (gated by a separate `PODTRACE_EXPORTER_INSECURE`, independent of the OTLP knob the Job sets), plus an admission-time scheme allowlist for every ExporterConfig variant.
- **Shared session ServiceAccount blast radius.** Every session ran as one fixed `podtrace-session` SA, so all sessions' cross-namespace pod-read RoleBindings bound it and it mounted into every session pod. Each session now gets a per-session UID-suffixed SA (`podtrace-session-<uid>`), bound by its own RoleBindings and cleaned up by the finalizer.
- **Session Job re-creation loop on multi-node completion skew.** A node's completed Job is TTL-garbage-collected while a slower sibling still runs, so the next reconcile recreated it and re-ran a full privileged `--diagnose` (duplicate captures + doubled export). Per-node completion is now tracked in status: completed nodes are carried forward across GC, skipped on re-create, and the session state is computed from the merged view.
- **Finalizer-clear NotFound race (log noise).** The PodTrace and PodTraceSession deletion paths handled `Conflict` but not `NotFound` on the finalizer-clear Update, so a completed deletion surfaced as an error-level "Reconciler error" with a stacktrace and a wasted requeue. A shared `finalizerUpdateOutcome` classifier now treats NotFound as success at all four set/clear sites, so routine deletions stay quiet.

## Behavior changes

Previously-accepted-but-unsafe inputs are now rejected: an ExporterConfig with a non-http(s) scheme fails admission, and a session naming a report object it did not create fails with `ReportObjectConflict` instead of overwriting it. No CRD schema changes.