### PR TITLE
fix: resolve container main PID and store Splunk token in a Secret

### DIFF
--- a/cmd/podtrace/nodespawn_hook.go
+++ b/cmd/podtrace/nodespawn_hook.go
@@ -143,7 +143,7 @@ func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.
 		Image:                 image,
 		SpawnNamespace:        ns,
 		BuildChildArgs:        build,
-		ExtraEnv:              splunkTokenEnv(),
+		SplunkToken:           tracingSplunkToken,
 		OwnerHost:             host,
 		OwnerPID:              os.Getpid(),
 		Streams:               streams,
@@ -160,15 +160,6 @@ func maybeSpawnOnNode(ctx context.Context, cmd *cobra.Command, resolver pkgkube.
 		return true, err
 	}
 	return true, nil
-}
-
-// splunkTokenEnv carries --tracing-splunk-token into the spawn pod as an
-// environment variable.
-func splunkTokenEnv() []corev1.EnvVar {
-	if tracingSplunkToken == "" {
-		return nil
-	}
-	return []corev1.EnvVar{{Name: "PODTRACE_SPLUNK_TOKEN", Value: tracingSplunkToken}}
 }
 
 // clusterHandles pulls the kube clientset and rest.Config from the resolver.

--- a/internal/agent/crypto_alert_unit_test.go
+++ b/internal/agent/crypto_alert_unit_test.go
@@ -39,7 +39,7 @@ func TestEmitCopyFailAlert(t *testing.T) {
 	emitCopyFailAlert(ev)
 }
 
-func TestFirstPIDFromCgroupProcs(t *testing.T) {
+func TestMainPIDFromCgroupProcs(t *testing.T) {
 	base := t.TempDir()
 	origBase := config.CgroupBasePath
 	config.CgroupBasePath = base
@@ -53,12 +53,11 @@ func TestFirstPIDFromCgroupProcs(t *testing.T) {
 	if err := os.MkdirAll(cg, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Leading blank line + entries; first valid PID wins.
-	if err := os.WriteFile(filepath.Join(cg, "cgroup.procs"), []byte("\n4242\n4243\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cg, "cgroup.procs"), []byte("\n9999\n4242\n4243\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := firstPIDFromCgroupProcs(cg); got != 4242 {
-		t.Errorf("firstPIDFromCgroupProcs = %d, want 4242", got)
+	if got := mainPIDFromCgroupProcs(cg); got != 4242 {
+		t.Errorf("mainPIDFromCgroupProcs = %d, want 4242 (lowest/main PID, not first-listed 9999)", got)
 	}
 
 	// No cgroup.procs -> 0.
@@ -66,7 +65,7 @@ func TestFirstPIDFromCgroupProcs(t *testing.T) {
 	if err := os.MkdirAll(empty, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got := firstPIDFromCgroupProcs(empty); got != 0 {
+	if got := mainPIDFromCgroupProcs(empty); got != 0 {
 		t.Errorf("missing cgroup.procs should give 0, got %d", got)
 	}
 }

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -420,7 +420,7 @@ func scanPodCgroups(pods []*corev1.Pod) []PodCgroupEntry {
 				Pod:           p,
 				ContainerName: containerName,
 				ContainerID:   containerID,
-				ContainerPID:  firstPIDFromCgroupProcs(child),
+				ContainerPID:  mainPIDFromCgroupProcs(child),
 			})
 		}
 	}
@@ -480,9 +480,10 @@ func identifyContainerCgroup(dir string, statuses map[string]string) (name, id s
 	return "", ""
 }
 
-// firstPIDFromCgroupProcs returns the first host PID listed in a cgroup
-// directory's cgroup.procs, or 0 if none/unreadable.
-func firstPIDFromCgroupProcs(cgroupDir string) uint32 {
+// mainPIDFromCgroupProcs returns the container's main host PID, the lowest
+// (oldest, hence the entrypoint) PID in the cgroup's cgroup.procs, or 0 if
+// none/unreadable.
+func mainPIDFromCgroupProcs(cgroupDir string) uint32 {
 	rel, ok := sysfs.CgroupRelative(cgroupDir)
 	if !ok {
 		return 0
@@ -491,12 +492,17 @@ func firstPIDFromCgroupProcs(cgroupDir string) uint32 {
 	if err != nil {
 		return 0
 	}
+	var main uint32
 	for _, f := range strings.Fields(string(data)) {
-		if pid, err := strconv.ParseUint(f, 10, 32); err == nil && pid > 0 {
-			return uint32(pid)
+		pid, err := strconv.ParseUint(f, 10, 32)
+		if err != nil || pid == 0 {
+			continue
+		}
+		if main == 0 || uint32(pid) < main {
+			main = uint32(pid)
 		}
 	}
-	return 0
+	return main
 }
 
 // kubepodsRootCandidates lists the well-known cgroup directories

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -890,9 +890,10 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 	}
 	t.filter.SetCgroupPaths(allPaths)
 
-	if t.containerPID == 0 {
+	if !pidInCgroupPaths(t.containerPID, allPaths) {
+		t.containerPID = 0
 		for _, cgroupPath := range allPaths {
-			if pid := readFirstPIDFromCgroupProcs(cgroupPath); pid != 0 {
+			if pid := readMainPIDFromCgroupProcs(cgroupPath); pid != 0 {
 				t.containerPID = pid
 				break
 			}
@@ -1091,11 +1092,32 @@ func readPIDsFromCgroupProcs(cgroupPath string) []uint32 {
 	return pids
 }
 
-func readFirstPIDFromCgroupProcs(cgroupPath string) uint32 {
-	if pids := readPIDsFromCgroupProcs(cgroupPath); len(pids) > 0 {
-		return pids[0]
+// readMainPIDFromCgroupProcs returns the container's main host PID, the lowest
+// (oldest, hence entrypoint) PID in cgroup.procs or 0.
+func readMainPIDFromCgroupProcs(cgroupPath string) uint32 {
+	var main uint32
+	for _, p := range readPIDsFromCgroupProcs(cgroupPath) {
+		if p != 0 && (main == 0 || p < main) {
+			main = p
+		}
 	}
-	return 0
+	return main
+}
+
+// pidInCgroupPaths reports whether pid is currently listed in any of the given
+// cgroups' cgroup.procs — i.e. still alive and a member, not exited or reused.
+func pidInCgroupPaths(pid uint32, cgroupPaths []string) bool {
+	if pid == 0 {
+		return false
+	}
+	for _, cp := range cgroupPaths {
+		for _, p := range readPIDsFromCgroupProcs(cp) {
+			if p == pid {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isCgroupV2Base(basePath string) bool {

--- a/internal/ebpf/tracer/tracer_test.go
+++ b/internal/ebpf/tracer/tracer_test.go
@@ -1825,7 +1825,39 @@ func TestGetCgroupIDFromPath_NonExistent(t *testing.T) {
 	}
 }
 
-func TestReadFirstPIDFromCgroupProcs_Valid(t *testing.T) {
+func TestReadMainPIDFromCgroupProcs_Valid(t *testing.T) {
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	pod := filepath.Join(base, "pod-1")
+	if err := os.MkdirAll(pod, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pod, "cgroup.procs"), []byte("5678\n1234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if pid := readMainPIDFromCgroupProcs(pod); pid != 1234 {
+		t.Errorf("expected main PID 1234 (lowest), got %d", pid)
+	}
+}
+
+func TestReadMainPIDFromCgroupProcs_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if pid := readMainPIDFromCgroupProcs(dir); pid != 0 {
+		t.Errorf("expected 0 for empty procs file, got %d", pid)
+	}
+}
+
+func TestReadMainPIDFromCgroupProcs_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	if pid := readMainPIDFromCgroupProcs(dir); pid != 0 {
+		t.Errorf("expected 0 when file does not exist, got %d", pid)
+	}
+}
+
+func TestPIDInCgroupPaths(t *testing.T) {
 	base := t.TempDir()
 	useCgroupBase(t, base)
 	pod := filepath.Join(base, "pod-1")
@@ -1835,39 +1867,28 @@ func TestReadFirstPIDFromCgroupProcs_Valid(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(pod, "cgroup.procs"), []byte("1234\n5678\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if pid := readFirstPIDFromCgroupProcs(pod); pid != 1234 {
-		t.Errorf("expected PID 1234, got %d", pid)
+	if !pidInCgroupPaths(1234, []string{pod}) {
+		t.Error("pid 1234 should be reported as a live member of the cgroup")
+	}
+	if pidInCgroupPaths(4242, []string{pod}) {
+		t.Error("pid 4242 is not in cgroup.procs and must be reported absent")
+	}
+	if pidInCgroupPaths(0, []string{pod}) {
+		t.Error("pid 0 must never be reported present")
 	}
 }
 
-func TestReadFirstPIDFromCgroupProcs_Empty(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("\n\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if pid := readFirstPIDFromCgroupProcs(dir); pid != 0 {
-		t.Errorf("expected 0 for empty procs file, got %d", pid)
-	}
-}
-
-func TestReadFirstPIDFromCgroupProcs_NoFile(t *testing.T) {
-	dir := t.TempDir()
-	if pid := readFirstPIDFromCgroupProcs(dir); pid != 0 {
-		t.Errorf("expected 0 when file does not exist, got %d", pid)
-	}
-}
-
-func TestReadFirstPIDFromCgroupProcs_InvalidContent(t *testing.T) {
+func TestReadMainPIDFromCgroupProcs_InvalidContent(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("not-a-pid\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if pid := readFirstPIDFromCgroupProcs(dir); pid != 0 {
+	if pid := readMainPIDFromCgroupProcs(dir); pid != 0 {
 		t.Errorf("expected 0 for non-numeric content, got %d", pid)
 	}
 }
 
-func TestReadFirstPIDFromCgroupProcs_LeadingBlankLines(t *testing.T) {
+func TestReadMainPIDFromCgroupProcs_LeadingBlankLines(t *testing.T) {
 	base := t.TempDir()
 	useCgroupBase(t, base)
 	pod := filepath.Join(base, "pod-1")
@@ -1877,7 +1898,7 @@ func TestReadFirstPIDFromCgroupProcs_LeadingBlankLines(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(pod, "cgroup.procs"), []byte("\n  \n9999\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if pid := readFirstPIDFromCgroupProcs(pod); pid != 9999 {
+	if pid := readMainPIDFromCgroupProcs(pod); pid != 9999 {
 		t.Errorf("expected PID 9999, got %d", pid)
 	}
 }
@@ -1925,7 +1946,7 @@ func TestAttachToCgroup_CRIOSubfolder(t *testing.T) {
 	}
 }
 
-func TestAttachToCgroup_PreserveExistingPID(t *testing.T) {
+func TestAttachToCgroup_ReresolveStalePID(t *testing.T) {
 	base := t.TempDir()
 	useCgroupBase(t, base)
 	pod := filepath.Join(base, "pod-1")
@@ -1935,13 +1956,37 @@ func TestAttachToCgroup_PreserveExistingPID(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(pod, "cgroup.procs"), []byte("100\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Cached PID 999 is NOT in cgroup.procs (exited or reused elsewhere), so
+	// it must be re-resolved to the live main PID (100) rather than preserved —
+	// this is the TOCTOU/PID-reuse guard for /proc/<pid>/root discovery.
 	tr := &Tracer{
 		filter:       filter.NewCgroupFilter(),
 		containerPID: 999,
 	}
 	_ = tr.AttachToCgroup(pod)
-	if tr.containerPID != 999 {
-		t.Errorf("expected containerPID to remain 999, got %d", tr.containerPID)
+	if tr.containerPID != 100 {
+		t.Errorf("stale containerPID 999 should re-resolve to live main PID 100, got %d", tr.containerPID)
+	}
+}
+
+func TestAttachToCgroup_PreserveLiveMemberPID(t *testing.T) {
+	base := t.TempDir()
+	useCgroupBase(t, base)
+	pod := filepath.Join(base, "pod-1")
+	if err := os.MkdirAll(pod, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Cached PID 100 IS still a member, so it is preserved (no needless churn).
+	if err := os.WriteFile(filepath.Join(pod, "cgroup.procs"), []byte("100\n250\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tr := &Tracer{
+		filter:       filter.NewCgroupFilter(),
+		containerPID: 100,
+	}
+	_ = tr.AttachToCgroup(pod)
+	if tr.containerPID != 100 {
+		t.Errorf("live cached containerPID 100 should be preserved, got %d", tr.containerPID)
 	}
 }
 

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -27,15 +27,20 @@ const (
 
 	EnvNodeLocalSentinel = "PODTRACE_NODE_LOCAL"
 
+	SplunkSecretKey = "token"
+
 	ReaperMaxAge = 2 * time.Hour
 )
 
+func SplunkSecretName(podName string) string {
+	return podName + "-splunk"
+}
+
 // PodSpecOptions configures BuildPodSpec.
 type PodSpecOptions struct {
-	// ExtraEnv carries values that must not appear in the container argv
-	// (e.g. the Splunk HEC token): argv is persisted in the Pod object
-	// and visible in ps on the node.
 	ExtraEnv []corev1.EnvVar
+
+	SplunkToken string
 
 	NodeName              string
 	Namespace             string
@@ -125,6 +130,18 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 		}
 	}
 	env = append(env, opts.ExtraEnv...)
+
+	if opts.SplunkToken != "" {
+		env = append(env, corev1.EnvVar{
+			Name: "PODTRACE_SPLUNK_TOKEN", // contract read by internal/config.SplunkToken
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: SplunkSecretName(name)},
+					Key:                  SplunkSecretKey,
+				},
+			},
+		})
+	}
 
 	container := corev1.Container{
 		Name:                     "podtrace",

--- a/internal/kubernetes/nodespawn/run.go
+++ b/internal/kubernetes/nodespawn/run.go
@@ -56,9 +56,9 @@ type RunOptions struct {
 
 	KeepSpawnPodOnFailure bool
 
-	// ExtraEnv is forwarded into the spawn pod's environment. Use for
-	// values that must not appear in argv (tokens, credentials).
 	ExtraEnv []corev1.EnvVar
+
+	SplunkToken string
 }
 
 // Run orchestrates the spawn + stream lifecycle. It returns when every per-node
@@ -119,6 +119,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 			OwnerHost:             opts.OwnerHost,
 			OwnerPID:              opts.OwnerPID,
 			ExtraEnv:              opts.ExtraEnv,
+			SplunkToken:           opts.SplunkToken,
 		})
 		if err != nil {
 			cmu.Lock()
@@ -200,14 +201,32 @@ func nodePodLabel(podRefs []PodRef) string {
 }
 
 func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multiNode bool, wmu *sync.Mutex, nodeLabel string) (retErr error) {
+	secretName := ""
+	if opts.SplunkToken != "" {
+		secretName = SplunkSecretName(podSpec.Name)
+		if serr := createSplunkTokenSecret(ctx, opts.Clientset, podSpec.Namespace, secretName, podSpec.Labels, opts.SplunkToken); serr != nil {
+			return serr
+		}
+	}
+
 	created, err := opts.Clientset.CoreV1().Pods(podSpec.Namespace).Create(ctx, podSpec, metav1.CreateOptions{})
 	if err != nil {
+		if secretName != "" {
+			_ = DeleteSecret(context.Background(), opts.Clientset, podSpec.Namespace, secretName)
+		}
 		if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "violates PodSecurity") {
 			return fmt.Errorf("spawn pod admission rejected by PodSecurity in namespace %q. "+
 				"Remediation: kubectl label ns/%s pod-security.kubernetes.io/enforce=privileged --overwrite\n  (or use --spawn-namespace to point at a namespace that allows privileged pods). "+
 				"Underlying error: %w", podSpec.Namespace, podSpec.Namespace, err)
 		}
 		return fmt.Errorf("create spawn pod %s/%s: %w", podSpec.Namespace, podSpec.Name, err)
+	}
+
+	if secretName != "" {
+		if oerr := ownSecretByPod(ctx, opts.Clientset, created, secretName); oerr != nil {
+			logger.Debug("Could not own Splunk token secret by pod",
+				zap.String("secret", secretName), zap.Error(oerr))
+		}
 	}
 	logger.Debug("Spawn pod created",
 		zap.String("namespace", created.Namespace),
@@ -227,6 +246,9 @@ func runOneNode(ctx context.Context, opts RunOptions, podSpec *corev1.Pod, multi
 			return
 		}
 		_ = DeletePod(cleanupCtx, opts.Clientset, created.Namespace, created.Name)
+		if secretName != "" {
+			_ = DeleteSecret(cleanupCtx, opts.Clientset, created.Namespace, secretName)
+		}
 	}()
 
 	running, err := waitForPodRunningOrTerminated(ctx, opts.Clientset, created.Namespace, created.Name)

--- a/internal/kubernetes/nodespawn/secret.go
+++ b/internal/kubernetes/nodespawn/secret.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nodespawn
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// createSplunkTokenSecret creates the Secret that backs the spawn pod's
+// PODTRACE_SPLUNK_TOKEN SecretKeyRef.
+func createSplunkTokenSecret(ctx context.Context, cs kubernetes.Interface, namespace, name string, labels map[string]string, token string) error {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{SplunkSecretKey: token},
+	}
+	_, err := cs.CoreV1().Secrets(namespace).Create(ctx, sec, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("nodespawn: create secret %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// ownSecretByPod makes the spawn pod the owner of its token Secret so the
+// Kubernetes garbage collector deletes the Secret when the pod is deleted,
+// covering the crash path where the CLI dies before explicit cleanup and the
+// reaper removes the pod later.
+func ownSecretByPod(ctx context.Context, cs kubernetes.Interface, pod *corev1.Pod, secretName string) error {
+	sec, err := cs.CoreV1().Secrets(pod.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Name:       pod.Name,
+		UID:        pod.UID,
+	})
+	_, err = cs.CoreV1().Secrets(pod.Namespace).Update(ctx, sec, metav1.UpdateOptions{})
+	return err
+}
+
+// DeleteSecret best-effort deletes a spawn Secret; NotFound is swallowed so
+// parallel reapers and owner-reference GC racing the explicit delete do not
+// error out.
+func DeleteSecret(ctx context.Context, cs kubernetes.Interface, namespace, name string) error {
+	err := cs.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err == nil || IsNotFound(err) {
+		return nil
+	}
+	return fmt.Errorf("nodespawn: delete secret %s/%s: %w", namespace, name, err)
+}

--- a/internal/kubernetes/nodespawn/splunk_secret_test.go
+++ b/internal/kubernetes/nodespawn/splunk_secret_test.go
@@ -1,0 +1,111 @@
+package nodespawn
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testSplunkToken = "super-secret-hec-token-value-01234"
+
+func splunkTokenEnvVar(t *testing.T, opts PodSpecOptions) (*corev1.EnvVar, string) {
+	t.Helper()
+	pod, err := BuildPodSpec(opts)
+	if err != nil {
+		t.Fatalf("BuildPodSpec: %v", err)
+	}
+	var env *corev1.EnvVar
+	for i := range pod.Spec.Containers[0].Env {
+		if pod.Spec.Containers[0].Env[i].Name == "PODTRACE_SPLUNK_TOKEN" {
+			env = &pod.Spec.Containers[0].Env[i]
+		}
+	}
+	blob, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("marshal pod: %v", err)
+	}
+	if opts.SplunkToken != "" && strings.Contains(string(blob), opts.SplunkToken) {
+		t.Fatalf("raw Splunk token leaked into the pod spec: %s", blob)
+	}
+	return env, pod.Name
+}
+
+func TestBuildPodSpec_SplunkTokenViaSecretRef(t *testing.T) {
+	o := baseOpts()
+	o.SplunkToken = testSplunkToken
+	env, podName := splunkTokenEnvVar(t, o)
+	if env == nil {
+		t.Fatalf("%s env not present when a token is set", "PODTRACE_SPLUNK_TOKEN")
+	}
+	if env.Value != "" {
+		t.Errorf("%s carried a plaintext value %q; must use a SecretKeyRef", "PODTRACE_SPLUNK_TOKEN", env.Value)
+	}
+	if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+		t.Fatalf("%s must be sourced from a SecretKeyRef", "PODTRACE_SPLUNK_TOKEN")
+	}
+	ref := env.ValueFrom.SecretKeyRef
+	if ref.Key != SplunkSecretKey {
+		t.Errorf("SecretKeyRef key = %q, want %q", ref.Key, SplunkSecretKey)
+	}
+	if ref.Name != SplunkSecretName(podName) {
+		t.Errorf("SecretKeyRef name = %q, want %q", ref.Name, SplunkSecretName(podName))
+	}
+}
+
+func TestBuildPodSpec_NoSplunkTokenNoEnv(t *testing.T) {
+	env, _ := splunkTokenEnvVar(t, baseOpts())
+	if env != nil {
+		t.Errorf("%s env must be absent when no token is set", "PODTRACE_SPLUNK_TOKEN")
+	}
+}
+
+func TestSplunkSecretName_Deterministic(t *testing.T) {
+	if got := SplunkSecretName("podtrace-cli-worker-1-abc"); got != "podtrace-cli-worker-1-abc-splunk" {
+		t.Errorf("SplunkSecretName = %q", got)
+	}
+}
+
+func TestSplunkTokenSecretLifecycle(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	const ns, name = "kube-system", "podtrace-cli-worker-1-splunk"
+
+	if err := createSplunkTokenSecret(ctx, cs, ns, name, map[string]string{"k": "v"}, testSplunkToken); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	sec, err := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := sec.StringData[SplunkSecretKey]; got != testSplunkToken {
+		t.Errorf("stored token = %q, want %q", got, testSplunkToken)
+	}
+
+	if err := createSplunkTokenSecret(ctx, cs, ns, name, nil, testSplunkToken); err != nil {
+		t.Errorf("re-create should be idempotent: %v", err)
+	}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podtrace-cli-worker-1", Namespace: ns, UID: "pod-uid-123"}}
+	if err := ownSecretByPod(ctx, cs, pod, name); err != nil {
+		t.Fatalf("own: %v", err)
+	}
+	sec, _ = cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+	if len(sec.OwnerReferences) != 1 || sec.OwnerReferences[0].UID != "pod-uid-123" {
+		t.Errorf("owner references = %+v, want one ref to pod-uid-123", sec.OwnerReferences)
+	}
+
+	if err := DeleteSecret(ctx, cs, ns, name); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := cs.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); !IsNotFound(err) {
+		t.Errorf("secret should be gone after delete, got err=%v", err)
+	}
+	if err := DeleteSecret(ctx, cs, ns, name); err != nil {
+		t.Errorf("delete of absent secret should be nil, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two correctness/security fixes to the agent's container-PID resolution and the CLI's Splunk token handling, plus a small gosec cleanup. Both were verified end-to-end on a kind cluster.

## Container PID selection + PID-reuse TOCTOU

The agent picked the first line of a cgroup's `cgroup.procs` as the container PID that drives `/proc/<pid>/root` libc/libssl uprobe discovery. `cgroup.procs` is unordered, so that first entry could be a short-lived exec/health-check process, and it was cached once and never revalidated, between the reconcile-time read and the attach the PID could exit or be reused, pointing discovery at the wrong rootfs or failing silently.

- Both resolvers now return the container's main process, the lowest (oldest, hence entrypoint) live PID, instead of an arbitrary line, so short-lived execs (which start later and carry higher PIDs) are never picked.
- The tracer now re-resolves the container PID whenever the cached one is no longer a live member of the target cgroup (exited or recycled), rather than caching it for the process lifetime.

## Splunk HEC token no longer a plaintext pod-spec env

`--tracing-splunk-token` was injected into each spawn pod as an `EnvVar{Value: token}`, making it readable via `kubectl get pod -o yaml` and storing it unencrypted in etcd.

- The token is now delivered via a per-pod Secret referenced with a `SecretKeyRef`, created before the pod (so the reference resolves at container start) and owned by the pod through an `ownerReference`, so the garbage collector reaps the Secret even if the CLI dies before cleanup; the normal teardown path also deletes it explicitly.
- The redundant `token`-named constant that tripped gosec G101 was removed in favour of inlining the env-var name at its single write site, matching how `internal/config` already references the same contract, no `#nosec` suppression was added.