### PR TITLE
fix: strip terminal control sequences from diagnose reports and sort kallsyms in n log n

### DIFF
--- a/internal/diagnose/formatter/formatter.go
+++ b/internal/diagnose/formatter/formatter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose/analyzer"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 func SectionHeader(title string) string {
@@ -42,7 +43,7 @@ func TopTargets(targets []analyzer.TargetCount, limit int, headerLabel, countLab
 		if i >= limit {
 			break
 		}
-		result += fmt.Sprintf("    - %s (%d %s)\n", target.Target, target.Count, countLabel)
+		result += fmt.Sprintf("    - %s (%d %s)\n", sanitize.Terminal(target.Target), target.Count, countLabel)
 	}
 	return result
 }
@@ -88,7 +89,7 @@ func TopItems(items map[string]int, limit int, headerLabel, itemLabel string) st
 		if i >= limit {
 			break
 		}
-		result += fmt.Sprintf("    - %s (%d %s)\n", ic.name, ic.count, itemLabel)
+		result += fmt.Sprintf("    - %s (%d %s)\n", sanitize.Terminal(ic.name), ic.count, itemLabel)
 	}
 	return result
 }
@@ -117,10 +118,11 @@ func TopItemsWithRate(items map[string]int, limit int, headerLabel, itemLabel st
 		if i >= limit {
 			break
 		}
+		name := sanitize.Terminal(ic.name)
 		if secs > 0 {
-			result += fmt.Sprintf("    - %s (%d %s, %.1f/sec)\n", ic.name, ic.count, itemLabel, float64(ic.count)/secs)
+			result += fmt.Sprintf("    - %s (%d %s, %.1f/sec)\n", name, ic.count, itemLabel, float64(ic.count)/secs)
 		} else {
-			result += fmt.Sprintf("    - %s (%d %s)\n", ic.name, ic.count, itemLabel)
+			result += fmt.Sprintf("    - %s (%d %s)\n", name, ic.count, itemLabel)
 		}
 	}
 	return result

--- a/internal/diagnose/formatter/formatter_sanitize_test.go
+++ b/internal/diagnose/formatter/formatter_sanitize_test.go
@@ -1,0 +1,27 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/diagnose/analyzer"
+)
+
+func TestFormatter_SanitizesUntrustedNames(t *testing.T) {
+	const evil = "GET /x\x1b[31m\x1b[2J\nFORGED LINE"
+
+	outputs := []string{
+		TopItems(map[string]int{evil: 3}, 5, "urls", "requests"),
+		TopItemsWithRate(map[string]int{evil: 3}, 5, "urls", "requests", time.Second),
+		TopTargets([]analyzer.TargetCount{{Target: evil, Count: 3}}, 5, "targets", "counts"),
+	}
+	for i, out := range outputs {
+		if strings.ContainsRune(out, 0x1b) {
+			t.Errorf("output %d leaked an ESC byte to the terminal: %q", i, out)
+		}
+		if strings.Contains(out, "\nFORGED LINE") {
+			t.Errorf("output %d let an injected newline forge a report line: %q", i, out)
+		}
+	}
+}

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -16,6 +16,7 @@ import (
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
 	"github.com/podtrace/podtrace/internal/events"
 	"github.com/podtrace/podtrace/internal/safeconv"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 type Diagnostician interface {
@@ -639,7 +640,7 @@ func formatOOMKills(oomKillEvents []*events.Event) string {
 			if procName == "" {
 				procName = fmt.Sprintf("PID %d", e.PID)
 			}
-			result += fmt.Sprintf("    - %s (%s)\n", procName, analyzer.FormatBytes(e.Bytes))
+			result += fmt.Sprintf("    - %s (%s)\n", sanitize.Terminal(procName), analyzer.FormatBytes(e.Bytes))
 		}
 	}
 	return result
@@ -743,7 +744,7 @@ func GeneratePoolSection(d Diagnostician, duration time.Duration) string {
 			if i >= config.MaxConnectionTargets {
 				break
 			}
-			report += fmt.Sprintf("    - %s:\n", summary.PoolID)
+			report += fmt.Sprintf("    - %s:\n", sanitize.Terminal(summary.PoolID))
 			report += fmt.Sprintf("        Acquires: %d, Releases: %d\n", summary.AcquireCount, summary.ReleaseCount)
 			report += fmt.Sprintf("        Release ratio: %.2f%% (releases/acquires)\n", summary.ReleaseRatio*100)
 			report += fmt.Sprintf("        Current connections: %d (peak: %d)\n", summary.CurrentConns, summary.MaxConns)
@@ -823,7 +824,7 @@ func GenerateSecuritySection(d Diagnostician) string {
 		if e.K8s != nil && e.K8s.PodName != "" {
 			pod = e.K8s.PodName
 		}
-		victims[pod] = fmt.Sprintf("%s, uid %d", e.ProcessName, e.Bytes)
+		victims[pod] = fmt.Sprintf("%s, uid %d", sanitize.Terminal(e.ProcessName), e.Bytes)
 	}
 	if len(victims) == 0 {
 		return ""
@@ -1068,7 +1069,7 @@ func formatFastCGIActivity(d Diagnostician, duration time.Duration) string {
 			if name == "" {
 				name = "unknown"
 			}
-			result += fmt.Sprintf("    PID %d (%s): %d req\n", w.pid, name, w.count)
+			result += fmt.Sprintf("    PID %d (%s): %d req\n", w.pid, sanitize.Terminal(name), w.count)
 		}
 	}
 
@@ -1161,7 +1162,7 @@ func formatFastCGIActivity(d Diagnostician, duration time.Duration) string {
 		if method == "" {
 			method = "REQ"
 		}
-		line := fmt.Sprintf("    - %s %s: %d req", method, s.uri, s.count)
+		line := fmt.Sprintf("    - %s %s: %d req", sanitize.Terminal(method), sanitize.Terminal(s.uri), s.count)
 		if len(s.latencies) > 0 {
 			line += fmt.Sprintf(", p50=%.2fms, p95=%.2fms, p99=%.2fms, max=%.2fms",
 				pctMs(s.latencies, 50), pctMs(s.latencies, 95),
@@ -1290,7 +1291,7 @@ func formatProcessActivity(allEvents []*events.Event) string {
 			name = "unknown"
 		}
 		result += fmt.Sprintf("    - PID %d (%s)%s: %d events (%.1f%%)\n",
-			pidInfo.Pid, name, pidInfo.PodSuffix(), pidInfo.Count, pidInfo.Percentage)
+			pidInfo.Pid, sanitize.Terminal(name), pidInfo.PodSuffix(), pidInfo.Count, pidInfo.Percentage)
 	}
 	result += "\n"
 	return result

--- a/internal/diagnose/stacktrace/kallsyms.go
+++ b/internal/diagnose/stacktrace/kallsyms.go
@@ -2,6 +2,7 @@ package stacktrace
 
 import (
 	"bufio"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -101,12 +102,12 @@ func isSorted(s []ksym) bool {
 	return true
 }
 
+// sortKsyms orders symbols by address so Resolve can binary-search. It
+// runs whenever /proc/kallsyms is not already address-sorted, which is
+// common once kernel modules are loaded. /proc/kallsyms holds ~10^5–10^6
+// symbols, so this must be O(n log n): an insertion sort here (~10^10+
+// comparisons) hung stack symbolication — and the whole diagnose report —
+// for minutes.
 func sortKsyms(s []ksym) {
-	for i := 1; i < len(s); i++ {
-		j := i
-		for j > 0 && s[j].Addr < s[j-1].Addr {
-			s[j], s[j-1] = s[j-1], s[j]
-			j--
-		}
-	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Addr < s[j].Addr })
 }

--- a/internal/diagnose/stacktrace/kallsyms_sort_test.go
+++ b/internal/diagnose/stacktrace/kallsyms_sort_test.go
@@ -1,0 +1,34 @@
+package stacktrace
+
+import (
+	"testing"
+)
+
+func TestSortKsyms_OrdersByAddress(t *testing.T) {
+	in := []ksym{
+		{Addr: 0x30, Name: "c"},
+		{Addr: 0x10, Name: "a"},
+		{Addr: 0x10, Name: "a_alias"},
+		{Addr: 0x20, Name: "b"},
+		{Addr: 0x00, Name: "zero"},
+	}
+	sortKsyms(in)
+	if !isSorted(in) {
+		t.Fatalf("sortKsyms did not produce address-sorted output: %+v", in)
+	}
+	if in[0].Addr != 0x00 || in[len(in)-1].Addr != 0x30 {
+		t.Errorf("unexpected bounds after sort: %+v", in)
+	}
+}
+
+func TestSortKsyms_LargeInputIsFast(t *testing.T) {
+	const n = 500_000
+	syms := make([]ksym, n)
+	for i := range syms {
+		syms[i] = ksym{Addr: uint64(n - i), Name: "s"}
+	}
+	sortKsyms(syms)
+	if !isSorted(syms) {
+		t.Fatal("large input not sorted")
+	}
+}

--- a/internal/diagnose/stacktrace/stacktrace.go
+++ b/internal/diagnose/stacktrace/stacktrace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/podtrace/podtrace/internal/hostfs"
 	"github.com/podtrace/podtrace/internal/procfs"
 	"github.com/podtrace/podtrace/internal/safeconv"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 type Diagnostician interface {
@@ -265,7 +266,7 @@ func GenerateStackTraceSectionWithContext(d Diagnostician, ctx context.Context) 
 			continue
 		}
 		if e.Target != "" {
-			report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, target=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), e.Target, float64(e.LatencyNS)/float64(config.NSPerMS))
+			report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, target=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), sanitize.Terminal(e.Target), float64(e.LatencyNS)/float64(config.NSPerMS))
 		} else {
 			report += fmt.Sprintf("  Hot stack %d: %d events, type=%s, avg latency=%.2fms\n", i+1, s.Count, e.TypeString(), float64(e.LatencyNS)/float64(config.NSPerMS))
 		}

--- a/internal/diagnose/tracker/connection.go
+++ b/internal/diagnose/tracker/connection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 type ConnectionInfo struct {
@@ -128,7 +129,7 @@ func GenerateConnectionCorrelation(events []*events.Event) string {
 		if i >= config.MaxConnectionTargets {
 			break
 		}
-		report += fmt.Sprintf("    - %s:\n", summary.Target)
+		report += fmt.Sprintf("    - %s:\n", sanitize.Terminal(summary.Target))
 		report += fmt.Sprintf("        Connect: %s\n", summary.ConnectTime.Format("15:04:05"))
 		report += fmt.Sprintf("        Operations: %d send, %d recv (total: %d)\n", summary.SendCount, summary.RecvCount, summary.TotalOps)
 		report += fmt.Sprintf("        Avg latency: %.2fms\n", float64(summary.AvgLatency.Nanoseconds())/float64(config.NSPerMS))

--- a/internal/diagnose/tracker/pod_communication.go
+++ b/internal/diagnose/tracker/pod_communication.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 type PodCommunication struct {
@@ -178,7 +179,7 @@ func GeneratePodCommunicationReport(summaries []PodCommunicationSummary) string 
 
 	for i := 0; i < maxDisplay; i++ {
 		summary := summaries[i]
-		report += fmt.Sprintf("    - %s (namespace: %s):\n", summary.Target, summary.Namespace)
+		report += fmt.Sprintf("    - %s (namespace: %s):\n", sanitize.Terminal(summary.Target), sanitize.Terminal(summary.Namespace))
 		report += fmt.Sprintf("        Connections: %d\n", summary.ConnectionCount)
 		if summary.TotalBytes > 0 {
 			report += fmt.Sprintf("        Total bytes: %s\n", formatBytes(summary.TotalBytes))

--- a/internal/diagnose/tracker/pool.go
+++ b/internal/diagnose/tracker/pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 type PoolInfo struct {
@@ -175,7 +176,7 @@ func GeneratePoolCorrelation(events []*events.Event) string {
 		if i >= config.MaxConnectionTargets {
 			break
 		}
-		report += fmt.Sprintf("    - %s:\n", summary.PoolID)
+		report += fmt.Sprintf("    - %s:\n", sanitize.Terminal(summary.PoolID))
 		report += fmt.Sprintf("        Acquires: %d, Releases: %d\n", summary.AcquireCount, summary.ReleaseCount)
 		report += fmt.Sprintf("        Release ratio: %.2f%% (releases/acquires)\n", summary.ReleaseRatio*100)
 		report += fmt.Sprintf("        Current connections: %d (peak: %d)\n", summary.CurrentConns, summary.MaxConns)

--- a/internal/profiling/correlator.go
+++ b/internal/profiling/correlator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/podtrace/podtrace/internal/clock"
 	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/sanitize"
 )
 
 func safeInt64(v uint64) int64 {
@@ -34,7 +35,7 @@ type ProcessCPU struct {
 	AvgBlockNS float64
 }
 
-// CorrelatedResult is the output of Correlate — it ties together BPF-observed
+// CorrelatedResult is the output of Correlate, it ties together BPF-observed
 // slow events, CPU hot-path frames from SchedSwitch stacks, memory page-fault
 // data, and optional pprof endpoint results fetched from the pod.
 type CorrelatedResult struct {
@@ -49,7 +50,7 @@ type CorrelatedResult struct {
 	CPUHotProcesses []ProcessCPU
 
 	// Memory — BPF-observed page faults and OOM kills.
-	PageFaultCounts map[uint32]int   // PID → fault count
+	PageFaultCounts map[uint32]int // PID → fault count
 	OOMEvents       []*events.Event
 
 	// Optional pprof endpoint data (nil if pod has no pprof server).
@@ -258,9 +259,9 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 			fmt.Fprintf(&sb, "    %s  PID=%-6d  %-12s  latency=%v  target=%s\n",
 				e.TypeString(),
 				e.PID,
-				e.ProcessName,
+				sanitize.Terminal(e.ProcessName),
 				time.Duration(safeInt64(e.LatencyNS)),
-				truncate(e.Target, 60))
+				sanitize.Terminal(truncate(e.Target, 60)))
 		}
 		sb.WriteString("\n")
 	}
@@ -272,7 +273,7 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 			"PID", "Process", "Switches", "Avg Block Time")
 		for _, ps := range cr.CPUHotProcesses {
 			fmt.Fprintf(&sb, "    %-8d  %-16s  %-10d  %v\n",
-				ps.PID, truncate(ps.Name, 15), ps.SchedCount,
+				ps.PID, sanitize.Terminal(truncate(ps.Name, 15)), ps.SchedCount,
 				time.Duration(int64(ps.AvgBlockNS)).Round(time.Microsecond))
 		}
 		sb.WriteString("\n")
@@ -339,7 +340,7 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 	if len(cr.OOMEvents) > 0 {
 		fmt.Fprintf(&sb, "  OOM Kill events: %d\n", len(cr.OOMEvents))
 		for _, e := range cr.OOMEvents {
-			fmt.Fprintf(&sb, "    task=%s  mem=%s\n", e.Target, formatBytes(safeInt64(e.Bytes)))
+			fmt.Fprintf(&sb, "    task=%s  mem=%s\n", sanitize.Terminal(e.Target), formatBytes(safeInt64(e.Bytes)))
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -1,0 +1,54 @@
+// Package sanitize scrubs attacker-influenced strings before they are
+// rendered into human-facing text (diagnose reports) that an operator may
+// view in a terminal.
+package sanitize
+
+import "strings"
+
+const Replacement = '�'
+
+// Terminal returns s with every terminal-unsafe rune replaced by
+// Replacement.
+func Terminal(s string) string {
+	if strings.IndexFunc(s, unsafeRune) < 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unsafeRune(r) {
+			b.WriteRune(Replacement)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// unsafeRune reports whether r can manipulate a terminal or forge report
+// structure when printed:
+//
+//   - C0 controls (0x00–0x1f): includes ESC (starts ANSI sequences) and
+//     TAB/CR/LF (would forge report columns and lines);
+//   - DEL (0x7f) and the C1 controls (0x80–0x9f);
+//   - the Unicode line/paragraph separators (U+2028/U+2029);
+//   - the bidirectional override and isolate format characters
+//     (U+202A–U+202E, U+2066–U+2069) — the Trojan-Source spoofing class.
+//
+// Every other rune, including normal printable Unicode, is preserved.
+func unsafeRune(r rune) bool {
+	switch {
+	case r < 0x20, r == 0x7f:
+		return true
+	case r >= 0x80 && r <= 0x9f:
+		return true
+	case r == 0x2028, r == 0x2029:
+		return true
+	case r >= 0x202a && r <= 0x202e:
+		return true
+	case r >= 0x2066 && r <= 0x2069:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -1,0 +1,73 @@
+package sanitize
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTerminal_PreservesCleanText(t *testing.T) {
+	clean := []string{
+		"",
+		"GET /api/v1/users",
+		"example.com (https)",
+		"münchen.example.de",        // multibyte UTF-8 (IDN host) must survive
+		"pool-7:redis://cache:6379", // punctuation, no control chars
+	}
+	for _, s := range clean {
+		if got := Terminal(s); got != s {
+			t.Errorf("Terminal(%q) = %q, want unchanged", s, got)
+		}
+	}
+}
+
+func TestTerminal_StripsTerminalEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"ansi-color", "\x1b[31mDROP TABLE\x1b[0m"},
+		{"cursor-move", "safe\x1b[2J\x1b[Hcleared"},
+		{"raw-esc", "a\x1bb"},
+		{"newline-injection", "GET /x\nFAKE LINE: pwned"},
+		{"carriage-return", "overwrite\rme"},
+		{"tab", "col1\tcol2"},
+		{"nul", "a\x00b"},
+		{"del", "a\x7fb"},
+		{"c1-control", "a\u0085b"},             // NEL
+		{"line-separator", "a\u2028b"},         // U+2028
+		{"bidi-override", "user\u202Egnp.exe"}, // Trojan-Source RTL override
+		{"bidi-isolate", "a\u2066b\u2069c"},    // LRI / PDI isolates
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Terminal(tc.in)
+			if strings.ContainsRune(got, 0x1b) {
+				t.Errorf("output still contains ESC: %q", got)
+			}
+			if i := strings.IndexFunc(got, unsafeRune); i >= 0 {
+				t.Errorf("output still contains an unsafe rune at %d: %q", i, got)
+			}
+			if strings.ContainsRune(got, '\n') || strings.ContainsRune(got, '\r') {
+				t.Errorf("output can still forge report lines: %q", got)
+			}
+		})
+	}
+}
+
+func TestTerminal_ReplacesWithMarker(t *testing.T) {
+	got := Terminal("a\x1bb")
+	want := "a" + string(Replacement) + "b"
+	if got != want {
+		t.Errorf("Terminal(%q) = %q, want %q", "a\x1bb", got, want)
+	}
+	if !strings.HasPrefix(got, "a") || !strings.HasSuffix(got, "b") {
+		t.Errorf("surrounding safe text not preserved: %q", got)
+	}
+}
+
+func TestTerminal_CleanInputReturnsSameString(t *testing.T) {
+	in := "no control chars here"
+	if got := Terminal(in); got != in {
+		t.Errorf("clean input mutated: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two independent issues in the diagnose report path: a terminal-escape / control-character injection through attacker-influenced report fields, and an O(n²) sort over `/proc/kallsyms` that could hang symbolication for minutes.

## Terminal-escape / control-char injection

Attacker-influenced L7 fields captured off the wire, URLs and paths, TLS SNI/ALPN, targets, and process/pod/OOM/pool names, were formatted straight into the operator's text report with no sanitization, so a traced workload could embed ANSI escape sequences to hijack the operator's terminal, newlines to forge report lines, or bidirectional-override characters to visually spoof values (Trojan Source). The existing `events.sanitizeString` only escapes `%` and was wired into none of these paths.

This adds a small leaf package `internal/sanitize` whose `Terminal` function replaces every terminal-unsafe rune (C0 controls including ESC/CR/LF/TAB, DEL, C1 controls, the Unicode line/paragraph separators, and the bidi override/isolate format characters) with U+FFFD while preserving ordinary printable text, including legitimate non-ASCII such as internationalized domain names; it is allocation-free on the common clean-string path. It is wired in at the formatter chokepoint (`TopItems`/`TopItemsWithRate`/`TopTargets`, which covers every map-rendered field) plus each direct render site in `report.go`, `tracker/{connection,pod_communication,pool}.go`, `profiling/correlator.go`, and `stacktrace/stacktrace.go`. Kernel and pprof symbol names are intentionally left unsanitized because they are not attacker-controlled.

## O(n²) kallsyms sort

`stacktrace/kallsyms.go` sorted the symbol table with an insertion sort whenever `/proc/kallsyms` was not already address-sorted, which is common once kernel modules are loaded; over the ~10⁵–10⁶ symbols a real table holds that is ~10¹⁰⁺ operations and hung stack symbolication, and therefore the whole report, for minutes. It now uses `sort.Slice` (n log n).