### PR TITLE
fix: harden graph, truncation, nil derefs, and analyzer bounds

### DIFF
--- a/internal/analysis/criticalpath/criticalpath.go
+++ b/internal/analysis/criticalpath/criticalpath.go
@@ -57,6 +57,20 @@ type requestWindow struct {
 	lastSeen time.Time
 }
 
+// addSegment appends seg, but once the window reaches maxSegmentsPerWindow it
+// folds further latency into a single trailing overflow segment.
+func (w *requestWindow) addSegment(seg Segment) {
+	if len(w.segments) < maxSegmentsPerWindow-1 {
+		w.segments = append(w.segments, seg)
+		return
+	}
+	if len(w.segments) == maxSegmentsPerWindow-1 {
+		w.segments = append(w.segments, Segment{Label: segmentOverflowLabel})
+	}
+	overflow := &w.segments[maxSegmentsPerWindow-1]
+	overflow.LatencyNS += seg.LatencyNS
+}
+
 // Analyzer correlates events by PID and emits CriticalPath summaries on
 // HTTP / FastCGI / gRPC response boundary events.
 type Analyzer struct {
@@ -83,7 +97,11 @@ func isBoundary(t events.EventType) bool {
 	return t == events.EventHTTPResp || t == events.EventFastCGIResp || t == events.EventGRPCMethod
 }
 
-const maxWindows = 8192
+const (
+	maxWindows           = 8192
+	maxSegmentsPerWindow = 1024
+	segmentOverflowLabel = "other"
+)
 
 // Feed processes one event. It is safe to call from multiple goroutines.
 // The emit callback runs after the analyzer's lock is released, so a slow
@@ -124,7 +142,7 @@ func (a *Analyzer) Feed(e *events.Event) {
 		if e.Details != "" {
 			label = e.Details
 		}
-		w.segments = append(w.segments, Segment{Label: label, LatencyNS: e.LatencyNS})
+		w.addSegment(Segment{Label: label, LatencyNS: e.LatencyNS})
 	}
 	a.mu.Unlock()
 

--- a/internal/analysis/criticalpath/segments_bound_test.go
+++ b/internal/analysis/criticalpath/segments_bound_test.go
@@ -1,0 +1,33 @@
+package criticalpath
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFeed_SegmentsBoundedPerWindow(t *testing.T) {
+	a := New(time.Hour, nil)
+	const pid = 42
+	const fed = maxSegmentsPerWindow + 500
+	for i := 0; i < fed; i++ {
+		a.Feed(nonBoundaryEvent(pid))
+	}
+
+	a.mu.Lock()
+	w := a.windows[pid]
+	a.mu.Unlock()
+	if w == nil {
+		t.Fatal("expected a window for the fed PID")
+	}
+	if len(w.segments) > maxSegmentsPerWindow {
+		t.Errorf("window segments = %d, want <= %d", len(w.segments), maxSegmentsPerWindow)
+	}
+
+	var total uint64
+	for _, s := range w.segments {
+		total += s.LatencyNS
+	}
+	if want := uint64(fed) * 1_000_000; total != want {
+		t.Errorf("summed segment latency = %d, want %d (overflow fold lost latency)", total, want)
+	}
+}

--- a/internal/diagnose/detector/issues.go
+++ b/internal/diagnose/detector/issues.go
@@ -12,6 +12,9 @@ func DetectIssues(allEvents []*events.Event, errorRateThreshold, rttSpikeThresho
 
 	var connectEvents []*events.Event
 	for _, e := range allEvents {
+		if e == nil {
+			continue
+		}
 		if e.Type == events.EventConnect {
 			connectEvents = append(connectEvents, e)
 		}
@@ -32,6 +35,9 @@ func DetectIssues(allEvents []*events.Event, errorRateThreshold, rttSpikeThresho
 
 	var tcpEvents []*events.Event
 	for _, e := range allEvents {
+		if e == nil {
+			continue
+		}
 		if e.Type == events.EventTCPSend || e.Type == events.EventTCPRecv {
 			tcpEvents = append(tcpEvents, e)
 		}
@@ -52,6 +58,9 @@ func DetectIssues(allEvents []*events.Event, errorRateThreshold, rttSpikeThresho
 
 	var resourceAlerts = make(map[string]int)
 	for _, e := range allEvents {
+		if e == nil {
+			continue
+		}
 		if e.Type == events.EventResourceLimit {
 			// e.Error is int32 carrying the utilization percentage;
 			// negative values are non-physical and skipped.

--- a/internal/diagnose/detector/issues_nilsafe_test.go
+++ b/internal/diagnose/detector/issues_nilsafe_test.go
@@ -1,0 +1,28 @@
+package detector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestDetectIssues_SkipsNilEvents(t *testing.T) {
+	evs := []*events.Event{
+		nil,
+		{Type: events.EventConnect, Error: 1},
+		nil,
+		{Type: events.EventConnect},
+		nil,
+	}
+	issues := DetectIssues(evs, 10, 100)
+	found := false
+	for _, s := range issues {
+		if strings.Contains(s, "High connection failure rate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a high connection failure rate issue, got %v", issues)
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/podtrace/podtrace/internal/clock"
 	"github.com/podtrace/podtrace/internal/safeconv"
@@ -37,14 +38,31 @@ func sanitizeString(s string) string {
 	return strings.ReplaceAll(s, "%", "%%")
 }
 
+// truncateString shortens s to at most max bytes without splitting a
+// multi-byte UTF-8 rune, so the result is always valid UTF-8.
 func truncateString(s string, max int) string {
 	if max <= 0 || len(s) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return cutRunes(s, max)
 	}
-	return s[:max-3] + "..."
+	return cutRunes(s, max-3) + "..."
+}
+
+// cutRunes returns s truncated to at most n bytes, backing off to the nearest
+// rune boundary.
+func cutRunes(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n >= len(s) {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }
 
 type EventType uint32

--- a/internal/events/truncate_runesafe_test.go
+++ b/internal/events/truncate_runesafe_test.go
@@ -1,0 +1,19 @@
+package events
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateString_RuneSafe(t *testing.T) {
+	s := "café-service"
+	for max := -1; max <= len(s)+2; max++ {
+		got := truncateString(s, max)
+		if !utf8.ValidString(got) {
+			t.Errorf("truncateString(%q, %d) = %q is not valid UTF-8", s, max, got)
+		}
+		if max > 0 && len(s) > max && len(got) > max {
+			t.Errorf("truncateString(%q, %d) = %q exceeds the %d-byte budget", s, max, got, max)
+		}
+	}
+}

--- a/internal/profiling/correlator.go
+++ b/internal/profiling/correlator.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/podtrace/podtrace/internal/clock"
 	"github.com/podtrace/podtrace/internal/config"
@@ -348,11 +349,31 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 	return sb.String()
 }
 
+// truncate shortens s to at most maxLen bytes. It never panics for small
+// maxLen and never splits a multi-byte UTF-8 rune.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	if maxLen <= 0 || len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + "..."
+	if maxLen <= 3 {
+		return cutRunes(s, maxLen)
+	}
+	return cutRunes(s, maxLen-3) + "..."
+}
+
+// cutRunes returns s truncated to at most n bytes, backing off to the nearest
+// rune boundary so the result is always valid UTF-8.
+func cutRunes(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n >= len(s) {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }
 
 func formatBytes(b int64) string {

--- a/internal/profiling/truncate_runesafe_unit_test.go
+++ b/internal/profiling/truncate_runesafe_unit_test.go
@@ -1,0 +1,19 @@
+package profiling
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncate_RuneSafeNoPanic(t *testing.T) {
+	s := "café"
+	for max := -1; max <= len(s)+2; max++ {
+		got := truncate(s, max)
+		if !utf8.ValidString(got) {
+			t.Errorf("truncate(%q, %d) = %q is not valid UTF-8", s, max, got)
+		}
+	}
+	if got := truncate("hello world", 8); got != "hello..." {
+		t.Errorf("ASCII truncate regressed: got %q, want %q", got, "hello...")
+	}
+}

--- a/internal/tracing/graph/graph.go
+++ b/internal/tracing/graph/graph.go
@@ -3,6 +3,8 @@ package graph
 import (
 	"fmt"
 	"sort"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/podtrace/podtrace/internal/diagnose/tracker"
@@ -35,6 +37,7 @@ type Edge struct {
 }
 
 type GraphBuilder struct {
+	mu    sync.Mutex
 	nodes map[string]*Node
 	edges map[string]*Edge
 }
@@ -47,6 +50,9 @@ func NewGraphBuilder() *GraphBuilder {
 }
 
 func (gb *GraphBuilder) BuildFromTraces(traces []*tracker.Trace) *RequestFlowGraph {
+	gb.mu.Lock()
+	defer gb.mu.Unlock()
+
 	gb.reset()
 
 	for _, trace := range traces {
@@ -199,8 +205,8 @@ func (g *RequestFlowGraph) ToDOT() string {
 	buf += "  node [shape=box];\n\n"
 
 	for _, node := range g.Nodes {
-		label := fmt.Sprintf("%s\\nRequests: %d\\nErrors: %d", node.Service, node.RequestCount, node.ErrorCount)
-		buf += fmt.Sprintf("  \"%s\" [label=\"%s\"];\n", node.ID, label)
+		label := dotEscape(node.Service) + fmt.Sprintf("\\nRequests: %d\\nErrors: %d", node.RequestCount, node.ErrorCount)
+		buf += fmt.Sprintf("  \"%s\" [label=\"%s\"];\n", dotEscape(node.ID), label)
 	}
 
 	buf += "\n"
@@ -210,9 +216,24 @@ func (g *RequestFlowGraph) ToDOT() string {
 		if edge.ErrorCount > 0 {
 			label += fmt.Sprintf("\\nErrors: %d", edge.ErrorCount)
 		}
-		buf += fmt.Sprintf("  \"%s\" -> \"%s\" [label=\"%s\"];\n", edge.Source, edge.Target, label)
+		buf += fmt.Sprintf("  \"%s\" -> \"%s\" [label=\"%s\"];\n", dotEscape(edge.Source), dotEscape(edge.Target), label)
 	}
 
 	buf += "}\n"
 	return buf
+}
+
+// dotEscaper makes a string safe to embed inside a double-quoted DOT string:
+// a service or node ID carrying a quote, backslash, or newline can otherwise
+// break the graph or inject arbitrary DOT.
+var dotEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	"\n", `\n`,
+	"\r", `\r`,
+	"\t", `\t`,
+)
+
+func dotEscape(s string) string {
+	return dotEscaper.Replace(s)
 }

--- a/internal/tracing/graph/graph_hardening_test.go
+++ b/internal/tracing/graph/graph_hardening_test.go
@@ -1,0 +1,41 @@
+package graph
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestToDOT_EscapesQuotesAndNewlines(t *testing.T) {
+	g := &RequestFlowGraph{
+		Nodes: []Node{{ID: `evil"node`, Service: "svc\nline", RequestCount: 1}},
+		Edges: []Edge{{Source: `s"rc`, Target: "tgt\n2", RequestCount: 1}},
+	}
+	out := g.ToDOT()
+
+	for _, raw := range []string{`evil"node`, `s"rc`, "svc\nline", "tgt\n2"} {
+		if strings.Contains(out, raw) {
+			t.Errorf("unescaped %q leaked into DOT:\n%s", raw, out)
+		}
+	}
+	for _, esc := range []string{`evil\"node`, `s\"rc`, `svc\nline`, `tgt\n2`} {
+		if !strings.Contains(out, esc) {
+			t.Errorf("expected escaped %q in DOT:\n%s", esc, out)
+		}
+	}
+}
+
+func TestBuildFromTraces_ConcurrentSafe(t *testing.T) {
+	gb := NewGraphBuilder()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = gb.BuildFromTraces(nil)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
Correctness and robustness hardening across five diagnose/analysis helpers from a review pass; no behavior is added, each change corrects or hardens existing code against malformed input, concurrency, or unbounded growth.

## Fixes
- **DOT injection/breakage** (`tracing/graph`): `ToDOT` interpolated node/edge IDs and service names into quoted DOT strings with no escaping, so a name containing `"` or a newline could break the graph or inject DOT; added `dotEscape` (single-pass replacer for `\ " \n \r \t`) applied to every untrusted field.
- **GraphBuilder data race** (`tracing/graph`): the `nodes`/`edges` maps were mutated without synchronization; added a mutex held for the whole `BuildFromTraces` build so a shared builder used from multiple goroutines cannot race (verified with `-race`).
- **Unsafe truncation** (`profiling`, `events`): `s[:maxLen-3]` panicked for `maxLen < 3` and byte-sliced UTF-8, leaving invalid runes at the boundary; both truncators now clamp small `maxLen` and back off to a rune boundary, so results are always valid UTF-8.
- **Nil dereference** (`diagnose/detector`): `DetectIssues` dereferenced `e.Type` with no nil check; added a nil guard to each `allEvents` loop so a nil entry is skipped rather than dereferenced.
- **Unbounded window growth** (`analysis/criticalpath`): a PID emitting many non-boundary events grew its window's `segments` slice without bound between `Evict` passes (`maxWindows` caps window count, not per-window size); added a per-window cap that folds overflow latency into a single trailing segment, bounding memory while preserving total latency.