### PR TITLE
fix: harden session child GC, dedup, env parsing, and artifact perms

### DIFF
--- a/cmd/podtrace/report_uploader.go
+++ b/cmd/podtrace/report_uploader.go
@@ -179,7 +179,7 @@ func uploadToObjectStore(ctx context.Context, opts reportUploaderOptions, report
 	if err := writeResolvedLocation(resolved); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: write resolved location: %v\n", err)
 	}
-	if err := hostfs.WriteFile(terminationLogPath, []byte(resolved), 0o644); err != nil {
+	if err := hostfs.WriteFile(terminationLogPath, []byte(resolved), 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: write termination message: %v\n", err)
 	}
 	return nil
@@ -248,16 +248,15 @@ func readPersistedKeyHint() (string, bool) {
 }
 
 // persistKeyHint writes the key suffix to the state file. Failures
-// are logged but non-fatal: a sidecar that cannot persist the hint
-// will simply pick a fresh one on restart (duplicate object).
+// are logged but non-fatal.
 func persistKeyHint(hint string) {
-	if err := hostfs.WriteFile(keyHintStateFile, []byte(hint), 0o644); err != nil {
+	if err := hostfs.WriteFile(keyHintStateFile, []byte(hint), 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: persist key hint: %v\n", err)
 	}
 }
 
 func writeResolvedLocation(uri string) error {
-	if err := hostfs.WriteFile(reportLocationFile, []byte(uri), 0o644); err != nil {
+	if err := hostfs.WriteFile(reportLocationFile, []byte(uri), 0o600); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/podtrace/session_sink.go
+++ b/cmd/podtrace/session_sink.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/podtrace/podtrace/internal/config"
 	"github.com/podtrace/podtrace/internal/diagnose"
 	"github.com/podtrace/podtrace/internal/hostfs"
 	"github.com/podtrace/podtrace/internal/logger"
@@ -26,10 +27,6 @@ func finalizeDiagnoseOutputs(ctx context.Context, report string, d *diagnose.Dia
 	if summaryFile == "" && terminationMessagePath == "" && reportTo == "" {
 		return
 	}
-	// On the interrupt path ctx is already cancelled (Ctrl+C, Job deletion,
-	// node drain), and every sink write derives a timeout from it — so the
-	// report was silently lost on exactly the early-termination cases the
-	// sinks exist for. Detach and bound with a grace period instead.
 	finalizeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalizeGracePeriod)
 	defer cancel()
 	node := os.Getenv("NODE_NAME")
@@ -44,9 +41,7 @@ func finalizeDiagnoseOutputs(ctx context.Context, report string, d *diagnose.Dia
 const finalizeGracePeriod = 30 * time.Second
 
 // SessionSummary is the compact, machine-readable summary the CLI emits
-// at the end of --diagnose. Matches the CRD's SessionSummary type
-// field-for-field so the operator can JSON-unmarshal the termination
-// message directly.
+// at the end of --diagnose.
 type SessionSummary struct {
 	TotalEvents    int64  `json:"totalEvents"`
 	DNSEvents      int64  `json:"dnsEvents,omitempty"`
@@ -93,9 +88,7 @@ func computeSessionSummary(d *diagnose.Diagnostician, node string) SessionSummar
 
 // categoryForEventType maps the internal events.Event.TypeString() value
 // (uppercase category names like DNS/NET/FS/CPU/PROC) into the five
-// top-level buckets the PodTrace CRD exposes. Categories outside this
-// set (MEM, LOCK, HTTP, …) contribute to TotalEvents but not to any
-// per-category count.
+// top-level buckets the PodTrace CRD exposes.
 func categoryForEventType(typeStr string) string {
 	switch strings.ToLower(typeStr) {
 	case "dns":
@@ -120,10 +113,6 @@ func categoryForEventType(typeStr string) string {
 //     via Kubernetes' terminationMessagePath contract.
 //   - reportTo: patches a ConfigMap or Secret with the human-readable
 //     report text (the "full artifact" per spec.reportRef).
-//
-// All three are best-effort individually: a failure on one does not
-// block the others. The return error is a composite when multiple paths
-// fail, so the Job log shows the complete picture.
 func emitSessionArtifacts(ctx context.Context, summary SessionSummary, reportText string) error {
 	var errs []string
 
@@ -149,6 +138,21 @@ func emitSessionArtifacts(ctx context.Context, summary SessionSummary, reportTex
 	return fmt.Errorf("session artifact emission: %s", strings.Join(errs, "; "))
 }
 
+// k8sTerminationLog is the fixed kubelet termination-message path, the one
+// artifact target that legitimately lives outside the session run directory.
+const k8sTerminationLog = "/dev/termination-log"
+
+// writeArtifactFile writes a session artifact, confining it to
+// config.ArtifactBaseDir() when the operator has set one (the privileged Job
+// context).
+func writeArtifactFile(path string, data []byte, perm os.FileMode) error {
+	base := config.ArtifactBaseDir()
+	if base == "" || path == k8sTerminationLog {
+		return hostfs.WriteFile(path, data, perm)
+	}
+	return hostfs.WriteFileWithin(base, path, data, perm)
+}
+
 // writeSummaryFile writes the JSON summary to the given path. Used by
 // the sidecar uploader (reads this file) as the source of truth for
 // summary content when the CLI succeeds.
@@ -157,13 +161,12 @@ func writeSummaryFile(path string, summary SessionSummary) error {
 	if err != nil {
 		return err
 	}
-	return hostfs.WriteFile(path, data, 0o600)
+	return writeArtifactFile(path, data, 0o600)
 }
 
 // writeTerminationMessage writes a compact JSON encoding of the summary
 // so the apiserver surfaces it in Pod.Status.ContainerStatuses[].
-// State.Terminated.Message. 4KB is the kernel-enforced ceiling on this
-// path; the SessionSummary shape intentionally fits well within it.
+// State.Terminated.Message.
 func writeTerminationMessage(path string, summary SessionSummary) error {
 	data, err := json.Marshal(summary)
 	if err != nil {
@@ -173,17 +176,19 @@ func writeTerminationMessage(path string, summary SessionSummary) error {
 	if len(data) > maxTerminationBytes {
 		return fmt.Errorf("summary JSON %d bytes exceeds 4KB termination message limit", len(data))
 	}
-	return hostfs.WriteFile(path, data, 0o600)
+	return writeArtifactFile(path, data, 0o600)
 }
 
 // objectStoreReportFile is the on-disk handoff path between the main
-// session container and the report-uploader sidecar. EmptyDir-mounted
-// at /var/run/podtrace in both containers; the main writes here when
-// the sink is an ObjectStore URI, the sidecar reads from here.
-const objectStoreReportFile = "/var/run/podtrace/report.txt"
+// session container and the report-uploader sidecar. A var, not a const,
+// so tests can redirect it. Lives in a pod-private emptyDir.
+var objectStoreReportFile = "/var/run/podtrace/report.txt"
 
 func uploadReport(ctx context.Context, spec, reportText string) error {
 	if strings.Contains(spec, "://") {
+		// 0644 (other-readable) is required, not lax: the main container runs
+		// as root but the report-uploader sidecar is the distroless nonroot
+		// user, and it must read this file over the shared emptyDir.
 		if err := hostfs.WriteFileAtomic(objectStoreReportFile, []byte(reportText), 0o644); err != nil {
 			return fmt.Errorf("write report file for sidecar: %w", err)
 		}
@@ -214,8 +219,7 @@ func uploadReport(ctx context.Context, spec, reportText string) error {
 }
 
 // parseReportToSpec breaks a string of the form "kind/namespace/name"
-// into its three components. Case-folds the kind so "ConfigMap",
-// "configmap", and "CONFIGMAP" all work.
+// into its three components.
 func parseReportToSpec(spec string) (kind, namespace, name string, err error) {
 	parts := strings.Split(spec, "/")
 	if len(parts) != 3 {
@@ -278,7 +282,6 @@ func upsertReportConfigMap(ctx context.Context, client kubernetes.Interface, nam
 			if cerr == nil || !apierrors.IsAlreadyExists(cerr) {
 				return cerr
 			}
-			// Lost the create race; fall through to a get+update.
 			existing, err = cms.Get(ctx, name, metav1.GetOptions{})
 		}
 		if err != nil {

--- a/cmd/podtrace/session_sink_jail_unit_test.go
+++ b/cmd/podtrace/session_sink_jail_unit_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/hostfs"
+)
+
+func TestWriteArtifactFile_JailGatedByEnv(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "elsewhere.txt")
+
+	t.Setenv(config.EnvArtifactBaseDir, "")
+	if err := writeArtifactFile(outside, []byte("x"), 0o600); err != nil {
+		t.Errorf("unconstrained write failed: %v", err)
+	}
+
+	t.Setenv(config.EnvArtifactBaseDir, base)
+	inside := filepath.Join(base, "summary.json")
+	if err := writeArtifactFile(inside, []byte("x"), 0o600); err != nil {
+		t.Errorf("in-base write failed: %v", err)
+	}
+	if got, err := os.ReadFile(inside); err != nil || string(got) != "x" {
+		t.Errorf("in-base file not written: got=%q err=%v", got, err)
+	}
+	if err := writeArtifactFile(outside, []byte("x"), 0o600); !errors.Is(err, hostfs.ErrOutsideBase) {
+		t.Errorf("out-of-base write: got %v, want ErrOutsideBase", err)
+	}
+
+	if err := writeArtifactFile(k8sTerminationLog, []byte("x"), 0o600); errors.Is(err, hostfs.ErrOutsideBase) {
+		t.Errorf("termination-log must be exempt from the base jail, got %v", err)
+	}
+}

--- a/cmd/podtrace/session_sink_report_perm_unit_test.go
+++ b/cmd/podtrace/session_sink_report_perm_unit_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUploadReport_ReportFileIsSidecarReadable(t *testing.T) {
+	dir := t.TempDir()
+	orig := objectStoreReportFile
+	objectStoreReportFile = filepath.Join(dir, "report.txt")
+	t.Cleanup(func() { objectStoreReportFile = orig })
+
+	if err := uploadReport(context.Background(), "s3://bucket/key", "report body"); err != nil {
+		t.Fatalf("uploadReport: %v", err)
+	}
+	info, err := os.Stat(objectStoreReportFile)
+	if err != nil {
+		t.Fatalf("stat report file: %v", err)
+	}
+	if info.Mode().Perm()&0o004 == 0 {
+		t.Errorf("report.txt mode = %v, must be other-readable for the nonroot sidecar", info.Mode().Perm())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,7 @@ const (
 	MaxCgroupFilePathLength          = 64
 	MaxContainerIDLength             = 128
 	DefaultCacheEvictionThreshold    = 0.9
-	MaxTraceContextCacheSize = 100000
+	MaxTraceContextCacheSize         = 100000
 )
 
 var (
@@ -58,7 +58,7 @@ var (
 	CircuitBreakerEnabled     = getBoolEnvOrDefault("PODTRACE_CIRCUIT_BREAKER_ENABLED", true)
 	TracingEnabled            = getBoolEnvOrDefault("PODTRACE_TRACING_ENABLED", false)
 	TracingSampleRate         = getFloatEnvOrDefault("PODTRACE_TRACING_SAMPLE_RATE", DefaultTracingSampleRate)
-	SynthesizeSpans = getBoolEnvOrDefault("PODTRACE_TRACING_SYNTHESIZE_SPANS", DefaultSynthesizeSpans)
+	SynthesizeSpans           = getBoolEnvOrDefault("PODTRACE_TRACING_SYNTHESIZE_SPANS", DefaultSynthesizeSpans)
 	OTLPEndpoint              = getEnvOrDefault("PODTRACE_OTLP_ENDPOINT", DefaultOTLPEndpoint)
 	JaegerEndpoint            = os.Getenv("PODTRACE_JAEGER_ENDPOINT")
 	SplunkEndpoint            = os.Getenv("PODTRACE_SPLUNK_ENDPOINT")
@@ -414,11 +414,16 @@ func ClampUint32(v int) uint32 {
 	return uint32(v)
 }
 
+// getInt64EnvOrDefault mirrors getIntEnvOrDefault for 64-bit knobs: the
+// positive-only constraint holds (every consumer is a size or threshold
+// where 0/negative would disable or break the feature), and a set-but-
+// rejected value is reported instead of silently falling back.
 func getInt64EnvOrDefault(key string, defaultValue int64) int64 {
 	if value := os.Getenv(key); value != "" {
 		if i, err := strconv.ParseInt(value, 10, 64); err == nil && i > 0 {
 			return i
 		}
+		warnIgnoredEnv(key, value, "must be a positive integer")
 	}
 	return defaultValue
 }
@@ -439,6 +444,14 @@ func GetMetricsAddress() string {
 		addr = DefaultMetricsHost + ":" + strconv.Itoa(DefaultMetricsPort)
 	}
 	return addr
+}
+
+const EnvArtifactBaseDir = "PODTRACE_ARTIFACT_BASE"
+
+// ArtifactBaseDir returns the directory session artifacts must be written
+// within, or "" when unconstrained.
+func ArtifactBaseDir() string {
+	return os.Getenv(EnvArtifactBaseDir)
 }
 
 func AllowNonLoopbackMetrics() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -403,6 +404,56 @@ func TestGetInt64EnvOrDefault(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetInt64EnvOrDefault_WarnsOnRejectedValue(t *testing.T) {
+	const key = "TEST_INT64_WARN_ENV_VAR"
+	orig := os.Getenv(key)
+	t.Cleanup(func() {
+		if orig != "" {
+			_ = os.Setenv(key, orig)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+
+	for _, tc := range []struct{ name, value string }{
+		{"malformed", "not-a-number"},
+		{"zero", "0"},
+		{"negative", "-7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = os.Setenv(key, tc.value)
+			stderr := captureStderr(t, func() {
+				if got := getInt64EnvOrDefault(key, 42); got != 42 {
+					t.Errorf("got %d, want default 42 for %q", got, tc.value)
+				}
+			})
+			if !strings.Contains(stderr, "environment variable ignored") || !strings.Contains(stderr, key) {
+				t.Errorf("expected an ignored-env warning for %q, stderr = %q", tc.value, stderr)
+			}
+		})
+	}
+
+	_ = os.Setenv(key, "123")
+	if stderr := captureStderr(t, func() { getInt64EnvOrDefault(key, 42) }); stderr != "" {
+		t.Errorf("valid positive value must not warn, stderr = %q", stderr)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	out, _ := io.ReadAll(r)
+	return string(out)
 }
 
 func TestGetDurationEnvOrDefault(t *testing.T) {

--- a/internal/hostfs/hostfs.go
+++ b/internal/hostfs/hostfs.go
@@ -18,19 +18,6 @@
 //   - filepath.Walk over a host directory derived from ld.so.conf —
 //     the entries returned by the linker config are themselves under
 //     /usr or /lib and the walker honours symlinks the linker would.
-//
-// gosec rules G304 (file inclusion via variable) and G703 (path
-// traversal via taint) flag these accesses because, in the abstract,
-// the path could be anything. This package surfaces three helpers
-// with the only `// #nosec` annotations in the codebase that admit
-// genuinely-unscoped access — every other callsite was migrated to
-// procfs / sysfs / ldsoconf.
-//
-// Each helper validates that the path is absolute and free of "..",
-// which prevents traversal-via-relative-path even though the
-// destination after symlink resolution is intentionally unconstrained.
-// Callers must continue to treat the result as untrusted (e.g. attach
-// uprobes only after verifying the underlying file is a real ELF).
 package hostfs
 
 import (
@@ -118,7 +105,36 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 	if perm&0o022 != 0 {
 		return fmt.Errorf("%w: %#o (%s)", ErrUnsafeMode, perm, path)
 	}
-	return os.WriteFile(path, data, perm) // #nosec G304,G306 -- path validated absolute/no-"..", mode asserted non-group/other-writable above; 0644 read is intended for sidecar/kubelet handoffs.
+	return os.WriteFile(path, data, perm) // #nosec G304,G306 -- path validated absolute/no-"..", mode asserted non-group/other-writable above; some handoffs pass 0644 so a nonroot sidecar can read a root-written file over a pod-private emptyDir.
+}
+
+// ErrOutsideBase is returned by WriteFileWithin when the target path
+// resolves outside the permitted base directory.
+var ErrOutsideBase = errors.New("hostfs: path escapes the permitted base directory")
+
+// WriteFileWithin is WriteFile plus a base-directory jail: it refuses to
+// write anywhere outside baseDir.
+func WriteFileWithin(baseDir, path string, data []byte, perm os.FileMode) error {
+	if err := ensureWithin(baseDir, path); err != nil {
+		return err
+	}
+	return WriteFile(path, data, perm)
+}
+
+// ensureWithin validates baseDir and path (absolute, no "..") and confirms
+// path does not escape baseDir.
+func ensureWithin(baseDir, path string) error {
+	if err := validate(baseDir); err != nil {
+		return err
+	}
+	if err := validate(path); err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(filepath.Clean(baseDir), filepath.Clean(path))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %s not under %s", ErrOutsideBase, path, baseDir)
+	}
+	return nil
 }
 
 // WriteFileAtomic writes data via a temp file + rename so a concurrent reader

--- a/internal/hostfs/hostfs_test.go
+++ b/internal/hostfs/hostfs_test.go
@@ -159,9 +159,6 @@ func TestWriteFile_RejectsTraversal(t *testing.T) {
 	}
 }
 
-// TestWriteFile_ModeGuard locks the invariant behind the G306 suppression:
-// group/other read is allowed (0644 handoffs) but group/other write is
-// rejected, regardless of call site.
 func TestWriteFile_ModeGuard(t *testing.T) {
 	dir := t.TempDir()
 
@@ -188,9 +185,36 @@ func TestWriteFile_ModeGuard(t *testing.T) {
 	}
 }
 
-// TestWriteFileAtomic verifies the temp+rename write: the final file has the
-// complete content, the correct perm, and no ".tmp" residue is left behind
-// (the sidecar polls the final path and must never observe a partial file).
+func TestWriteFileWithin(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFileWithin(base, filepath.Join(base, "sub", "ok"), []byte("x"), 0o600); err != nil {
+		t.Errorf("write inside base rejected: %v", err)
+	}
+
+	sibling := base + "-evil"
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sibling) })
+	if err := WriteFileWithin(base, filepath.Join(sibling, "x"), []byte("x"), 0o600); !errors.Is(err, ErrOutsideBase) {
+		t.Errorf("sibling-prefix path: got %v, want ErrOutsideBase", err)
+	}
+
+	if err := WriteFileWithin(base, "/etc/passwd", []byte("x"), 0o600); !errors.Is(err, ErrOutsideBase) {
+		t.Errorf("escape path: got %v, want ErrOutsideBase", err)
+	}
+	if err := WriteFileWithin(base, base+"/../x", []byte("x"), 0o600); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("traversal path: got %v, want ErrInvalidPath", err)
+	}
+	if err := WriteFileWithin("relative-base", filepath.Join(base, "x"), []byte("x"), 0o600); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("relative base: got %v, want ErrInvalidPath", err)
+	}
+}
+
 func TestWriteFileAtomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.txt")
@@ -219,8 +243,6 @@ func TestWriteFileAtomic(t *testing.T) {
 	}
 }
 
-// TestWriteFileAtomic_Overwrite confirms an existing file is replaced wholesale
-// (rename semantics), not appended to.
 func TestWriteFileAtomic_Overwrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.txt")

--- a/internal/operator/operator_regression_test.go
+++ b/internal/operator/operator_regression_test.go
@@ -87,11 +87,12 @@ func TestSessionPodNamespaces(t *testing.T) {
 }
 
 func TestEnsureSessionPodReadRBAC(t *testing.T) {
-	c := fake.NewClientBuilder().WithScheme(findingsScheme(t)).Build()
+	scheme := findingsScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	s := newSession(nil)
 	const systemNS = "podtrace-system"
 
-	if err := ensureSessionPodReadRBAC(context.Background(), c, s, []string{"team-a", "team-b"}, systemNS); err != nil {
+	if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-a", "team-b"}, systemNS); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -51,6 +51,7 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var session podtracev1alpha1.PodTraceSession
 	if err := r.Get(ctx, req.NamespacedName, &session); err != nil {
 		if apierrors.IsNotFound(err) {
+			forgetReportObservations(req.Namespace, req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get PodTraceSession: %w", err)
@@ -165,12 +166,12 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	if err := ensureSessionReportRBAC(ctx, r.Client, &session, systemNS); err != nil {
+	if err := ensureSessionReportRBAC(ctx, r.Client, &session, r.Scheme, systemNS); err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, sessionPodNamespaces(&session, targets), systemNS); err != nil {
+	if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, r.Scheme, sessionPodNamespaces(&session, targets), systemNS); err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
@@ -528,8 +529,11 @@ func effectiveMaxConcurrentSessionsPerNode(tc *podtracev1alpha1.TracerConfig) in
 	return tc.Spec.MaxConcurrentSessionsPerNode
 }
 
-// ensureJobs creates-or-updates one Job per target node, owner-ref'd to
-// the session.
+// ensureJobs creates-or-updates one Job per target node in the system
+// namespace. The Jobs cannot carry an ownerReference back to the session
+// (Kubernetes forbids cross-namespace owner refs), so their lifecycle is
+// bounded by TTLSecondsAfterFinished, the podtrace.io/cleanup finalizer, and
+// the orphan sweep (see SessionChildReaper) as a finalizer-bypass backstop.
 func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, targets sessionTargets, completedNodes map[string]struct{}) ([]batchv1.Job, error) {
 	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
 

--- a/internal/operator/podtracesession_dedup_gc_test.go
+++ b/internal/operator/podtracesession_dedup_gc_test.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func sessionObservationCount(ns, name string) int {
+	observed.Lock()
+	defer observed.Unlock()
+	n := 0
+	for k := range observed.seen {
+		if k.Namespace == ns && k.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+func TestReconcile_NotFound_ClearsDedupEntry(t *testing.T) {
+	const ns, name = "team-a", "ghost"
+	observed.Lock()
+	observed.seen[reportObservationKey{Namespace: ns, Name: name, Attempts: 1, Succeeded: true}] = struct{}{}
+	observed.Unlock()
+	defer forgetReportObservations(ns, name)
+
+	if got := sessionObservationCount(ns, name); got != 1 {
+		t.Fatalf("precondition: dedup count = %d, want 1", got)
+	}
+
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	res, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error = %v", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Errorf("result = %+v, want empty", res)
+	}
+	if got := sessionObservationCount(ns, name); got != 0 {
+		t.Errorf("dedup entry leaked: count = %d, want 0 after NotFound reconcile", got)
+	}
+}

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+	"github.com/podtrace/podtrace/internal/config"
 )
 
 func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, node string, targets sessionTargets) batchv1.JobSpec {
@@ -123,6 +124,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		},
 		{Name: "PODTRACE_CRITICAL_PATH", Value: "false"},
 		{Name: "PODTRACE_OTLP_INSECURE", Value: "1"},
+		{Name: config.EnvArtifactBaseDir, Value: "/var/run/podtrace"},
 	}
 	if tc != nil {
 		mainEnv = append(mainEnv, redactionEnv(tc.Spec.Redaction)...)

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -140,6 +140,18 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	if !strings.Contains(args, "--termination-message-path /dev/termination-log") {
 		t.Errorf("missing --termination-message-path: %v", spec.Template.Spec.Containers[0].Args)
 	}
+	foundArtifactBase := false
+	for _, e := range spec.Template.Spec.Containers[0].Env {
+		if e.Name == "PODTRACE_ARTIFACT_BASE" {
+			foundArtifactBase = true
+			if e.Value != "/var/run/podtrace" {
+				t.Errorf("PODTRACE_ARTIFACT_BASE=%q, want /var/run/podtrace", e.Value)
+			}
+		}
+	}
+	if !foundArtifactBase {
+		t.Error("main container missing PODTRACE_ARTIFACT_BASE env (artifact base-dir jail)")
+	}
 	if n := len(spec.Template.Spec.Containers[0].VolumeMounts); n != 9 {
 		t.Errorf("main container mounts=%d want 9", n)
 	}

--- a/internal/operator/runtime.go
+++ b/internal/operator/runtime.go
@@ -135,6 +135,10 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("register TracerConfig bootstrap: %w", err)
 	}
 
+	if err := mgr.Add(&SessionChildReaper{Client: mgr.GetClient()}); err != nil {
+		return fmt.Errorf("register session-child reaper: %w", err)
+	}
+
 	return mgr.Start(ctx)
 }
 

--- a/internal/operator/session_rbac.go
+++ b/internal/operator/session_rbac.go
@@ -9,6 +9,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -45,7 +46,7 @@ func cleanupSessionServiceAccount(ctx context.Context, c client.Client, s *podtr
 
 // ensureSessionReportRBAC provisions per-session RBAC in the user
 // namespace.
-func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) error {
+func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, systemNS string) error {
 	roleName := SessionReportRoleName(s.UID)
 	bindingName := SessionReportRoleBindingName(s.UID)
 
@@ -60,7 +61,7 @@ func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1
 			LabelSessionNS:   s.Namespace,
 		})
 		role.Rules = buildSessionReportRules(s.Spec.ReportRef)
-		return nil
+		return controllerutil.SetControllerReference(s, role, scheme)
 	}); err != nil {
 		return fmt.Errorf("ensure session report Role: %w", err)
 	}
@@ -85,7 +86,7 @@ func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1
 			Name:      SessionServiceAccountName(s.UID),
 			Namespace: systemNS,
 		}}
-		return nil
+		return controllerutil.SetControllerReference(s, binding, scheme)
 	}); err != nil {
 		return fmt.Errorf("ensure session report RoleBinding: %w", err)
 	}
@@ -149,14 +150,18 @@ func sessionPodNamespaces(s *podtracev1alpha1.PodTraceSession, targets sessionTa
 
 // ensureSessionPodReadRBAC grants the session SA pods+events read in each
 // extra namespace a cross-namespace session targets.
-func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, namespaces []string, systemNS string) error {
+func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, namespaces []string, systemNS string) error {
 	for _, ns := range namespaces {
+		sameNS := ns == s.Namespace
 		role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: SessionPodReadRoleName(s.UID), Namespace: ns}}
 		if _, err := controllerutil.CreateOrUpdate(ctx, c, role, func() error {
 			role.Labels = mergeLabels(role.Labels, sessionRBACLabels(s))
 			role.Rules = []rbacv1.PolicyRule{
 				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
 				{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"get", "list", "watch"}},
+			}
+			if sameNS {
+				return controllerutil.SetControllerReference(s, role, scheme)
 			}
 			return nil
 		}); err != nil {
@@ -176,6 +181,9 @@ func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev
 				Name:      SessionServiceAccountName(s.UID),
 				Namespace: systemNS,
 			}}
+			if sameNS {
+				return controllerutil.SetControllerReference(s, binding, scheme)
+			}
 			return nil
 		}); err != nil {
 			return fmt.Errorf("ensure session pod-read RoleBinding in %s: %w", ns, err)

--- a/internal/operator/session_rbac_test.go
+++ b/internal/operator/session_rbac_test.go
@@ -57,7 +57,7 @@ func TestEnsureSessionReportRBAC_CreatesNarrowRole(t *testing.T) {
 		},
 	}
 
-	if err := ensureSessionReportRBAC(ctx, c, s, "podtrace-system"); err != nil {
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
 		t.Fatalf("ensureSessionReportRBAC: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestEnsureSessionReportRBAC_NoSinkStillGrantsPodRead(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-abc"},
 	}
-	if err := ensureSessionReportRBAC(ctx, c, s, "podtrace-system"); err != nil {
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
 		t.Fatalf("ensureSessionReportRBAC: %v", err)
 	}
 
@@ -145,9 +145,6 @@ func TestBuildSessionReportRules_IncludesPodReads(t *testing.T) {
 			t.Errorf("session Role must not grant events:%s (read-only): %+v", verb, rules)
 		}
 	}
-	// Without reportRef, the rule set must not grant any configmap/
-	// secret verbs — those need a resourceNames-scoped rule that only
-	// appears when reportRef is configured.
 	if hasRuleFor(rules, "configmaps", "update") || hasRuleFor(rules, "secrets", "update") {
 		t.Errorf("no-reportRef ruleset leaked write verbs: %+v", rules)
 	}
@@ -171,9 +168,6 @@ func TestBuildSessionReportRules_ResourceNamesScoped(t *testing.T) {
 	if scoped[0].ResourceNames[0] != "rpt" {
 		t.Errorf("resourceNames=%v want [rpt]", scoped[0].ResourceNames)
 	}
-	// The scoped rule must not contain the "create" verb — create is
-	// checked at the collection level, so it belongs on a separate
-	// unscoped rule. A scoped rule with create would be dead code.
 	for _, v := range scoped[0].Verbs {
 		if v == "create" {
 			t.Errorf("resourceNames-scoped rule contains create verb: %+v", scoped[0])
@@ -181,10 +175,6 @@ func TestBuildSessionReportRules_ResourceNamesScoped(t *testing.T) {
 	}
 }
 
-// hasRuleFor reports whether any policy rule grants the given verb on
-// the given core-API resource. Matches regardless of ResourceNames
-// scoping; tests that care about that scope check ResourceNames
-// directly.
 func hasRuleFor(rules []rbacv1.PolicyRule, resource, verb string) bool {
 	for _, r := range rules {
 		resMatch := false
@@ -259,5 +249,72 @@ func TestReportToSpecFromReportRef(t *testing.T) {
 	}
 	if got := reportToSpecFromReportRef(s); got != "secret/team-a/rpt" {
 		t.Errorf("secret spec: %q", got)
+	}
+}
+
+func ownedBySession(refs []metav1.OwnerReference, s *podtracev1alpha1.PodTraceSession) bool {
+	for _, o := range refs {
+		if o.Kind == "PodTraceSession" && o.UID == s.UID && o.Controller != nil && *o.Controller {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnsureSessionReportRBAC_OwnsSameNamespaceRBAC(t *testing.T) {
+	scheme := newRBACScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "own-1"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			ReportRef: &podtracev1alpha1.ReportReference{ConfigMap: &corev1.LocalObjectReference{Name: "r"}},
+		},
+	}
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
+		t.Fatalf("ensureSessionReportRBAC: %v", err)
+	}
+
+	var role rbacv1.Role
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionReportRoleName(s.UID), Namespace: "team-a"}, &role); err != nil {
+		t.Fatalf("role: %v", err)
+	}
+	if !ownedBySession(role.OwnerReferences, s) {
+		t.Errorf("report Role not owned by session: %+v", role.OwnerReferences)
+	}
+	var rb rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionReportRoleBindingName(s.UID), Namespace: "team-a"}, &rb); err != nil {
+		t.Fatalf("rolebinding: %v", err)
+	}
+	if !ownedBySession(rb.OwnerReferences, s) {
+		t.Errorf("report RoleBinding not owned by session: %+v", rb.OwnerReferences)
+	}
+}
+
+func TestEnsureSessionPodReadRBAC_OwnsOnlySameNamespace(t *testing.T) {
+	scheme := newRBACScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "own-2"},
+	}
+	if err := ensureSessionPodReadRBAC(ctx, c, s, scheme, []string{"team-a", "team-b"}, "podtrace-system"); err != nil {
+		t.Fatalf("ensureSessionPodReadRBAC: %v", err)
+	}
+
+	var sameRole rbacv1.Role
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionPodReadRoleName(s.UID), Namespace: "team-a"}, &sameRole); err != nil {
+		t.Fatalf("same-ns role: %v", err)
+	}
+	if !ownedBySession(sameRole.OwnerReferences, s) {
+		t.Errorf("same-namespace pod-read Role must be owned: %+v", sameRole.OwnerReferences)
+	}
+
+	var crossRole rbacv1.Role
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionPodReadRoleName(s.UID), Namespace: "team-b"}, &crossRole); err != nil {
+		t.Fatalf("cross-ns role: %v", err)
+	}
+	if len(crossRole.OwnerReferences) != 0 {
+		t.Errorf("cross-namespace pod-read Role must NOT be owned (k8s forbids): %+v", crossRole.OwnerReferences)
 	}
 }

--- a/internal/operator/session_reaper.go
+++ b/internal/operator/session_reaper.go
@@ -1,0 +1,166 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+const (
+	defaultReaperInterval = 15 * time.Minute
+	defaultReaperGrace    = 10 * time.Minute
+)
+
+// SessionChildReaper is the finalizer-bypass backstop for a PodTraceSession's
+// cross-namespace children (per-node Jobs, exporter bundle, objectStore creds,
+// ServiceAccount, and cross-namespace pod-read RBAC). Those objects live in a
+// namespace the session cannot own via ownerReferences, so if the
+// podtrace.io/cleanup finalizer is stripped or the operator is down at deletion
+// time, nothing garbage-collects them. This Runnable periodically deletes any
+// such child whose owning session no longer exists.
+type SessionChildReaper struct {
+	Client   client.Client
+	Interval time.Duration
+	Grace    time.Duration
+}
+
+// NeedLeaderElection keeps the sweep on a single replica.
+func (r *SessionChildReaper) NeedLeaderElection() bool { return true }
+
+func (r *SessionChildReaper) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("session-child-reaper")
+	interval := r.Interval
+	if interval <= 0 {
+		interval = defaultReaperInterval
+	}
+	grace := r.Grace
+	if grace <= 0 {
+		grace = defaultReaperGrace
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if n, err := reapOrphanSessionChildren(ctx, r.Client, time.Now(), grace); err != nil {
+			logger.Error(err, "orphan session-child sweep failed; will retry next tick")
+		} else if n > 0 {
+			logger.Info("reaped orphaned session children", "count", n)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+type reapCandidate struct {
+	obj         client.Object
+	sessionNS   string
+	sessionName string
+}
+
+// reapOrphanSessionChildren lists every operator-managed object that names an
+// owning session via labels and deletes those whose session is gone.
+func reapOrphanSessionChildren(ctx context.Context, c client.Client, now time.Time, grace time.Duration) (int, error) {
+	var candidates []reapCandidate
+	consider := func(o client.Object) {
+		labels := o.GetLabels()
+		sns, sn := labels[LabelSessionNS], labels[LabelSessionName]
+		if sns == "" || sn == "" {
+			return
+		}
+		if labels[labelReportKind] == reportKindValue {
+			return
+		}
+		if grace > 0 && now.Sub(o.GetCreationTimestamp().Time) < grace {
+			return
+		}
+		candidates = append(candidates, reapCandidate{obj: o, sessionNS: sns, sessionName: sn})
+	}
+
+	sel := client.MatchingLabels{LabelManagedBy: ManagedByValue}
+
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, sel); err != nil {
+		return 0, fmt.Errorf("list session Jobs: %w", err)
+	}
+	for i := range jobs.Items {
+		consider(&jobs.Items[i])
+	}
+	var cms corev1.ConfigMapList
+	if err := c.List(ctx, &cms, sel); err != nil {
+		return 0, fmt.Errorf("list session ConfigMaps: %w", err)
+	}
+	for i := range cms.Items {
+		consider(&cms.Items[i])
+	}
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets, sel); err != nil {
+		return 0, fmt.Errorf("list session Secrets: %w", err)
+	}
+	for i := range secrets.Items {
+		consider(&secrets.Items[i])
+	}
+	var sas corev1.ServiceAccountList
+	if err := c.List(ctx, &sas, sel); err != nil {
+		return 0, fmt.Errorf("list session ServiceAccounts: %w", err)
+	}
+	for i := range sas.Items {
+		consider(&sas.Items[i])
+	}
+	var roles rbacv1.RoleList
+	if err := c.List(ctx, &roles, sel); err != nil {
+		return 0, fmt.Errorf("list session Roles: %w", err)
+	}
+	for i := range roles.Items {
+		consider(&roles.Items[i])
+	}
+	var bindings rbacv1.RoleBindingList
+	if err := c.List(ctx, &bindings, sel); err != nil {
+		return 0, fmt.Errorf("list session RoleBindings: %w", err)
+	}
+	for i := range bindings.Items {
+		consider(&bindings.Items[i])
+	}
+
+	type sessionKey struct{ ns, name string }
+	alive := map[sessionKey]bool{}
+	deleted := 0
+	for _, cand := range candidates {
+		key := sessionKey{cand.sessionNS, cand.sessionName}
+		live, checked := alive[key]
+		if !checked {
+			var s podtracev1alpha1.PodTraceSession
+			err := c.Get(ctx, types.NamespacedName{Namespace: cand.sessionNS, Name: cand.sessionName}, &s)
+			switch {
+			case err == nil:
+				live = true
+			case apierrors.IsNotFound(err):
+				live = false
+			default:
+				continue
+			}
+			alive[key] = live
+		}
+		if live {
+			continue
+		}
+		if err := c.Delete(ctx, cand.obj); err != nil && !apierrors.IsNotFound(err) {
+			return deleted, fmt.Errorf("reap orphan %T %s/%s: %w",
+				cand.obj, cand.obj.GetNamespace(), cand.obj.GetName(), err)
+		}
+		deleted++
+	}
+	return deleted, nil
+}

--- a/internal/operator/session_reaper_test.go
+++ b/internal/operator/session_reaper_test.go
@@ -1,0 +1,129 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func reaperSessionLabels(sessionName, sessionNS string) map[string]string {
+	return map[string]string{
+		LabelManagedBy:   ManagedByValue,
+		LabelComponent:   ComponentSession,
+		LabelSessionName: sessionName,
+		LabelSessionNS:   sessionNS,
+	}
+}
+
+func TestReapOrphanSessionChildren_DeletesOnlyOrphans(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-time.Hour))
+	young := metav1.NewTime(now)
+
+	live := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "live", Namespace: "team-a"},
+	}
+
+	orphanJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "podtrace-gone-n1", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: old,
+	}}
+	orphanCreds := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: "creds-gone", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: old,
+	}}
+	orphanSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: "sa-gone", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: old,
+	}}
+	orphanCrossRB := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{
+		Name: "podread-gone", Namespace: "team-b",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: old,
+	}}
+
+	liveJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "podtrace-live-n1", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("live", "team-a"), CreationTimestamp: old,
+	}}
+	reportCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: "report-gone", Namespace: "team-a",
+		Labels: func() map[string]string {
+			l := reaperSessionLabels("gone", "team-a")
+			l[labelReportKind] = reportKindValue
+			return l
+		}(),
+		CreationTimestamp: old,
+	}}
+	youngOrphan := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "podtrace-gone-n2", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: young,
+	}}
+	agentRole := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{
+		Name: "podtrace-agent", Namespace: "podtrace-system",
+		Labels: map[string]string{LabelManagedBy: ManagedByValue}, CreationTimestamp: old,
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(live, orphanJob, orphanCreds, orphanSA, orphanCrossRB,
+			liveJob, reportCM, youngOrphan, agentRole).Build()
+
+	ctx := context.Background()
+	n, err := reapOrphanSessionChildren(ctx, c, now, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("reap error = %v", err)
+	}
+	if n != 4 {
+		t.Errorf("reaped %d, want 4 (orphan job + creds + SA + cross-ns RB)", n)
+	}
+
+	gone := func(name, ns string, obj client.Object) {
+		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, obj); !apierrors.IsNotFound(err) {
+			t.Errorf("%T %s/%s should be reaped (err=%v)", obj, ns, name, err)
+		}
+	}
+	present := func(name, ns string, obj client.Object) {
+		if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, obj); err != nil {
+			t.Errorf("%T %s/%s should survive: %v", obj, ns, name, err)
+		}
+	}
+
+	gone(orphanJob.Name, orphanJob.Namespace, &batchv1.Job{})
+	gone(orphanCreds.Name, orphanCreds.Namespace, &corev1.Secret{})
+	gone(orphanSA.Name, orphanSA.Namespace, &corev1.ServiceAccount{})
+	gone(orphanCrossRB.Name, orphanCrossRB.Namespace, &rbacv1.RoleBinding{})
+
+	present(liveJob.Name, liveJob.Namespace, &batchv1.Job{})         // session alive
+	present(reportCM.Name, reportCM.Namespace, &corev1.ConfigMap{})  // retained report object
+	present(youngOrphan.Name, youngOrphan.Namespace, &batchv1.Job{}) // within grace
+	present(agentRole.Name, agentRole.Namespace, &rbacv1.Role{})     // not a session child
+}
+
+func TestReapOrphanSessionChildren_NoGraceReapsYoung(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	now := time.Now()
+	youngOrphan := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "podtrace-gone-n2", Namespace: "podtrace-system",
+		Labels: reaperSessionLabels("gone", "team-a"), CreationTimestamp: metav1.NewTime(now),
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(youngOrphan).Build()
+
+	n, err := reapOrphanSessionChildren(context.Background(), c, now, 0)
+	if err != nil {
+		t.Fatalf("reap error = %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reaped %d, want 1 with grace=0", n)
+	}
+}


### PR DESCRIPTION
## Summary
Two security-review batches on the operator's session lifecycle and on config/artifact I/O.

## Session child garbage collection
- Same-namespace session children (report Role/RoleBinding, same-namespace pod-read RBAC) now carry an ownerReference, so Kubernetes GC reaps them even if the `podtrace.io/cleanup` finalizer is stripped or the operator is down at deletion time.
- New `SessionChildReaper`: a leader-elected periodic sweep that deletes cross-namespace children (per-node Jobs, exporter bundle, objectStore creds, ServiceAccount, cross-namespace pod-read RBAC) whose owning session no longer exists. It skips children younger than a grace window and leaves them untouched on a transient lookup error, so it never races a just-created session.
- The report-upload dedup map is now cleared on the `NotFound` reconcile path, not only the finalizer path, so it never retains entries for sessions deleted without their finalizer running.

## Config and artifact I/O
- `getInt64EnvOrDefault` now emits an "environment variable ignored" warning on malformed or non-positive values, consistent with the int/float/duration helpers, instead of silently falling back to the default.
- Added an env-gated base-dir jail (`hostfs.WriteFileWithin` + `PODTRACE_ARTIFACT_BASE`) that confines operator-supplied artifact paths to the shared run directory in the privileged session Job; local CLI runs leave it unset and are unaffected.