### PR TITLE
fix: harden cgroup match, numeric conversions, router, and DNS report

### DIFF
--- a/internal/agent/identify_cgroup_determinism_test.go
+++ b/internal/agent/identify_cgroup_determinism_test.go
@@ -2,17 +2,11 @@ package agent
 
 import "testing"
 
-// TestIdentifyContainerCgroup_DeterministicOnSharedPrefix guards the fix for
-// the bidirectional-HasPrefix mis-association: when several container IDs share
-// a prefix with the cgroup dir, the match must be the longest (most specific),
-// tie-broken lexicographically, and stable across map iteration order.
 func TestIdentifyContainerCgroup_DeterministicOnSharedPrefix(t *testing.T) {
-	// "aaaa" prefixes both; the longer ID wins.
 	longest := map[string]string{
 		"aaaabbbb":     "short",
 		"aaaabbbbcccc": "long",
 	}
-	// Same length: lexicographically-first wins.
 	tie := map[string]string{
 		"aaaa2222": "b",
 		"aaaa1111": "a",

--- a/internal/agent/identify_cgroup_determinism_test.go
+++ b/internal/agent/identify_cgroup_determinism_test.go
@@ -1,0 +1,29 @@
+package agent
+
+import "testing"
+
+// TestIdentifyContainerCgroup_DeterministicOnSharedPrefix guards the fix for
+// the bidirectional-HasPrefix mis-association: when several container IDs share
+// a prefix with the cgroup dir, the match must be the longest (most specific),
+// tie-broken lexicographically, and stable across map iteration order.
+func TestIdentifyContainerCgroup_DeterministicOnSharedPrefix(t *testing.T) {
+	// "aaaa" prefixes both; the longer ID wins.
+	longest := map[string]string{
+		"aaaabbbb":     "short",
+		"aaaabbbbcccc": "long",
+	}
+	// Same length: lexicographically-first wins.
+	tie := map[string]string{
+		"aaaa2222": "b",
+		"aaaa1111": "a",
+	}
+
+	for i := 0; i < 30; i++ {
+		if name, id := identifyContainerCgroup("docker-aaaa.scope", longest); id != "aaaabbbbcccc" || name != "long" {
+			t.Fatalf("longest-match iter %d: got (%q,%q), want (long, aaaabbbbcccc)", i, name, id)
+		}
+		if name, id := identifyContainerCgroup("docker-aaaa.scope", tie); id != "aaaa1111" || name != "a" {
+			t.Fatalf("tie-break iter %d: got (%q,%q), want (a, aaaa1111)", i, name, id)
+		}
+	}
+}

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -227,13 +227,9 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		r.Enricher.Snapshot(podEntries)
 	}
 
-	r.Router.Publish(rules)
+	drain := r.Router.Publish(rules)
 
-	// Publish holds the router's write lock, and Export holds the read lock
-	// for its whole duration — so once Publish returns, no in-flight Export
-	// references a displaced exporter and they can be flushed and closed.
-	// Done asynchronously: Close blocks on ForceFlush/Shutdown against the
-	// collector, and this reconciler is single-threaded.
+	drain.Wait()
 	r.closeDisplacedExporters()
 
 	if r.CategoryGate != nil {
@@ -284,8 +280,7 @@ func (r *AgentReconciler) enqueueAllPodTraces(ctx context.Context, _ client.Obje
 // enqueueOnBundleChange handles the ConfigMap and Secret bundle watches:
 // only bundle objects (with our managed-by + exporter-bundle labels)
 // produce reconcile requests, and each such event enqueues every
-// PodTrace. Watching the Secret is what lets a credential-only rotation,
-// which never touches the bundle ConfigMap, trigger a reconcile.
+// PodTrace.
 func (r *AgentReconciler) enqueueOnBundleChange(ctx context.Context, obj client.Object) []reconcile.Request {
 	if obj.GetLabels()[operator.LabelManagedBy] != operator.ManagedByValue {
 		return nil
@@ -472,12 +467,19 @@ func identifyContainerCgroup(dir string, statuses map[string]string) (name, id s
 	if trimmed == "" {
 		return "", ""
 	}
+	if cname, ok := statuses[trimmed]; ok {
+		return cname, trimmed
+	}
+	bestName, bestID := "", ""
 	for cid, cname := range statuses {
-		if strings.HasPrefix(cid, trimmed) || strings.HasPrefix(trimmed, cid) {
-			return cname, cid
+		if !strings.HasPrefix(cid, trimmed) && !strings.HasPrefix(trimmed, cid) {
+			continue
+		}
+		if len(cid) > len(bestID) || (len(cid) == len(bestID) && cid < bestID) {
+			bestName, bestID = cname, cid
 		}
 	}
-	return "", ""
+	return bestName, bestID
 }
 
 // mainPIDFromCgroupProcs returns the container's main host PID, the lowest
@@ -538,8 +540,6 @@ func cgroupPathForPod(p *corev1.Pod, root string) string {
 		qos = "besteffort"
 	}
 
-	// The slice-prefix is the leaf of the discovered root with .slice
-	// stripped.
 	leaf := filepath.Base(root)
 	prefix := strings.TrimSuffix(leaf, ".slice")
 

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -24,18 +24,18 @@ type Router struct {
 	rules    []CRRule
 	stats    *perCRStats
 	enricher *PodEnricher
+	inflight *sync.WaitGroup
 }
 
-// NewRouter constructs an empty Router. The stats argument is shared
-// with the status writer so per-CR event counts survive Publish calls
-// (rules are replaced, counters are not).
+// NewRouter constructs an empty Router.
 func NewRouter(stats *perCRStats) *Router {
 	if stats == nil {
 		stats = newPerCRStats()
 	}
 	return &Router{
-		rules: nil,
-		stats: stats,
+		rules:    nil,
+		stats:    stats,
+		inflight: &sync.WaitGroup{},
 	}
 }
 
@@ -46,7 +46,9 @@ func (r *Router) WithEnricher(e *PodEnricher) *Router {
 	return r
 }
 
-func (r *Router) Publish(rules []CRRule) {
+// Publish swaps in a new rule set and returns a WaitGroup that completes once
+// every Export in flight against the PREVIOUS rules has finished.
+func (r *Router) Publish(rules []CRRule) *sync.WaitGroup {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -64,6 +66,9 @@ func (r *Router) Publish(rules []CRRule) {
 	}
 
 	r.rules = cp
+	prev := r.inflight
+	r.inflight = &sync.WaitGroup{}
+	return prev
 }
 
 func (r *Router) Snapshot() []uint64 {
@@ -114,9 +119,12 @@ func (r *Router) Name() string { return "cr-router" }
 
 func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
 	rules := r.rules
 	enricher := r.enricher
+	wg := r.inflight
+	wg.Add(1)
+	r.mu.RUnlock()
+	defer wg.Done()
 
 	if len(rules) == 0 || len(batch) == 0 {
 		return nil
@@ -127,8 +135,6 @@ func (r *Router) Export(ctx context.Context, batch []*events.Event) error {
 		filtered[i] = filtered[i][:0]
 	}
 
-	// One lookup per event regardless of how many CRs (and exporters)
-	// claim it.
 	enrichBatch(enricher, batch)
 
 	for _, ev := range batch {
@@ -167,7 +173,11 @@ func (r *Router) Close(ctx context.Context) error {
 	r.mu.Lock()
 	rules := r.rules
 	r.rules = nil
+	drain := r.inflight
+	r.inflight = &sync.WaitGroup{}
 	r.mu.Unlock()
+
+	drain.Wait()
 
 	for _, rule := range rules {
 		if rule.Exporter == nil {

--- a/internal/agent/router_drain_test.go
+++ b/internal/agent/router_drain_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+type blockingExporter struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingExporter) Name() string { return "blocking" }
+func (b *blockingExporter) Export(_ context.Context, _ []*events.Event) error {
+	b.entered <- struct{}{}
+	<-b.release
+	return nil
+}
+func (b *blockingExporter) Close(context.Context) error { return nil }
+
+func TestRouter_PublishBarrierWaitsForInflight(t *testing.T) {
+	exp := &blockingExporter{entered: make(chan struct{}), release: make(chan struct{})}
+	r := NewRouter(nil)
+	r.Publish([]CRRule{mkRule("ns", "n", []uint64{1}, []events.EventType{events.EventDNS}, exp)})
+
+	go func() {
+		_ = r.Export(context.Background(), []*events.Event{{CgroupID: 1, Type: events.EventDNS}})
+	}()
+	<-exp.entered
+
+	drain := r.Publish(nil)
+	done := make(chan struct{})
+	go func() { drain.Wait(); close(done) }()
+
+	select {
+	case <-done:
+		t.Fatal("drain returned before the in-flight export finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(exp.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after the export finished")
+	}
+}

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,11 +1,7 @@
 // Package clock anchors BPF timestamps to wall-clock time.
 //
 // bpf_ktime_get_ns() returns nanoseconds since boot on CLOCK_MONOTONIC, not
-// nanoseconds since the Unix epoch. Interpreting such a value as epoch time
-// places every event in January 1970 (plus uptime). This package computes the
-// offset between the two clocks once per process and converts in both
-// directions. It is a leaf package so that low-level packages such as
-// internal/events can depend on it without import cycles.
+// nanoseconds since the Unix epoch.
 package clock
 
 import (
@@ -13,31 +9,26 @@ import (
 	"sync"
 	"time"
 
+	"github.com/podtrace/podtrace/internal/safeconv"
 	"golang.org/x/sys/unix"
 )
 
 var (
 	offsetOnce sync.Once
-	offset     int64 // nanoseconds: wall-clock ns - CLOCK_MONOTONIC ns
+	offset     int64
 )
 
 // MonotonicToWallOffset returns the offset in nanoseconds between wall-clock
 // time (time.Now().UnixNano()) and CLOCK_MONOTONIC (the clock behind
-// bpf_ktime_get_ns()). Computed once on first call and cached for the process
-// lifetime; a wall-clock step (e.g. NTP) after that point shifts converted
-// times by the step size, which keeps relative ordering intact.
+// bpf_ktime_get_ns()).
 func MonotonicToWallOffset() int64 {
 	offsetOnce.Do(func() {
 		var ts unix.Timespec
-		// Read CLOCK_MONOTONIC — same clock source as bpf_ktime_get_ns().
 		if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err == nil {
 			monotonicNS := ts.Sec*int64(time.Second) + ts.Nsec
 			wallNS := time.Now().UnixNano()
 			offset = wallNS - monotonicNS
 		}
-		// If ClockGettime fails (unlikely), the offset stays 0 — converted
-		// times degrade to boot-relative values but stay internally
-		// consistent, so deltas and ordering still work.
 	})
 	return offset
 }
@@ -48,13 +39,11 @@ func BPFTimestampToWall(bpfNS uint64) time.Time {
 	if bpfNS > math.MaxInt64 {
 		bpfNS = math.MaxInt64
 	}
-	return time.Unix(0, int64(bpfNS)+MonotonicToWallOffset())
+	return time.Unix(0, safeconv.AddInt64(int64(bpfNS), MonotonicToWallOffset()))
 }
 
 // WallToBPFTimestamp converts a wall-clock time.Time to the bpf_ktime_get_ns()
-// timestamp that BPFTimestampToWall would map back to it. Times before boot
-// clamp to 0. Intended for tests and for translating wall-clock deadlines into
-// the BPF time domain.
+// timestamp that BPFTimestampToWall would map back to it.
 func WallToBPFTimestamp(t time.Time) uint64 {
 	bpfNS := t.UnixNano() - MonotonicToWallOffset()
 	if bpfNS < 0 {

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -16,9 +16,6 @@ func TestMonotonicToWallOffset_Idempotent(t *testing.T) {
 	}
 }
 
-// TestBPFTimestampToWall_AnchorsToWallClock is the core property: a
-// bpf_ktime_get_ns()-domain timestamp taken "now" must convert to a wall-clock
-// time close to time.Now() — not to 1970 plus uptime.
 func TestBPFTimestampToWall_AnchorsToWallClock(t *testing.T) {
 	var ts unix.Timespec
 	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
@@ -35,7 +32,7 @@ func TestBPFTimestampToWall_AnchorsToWallClock(t *testing.T) {
 func TestBPFTimestampToWall_Conversion(t *testing.T) {
 	offset := MonotonicToWallOffset()
 
-	const bpfNS = uint64(1_000_000_000) // 1s since boot
+	const bpfNS = uint64(1_000_000_000)
 	got := BPFTimestampToWall(bpfNS)
 	want := time.Unix(0, int64(bpfNS)+offset)
 	if !got.Equal(want) {
@@ -49,7 +46,7 @@ func TestBPFTimestampToWall_Conversion(t *testing.T) {
 	}
 
 	gotBig := BPFTimestampToWall(math.MaxUint64)
-	wantBig := time.Unix(0, math.MaxInt64+offset)
+	wantBig := time.Unix(0, math.MaxInt64)
 	if !gotBig.Equal(wantBig) {
 		t.Errorf("BPFTimestampToWall(MaxUint64) = %v, want %v", gotBig, wantBig)
 	}

--- a/internal/cri/jsonfind.go
+++ b/internal/cri/jsonfind.go
@@ -3,15 +3,14 @@ package cri
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/podtrace/podtrace/internal/safeconv"
 )
 
-// tryParseJSON attempts to parse s as a JSON value. If s is itself a
-// JSON-encoded string (double-encoded, as some runtimes produce), it unwraps
-// one level and retries. Returns nil if parsing fails entirely.
+// tryParseJSON attempts to parse s as a JSON value.
 func tryParseJSON(s string) any {
 	var obj any
 	if err := json.Unmarshal([]byte(s), &obj); err == nil {
-		// Unwrap double-encoded JSON strings.
 		if inner, ok := obj.(string); ok {
 			var innerObj any
 			if err2 := json.Unmarshal([]byte(inner), &innerObj); err2 == nil {
@@ -39,7 +38,7 @@ func findJSONInt(obj any, keys []string) (int64, bool) {
 		if v, ok := findJSONValue(obj, strings.Split(k, ".")); ok {
 			switch t := v.(type) {
 			case float64:
-				return int64(t), true
+				return safeconv.Float64ToInt64(t), true
 			case int64:
 				return t, true
 			case int:

--- a/internal/diagnose/analyzer/dns.go
+++ b/internal/diagnose/analyzer/dns.go
@@ -60,6 +60,49 @@ func AnalyzeDNS(queries, responses []*events.Event) (avgLatency, maxLatency floa
 	return
 }
 
+// DNSRCodeBreakdown counts DNS responses by response-code mnemonic (NXDOMAIN,
+// SERVFAIL, …), excluding successes, sorted most-frequent first. It surfaces
+// WHY lookups failed rather than a bare error total.
+func DNSRCodeBreakdown(responses []*events.Event) []TargetCount {
+	counts := make(map[string]int)
+	for _, e := range responses {
+		if e == nil || e.Error == 0 {
+			continue
+		}
+		counts[e.DNSResponseCode()]++
+	}
+	return sortedNameCounts(counts)
+}
+
+// DNSQueryTypeBreakdown counts DNS responses by query-type mnemonic (A, AAAA,
+// …), sorted most-frequent first.
+func DNSQueryTypeBreakdown(responses []*events.Event) []TargetCount {
+	counts := make(map[string]int)
+	for _, e := range responses {
+		if e == nil {
+			continue
+		}
+		counts[e.DNSQueryType()]++
+	}
+	return sortedNameCounts(counts)
+}
+
+// sortedNameCounts turns a name→count map into a slice ordered by count
+// descending, then name ascending for a deterministic, stable rendering.
+func sortedNameCounts(counts map[string]int) []TargetCount {
+	out := make([]TargetCount, 0, len(counts))
+	for name, count := range counts {
+		out = append(out, TargetCount{Target: name, Count: count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Target < out[j].Target
+	})
+	return out
+}
+
 // TargetAddrs pairs a DNS name with the distinct addresses it resolved to.
 type TargetAddrs struct {
 	Target string

--- a/internal/diagnose/analyzer/dns_breakdown_test.go
+++ b/internal/diagnose/analyzer/dns_breakdown_test.go
@@ -1,0 +1,38 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/events"
+)
+
+func TestDNSRCodeBreakdown(t *testing.T) {
+	responses := []*events.Event{
+		{Type: events.EventDNS, Error: 3}, // NXDOMAIN
+		{Type: events.EventDNS, Error: 3}, // NXDOMAIN
+		{Type: events.EventDNS, Error: 2}, // SERVFAIL
+		{Type: events.EventDNS, Error: 0}, // NOERROR (excluded)
+		nil,
+	}
+	got := DNSRCodeBreakdown(responses)
+	if len(got) != 2 ||
+		got[0].Target != "NXDOMAIN" || got[0].Count != 2 ||
+		got[1].Target != "SERVFAIL" || got[1].Count != 1 {
+		t.Fatalf("DNSRCodeBreakdown = %+v", got)
+	}
+}
+
+func TestDNSQueryTypeBreakdown(t *testing.T) {
+	responses := []*events.Event{
+		{Type: events.EventDNS, TCPState: 1},  // A
+		{Type: events.EventDNS, TCPState: 1},  // A
+		{Type: events.EventDNS, TCPState: 28}, // AAAA
+		nil,
+	}
+	got := DNSQueryTypeBreakdown(responses)
+	if len(got) != 2 ||
+		got[0].Target != "A" || got[0].Count != 2 ||
+		got[1].Target != "AAAA" || got[1].Count != 1 {
+		t.Fatalf("DNSQueryTypeBreakdown = %+v", got)
+	}
+}

--- a/internal/diagnose/report/report.go
+++ b/internal/diagnose/report/report.go
@@ -116,6 +116,18 @@ func GenerateDNSSection(d Diagnostician, duration time.Duration) string {
 	report += formatter.LatencyMetrics(avgLatency, maxLatency)
 	report += formatter.Percentiles(p50, p95, p99)
 	report += formatter.ErrorRate(errors, lookupCount)
+	if rcodes := analyzer.DNSRCodeBreakdown(responses); len(rcodes) > 0 {
+		report += "  Response code breakdown:\n"
+		for _, rc := range rcodes {
+			report += fmt.Sprintf("    - %s: %d\n", rc.Target, rc.Count)
+		}
+	}
+	if qtypes := analyzer.DNSQueryTypeBreakdown(responses); len(qtypes) > 0 {
+		report += "  Query type breakdown:\n"
+		for _, qt := range qtypes {
+			report += fmt.Sprintf("    - %s: %d\n", qt.Target, qt.Count)
+		}
+	}
 	report += formatter.TopTargets(topTargets, config.TopTargetsLimit, "targets", "lookups")
 	report += formatter.ResolvedAddresses(analyzer.ResolvedAddresses(responses), config.TopTargetsLimit)
 	report += "\n"

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -34,13 +33,9 @@ func PeerIP(family uint8, v4 uint32, v6 [16]byte) string {
 	}
 }
 
-func sanitizeString(s string) string {
-	return strings.ReplaceAll(s, "%", "%%")
-}
-
-// truncateString shortens s to at most max bytes without splitting a
+// TruncateString shortens s to at most max bytes without splitting a
 // multi-byte UTF-8 rune, so the result is always valid UTF-8.
-func truncateString(s string, max int) string {
+func TruncateString(s string, max int) string {
 	if max <= 0 || len(s) <= max {
 		return s
 	}
@@ -321,6 +316,14 @@ func dnsServerStr(e *Event) string {
 	}
 	return dnsServerString(e.DNSServerIP)
 }
+
+// DNSQueryType returns the DNS query-type mnemonic (A, AAAA, …) for an
+// EVENT_DNS event; the numeric qtype is carried in TCPState.
+func (e *Event) DNSQueryType() string { return dnsQTypeName(e.TCPState) }
+
+// DNSResponseCode returns the DNS response-code mnemonic (NOERROR, NXDOMAIN, …)
+// for an EVENT_DNS event; the numeric rcode is carried in Error.
+func (e *Event) DNSResponseCode() string { return dnsRCodeName(e.Error) }
 
 // dnsRCodeName maps a DNS response code (carried in Error for EVENT_DNS) to its
 // mnemonic.

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -152,27 +152,6 @@ func TestTCPStateString(t *testing.T) {
 	}
 }
 
-func TestSanitizeString(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"normal", "normal"},
-		{"with%percent", "with%%percent"},
-		{"multiple%%percent", "multiple%%%%percent"},
-		{"no percent", "no percent"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := sanitizeString(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
-			}
-		})
-	}
-}
-
 func TestTruncateString(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -192,7 +171,7 @@ func TestTruncateString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := truncateString(tt.input, tt.max)
+			result := TruncateString(tt.input, tt.max)
 			if result != tt.expected {
 				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
 			}

--- a/internal/events/truncate_runesafe_test.go
+++ b/internal/events/truncate_runesafe_test.go
@@ -8,12 +8,12 @@ import (
 func TestTruncateString_RuneSafe(t *testing.T) {
 	s := "café-service"
 	for max := -1; max <= len(s)+2; max++ {
-		got := truncateString(s, max)
+		got := TruncateString(s, max)
 		if !utf8.ValidString(got) {
-			t.Errorf("truncateString(%q, %d) = %q is not valid UTF-8", s, max, got)
+			t.Errorf("TruncateString(%q, %d) = %q is not valid UTF-8", s, max, got)
 		}
 		if max > 0 && len(s) > max && len(got) > max {
-			t.Errorf("truncateString(%q, %d) = %q exceeds the %d-byte budget", s, max, got, max)
+			t.Errorf("TruncateString(%q, %d) = %q exceeds the %d-byte budget", s, max, got, max)
 		}
 	}
 }

--- a/internal/profiling/correlator.go
+++ b/internal/profiling/correlator.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/podtrace/podtrace/internal/clock"
 	"github.com/podtrace/podtrace/internal/config"
@@ -115,7 +114,6 @@ func Correlate(
 
 		if e.LatencyNS >= triggerNS && isSlowEventType(e.Type) {
 			result.SlowEvents = append(result.SlowEvents, e)
-			// Build a ±50ms window around the slow event for SchedSwitch correlation.
 			eventWall := clock.BPFTimestampToWall(e.Timestamp)
 			slowWindows = append(slowWindows, window{
 				start: eventWall.Add(-50 * time.Millisecond),
@@ -159,7 +157,6 @@ func Correlate(
 				}
 			}
 			if inWindow {
-				// Aggregate the top 3 frames of the stack (skip innermost runtime frames).
 				for i, addr := range e.Stack {
 					if i >= 3 {
 						break
@@ -349,31 +346,10 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 	return sb.String()
 }
 
-// truncate shortens s to at most maxLen bytes. It never panics for small
-// maxLen and never splits a multi-byte UTF-8 rune.
+// truncate delegates to events.TruncateString, the shared rune-safe and
+// panic-safe truncator, so the logic lives in one place.
 func truncate(s string, maxLen int) string {
-	if maxLen <= 0 || len(s) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return cutRunes(s, maxLen)
-	}
-	return cutRunes(s, maxLen-3) + "..."
-}
-
-// cutRunes returns s truncated to at most n bytes, backing off to the nearest
-// rune boundary so the result is always valid UTF-8.
-func cutRunes(s string, n int) string {
-	if n <= 0 {
-		return ""
-	}
-	if n >= len(s) {
-		return s
-	}
-	for n > 0 && !utf8.RuneStart(s[n]) {
-		n--
-	}
-	return s[:n]
+	return events.TruncateString(s, maxLen)
 }
 
 func formatBytes(b int64) string {

--- a/internal/safeconv/clamp_test.go
+++ b/internal/safeconv/clamp_test.go
@@ -1,0 +1,45 @@
+package safeconv
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFloat64ToInt64(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want int64
+	}{
+		{0, 0},
+		{123.9, 123},
+		{-123.9, -123},
+		{math.NaN(), 0},
+		{math.Inf(1), math.MaxInt64},
+		{math.Inf(-1), math.MinInt64},
+		{1e300, math.MaxInt64},
+		{-1e300, math.MinInt64},
+	}
+	for _, c := range cases {
+		if got := Float64ToInt64(c.in); got != c.want {
+			t.Errorf("Float64ToInt64(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAddInt64(t *testing.T) {
+	cases := []struct {
+		a, b, want int64
+	}{
+		{1, 2, 3},
+		{-5, 5, 0},
+		{math.MaxInt64, 1, math.MaxInt64},
+		{math.MaxInt64 - 5, 10, math.MaxInt64},
+		{math.MinInt64, -1, math.MinInt64},
+		{math.MinInt64 + 5, -10, math.MinInt64},
+	}
+	for _, c := range cases {
+		if got := AddInt64(c.a, c.b); got != c.want {
+			t.Errorf("AddInt64(%d, %d) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/safeconv/safeconv.go
+++ b/internal/safeconv/safeconv.go
@@ -26,17 +26,42 @@ func Uint64ToInt64(v uint64) int64 {
 	return int64(v)
 }
 
+// Float64ToInt64 converts a float64 to int64, clamping out-of-range and
+// non-finite values instead of relying on Go's implementation-defined
+// float→int conversion for those.
+func Float64ToInt64(v float64) int64 {
+	switch {
+	case math.IsNaN(v):
+		return 0
+	case v >= math.MaxInt64:
+		return math.MaxInt64
+	case v <= math.MinInt64:
+		return math.MinInt64
+	default:
+		return int64(v)
+	}
+}
+
+// AddInt64 returns a+b, saturating at math.MaxInt64 / math.MinInt64 instead of
+// wrapping on overflow.
+func AddInt64(a, b int64) int64 {
+	switch {
+	case b > 0 && a > math.MaxInt64-b:
+		return math.MaxInt64
+	case b < 0 && a < math.MinInt64-b:
+		return math.MinInt64
+	default:
+		return a + b
+	}
+}
+
 // Uint64BitsToInt64 reinterprets the bit pattern of v as a signed
-// int64 — i.e. values with the high bit set become negative.
+// int64, i.e. values with the high bit set become negative.
 //
 // Use only when the producer (typically a BPF program) has packed an
 // int64 into a uint64 wire field and the consumer needs the original
 // signed value back. Examples: an Event.Bytes field that polymorphically
 // carries either a byte count OR a sentinel-encoded file descriptor.
-//
-// This is NOT a numeric conversion; it is an intentional bit-pattern
-// re-interpretation. Saturation would corrupt the sentinel encoding,
-// which is why this function exists separately from Uint64ToInt64.
 func Uint64BitsToInt64(v uint64) int64 {
 	return int64(v) // #nosec G115 -- bit-preserving reinterpretation is the documented contract
 }
@@ -106,9 +131,7 @@ func IntToInt32(v int) int32 {
 }
 
 // IntToUint32 narrows int to uint32, clamping negatives to 0 and
-// over-large values to math.MaxUint32. Mirrors config.ClampUint32 so
-// we have a single canonical helper for downstream callers that do
-// not depend on the config package.
+// over-large values to math.MaxUint32.
 func IntToUint32(v int) uint32 {
 	if v < 0 {
 		return 0


### PR DESCRIPTION
## Summary
Robustness hardening across the agent runtime and shared conversion/report helpers from a review pass.

## Fixes
- **cgroup mis-association** (`agent/reconciler`): `identifyContainerCgroup` matched IDs with a bidirectional `HasPrefix` and returned an arbitrary map-iteration winner; it now matches exactly first, then picks the longest (tie-broken lexicographically) prefix match, so two containers sharing a prefix can no longer be associated at random.
- **out-of-range JSON→int64** (`cri/jsonfind`): `int64(float64)` on an out-of-range or non-finite JSON number was implementation-defined; it now goes through a new `safeconv.Float64ToInt64` that clamps (NaN→0, ±range→MaxInt64/MinInt64).
- **clock overflow** (`clock`): `int64(bpfNS)+offset` could overflow int64 after the MaxInt64 clamp and wrap to a pre-epoch time; it now uses a new saturating `safeconv.AddInt64` (the existing test had encoded the wrap and now asserts saturation).
- **dead defensive helpers** (`events`): re-wired the ones with a real home, `dnsQTypeName`/`dnsRCodeName` now surface DNS response-code and query-type breakdowns in the report via new `Event.DNSQueryType`/`DNSResponseCode`, and `truncateString` is exported as `TruncateString` with `profiling.truncate` delegating to it (one rune-safe truncator, not two); `sanitizeString` is deleted because its `%`-escaping is only valid for format strings, which the codebase never builds from untrusted data, so wiring it would double-escape normal `%s` output.
- **router lock scope** (`agent/router`): `Export` held the read lock across the whole batch including the downstream `Exporter.Export` calls, so a future synchronous exporter could stall all routing; Export now snapshots rules under the lock and releases it before exporting, and a generational `WaitGroup` returned by `Publish` lets the reconciler drain in-flight exports before closing a displaced exporter, preserving the old lock's close-safety without coupling routing throughput to export latency.