### PR TITLE
fix: redact session/auth headers and harden pid-reuse attribution guard

### DIFF
--- a/internal/attribution/attribution.go
+++ b/internal/attribution/attribution.go
@@ -88,8 +88,9 @@ func (t *Table) Record(pid uint32, cgroupID uint64, comm string) {
 	})
 }
 
-// Lookup returns the comm recorded for pid, if it is still within TTL
-// and its cgroup is consistent with the event being attributed.
+// Lookup returns the comm recorded for pid when it is still within TTL and
+// its cgroup can be positively confirmed to match the event being
+// attributed.
 func (t *Table) Lookup(pid uint32, cgroupID uint64) (comm string, ok bool, reuseSuspected bool) {
 	if t == nil || pid == 0 {
 		return "", false, false
@@ -106,7 +107,10 @@ func (t *Table) Lookup(pid uint32, cgroupID uint64) (comm string, ok bool, reuse
 		delete(t.entries, pid)
 		return "", false, false
 	}
-	if cgroupID != 0 && e.cgroupID != 0 && e.cgroupID != cgroupID {
+	if cgroupID == 0 || e.cgroupID == 0 {
+		return "", false, false
+	}
+	if e.cgroupID != cgroupID {
 		t.order.Remove(el)
 		delete(t.entries, pid)
 		return "", false, true

--- a/internal/attribution/attribution_test.go
+++ b/internal/attribution/attribution_test.go
@@ -99,16 +99,22 @@ func TestCgroupMismatchSuspectsPidReuse(t *testing.T) {
 	}
 }
 
-func TestZeroCgroupSkipsReuseCheck(t *testing.T) {
+// TestZeroCgroupIsUnverifiable is the regression for the pid-reuse guard
+// bypass.
+func TestZeroCgroupIsUnverifiable(t *testing.T) {
 	table, _ := newTestTable(time.Minute, 16)
-	table.Record(42, 0, "no-cgroup-producer")
-	if _, ok, reuse := table.Lookup(42, 200); !ok || reuse {
-		t.Fatalf("zero recorded cgroup must not trigger reuse: hit=%v reuse=%v", ok, reuse)
+
+	table.Record(42, 0, "victim-pod-comm")
+	if comm, ok, reuse := table.Lookup(42, 200); ok || reuse || comm != "" {
+		t.Fatalf("zero recorded cgroup must be unverifiable (miss), got hit=%v reuse=%v comm=%q", ok, reuse, comm)
 	}
 
 	table.Record(43, 100, "curl")
-	if _, ok, reuse := table.Lookup(43, 0); !ok || reuse {
-		t.Fatalf("zero lookup cgroup must not trigger reuse: hit=%v reuse=%v", ok, reuse)
+	if comm, ok, reuse := table.Lookup(43, 0); ok || reuse || comm != "" {
+		t.Fatalf("zero event cgroup must be unverifiable (miss), got hit=%v reuse=%v comm=%q", ok, reuse, comm)
+	}
+	if comm, ok, reuse := table.Lookup(43, 100); !ok || reuse || comm != "curl" {
+		t.Fatalf("unverifiable lookup must not evict the entry; want curl hit, got hit=%v reuse=%v comm=%q", ok, reuse, comm)
 	}
 }
 

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -101,14 +101,32 @@ func (r *Redactor) Redact(e *events.Event) {
 	for _, rule := range r.rules {
 		e.Target = rule.Pattern.ReplaceAllString(e.Target, rule.Replace)
 		e.Details = rule.Pattern.ReplaceAllString(e.Details, rule.Replace)
+		e.TraceState = rule.Pattern.ReplaceAllString(e.TraceState, rule.Replace)
 	}
 }
+
+// credentialKeyNames is the single source of truth for the key names whose
+// values are treated as secrets, shared by the key=value, JSON, and YAML
+// rules so coverage cannot drift between formats.
+const credentialKeyNames = `password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key|` +
+	`authorization|auth|bearer|session[_-]?id|jsessionid|phpsessid|asp\.net_sessionid|session|sid|` +
+	`csrf[_-]?token|xsrf[_-]?token|refresh[_-]?token|id[_-]?token`
+
+// sensitiveHeaderNames are HTTP header names whose entire value is a
+// credential (or a cookie jar of them).
+const sensitiveHeaderNames = `cookie|set-cookie|authorization|proxy-authorization|` +
+	`x-auth-token|x-api-key|x-csrf-token|x-xsrf-token`
 
 func defaultRules() []Rule {
 	return []Rule{
 		{
+			Name:    "sensitive_headers",
+			Pattern: regexp.MustCompile(`(?im)^(` + sensitiveHeaderNames + `)[ \t]*:[ \t]*.+$`),
+			Replace: "${1}: ***",
+		},
+		{
 			Name:    "credential_kv",
-			Pattern: regexp.MustCompile(`(?i)(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key|auth)=[^\s&]+`),
+			Pattern: regexp.MustCompile(`(?i)(` + credentialKeyNames + `)=[^\s&;,]+`),
 			Replace: "${1}=***",
 		},
 		{
@@ -123,12 +141,12 @@ func defaultRules() []Rule {
 		},
 		{
 			Name:    "credential_json",
-			Pattern: regexp.MustCompile(`(?i)"(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key)"\s*:\s*"[^"]*"`),
+			Pattern: regexp.MustCompile(`(?i)"(` + credentialKeyNames + `)"\s*:\s*"[^"]*"`),
 			Replace: `"${1}":"***"`,
 		},
 		{
 			Name:    "credential_yaml",
-			Pattern: regexp.MustCompile(`(?i)\b(password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key)\s*:\s+[^\s,}]+`),
+			Pattern: regexp.MustCompile(`(?i)\b(` + credentialKeyNames + `)\s*:\s+[^\s,}]+`),
 			Replace: "${1}: ***",
 		},
 		{

--- a/internal/redactor/redactor_test.go
+++ b/internal/redactor/redactor_test.go
@@ -27,13 +27,25 @@ func TestRedact_Password(t *testing.T) {
 
 func TestRedact_BearerToken(t *testing.T) {
 	r := redactor.Default()
-	e := makeEvent("", "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload")
+	e := makeEvent("", "grpc call carried Bearer eyJhbGciOiJSUzI1NiJ9.payload downstream")
 	r.Redact(e)
 	if strings.Contains(e.Details, "eyJ") {
 		t.Errorf("bearer token not redacted: %q", e.Details)
 	}
 	if !strings.Contains(e.Details, "Bearer ***") {
 		t.Errorf("expected Bearer ***: %q", e.Details)
+	}
+}
+
+func TestRedact_AuthorizationHeaderFullyRedacted(t *testing.T) {
+	r := redactor.Default()
+	e := makeEvent("", "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload")
+	r.Redact(e)
+	if strings.Contains(e.Details, "eyJ") {
+		t.Errorf("authorization token not redacted: %q", e.Details)
+	}
+	if !strings.Contains(e.Details, "Authorization: ***") {
+		t.Errorf("expected the whole Authorization value redacted: %q", e.Details)
 	}
 }
 

--- a/internal/redactor/session_cookie_regression_test.go
+++ b/internal/redactor/session_cookie_regression_test.go
@@ -1,0 +1,92 @@
+package redactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestDefaultRules_SessionAndAuthHeaders(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		leaked   []string
+		survives string
+	}{
+		{
+			name:     "cookie header jar",
+			in:       "cookie: session=abc123; JSESSIONID=deadbeef; sid=99",
+			leaked:   []string{"abc123", "deadbeef", "99"},
+			survives: "cookie",
+		},
+		{
+			name:     "set-cookie header",
+			in:       "set-cookie: sid=s3cr3t; Path=/; HttpOnly",
+			leaked:   []string{"s3cr3t"},
+			survives: "set-cookie",
+		},
+		{
+			name:     "opaque authorization header",
+			in:       "authorization: opaque-token-xyz",
+			leaked:   []string{"opaque-token-xyz"},
+			survives: "authorization",
+		},
+		{
+			name:     "bearer authorization header",
+			in:       "authorization: Bearer aGVsbG8xMjM0NTY",
+			leaked:   []string{"aGVsbG8xMjM0NTY"},
+			survives: "authorization",
+		},
+		{
+			name:     "authorization equals form",
+			in:       "GET /cb?authorization=mytoken&next=/home",
+			leaked:   []string{"mytoken"},
+			survives: "/home",
+		},
+		{
+			name:     "sessionid query param",
+			in:       "GET /login?sessionid=leakme&theme=dark",
+			leaked:   []string{"leakme"},
+			survives: "theme=dark",
+		},
+		{
+			name:     "session in body stops at semicolon",
+			in:       "body: session=abc;keepme=1",
+			leaked:   []string{"abc"},
+			survives: "keepme=1",
+		},
+	}
+
+	r := Default()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := &events.Event{Type: events.EventHTTPReq, Target: c.in, Details: c.in}
+			r.Redact(e)
+			for field, v := range map[string]string{"Target": e.Target, "Details": e.Details} {
+				for _, leak := range c.leaked {
+					if strings.Contains(v, leak) {
+						t.Errorf("%s still leaks %q: %q", field, leak, v)
+					}
+				}
+				if c.survives != "" && !strings.Contains(v, c.survives) {
+					t.Errorf("%s lost non-secret context %q: %q", field, c.survives, v)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultRules_TraceStateRedacted(t *testing.T) {
+	e := &events.Event{
+		Type:       events.EventHTTPReq,
+		TraceState: "vendorA=ok,token=supersecret,vendorB=fine",
+	}
+	Default().Redact(e)
+	if strings.Contains(e.TraceState, "supersecret") {
+		t.Errorf("TraceState still leaks the token: %q", e.TraceState)
+	}
+	if !strings.Contains(e.TraceState, "vendorA=ok") || !strings.Contains(e.TraceState, "vendorB=fine") {
+		t.Errorf("TraceState lost non-secret vendor entries: %q", e.TraceState)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two independent, opt-in-gated data-integrity issues: session cookies and Authorization headers were not covered by the PII redactor, and the attribution pid-reuse guard could be bypassed when a cgroup id was unknown, causing cross-pod misattribution.

## Session-cookie / authorization redaction gap

With `PODTRACE_REDACT_PII=true` and header capture enabled, captured Cookie/Authorization headers land in `e.Details` as `name: value` lines, but the default rules matched only `password=`/`token=`/`Bearer`/`Basic`, not `Cookie:`/`Set-Cookie:`/`session=`/`sid=`/`JSESSIONID=`, and `auth=` never matched `authorization=`, so session tokens flowed to exporters and report sinks verbatim.

This adds a `sensitive_headers` rule that redacts the entire value of `Cookie`/`Set-Cookie`/`Authorization`/`Proxy-Authorization`/`X-Auth-Token`/`X-Api-Key`/`X-CSRF-Token`/`X-XSRF-Token` lines (covering whole cookie jars and opaque, non-Bearer tokens), a single shared `credentialKeyNames` constant used by the key=value/JSON/YAML rules so coverage cannot drift between formats, now including `authorization`, `session`, `sid`, `jsessionid`, `phpsessid`, `asp.net_sessionid`, and the csrf/xsrf/refresh/id-token families, and a tighter value class (`[^\s&;,]+`) that stops at the cookie `;` and tracestate `,` separators. `Redact` also scrubs `e.TraceState`, which previously bypassed redaction entirely. `PeerSrcIP`/`PeerDstIP` are intentionally left untouched: they are core network telemetry, not credentials, and DNS-name redaction is a separate opt-in.

Behavior change: an `Authorization` header now fully redacts to `Authorization: ***` instead of `Authorization: Bearer ***`, which is both safer and what closes the opaque-token gap.

## Attribution pid-reuse guard bypass

The lookup guard only rejected a cgroup mismatch when both the event's and the stored identity's cgroup id were non-zero, so a zero on either side fell through to a confident hit; within the 30s TTL a recycled host PID would then return the previous pod's `comm`, silently attributing one pod's DNS/QUIC traffic to another.

Lookup now fails closed: an unverifiable cgroup (0 on either side) returns a miss without evicting the entry, so a later event that does carry a cgroup can still verify it, while a confirmed cgroup mismatch still evicts and flags reuse. On a miss the caller falls back to a fresh `/proc` read of the PID's current owner, which is strictly safer than trusting a stale cached identity.