### PR TITLE
fix: harden fastcgi/dns/grpc L7 parsing against malformed input

### DIFF
--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -466,11 +466,12 @@ int dns_ingress(struct __sk_buff *skb) {
 		ancount = bpf_ntohs(ancount);
 	e->bytes = ancount;
 
-	int aoff = skip_name(skb, dns_off + 12) + 4;
+	int qname_end = skip_name(skb, dns_off + 12);
+	int aoff = qname_end + 4;
 	int wrote_detail = 0;
 
 	for (int a = 0; a < MAX_ANSWERS; a++) {
-		if (a >= ancount)
+		if (a >= ancount || qname_end < 0)
 			break;
 		aoff = skip_name(skb, aoff);
 		if (aoff < 0)

--- a/bpf/fastcgi.c
+++ b/bpf/fastcgi.c
@@ -113,6 +113,12 @@ emit_params: ;
 	u8 params[FCGI_PARAMS_SCAN_LEN] = {};
 	u32 scan_len = content_len < FCGI_PARAMS_SCAN_LEN ? content_len : FCGI_PARAMS_SCAN_LEN;
 
+	u32 avail = (u32)rc_bytes > params_buf_offset ? (u32)rc_bytes - params_buf_offset : 0;
+	if (scan_len > avail)
+		scan_len = avail;
+	if (scan_len == 0)
+		return 0;
+
 	u8 *params_base = (u8 *)user_ptr + params_buf_offset;
 	if (bpf_probe_read_user(params, scan_len & 0xFF, params_base) != 0)
 		return 0;
@@ -139,6 +145,8 @@ emit_params: ;
 					}
 					if (copy >= MAX_STRING_LEN)
 						copy = MAX_STRING_LEN - 1;
+					if (vstart + copy > FCGI_PARAMS_SCAN_LEN)
+						copy = FCGI_PARAMS_SCAN_LEN - vstart;
 					bpf_probe_read_kernel(e->target, copy & (MAX_STRING_LEN - 1),
 					                     &params[vstart]);
 					e->target[copy & (MAX_STRING_LEN - 1)] = '\0';

--- a/bpf/grpcgo.c
+++ b/bpf/grpcgo.c
@@ -162,8 +162,7 @@ static __always_inline void grpc_go_process(void *ctx, u64 fields, u64 n, u32 st
 			e->pid = pid;
 			e->type = EVENT_HTTP_RESP;
 			e->latency_ns = 0;
-			s32 code = (s->status[0] - '0') * 100 + (s->status[1] - '0') * 10 +
-				   (s->status[2] - '0');
+			s32 code = http_parse_status3(s->status);
 			e->error = code >= 500 ? code : 0;
 			e->bytes = 0;
 			e->tcp_state = HTTP_TRANSPORT_H2_TLS;

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -17,8 +17,6 @@ static inline struct pair_key make_pair_key(u32 pair) {
 	return k;
 }
 
-// fill_event_peer fuses an L7 event with its L4 peer 4-tuple, read from the
-// per-thread stash that the tcp_sendmsg/tcp_recvmsg kprobes maintain.
 static inline struct tcp_peer *lookup_tcp_peer(u32 prefer_pair) {
 	struct pair_key k = {};
 	k.pid_tgid = bpf_get_current_pid_tgid();
@@ -43,8 +41,6 @@ static inline void fill_event_peer(struct event *e) {
 	__builtin_memcpy(e->peer_daddr6, p->daddr6, 16);
 }
 
-// fill_h2_record_peer fuses an h2 header record with its L4 peer, preferring the
-// stash matching the record's direction (egress->send, ingress->recv).
 static inline void fill_h2_record_peer(struct h2_hdr_record *rec, u32 dir) {
 	u32 prefer = (dir == H2_DIR_EGRESS) ? PAIR_TCP_SENDMSG : PAIR_TCP_RECVMSG;
 	struct tcp_peer *p = lookup_tcp_peer(prefer);
@@ -203,6 +199,15 @@ static inline void capture_user_stack(void *ctx, u32 pid, u32 tid, struct event 
 	u64 key = build_stack_key(pid, tid, e->timestamp);
 	bpf_map_update_elem(&stack_traces, &key, trace, BPF_ANY);
 	e->stack_key = key;
+}
+
+static __always_inline s32 http_parse_status3(const char *s)
+{
+	if (s[0] < '0' || s[0] > '9' ||
+	    s[1] < '0' || s[1] > '9' ||
+	    s[2] < '0' || s[2] > '9')
+		return -1;
+	return (s32)((s[0] - '0') * 100 + (s[1] - '0') * 10 + (s[2] - '0'));
 }
 
 #endif

--- a/bpf/http.c
+++ b/bpf/http.c
@@ -212,8 +212,7 @@ static __noinline void http_emit_response(void *ctx, void *base, u64 len,
 		return;
 
 	u64 latency_ns = calc_latency(req->start_ns);
-	s32 status_num = (status[0] - '0') * 100 + (status[1] - '0') * 10 +
-			 (status[2] - '0');
+	s32 status_num = http_parse_status3(status);
 
 	struct event *e = get_event_buf();
 	if (e) {


### PR DESCRIPTION
## Summary

This hardens three L7 protocol parsers against malformed or split input and removes a latent out-of-bounds fragility in the FastCGI path. All four are correctness/robustness fixes with no behaviour change for valid, complete inputs; the eBPF verifier already guaranteed memory safety, so none were exploitable crashes, the impact was wrong or stale captured data.

## Fixes

- **FastCGI PARAMS scan bounded to received bytes**: the params scan was capped by the record's application-supplied `content_len` and the 128-byte scan constant, but not by the bytes `recvmsg` actually returned; a PARAMS record split across two `recvmsg` calls scanned stale adjacent recv-buffer bytes and could surface a bogus `REQUEST_URI`/`REQUEST_METHOD`. It is now also capped at `rc_bytes - header_offset` (what really arrived), and the untouched tail stays zeroed.
- **DNS answer parsing guards a failed name skip**: `skip_name()` returns `-1` on a malformed/truncated response, and the unguarded `+ 4` left the answer offset at `3` (inside the DNS header), so the loop parsed header bytes as an answer and could cache a wrong IP, hostname mapping that later mislabels a connection. The initial `skip_name()` result is now checked, so malformed responses parse no answers.
- **gRPC-Go `:status` is digit-validated**: the status was decoded arithmetically with no length or digit check (unlike the HTTP/1.x and HTTP/3 paths), so a short or non-numeric `:status` produced a nonsensical, sometimes ≥500, code. The gRPC-Go and HTTP/1.x decoders now share one validated `http_parse_status3()` helper that returns -1 unless the value is exactly three ASCII digits.
- **FastCGI URI copy makes its bound explicit**: the variable-offset stack read for `REQUEST_URI` was in-bounds only implicitly (via how `copy` was initialised); it now carries the same explicit `vstart + copy <= scan-buffer` clamp the `REQUEST_METHOD` path already had, so a future edit cannot reintroduce an out-of-bounds stack read. This is a no-op for current inputs.