### PR TITLE
test: expand unit-test coverage across cmd and internal packages

### DIFF
--- a/cmd/podtrace/cli_pure_helpers_test.go
+++ b/cmd/podtrace/cli_pure_helpers_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/podtrace/podtrace/internal/config"
+	"github.com/podtrace/podtrace/internal/events"
+	"github.com/podtrace/podtrace/internal/kubernetes"
+	"github.com/podtrace/podtrace/internal/kubernetes/nodespawn"
+)
+
+func TestFilterEvents_CryptoFilter(t *testing.T) {
+	in := make(chan *events.Event, 3)
+	out := make(chan *events.Event, 3)
+
+	go func() {
+		defer close(in)
+		in <- &events.Event{Type: events.EventAFALG}
+		in <- &events.Event{Type: events.EventConnect}
+		in <- &events.Event{Type: events.EventAFALG}
+	}()
+
+	go filterEvents(context.Background(), in, out, "crypto")
+
+	count := 0
+	for ev := range out {
+		if ev.Type != events.EventAFALG {
+			t.Errorf("crypto filter passed a non-AFALG event: %v", ev.Type)
+		}
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected 2 crypto events, got %d", count)
+	}
+}
+
+func TestPodContainerTargets_NilReturnsNil(t *testing.T) {
+	if got := podContainerTargets(nil); got != nil {
+		t.Errorf("podContainerTargets(nil) = %v, want nil", got)
+	}
+}
+
+func TestPodContainerTargets_UsesContainersList(t *testing.T) {
+	p := &kubernetes.PodInfo{
+		Containers: []kubernetes.ContainerTarget{
+			{Name: "a", ID: "id-a", CgroupPath: "/cg/a"},
+			{Name: "b", ID: "id-b", CgroupPath: "/cg/b"},
+		},
+	}
+	got := podContainerTargets(p)
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Fatalf("expected the pod's Containers list verbatim, got %+v", got)
+	}
+}
+
+func TestPodContainerTargets_FallsBackToSingularFields(t *testing.T) {
+	p := &kubernetes.PodInfo{
+		ContainerName: "solo",
+		ContainerID:   "id-solo",
+		CgroupPath:    "/cg/solo",
+	}
+	got := podContainerTargets(p)
+	if len(got) != 1 {
+		t.Fatalf("expected a single synthesized target, got %d", len(got))
+	}
+	if got[0].Name != "solo" || got[0].ID != "id-solo" || got[0].CgroupPath != "/cg/solo" {
+		t.Fatalf("synthesized target lost the singular fields: %+v", got[0])
+	}
+}
+
+func TestApplyTracingFlags_JaegerSplunkSynthesize(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	origSynthesizeFlag := enableSynthesizeSpans
+	origSynthesizeConfig := config.SynthesizeSpans
+	t.Cleanup(func() {
+		enableSynthesizeSpans = origSynthesizeFlag
+		config.SynthesizeSpans = origSynthesizeConfig
+	})
+	defer resetTracingConfig()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolVar(&enableTracing, "tracing", false, "")
+	cmd.Flags().StringVar(&tracingJaegerEndpoint, "tracing-jaeger-endpoint", "", "")
+	cmd.Flags().StringVar(&tracingSplunkEndpoint, "tracing-splunk-endpoint", "", "")
+	cmd.Flags().StringVar(&tracingSplunkToken, "tracing-splunk-token", "", "")
+	cmd.Flags().BoolVar(&enableSynthesizeSpans, "tracing-synthesize-spans", false, "")
+
+	for flag, value := range map[string]string{
+		"tracing":                  "true",
+		"tracing-jaeger-endpoint":  "jaeger:4318",
+		"tracing-splunk-endpoint":  "splunk:8088",
+		"tracing-splunk-token":     "hec-token",
+		"tracing-synthesize-spans": "true",
+	} {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			t.Fatalf("set %s: %v", flag, err)
+		}
+	}
+
+	if err := applyTracingFlags(cmd); err != nil {
+		t.Fatalf("applyTracingFlags: %v", err)
+	}
+	if !config.TracingEnabled {
+		t.Error("TracingEnabled not set")
+	}
+	if config.JaegerEndpoint != "jaeger:4318" {
+		t.Errorf("JaegerEndpoint=%q, want jaeger:4318", config.JaegerEndpoint)
+	}
+	if config.SplunkEndpoint != "splunk:8088" {
+		t.Errorf("SplunkEndpoint=%q, want splunk:8088", config.SplunkEndpoint)
+	}
+	if config.SplunkToken != "hec-token" {
+		t.Errorf("SplunkToken=%q, want hec-token", config.SplunkToken)
+	}
+	if !config.SynthesizeSpans {
+		t.Error("SynthesizeSpans not set by --tracing-synthesize-spans")
+	}
+}
+
+type unwrapToNilError struct{}
+
+func (unwrapToNilError) Error() string { return "unwrap-nil" }
+func (unwrapToNilError) Unwrap() error { return nil }
+
+func TestErrorsAs_UnwrapChainEndsAtNil(t *testing.T) {
+	var target *nodespawn.ExitError
+	if errorsAs(unwrapToNilError{}, &target) {
+		t.Fatal("errorsAs must return false when the chain unwraps to nil without matching")
+	}
+	if target != nil {
+		t.Fatalf("target must stay nil, got %#v", target)
+	}
+}
+
+func TestErrorsAs_DeepWrappedExitError(t *testing.T) {
+	base := &nodespawn.ExitError{Code: 3, Node: "n"}
+	chain := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", base))
+
+	var target *nodespawn.ExitError
+	if !errorsAs(chain, &target) {
+		t.Fatal("errorsAs must find an ExitError two levels deep")
+	}
+	if target == nil || target.Code != 3 {
+		t.Fatalf("unexpected unwrapped target: %#v", target)
+	}
+}

--- a/cmd/podtrace/session_artifacts_error_test.go
+++ b/cmd/podtrace/session_artifacts_error_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/podtrace/podtrace/internal/config"
+)
+
+func TestEmitSessionArtifacts_AggregatesSinkErrors(t *testing.T) {
+	saveSinkGlobals(t)
+	t.Setenv(config.EnvArtifactBaseDir, "")
+
+	dir := t.TempDir()
+	summaryFile = filepath.Join(dir, "missing-summary-dir", "summary.json")
+	terminationMessagePath = filepath.Join(dir, "missing-term-dir", "term.json")
+	reportTo = ""
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := emitSessionArtifacts(ctx, SessionSummary{TotalEvents: 1}, "report body")
+	if err == nil {
+		t.Fatal("expected an aggregated error when both file sinks fail")
+	}
+	if !strings.Contains(err.Error(), "summary-file:") {
+		t.Errorf("expected summary-file failure in aggregated error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "termination-message:") {
+		t.Errorf("expected termination-message failure in aggregated error, got %v", err)
+	}
+}

--- a/cmd/podtrace/watch_validate_test.go
+++ b/cmd/podtrace/watch_validate_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeriveWatchName_RejectsOver63Chars(t *testing.T) {
+	long := strings.Repeat("a", 64)
+	_, err := deriveWatchName(watchOptions{Name: long})
+	if err == nil || !strings.Contains(err.Error(), "exceeds 63 characters") {
+		t.Fatalf("expected a 63-character-limit error for a valid but overlong DNS name, got %v", err)
+	}
+}
+
+func TestDeriveWatchName_AppNameDerivesResourceName(t *testing.T) {
+	name, err := deriveWatchName(watchOptions{AppName: "Checkout"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "checkout" {
+		t.Fatalf("expected lowercased app name, got %q", name)
+	}
+}
+
+func TestCommonTargetValidate_InvalidNamespace(t *testing.T) {
+	opts := watchOptions{
+		Namespace:     "Bad_NS",
+		Exporter:      "default",
+		SamplePercent: -1,
+	}
+	_, _, _, err := commonTargetValidate(opts)
+	if err == nil || !strings.Contains(err.Error(), "invalid namespace") {
+		t.Fatalf("expected invalid-namespace error, got %v", err)
+	}
+}
+
+func TestCommonTargetValidate_InvalidNamespaceSelector(t *testing.T) {
+	opts := watchOptions{
+		Namespace:         "default",
+		Exporter:          "default",
+		NamespaceSelector: "@@@",
+		SamplePercent:     -1,
+	}
+	_, _, _, err := commonTargetValidate(opts)
+	if err == nil || !strings.Contains(err.Error(), "invalid --namespace-selector") {
+		t.Fatalf("expected invalid namespace-selector error, got %v", err)
+	}
+}

--- a/internal/agent/scan_pod_cgroups_test.go
+++ b/internal/agent/scan_pod_cgroups_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestScanPodCgroups_SkipsPodWithNoCgroupDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "kubepods.slice")
+	uidUnder := strings.ReplaceAll(testPodUID, "-", "_")
+	resolvable := filepath.Join(root,
+		"kubepods-besteffort.slice",
+		"kubepods-besteffort-pod"+uidUnder+".slice",
+	)
+	if err := os.MkdirAll(resolvable, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	withKubepodsRoot(t, root)
+
+	resolved := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "resolved", Namespace: "ns", UID: types.UID(testPodUID)},
+		Status:     corev1.PodStatus{QOSClass: corev1.PodQOSBestEffort},
+	}
+	unresolved := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "unresolved", Namespace: "ns", UID: "no-such-pod-uid"},
+		Status:     corev1.PodStatus{QOSClass: corev1.PodQOSBestEffort},
+	}
+
+	entries := scanPodCgroups([]*corev1.Pod{resolved, unresolved})
+	for _, e := range entries {
+		if e.Pod == unresolved {
+			t.Fatalf("pod without a cgroup directory must be skipped, got entry %+v", e)
+		}
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least the resolvable pod's entry")
+	}
+}
+
+func TestScanPodCgroups_SkipsWhenPodPathIsNotADirectory(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "kubepods.slice")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	uidUnder := strings.ReplaceAll(testPodUID, "-", "_")
+	podPathAsFile := filepath.Join(root, "kubepods-pod"+uidUnder+".slice")
+	if err := os.WriteFile(podPathAsFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	withKubepodsRoot(t, root)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "filepod", Namespace: "ns", UID: types.UID(testPodUID)},
+		Status:     corev1.PodStatus{QOSClass: corev1.PodQOSBestEffort},
+	}
+
+	entries := scanPodCgroups([]*corev1.Pod{pod})
+	for _, e := range entries {
+		if e.ContainerName != "" {
+			t.Fatalf("no container entries expected when the pod path is a file, got %+v", e)
+		}
+	}
+}

--- a/internal/ebpf/probes/dwarffixture_test.go
+++ b/internal/ebpf/probes/dwarffixture_test.go
@@ -1,0 +1,89 @@
+package probes
+
+import (
+	"debug/dwarf"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	fixtureOnce sync.Once
+	fixtureBin  string
+	fixtureErr  error
+)
+
+const fixtureSource = `package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+var sink any
+
+func main() {
+	var a net.UDPAddr
+	var r http.Request
+	var resp http.Response
+	var u url.URL
+	var o sync.Once
+	sink = []any{&a, &r, &resp, &u, &o}
+	fmt.Println(sink)
+}
+`
+
+func buildGoFixture() {
+	goTool, err := exec.LookPath("go")
+	if err != nil {
+		fixtureErr = err
+		return
+	}
+	dir, err := os.MkdirTemp("", "probesdwarffix")
+	if err != nil {
+		fixtureErr = err
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(fixtureSource), 0o644); err != nil {
+		fixtureErr = err
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module probesdwarffix\ngo 1.21\n"), 0o644); err != nil {
+		fixtureErr = err
+		return
+	}
+	bin := filepath.Join(dir, "fixture")
+	cmd := exec.Command(goTool, "build", "-o", bin, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fixtureErr = fmt.Errorf("go build: %v\n%s", err, out)
+		return
+	}
+	fixtureBin = bin
+}
+
+func goFixtureBinary(t *testing.T) string {
+	t.Helper()
+	fixtureOnce.Do(buildGoFixture)
+	if fixtureErr != nil {
+		t.Skipf("cannot build Go fixture binary: %v", fixtureErr)
+	}
+	return fixtureBin
+}
+
+func fixtureDWARF(t *testing.T) (*dwarf.Data, func(), map[string]dwarf.Offset) {
+	t.Helper()
+	bin := goFixtureBinary(t)
+	d, cleanup, ok := openDWARF(bin)
+	if !ok {
+		t.Skip("fixture binary carries no readable DWARF")
+	}
+	return d, cleanup, indexDWARFStructs(d)
+}

--- a/internal/ebpf/probes/elffixture_test.go
+++ b/internal/ebpf/probes/elffixture_test.go
@@ -1,0 +1,83 @@
+package probes
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+)
+
+type fixtureSection struct {
+	name string
+	typ  uint32
+	data []byte
+}
+
+func buildELFWithSections(secs []fixtureSection) []byte {
+	le := binary.LittleEndian
+	const ehsize = 64
+	const shentsize = 64
+
+	shstr := []byte{0}
+	nameOff := make([]uint32, len(secs))
+	for i, s := range secs {
+		nameOff[i] = uint32(len(shstr))
+		shstr = append(shstr, s.name...)
+		shstr = append(shstr, 0)
+	}
+	shstrtabNameOff := uint32(len(shstr))
+	shstr = append(shstr, ".shstrtab"...)
+	shstr = append(shstr, 0)
+
+	var buf bytes.Buffer
+	buf.Write(make([]byte, ehsize))
+	dataOff := make([]uint64, len(secs))
+	for i, s := range secs {
+		dataOff[i] = uint64(buf.Len())
+		buf.Write(s.data)
+	}
+	shstrOff := uint64(buf.Len())
+	buf.Write(shstr)
+	for buf.Len()%8 != 0 {
+		buf.WriteByte(0)
+	}
+	shoff := uint64(buf.Len())
+
+	writeSH := func(no, typ uint32, off, size uint64) {
+		h := make([]byte, shentsize)
+		le.PutUint32(h[0:], no)
+		le.PutUint32(h[4:], typ)
+		le.PutUint64(h[24:], off)
+		le.PutUint64(h[32:], size)
+		le.PutUint64(h[48:], 1)
+		buf.Write(h)
+	}
+	buf.Write(make([]byte, shentsize))
+	for i, s := range secs {
+		writeSH(nameOff[i], s.typ, dataOff[i], uint64(len(s.data)))
+	}
+	writeSH(shstrtabNameOff, 3, shstrOff, uint64(len(shstr)))
+
+	out := buf.Bytes()
+	copy(out[0:], []byte{0x7f, 'E', 'L', 'F'})
+	out[4] = 2
+	out[5] = 1
+	out[6] = 1
+	le.PutUint16(out[16:], 2)
+	le.PutUint16(out[18:], 0x3e)
+	le.PutUint32(out[20:], 1)
+	le.PutUint16(out[52:], ehsize)
+	nsec := len(secs) + 2
+	le.PutUint64(out[40:], shoff)
+	le.PutUint16(out[58:], shentsize)
+	le.PutUint16(out[60:], uint16(nsec))
+	le.PutUint16(out[62:], uint16(nsec-1))
+	return out
+}
+
+func elfFromSections(secs []fixtureSection) (*elf.File, error) {
+	return elf.NewFile(bytes.NewReader(buildELFWithSections(secs)))
+}
+
+func emptyELF() (*elf.File, error) {
+	return elfFromSections(nil)
+}

--- a/internal/ebpf/probes/gosym_offsets_test.go
+++ b/internal/ebpf/probes/gosym_offsets_test.go
@@ -1,0 +1,90 @@
+package probes
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestVaddrToFileOffset(t *testing.T) {
+	bin := goFixtureBinary(t)
+	f, err := openELFCapped(bin)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	vaddr, ok := symbolVaddr(f, "runtime.main")
+	if !ok {
+		t.Fatal("could not resolve runtime.main vaddr")
+	}
+	off, ok := vaddrToFileOffset(f, vaddr)
+	if !ok {
+		t.Fatal("vaddrToFileOffset failed for a valid text vaddr")
+	}
+	if off == 0 || off > vaddr {
+		t.Errorf("file offset %#x implausible for vaddr %#x", off, vaddr)
+	}
+
+	if _, ok := vaddrToFileOffset(f, 0xffffffffffff0000); ok {
+		t.Error("vaddrToFileOffset must fail for a vaddr outside every PT_LOAD")
+	}
+}
+
+func TestGoSymbolFileOffsetMissingFile(t *testing.T) {
+	if _, ok := goSymbolFileOffset(filepath.Join(t.TempDir(), "nope"), "runtime.main"); ok {
+		t.Error("expected ok=false for a missing binary")
+	}
+}
+
+func TestGoSymbolFileOffsetNoPclntab(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-pclntab")
+	if err := os.WriteFile(path, buildELFWithSections(nil), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := goSymbolFileOffset(path, "runtime.main"); ok {
+		t.Error("expected ok=false for an ELF without .gopclntab")
+	}
+}
+
+func TestExecutableExportsSSLNegative(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("scans the test binary's symbol tables")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot find test executable: %v", err)
+	}
+	if executableExportsSSL(exe) {
+		t.Error("a pure-Go test binary must not export SSL_write")
+	}
+	if executableExportsSSL(filepath.Join(t.TempDir(), "missing")) {
+		t.Error("a missing binary must not report SSL exports")
+	}
+}
+
+func TestExecutableExportsSSLPositive(t *testing.T) {
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		if cc, err = exec.LookPath("gcc"); err != nil {
+			t.Skip("no C compiler available")
+		}
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "ssl.c")
+	if err := os.WriteFile(src, []byte(`
+int SSL_write(void *s, void *b, int n) { return n; }
+int main(void) { return SSL_write(0, 0, 0); }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "ssl_exe")
+	if out, err := exec.Command(cc, "-O0", "-no-pie", "-o", bin, src).CombinedOutput(); err != nil {
+		t.Skipf("compile failed: %v\n%s", err, out)
+	}
+	if !executableExportsSSL(bin) {
+		t.Error("expected executableExportsSSL to detect the SSL_write symbol")
+	}
+}

--- a/internal/ebpf/probes/h3offsets_dwarf_test.go
+++ b/internal/ebpf/probes/h3offsets_dwarf_test.go
@@ -1,0 +1,28 @@
+package probes
+
+import (
+	"testing"
+)
+
+func TestH3OffsetsFromDWARFRealBinary(t *testing.T) {
+	bin := goFixtureBinary(t)
+	off, ok := h3OffsetsFromDWARF(bin)
+	if !ok {
+		t.Fatal("expected DWARF offset resolution to succeed on the fixture binary")
+	}
+	want := h3FieldOffsets{Method: 0, URL: 16, Path: 56, Status: 16}
+	if off != want {
+		t.Fatalf("DWARF offsets = %+v, want %+v", off, want)
+	}
+}
+
+func TestResolveH3FieldOffsetsPrefersDWARF(t *testing.T) {
+	bin := goFixtureBinary(t)
+	off, source := resolveH3FieldOffsets(bin)
+	if source != "dwarf" {
+		t.Fatalf("source = %q, want dwarf when the binary carries usable DWARF", source)
+	}
+	if off != (h3FieldOffsets{Method: 0, URL: 16, Path: 56, Status: 16}) {
+		t.Fatalf("offsets = %+v", off)
+	}
+}

--- a/internal/ebpf/probes/h3peer_dwarf_test.go
+++ b/internal/ebpf/probes/h3peer_dwarf_test.go
@@ -1,0 +1,164 @@
+package probes
+
+import (
+	"testing"
+)
+
+func TestOpenDWARFMissingFile(t *testing.T) {
+	if _, _, ok := openDWARF("/no/such/binary/here"); ok {
+		t.Error("expected openDWARF to fail for a missing file")
+	}
+}
+
+func TestOpenDWARFFixture(t *testing.T) {
+	bin := goFixtureBinary(t)
+	d, cleanup, ok := openDWARF(bin)
+	if !ok {
+		t.Fatal("expected openDWARF to succeed on a DWARF-bearing Go binary")
+	}
+	defer cleanup()
+	if d == nil {
+		t.Fatal("openDWARF returned nil data with ok=true")
+	}
+}
+
+func TestIndexDWARFStructs(t *testing.T) {
+	d, cleanup, idx := fixtureDWARF(t)
+	defer cleanup()
+	_ = d
+
+	for _, name := range []string{"runtime.g", "runtime.m", "net/http.Request", "net/url.URL", "net.UDPAddr", "sync.Once"} {
+		if _, ok := idx[name]; !ok {
+			t.Errorf("expected struct %q in the DWARF index", name)
+		}
+	}
+	if _, ok := idx["this.Type.Does.Not.Exist"]; ok {
+		t.Error("index unexpectedly contains a bogus type")
+	}
+}
+
+func TestStructByNameAndMembers(t *testing.T) {
+	d, cleanup, idx := fixtureDWARF(t)
+	defer cleanup()
+
+	g := structByName(d, idx, "runtime.g")
+	if g == nil {
+		t.Fatal("runtime.g not resolved")
+	}
+	m := findMember(g, "m")
+	if m == nil {
+		t.Fatal("runtime.g.m member not found")
+	}
+	if m.ByteOffset != 48 {
+		t.Errorf("runtime.g.m offset = %d, want 48", m.ByteOffset)
+	}
+	if findMember(g, "no_such_member") != nil {
+		t.Error("findMember returned a value for an absent member")
+	}
+	if !hasMember(g, "m", nil) {
+		t.Error("hasMember should report m present")
+	}
+	if hasMember(g, "no_such_member", nil) {
+		t.Error("hasMember should report an absent member as missing")
+	}
+
+	if structByName(d, idx, "this.Type.Does.Not.Exist") != nil {
+		t.Error("structByName should return nil for an unknown type")
+	}
+}
+
+func TestFollowMemberPointer(t *testing.T) {
+	d, cleanup, idx := fixtureDWARF(t)
+	defer cleanup()
+
+	g := structByName(d, idx, "runtime.g")
+	if g == nil {
+		t.Fatal("runtime.g not resolved")
+	}
+	target, step, ok := followMember(d, idx, g, "m", nil)
+	if !ok {
+		t.Fatal("followMember failed to follow runtime.g.m pointer")
+	}
+	if step.Off != 48 || step.Iface != 0 {
+		t.Errorf("step = %+v, want Off=48 Iface=0", step)
+	}
+	if target == nil || target.StructName != "runtime.m" {
+		t.Errorf("followMember target = %v, want runtime.m", target)
+	}
+
+	if _, _, ok := followMember(d, idx, g, "no_such_member", nil); ok {
+		t.Error("followMember must fail for an absent member")
+	}
+
+	udp := structByName(d, idx, "net.UDPAddr")
+	if udp == nil {
+		t.Fatal("net.UDPAddr not resolved")
+	}
+	if _, _, ok := followMember(d, idx, udp, "Port", nil); ok {
+		t.Error("followMember must fail for a non-pointer, non-interface member")
+	}
+}
+
+func TestFollowMemberInterface(t *testing.T) {
+	d, cleanup, idx := fixtureDWARF(t)
+	defer cleanup()
+
+	req := structByName(d, idx, "net/http.Request")
+	if req == nil {
+		t.Fatal("net/http.Request not resolved")
+	}
+	target, step, ok := followMember(d, idx, req, "Body", []string{"net.UDPAddr"})
+	if !ok {
+		t.Fatal("followMember failed to follow the Body interface to a candidate impl")
+	}
+	if step.Iface != 1 {
+		t.Errorf("interface step Iface = %d, want 1", step.Iface)
+	}
+	if step.Off != 64 {
+		t.Errorf("Body offset = %d, want 64", step.Off)
+	}
+	if target == nil || target.StructName != "net.UDPAddr" {
+		t.Errorf("target = %v, want net.UDPAddr", target)
+	}
+
+	if _, _, ok := followMember(d, idx, req, "Body", []string{"no.such.Impl"}); ok {
+		t.Error("followMember must fail when no candidate impl exists in the binary")
+	}
+}
+
+func TestBuildH3PeerPathNoQuicTypes(t *testing.T) {
+	d, cleanup, idx := fixtureDWARF(t)
+	defer cleanup()
+
+	if _, ok := buildH3PeerPath(d, idx, "this.Type.Does.Not.Exist", nil); ok {
+		t.Error("buildH3PeerPath must fail when the root type is absent")
+	}
+	if _, ok := buildH3PeerPath(d, idx, "runtime.g", nil); ok {
+		t.Error("buildH3PeerPath must fail when the root lacks the quic conn chain")
+	}
+}
+
+func TestResolveH3PeerPathsNoQuicTypes(t *testing.T) {
+	bin := goFixtureBinary(t)
+	if _, ok := resolveH3PeerPaths(bin, ""); ok {
+		t.Error("resolveH3PeerPaths must fail on a binary without quic-go types")
+	}
+}
+
+func TestResolveH3PeerPathsMissingFile(t *testing.T) {
+	if _, ok := resolveH3PeerPaths("/no/such/binary", "some.Root"); ok {
+		t.Error("resolveH3PeerPaths must fail when the binary is missing")
+	}
+}
+
+func TestMemberOffset32(t *testing.T) {
+	if off, ok := memberOffset32(48); !ok || off != 48 {
+		t.Errorf("memberOffset32(48) = (%d,%v), want (48,true)", off, ok)
+	}
+	if _, ok := memberOffset32(-1); ok {
+		t.Error("memberOffset32 must reject a negative offset")
+	}
+	if _, ok := memberOffset32(maxStructFieldOffset + 1); ok {
+		t.Error("memberOffset32 must reject an implausibly large offset")
+	}
+}

--- a/internal/ebpf/probes/quicherustresolve_elf_test.go
+++ b/internal/ebpf/probes/quicherustresolve_elf_test.go
@@ -1,0 +1,46 @@
+package probes
+
+import (
+	"testing"
+)
+
+func TestFindSymbolsContaining(t *testing.T) {
+	bin := goFixtureBinary(t)
+	f, err := openELFCapped(bin)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	four := findSymbolsContaining(f, 4, "net/http")
+	if len(four) == 0 {
+		t.Fatal("expected at least one net/http function symbol")
+	}
+	if len(four) > 4 {
+		t.Errorf("returned %d symbols, want at most 4", len(four))
+	}
+	for i, v := range four {
+		if v == 0 {
+			t.Errorf("symbol %d has vaddr 0", i)
+		}
+	}
+
+	one := findSymbolsContaining(f, 1, "net/http")
+	if len(one) != 1 {
+		t.Errorf("with max=1 got %d symbols, want 1", len(one))
+	}
+
+	if got := findSymbolsContaining(f, 4, "no_such_symbol_zzz"); got != nil {
+		t.Errorf("expected nil for an absent substring, got %v", got)
+	}
+}
+
+func TestFindSymbolsContainingNoSymtab(t *testing.T) {
+	f, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findSymbolsContaining(f, 4, "anything"); got != nil {
+		t.Errorf("expected nil when the ELF has no symbol table, got %v", got)
+	}
+}

--- a/internal/ebpf/probes/rustlsresolve_elf_test.go
+++ b/internal/ebpf/probes/rustlsresolve_elf_test.go
@@ -1,0 +1,74 @@
+package probes
+
+import (
+	"testing"
+)
+
+func TestElfIsRust(t *testing.T) {
+	rust, err := elfFromSections([]fixtureSection{
+		{name: ".comment", typ: 1, data: []byte("rustc version 1.70.0 (90c541806 2023-05-31)")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !elfIsRust(rust) {
+		t.Error("expected rustc .comment to be detected as Rust")
+	}
+
+	gcc, err := elfFromSections([]fixtureSection{
+		{name: ".comment", typ: 1, data: []byte("GCC: (Debian 12.2.0-14) 12.2.0")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elfIsRust(gcc) {
+		t.Error("a GCC .comment must not be detected as Rust")
+	}
+
+	none, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elfIsRust(none) {
+		t.Error("an ELF with no .comment must not be detected as Rust")
+	}
+}
+
+func TestFindSymbolContaining(t *testing.T) {
+	bin := goFixtureBinary(t)
+	f, err := openELFCapped(bin)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	vaddr, ok := findSymbolContaining(f, "runtime.main")
+	if !ok {
+		t.Fatal("expected to find runtime.main via single substring")
+	}
+	if vaddr == 0 {
+		t.Error("runtime.main vaddr is 0")
+	}
+
+	v2, ok := findSymbolContaining(f, "runtime", "main")
+	if !ok || v2 == 0 {
+		t.Error("expected to find a symbol containing both runtime and main")
+	}
+
+	if _, ok := findSymbolContaining(f, "runtime", "no_such_symbol_zzz"); ok {
+		t.Error("expected no match when one substring is absent")
+	}
+	if _, ok := findSymbolContaining(f, "definitely_absent_symbol_zzz"); ok {
+		t.Error("expected no match for an absent symbol")
+	}
+}
+
+func TestFindSymbolContainingNoSymtab(t *testing.T) {
+	f, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findSymbolContaining(f, "anything"); ok {
+		t.Error("expected false when the ELF has no .symtab")
+	}
+}

--- a/internal/ebpf/probes/safeelf_recover_test.go
+++ b/internal/ebpf/probes/safeelf_recover_test.go
@@ -1,0 +1,51 @@
+package probes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDWARFWithinCapRealBinary(t *testing.T) {
+	bin := goFixtureBinary(t)
+	f, err := openELFCapped(bin)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	hasDebug := false
+	for _, s := range f.Sections {
+		if strings.HasPrefix(s.Name, ".debug_") || strings.HasPrefix(s.Name, ".zdebug_") {
+			hasDebug = true
+			break
+		}
+	}
+	if !hasDebug {
+		t.Skip("fixture binary was built without DWARF")
+	}
+	if !dwarfWithinCap(f) {
+		t.Error("a normal Go binary's DWARF must be within cap")
+	}
+}
+
+func TestDWARFWithinCapEmpty(t *testing.T) {
+	f, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dwarfWithinCap(f) {
+		t.Error("an ELF with no debug sections is trivially within cap")
+	}
+}
+
+func TestRecoverParseSwallowsPanic(t *testing.T) {
+	reached := false
+	func() {
+		defer recoverParse("test-panic-site")
+		panic("simulated malformed-binary panic")
+	}()
+	reached = true
+	if !reached {
+		t.Fatal("recoverParse did not swallow the panic; control never returned")
+	}
+}

--- a/internal/ebpf/probes/tlsresolve_elf_test.go
+++ b/internal/ebpf/probes/tlsresolve_elf_test.go
@@ -1,0 +1,85 @@
+package probes
+
+import (
+	"encoding/hex"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestElfBuildIDRealBinary(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("uses the test binary's .note.gnu.build-id")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot find test executable: %v", err)
+	}
+	f, err := openELFCapped(exe)
+	if err != nil {
+		t.Skipf("cannot open test executable: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if f.Section(".note.gnu.build-id") == nil {
+		t.Skip("test binary has no GNU build-id note")
+	}
+	id := elfBuildID(f)
+	if len(id) == 0 {
+		t.Fatal("expected a non-empty build-id from a note-bearing binary")
+	}
+	if _, err := hex.DecodeString(id); err != nil {
+		t.Errorf("build-id %q is not valid lowercase hex: %v", id, err)
+	}
+}
+
+func TestElfBuildIDNoNote(t *testing.T) {
+	f, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id := elfBuildID(f); id != "" {
+		t.Errorf("expected empty build-id when the note is absent, got %q", id)
+	}
+}
+
+func TestDebugLink(t *testing.T) {
+	data := append([]byte("libfoo.so.debug"), 0, 0, 0xde, 0xad, 0xbe, 0xef)
+	f, err := elfFromSections([]fixtureSection{{name: ".gnu_debuglink", typ: 1, data: data}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := debugLink(f); got != "libfoo.so.debug" {
+		t.Errorf("debugLink = %q, want libfoo.so.debug", got)
+	}
+}
+
+func TestDebugLinkAbsent(t *testing.T) {
+	f, err := emptyELF()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := debugLink(f); got != "" {
+		t.Errorf("debugLink = %q, want empty when the section is absent", got)
+	}
+}
+
+func TestSymbolVaddr(t *testing.T) {
+	bin := goFixtureBinary(t)
+	f, err := openELFCapped(bin)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	vaddr, ok := symbolVaddr(f, "runtime.main")
+	if !ok {
+		t.Fatal("expected to resolve runtime.main from .symtab")
+	}
+	if vaddr == 0 {
+		t.Error("runtime.main vaddr is 0")
+	}
+	if _, ok := symbolVaddr(f, "definitely_absent_symbol_zzz"); ok {
+		t.Error("expected not-found for an absent symbol name")
+	}
+}

--- a/internal/ebpf/probes/usdt_copy_cstring_test.go
+++ b/internal/ebpf/probes/usdt_copy_cstring_test.go
@@ -1,0 +1,14 @@
+package probes
+
+import "testing"
+
+func TestCopyCStringEmptyDst(t *testing.T) {
+	copyCString([]byte{}, "anything")
+	copyCString(nil, "anything")
+
+	dst := make([]byte, 1)
+	copyCString(dst, "x")
+	if dst[0] != 0 {
+		t.Errorf("single-byte buffer must hold only the NUL terminator, got %d", dst[0])
+	}
+}

--- a/internal/ebpf/tracer/error_handler_branches_test.go
+++ b/internal/ebpf/tracer/error_handler_branches_test.go
@@ -1,0 +1,58 @@
+package tracer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSlidingWindow_NonPositiveBucketsClampsToOne(t *testing.T) {
+	for _, n := range []int{0, -1, -100} {
+		sw := newSlidingWindow(5*time.Second, n)
+		if sw.numBuckets != 1 {
+			t.Errorf("newSlidingWindow(_, %d).numBuckets = %d, want 1", n, sw.numBuckets)
+		}
+		if cap(sw.buckets) != 1 {
+			t.Errorf("newSlidingWindow(_, %d) bucket capacity = %d, want 1", n, cap(sw.buckets))
+		}
+	}
+}
+
+func TestCircuitBreaker_RecordFailureFromHalfOpenReopens(t *testing.T) {
+	cb := newCircuitBreaker(2, time.Minute)
+	cb.recordFailure()
+	cb.recordFailure()
+
+	cb.mu.Lock()
+	cb.state = circuitBreakerHalfOpen
+	cb.successCount = 2
+	cb.mu.Unlock()
+
+	cb.recordFailure()
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.state != circuitBreakerOpen {
+		t.Errorf("state after failure in half-open = %d, want open (%d)", cb.state, circuitBreakerOpen)
+	}
+	if cb.successCount != 0 {
+		t.Errorf("successCount after reopen = %d, want 0", cb.successCount)
+	}
+}
+
+func TestCircuitBreaker_CanProceedInHalfOpenReturnsTrue(t *testing.T) {
+	cb := newCircuitBreaker(2, time.Minute)
+
+	cb.mu.Lock()
+	cb.state = circuitBreakerHalfOpen
+	cb.mu.Unlock()
+
+	if !cb.canProceed() {
+		t.Error("canProceed in half-open state = false, want true")
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.state != circuitBreakerHalfOpen {
+		t.Errorf("canProceed changed half-open state to %d, want it left half-open (%d)", cb.state, circuitBreakerHalfOpen)
+	}
+}

--- a/internal/ebpf/tracer/resource_monitor_activate_test.go
+++ b/internal/ebpf/tracer/resource_monitor_activate_test.go
@@ -1,0 +1,49 @@
+package tracer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestResourceMonitorManager_ActivateAssignsFactoryAndActivates(t *testing.T) {
+	m := newResourceMonitorManager()
+	limits := &ebpf.Map{}
+	alerts := &ebpf.Map{}
+
+	m.activate(context.Background(), nil, limits, alerts, nil)
+
+	if !m.active {
+		t.Error("manager not active after activate with non-nil maps")
+	}
+	m.mu.Lock()
+	factorySet := m.startMonitor != nil
+	m.mu.Unlock()
+	if !factorySet {
+		t.Error("activate did not install a startMonitor factory")
+	}
+	if got := m.runningCount(); got != 0 {
+		t.Fatalf("running monitors with empty desired set = %d, want 0", got)
+	}
+}
+
+func TestResourceMonitorManager_ReconcileSkipsFailedMonitors(t *testing.T) {
+	m := newResourceMonitorManager()
+	m.mu.Lock()
+	m.startMonitor = func(path string) (stoppable, error) {
+		if path == "/cg/bad" {
+			return nil, fmt.Errorf("cannot start monitor for %s", path)
+		}
+		return &fakeMonitor{}, nil
+	}
+	m.active = true
+	m.mu.Unlock()
+
+	m.reconcile([]string{"/cg/good", "/cg/bad"})
+
+	if got := m.runningCount(); got != 1 {
+		t.Fatalf("running monitors = %d, want 1 (failed monitor must be skipped)", got)
+	}
+}

--- a/internal/ebpf/tracer/tracer_pure_helpers_test.go
+++ b/internal/ebpf/tracer/tracer_pure_helpers_test.go
@@ -1,0 +1,110 @@
+package tracer
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/link"
+
+	"github.com/podtrace/podtrace/internal/ebpf/probes"
+)
+
+func TestSamePIDSet_Comparisons(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []uint32
+		want bool
+	}{
+		{"equal", []uint32{1, 2, 3}, []uint32{1, 2, 3}, true},
+		{"length differs", []uint32{1, 2}, []uint32{1, 2, 3}, false},
+		{"element differs", []uint32{1, 2, 3}, []uint32{1, 9, 3}, false},
+		{"both empty", []uint32{}, []uint32{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := samePIDSet(c.a, c.b); got != c.want {
+				t.Errorf("samePIDSet(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAddLinks_EmptyIsNoop(t *testing.T) {
+	tr := &Tracer{}
+	tr.addLinks(nil)
+	tr.addLinks([]link.Link{})
+	if got := tr.linkCount(); got != 0 {
+		t.Errorf("linkCount after empty addLinks = %d, want 0", got)
+	}
+}
+
+func TestWarnOnCgroupCapacity_ExceededRecordsCount(t *testing.T) {
+	tr := &Tracer{}
+	tr.warnOnCgroupCapacity(5000, 4096)
+	if got := tr.cgroupCapacityWarned.Load(); got != 5000 {
+		t.Errorf("cgroupCapacityWarned after exceeded = %d, want 5000", got)
+	}
+}
+
+func TestIsLikelyTransientComm(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"0", true},
+		{"5", true},
+		{"9", true},
+		{"a", false},
+		{":", false},
+		{"/", false},
+		{"12", false},
+	}
+	for _, c := range cases {
+		if got := isLikelyTransientComm(c.in); got != c.want {
+			t.Errorf("isLikelyTransientComm(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestProbeGroupNeededBy(t *testing.T) {
+	cases := []struct {
+		name   string
+		group  probes.ProbeGroup
+		wanted map[string]struct{}
+		want   bool
+	}{
+		{"ungated group always needed", probes.GroupDatabase, map[string]struct{}{}, true},
+		{"gated group with matching category", probes.GroupFileSystem, map[string]struct{}{"fs": {}}, true},
+		{"gated group without matching category", probes.GroupFileSystem, map[string]struct{}{"net": {}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := probeGroupNeededBy(c.group, c.wanted); got != c.want {
+				t.Errorf("probeGroupNeededBy(%q, %v) = %v, want %v", c.group, c.wanted, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEnableProbeGroup_AlreadyAttachedIsNoop(t *testing.T) {
+	existing := &fakeLink{}
+	tr := &Tracer{
+		probeGroups: map[probes.ProbeGroup][]link.Link{
+			probes.GroupTLS: {existing},
+		},
+	}
+
+	if err := tr.EnableProbeGroup(probes.GroupTLS); err != nil {
+		t.Fatalf("EnableProbeGroup on already-attached group: %v", err)
+	}
+
+	tr.probeGroupsMu.Lock()
+	defer tr.probeGroupsMu.Unlock()
+	got := tr.probeGroups[probes.GroupTLS]
+	if len(got) != 1 || got[0] != existing {
+		t.Errorf("EnableProbeGroup mutated an already-attached group: got %v", got)
+	}
+	if existing.closes.Load() != 0 {
+		t.Errorf("already-attached link was closed %d times, want 0", existing.closes.Load())
+	}
+}

--- a/internal/ebpf/tracer/verifier_log_failure_test.go
+++ b/internal/ebpf/tracer/verifier_log_failure_test.go
@@ -1,0 +1,25 @@
+package tracer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestLogVerifierFailure_RealVerifierErrorLogsWithoutPanic(t *testing.T) {
+	ve := &ebpf.VerifierError{
+		Cause: fmt.Errorf("load rejected"),
+		Log:   []string{"0: (b7) r1 = 1", "R1 invalid mem access"},
+	}
+	wrapped := fmt.Errorf("failed to create eBPF collection: %w", ve)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logVerifierFailure panicked on a real verifier error: %v", r)
+		}
+	}()
+
+	logVerifierFailure(ve)
+	logVerifierFailure(wrapped)
+}

--- a/internal/kubernetes/informers_cache_service_lookup_test.go
+++ b/internal/kubernetes/informers_cache_service_lookup_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetServiceByEndpoint_UnknownEndpointReturnsNil(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	ic := NewInformerCache(clientset)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ic.Start(ctx)
+	defer ic.Stop()
+
+	ic.mu.RLock()
+	esInf := ic.esInf
+	ic.mu.RUnlock()
+	if esInf == nil {
+		t.Skip("endpointslice informer not initialized")
+	}
+
+	if svc := ic.GetServiceByEndpoint("10.99.99.99", 8080); svc != nil {
+		t.Errorf("expected nil for an endpoint not present in the index, got %+v", svc)
+	}
+}
+
+func TestGetServiceByEndpoint_WhitespaceServiceNameReturnsNil(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	ic := NewInformerCache(clientset)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ic.Start(ctx)
+	defer ic.Stop()
+
+	ic.mu.RLock()
+	esInf := ic.esInf
+	ic.mu.RUnlock()
+	if esInf == nil {
+		t.Skip("endpointslice informer not initialized")
+	}
+
+	port := int32(9000)
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "blank-name", Labels: map[string]string{serviceNameKey: "   "}},
+		Ports:      []discoveryv1.EndpointPort{{Port: &port}},
+		Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.3.3.3"}}},
+	}
+	if err := esInf.GetIndexer().Add(es); err != nil {
+		t.Fatalf("add endpointslice: %v", err)
+	}
+
+	if svc := ic.GetServiceByEndpoint("10.3.3.3", 9000); svc != nil {
+		t.Errorf("expected nil when the service-name label is only whitespace, got %+v", svc)
+	}
+}

--- a/internal/kubernetes/nodespawn/stream_events_test.go
+++ b/internal/kubernetes/nodespawn/stream_events_test.go
@@ -1,0 +1,58 @@
+package nodespawn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestStuckPodEventReason_ReturnsNewestFatalReason(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"}}
+	older := metav1.NewTime(time.Now().Add(-time.Minute))
+	newer := metav1.NewTime(time.Now())
+	cs := fake.NewSimpleClientset(
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: "ns", Name: "old"},
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "spawn", Namespace: "ns"},
+			Reason:         "FailedAttachVolume",
+			Message:        "attach timed out",
+			LastTimestamp:  older,
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: "ns", Name: "new"},
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "spawn", Namespace: "ns"},
+			Reason:         "FailedMount",
+			Message:        "  securityfs hostPath check failed  ",
+			LastTimestamp:  newer,
+		},
+	)
+
+	got := stuckPodEventReason(context.Background(), cs, pod)
+	if got != "FailedMount: securityfs hostPath check failed" {
+		t.Errorf("stuckPodEventReason = %q, want the trimmed newest fatal reason", got)
+	}
+}
+
+func TestWaitForExitCode_ContextCancelledDuringPoll(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "spawn"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "podtrace",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+	cs := fake.NewSimpleClientset(pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if got := WaitForExitCode(ctx, cs, "ns", "spawn"); got != -1 {
+		t.Errorf("WaitForExitCode = %d, want -1 when ctx cancels while the container keeps running", got)
+	}
+}

--- a/internal/kubernetes/pod_restconfig_test.go
+++ b/internal/kubernetes/pod_restconfig_test.go
@@ -1,0 +1,22 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestPodResolver_GetRestConfig(t *testing.T) {
+	cfg := &rest.Config{Host: "https://api.example.com"}
+	r := &PodResolver{restConfig: cfg}
+	if got := r.GetRestConfig(); got != cfg {
+		t.Errorf("GetRestConfig returned %p, want the injected config %p", got, cfg)
+	}
+}
+
+func TestPodResolver_GetRestConfigNil(t *testing.T) {
+	r := &PodResolver{}
+	if got := r.GetRestConfig(); got != nil {
+		t.Errorf("GetRestConfig on a resolver with no config = %+v, want nil", got)
+	}
+}

--- a/internal/kubernetes/target_source_empty_test.go
+++ b/internal/kubernetes/target_source_empty_test.go
@@ -1,0 +1,16 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/podtrace/podtrace/internal/kubernetes"
+)
+
+func TestToTracerTargets_EmptyInputReturnsNil(t *testing.T) {
+	if out := kubernetes.ToTracerTargets(nil); out != nil {
+		t.Errorf("ToTracerTargets(nil) = %v, want nil", out)
+	}
+	if out := kubernetes.ToTracerTargets([]*kubernetes.PodInfo{}); out != nil {
+		t.Errorf("ToTracerTargets(empty) = %v, want nil", out)
+	}
+}

--- a/internal/operator/applicationtrace_reconcile_branches_test.go
+++ b/internal/operator/applicationtrace_reconcile_branches_test.go
@@ -1,0 +1,75 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestApplicationTraceBranch_ReconcileNotFound(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "demo", Name: "missing"},
+	})
+	if err != nil {
+		t.Fatalf("missing ApplicationTrace must reconcile to a clean no-op, got %v", err)
+	}
+	if res != (ctrl.Result{}) {
+		t.Fatalf("missing ApplicationTrace result = %+v, want empty", res)
+	}
+}
+
+func TestApplicationTraceBranch_ChildErrorAndPatchStatusError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	app := mkApp()
+	foreign := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: app.Name, Namespace: app.Namespace},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app, foreign).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: app.Namespace, Name: app.Name},
+	}); err == nil {
+		t.Fatal("adopting a foreign PodTrace must fail, and a failing status write must surface that error")
+	}
+}
+
+func TestApplicationTraceBranch_EnsureChildCreateError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	app := mkApp()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).
+		WithObjects(app).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*podtracev1alpha1.PodTrace); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+
+	if _, err := r.ensureChildPodTrace(context.Background(), app); err == nil {
+		t.Fatal("a failing PodTrace create-or-update must be surfaced")
+	}
+}

--- a/internal/operator/exporter_bundle_optional_fields_test.go
+++ b/internal/operator/exporter_bundle_optional_fields_test.go
@@ -1,0 +1,98 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestRenderBundlePayload_SynthesizeSpansStamped(t *testing.T) {
+	enabled := true
+	spec := otlpSpec(&podtracev1alpha1.OTLPExporter{Endpoint: "collector:4318"})
+	spec.SynthesizeSpans = &enabled
+	data, _, _, err := renderBundlePayload(nil, ec("otlp-synth", spec), nil)
+	if err != nil {
+		t.Fatalf("renderBundlePayload: %v", err)
+	}
+	if data["synthesize_spans"] != "true" {
+		t.Errorf("synthesize_spans = %q, want true", data["synthesize_spans"])
+	}
+}
+
+func TestRenderBundlePayload_SynthesizeSpansDisabledOmitsKey(t *testing.T) {
+	disabled := false
+	spec := otlpSpec(&podtracev1alpha1.OTLPExporter{Endpoint: "collector:4318"})
+	spec.SynthesizeSpans = &disabled
+	data, _, _, err := renderBundlePayload(nil, ec("otlp-nosynth", spec), nil)
+	if err != nil {
+		t.Fatalf("renderBundlePayload: %v", err)
+	}
+	if _, ok := data["synthesize_spans"]; ok {
+		t.Errorf("synthesize_spans key must be absent when disabled, got %q", data["synthesize_spans"])
+	}
+}
+
+func TestRenderBundlePayload_HeadersFromSecretReturned(t *testing.T) {
+	_, _, headersFrom, err := renderBundlePayload(nil, ec("otlp-hfs", otlpSpec(&podtracev1alpha1.OTLPExporter{
+		Endpoint:          "collector:4318",
+		HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "extra-headers"},
+	})), nil)
+	if err != nil {
+		t.Fatalf("renderBundlePayload: %v", err)
+	}
+	if headersFrom == nil || headersFrom.Name != "extra-headers" {
+		t.Errorf("headersFrom = %+v, want name=extra-headers", headersFrom)
+	}
+}
+
+func TestRenderBundlePayload_HeadersFromSecretEmptyNameIgnored(t *testing.T) {
+	_, _, headersFrom, err := renderBundlePayload(nil, ec("otlp-hfs-empty", otlpSpec(&podtracev1alpha1.OTLPExporter{
+		Endpoint:          "collector:4318",
+		HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: ""},
+	})), nil)
+	if err != nil {
+		t.Fatalf("renderBundlePayload: %v", err)
+	}
+	if headersFrom != nil {
+		t.Errorf("empty HeadersFromSecret name must yield nil, got %+v", headersFrom)
+	}
+}
+
+func TestBuildBundleSecretData_CredentialKeyMissing(t *testing.T) {
+	cred := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "user-ns"},
+		Data:       map[string][]byte{"other": []byte("x")},
+	}
+	c := fake.NewClientBuilder().WithObjects(cred).Build()
+
+	if _, err := buildBundleSecretData(context.Background(), c, "user-ns",
+		&podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"}, nil); err == nil {
+		t.Fatal("expected error for missing credential key")
+	}
+}
+
+func TestBuildBundleSecretData_HeadersFromSecretNotFound(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+
+	if _, err := buildBundleSecretData(context.Background(), c, "user-ns",
+		nil, &podtracev1alpha1.LocalObjectReference{Name: "absent-headers"}); err == nil {
+		t.Fatal("expected error when headersFromSecret is not found")
+	}
+}
+
+func TestBuildBundleSecretData_NoSourcesReturnsNil(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+
+	got, err := buildBundleSecretData(context.Background(), c, "user-ns", nil, nil)
+	if err != nil {
+		t.Fatalf("buildBundleSecretData: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil map when neither credRef nor headersFrom is set, got %v", got)
+	}
+}

--- a/internal/operator/finalizer_cleanup_branches_test.go
+++ b/internal/operator/finalizer_cleanup_branches_test.go
@@ -1,0 +1,111 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func finalizerTestPodTrace() *podtracev1alpha1.PodTrace {
+	return &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "team-a", UID: "pt-uid"},
+	}
+}
+
+func finalizerTestSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "sess-uid"},
+	}
+}
+
+func TestCleanupOrphanBundles_ConfigMapDeleteError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	pt := finalizerTestPodTrace()
+	orphan := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ExporterBundleName(pt.UID),
+			Namespace: "old-ns",
+			Labels: map[string]string{
+				LabelManagedBy:    ManagedByValue,
+				LabelComponent:    ComponentBundle,
+				LabelPodTraceName: pt.Name,
+				LabelPodTraceNS:   pt.Namespace,
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(orphan).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+
+	if err := cleanupOrphanBundles(context.Background(), c, pt, "podtrace-system"); err == nil {
+		t.Fatal("orphan bundle ConfigMap delete failure must be surfaced")
+	}
+}
+
+func TestCleanupOrphanBundles_SecretListError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	pt := finalizerTestPodTrace()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.SecretList); ok {
+					return errInternal()
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	if err := cleanupOrphanBundles(context.Background(), c, pt, "podtrace-system"); err == nil {
+		t.Fatal("orphan bundle Secret list failure must be surfaced")
+	}
+}
+
+func TestCleanupSessionChildren_PodReadRBACError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finalizerTestSession()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*rbacv1.RoleBindingList); ok {
+					return errInternal()
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).Build()
+
+	if err := cleanupPodTraceSessionChildren(context.Background(), c, s, "podtrace-system"); err == nil {
+		t.Fatal("session pod-read RBAC cleanup failure must be surfaced")
+	}
+}
+
+func TestCleanupSessionChildren_ServiceAccountError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finalizerTestSession()
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					return errInternal()
+				}
+				return cl.Delete(ctx, obj, opts...)
+			},
+		}).Build()
+
+	if err := cleanupPodTraceSessionChildren(context.Background(), c, s, "podtrace-system"); err == nil {
+		t.Fatal("session ServiceAccount cleanup failure must be surfaced")
+	}
+}

--- a/internal/operator/namespace_resolver_list_error_test.go
+++ b/internal/operator/namespace_resolver_list_error_test.go
@@ -1,0 +1,34 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestResolveNamespaceSelector_ListError(t *testing.T) {
+	scheme, err := NewScheme()
+	if err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+			return apierrors.NewInternalError(errors.New("synthetic namespace list failure"))
+		},
+	}).Build()
+
+	allowed, denied, err := ResolveNamespaceSelector(context.Background(), c,
+		&metav1.LabelSelector{MatchLabels: map[string]string{"tier": "prod"}}, "observer")
+	if err == nil {
+		t.Fatal("expected error when namespace List fails")
+	}
+	if allowed != nil || denied != nil {
+		t.Errorf("expected nil result slices on error, got allowed=%v denied=%v", allowed, denied)
+	}
+}

--- a/internal/operator/podtrace_syncbundle_branches_test.go
+++ b/internal/operator/podtrace_syncbundle_branches_test.go
@@ -1,0 +1,67 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func syncBundleTestPodTrace() *podtracev1alpha1.PodTrace {
+	return &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "team-a", UID: "pt-uid"},
+	}
+}
+
+func TestSyncExporterBundle_RenderError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
+		Spec:       podtracev1alpha1.ExporterConfigSpec{Type: podtracev1alpha1.ExporterTypeOTLP},
+	}
+	if err := r.syncExporterBundle(context.Background(), syncBundleTestPodTrace(), ec, []string{"team-a"}); err == nil {
+		t.Fatal("an OTLP ExporterConfig with a nil OTLP block must fail bundle rendering")
+	}
+}
+
+func TestSyncExporterBundle_SecretCreateError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	headers := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "hdr", Namespace: "team-a"},
+		Data:       map[string][]byte{"Authorization": []byte("Bearer x")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(headers).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{
+				Endpoint:          "otel:4318",
+				Protocol:          podtracev1alpha1.OTLPProtocolHTTP,
+				HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "hdr"},
+			},
+		},
+	}
+	if err := r.syncExporterBundle(context.Background(), syncBundleTestPodTrace(), ec, []string{"team-a"}); err == nil {
+		t.Fatal("a failing bundle Secret create-or-update must be surfaced")
+	}
+}

--- a/internal/operator/podtraceschedule_parse_test.go
+++ b/internal/operator/podtraceschedule_parse_test.go
@@ -1,0 +1,60 @@
+package operator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func scheduleWith(schedule string, tz *string) *podtracev1alpha1.PodTraceSchedule {
+	return &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: schedule,
+			TimeZone: tz,
+		},
+	}
+}
+
+func TestParseSchedule_DefaultLocation(t *testing.T) {
+	r := &PodTraceScheduleReconciler{}
+	parsed, loc, err := r.parseSchedule(scheduleWith("*/5 * * * *", nil))
+	if err != nil {
+		t.Fatalf("parseSchedule: %v", err)
+	}
+	if parsed == nil {
+		t.Fatal("expected a parsed schedule")
+	}
+	if loc == nil {
+		t.Fatal("expected a non-nil location")
+	}
+}
+
+func TestParseSchedule_NamedTimeZone(t *testing.T) {
+	tz := "Europe/Amsterdam"
+	r := &PodTraceScheduleReconciler{}
+	_, loc, err := r.parseSchedule(scheduleWith("0 3 * * *", &tz))
+	if err != nil {
+		t.Fatalf("parseSchedule: %v", err)
+	}
+	if loc == nil || loc.String() != tz {
+		t.Errorf("location = %v, want %s", loc, tz)
+	}
+}
+
+func TestParseSchedule_InvalidTimeZone(t *testing.T) {
+	tz := "Mars/Phobos"
+	r := &PodTraceScheduleReconciler{}
+	if _, _, err := r.parseSchedule(scheduleWith("0 3 * * *", &tz)); err == nil {
+		t.Fatal("expected error for an unknown timezone")
+	}
+}
+
+func TestParseSchedule_InvalidCronExpression(t *testing.T) {
+	r := &PodTraceScheduleReconciler{}
+	if _, _, err := r.parseSchedule(scheduleWith("not-a-cron", nil)); err == nil {
+		t.Fatal("expected error for a malformed cron expression")
+	}
+}

--- a/internal/operator/podtraceschedule_reconcile_branches_test.go
+++ b/internal/operator/podtraceschedule_reconcile_branches_test.go
@@ -1,0 +1,398 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func schBranchOwnerRef(sch *podtracev1alpha1.PodTraceSchedule) []metav1.OwnerReference {
+	return []metav1.OwnerReference{{
+		APIVersion: podtracev1alpha1.GroupVersion.String(),
+		Kind:       "PodTraceSchedule",
+		Name:       sch.Name,
+		UID:        sch.UID,
+	}}
+}
+
+func schBranchAt(name string, creation time.Time, mutate func(*podtracev1alpha1.PodTraceSchedule)) *podtracev1alpha1.PodTraceSchedule {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			UID:               types.UID(name + "-uid"),
+			Generation:        1,
+			CreationTimestamp: metav1.NewTime(creation),
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+	if mutate != nil {
+		mutate(sch)
+	}
+	return sch
+}
+
+func schBranchActive(sch *podtracev1alpha1.PodTraceSchedule, name string) *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       sch.Namespace,
+			OwnerReferences: schBranchOwnerRef(sch),
+		},
+	}
+}
+
+func schBranchCompleted(sch *podtracev1alpha1.PodTraceSchedule, name string, at time.Time) *podtracev1alpha1.PodTraceSession {
+	ct := metav1.NewTime(at)
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       sch.Namespace,
+			OwnerReferences: schBranchOwnerRef(sch),
+		},
+		Status: podtracev1alpha1.PodTraceSessionStatus{
+			State:          podtracev1alpha1.SessionStateCompleted,
+			CompletionTime: &ct,
+		},
+	}
+}
+
+func newSchBranchReconciler(t *testing.T, funcs interceptor.Funcs, objs ...client.Object) *PodTraceScheduleReconciler {
+	t.Helper()
+	s := newOperatorScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSchedule{}).
+		WithObjects(objs...).
+		WithInterceptorFuncs(funcs).
+		Build()
+	return &PodTraceScheduleReconciler{Client: c, Scheme: s, nowFn: func() time.Time { return fixedScheduleNow }}
+}
+
+func reconcileSchBranch(r *PodTraceScheduleReconciler, sch *podtracev1alpha1.PodTraceSchedule) (ctrl.Result, error) {
+	return r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+}
+
+var failAllDeletes = interceptor.Funcs{
+	Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+		return errInternal()
+	},
+}
+
+var failStatusUpdate = interceptor.Funcs{
+	SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+		return errInternal()
+	},
+}
+
+func TestSchedBranch_SuspendPatchStatusError(t *testing.T) {
+	suspend := true
+	sch := schBranchAt("suspend-patcherr", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.Suspend = &suspend
+	})
+	r := newSchBranchReconciler(t, failStatusUpdate, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("suspended schedule with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_SuspendHistoryGCError(t *testing.T) {
+	suspend := true
+	limit := int32(0)
+	sch := schBranchAt("suspend-gcerr", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.Suspend = &suspend
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("suspended schedule with failing history GC delete must return error")
+	}
+}
+
+func TestSchedBranch_SuspendPatchStatusNotFoundSwallowed(t *testing.T) {
+	suspend := true
+	sch := schBranchAt("suspend-notfound", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.Suspend = &suspend
+	})
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+			return apierrors.NewNotFound(schema.GroupResource{Group: "podtrace.io", Resource: "podtraceschedules"}, sch.Name)
+		},
+	}
+	r := newSchBranchReconciler(t, funcs, sch)
+	res, err := reconcileSchBranch(r, sch)
+	if err != nil {
+		t.Fatalf("a NotFound status update means the schedule was deleted; must be swallowed, got %v", err)
+	}
+	if res.RequeueAfter != scheduleResyncCeiling {
+		t.Fatalf("suspended schedule should requeue after ceiling %v, got %v", scheduleResyncCeiling, res.RequeueAfter)
+	}
+}
+
+func TestSchedBranch_PatchStatusInnerGetError(t *testing.T) {
+	suspend := true
+	sch := schBranchAt("suspend-geterr", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.Suspend = &suspend
+	})
+	gets := 0
+	funcs := interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			gets++
+			if gets >= 2 {
+				return errInternal()
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+	}
+	r := newSchBranchReconciler(t, funcs, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("patchStatus inner Get failure must propagate as error")
+	}
+}
+
+func TestSchedBranch_InvalidSchedulePatchStatusError(t *testing.T) {
+	sch := schBranchAt("invalid-sched", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.Schedule = "this is not a cron expression"
+	})
+	r := newSchBranchReconciler(t, failStatusUpdate, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("invalid schedule with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_BeforeNextRunPatchStatusError(t *testing.T) {
+	sch := schBranchAt("before-patcherr", fixedScheduleNow, nil)
+	r := newSchBranchReconciler(t, failStatusUpdate, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("not-yet-due schedule with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_BeforeNextRunHistoryGCError(t *testing.T) {
+	limit := int32(0)
+	sch := schBranchAt("before-gcerr", fixedScheduleNow, func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("not-yet-due schedule with failing history GC must return error")
+	}
+}
+
+func TestSchedBranch_MissedDeadlinePatchStatusError(t *testing.T) {
+	deadline := int64(1)
+	sch := schBranchAt("missed-patcherr", fixedScheduleNow.Add(-10*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.StartingDeadlineSeconds = &deadline
+	})
+	r := newSchBranchReconciler(t, failStatusUpdate, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("missed-deadline schedule with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_MissedDeadlineHistoryGCError(t *testing.T) {
+	deadline := int64(1)
+	limit := int32(0)
+	sch := schBranchAt("missed-gcerr", fixedScheduleNow.Add(-10*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.StartingDeadlineSeconds = &deadline
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("missed-deadline schedule with failing history GC must return error")
+	}
+}
+
+func TestSchedBranch_TooManyMissedHistoryGCError(t *testing.T) {
+	limit := int32(0)
+	sch := schBranchAt("toomany-gcerr", fixedScheduleNow.Add(-24*time.Hour), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("backlog-skipping schedule with failing history GC must return error")
+	}
+}
+
+func TestSchedBranch_MaxActivePatchStatusError(t *testing.T) {
+	cap := int32(1)
+	sch := schBranchAt("maxactive-patcherr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.MaxActiveSessions = &cap
+	})
+	active := schBranchActive(sch, "running")
+	r := newSchBranchReconciler(t, failStatusUpdate, sch, active)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("at-capacity schedule with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_MaxActiveHistoryGCError(t *testing.T) {
+	cap := int32(1)
+	limit := int32(0)
+	sch := schBranchAt("maxactive-gcerr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.MaxActiveSessions = &cap
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	active := schBranchActive(sch, "running")
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, active, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("at-capacity schedule with failing history GC must return error")
+	}
+}
+
+func TestSchedBranch_ForbidPatchStatusError(t *testing.T) {
+	sch := schBranchAt("forbid-patcherr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.ConcurrencyPolicy = podtracev1alpha1.ForbidConcurrent
+	})
+	active := schBranchActive(sch, "running")
+	r := newSchBranchReconciler(t, failStatusUpdate, sch, active)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("Forbid schedule with active sessions and failing status update must return error")
+	}
+}
+
+func TestSchedBranch_ForbidHistoryGCError(t *testing.T) {
+	limit := int32(0)
+	sch := schBranchAt("forbid-gcerr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.ConcurrencyPolicy = podtracev1alpha1.ForbidConcurrent
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	active := schBranchActive(sch, "running")
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, active, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("Forbid schedule with active sessions and failing history GC must return error")
+	}
+}
+
+func TestSchedBranch_ReplaceDeleteError(t *testing.T) {
+	sch := schBranchAt("replace-delerr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.ConcurrencyPolicy = podtracev1alpha1.ReplaceConcurrent
+	})
+	active := schBranchActive(sch, "running")
+	r := newSchBranchReconciler(t, failAllDeletes, sch, active)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("Replace schedule that fails to delete an active session must return error")
+	}
+}
+
+func TestSchedBranch_CreateSessionError(t *testing.T) {
+	sch := schBranchAt("create-err", fixedScheduleNow.Add(-6*time.Minute), nil)
+	funcs := interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*podtracev1alpha1.PodTraceSession); ok {
+				return errInternal()
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+	}
+	r := newSchBranchReconciler(t, funcs, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("failed session creation must surface as a Reconcile error")
+	}
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(context.Background(), types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if c := findScheduleCondition(got.Status.Conditions, ConditionDegraded); c == nil || c.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Degraded=True after create failure, conditions=%+v", got.Status.Conditions)
+	}
+}
+
+func TestSchedBranch_CreateSessionErrorAndPatchStatusError(t *testing.T) {
+	sch := schBranchAt("create-patcherr", fixedScheduleNow.Add(-6*time.Minute), nil)
+	funcs := interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*podtracev1alpha1.PodTraceSession); ok {
+				return errInternal()
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+		SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+			return errInternal()
+		},
+	}
+	r := newSchBranchReconciler(t, funcs, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("create failure with failing status update must return error")
+	}
+}
+
+func TestSchedBranch_FinalPatchStatusError(t *testing.T) {
+	sch := schBranchAt("final-patcherr", fixedScheduleNow.Add(-6*time.Minute), nil)
+	r := newSchBranchReconciler(t, failStatusUpdate, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("successful run with failing final status update must return error")
+	}
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(context.Background(), &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions.Items) != 1 {
+		t.Fatalf("session should still be created before the status write fails, got %d", len(sessions.Items))
+	}
+}
+
+func TestSchedBranch_SecondListError(t *testing.T) {
+	sch := schBranchAt("second-list-err", fixedScheduleNow.Add(-6*time.Minute), nil)
+	lists := 0
+	funcs := interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*podtracev1alpha1.PodTraceSessionList); ok {
+				lists++
+				if lists >= 2 {
+					return errInternal()
+				}
+			}
+			return cl.List(ctx, list, opts...)
+		},
+	}
+	r := newSchBranchReconciler(t, funcs, sch)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("post-create session re-list failure must return error")
+	}
+}
+
+func TestSchedBranch_PostCreateHistoryGCError(t *testing.T) {
+	limit := int32(0)
+	sch := schBranchAt("postcreate-gcerr", fixedScheduleNow.Add(-6*time.Minute), func(s *podtracev1alpha1.PodTraceSchedule) {
+		s.Spec.SuccessfulSessionsHistoryLimit = &limit
+	})
+	done := schBranchCompleted(sch, "done", fixedScheduleNow.Add(-time.Hour))
+	r := newSchBranchReconciler(t, failAllDeletes, sch, done)
+	if _, err := reconcileSchBranch(r, sch); err == nil {
+		t.Fatal("post-create history GC failure must return error")
+	}
+}
+
+func findScheduleCondition(conds []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == condType {
+			return &conds[i]
+		}
+	}
+	return nil
+}

--- a/internal/operator/podtracesession_capacity_test.go
+++ b/internal/operator/podtracesession_capacity_test.go
@@ -1,0 +1,51 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNodesAtCapacity_JobWithoutNodeLabelIgnored(t *testing.T) {
+	const ns = "team-a"
+	scheme := newOperatorScheme(t)
+
+	labelled := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labelled",
+			Namespace: "podtrace-system",
+			Labels: map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: "other",
+				LabelSessionNS:   ns,
+				LabelNodeName:    "n1",
+			},
+		},
+	}
+	unlabelled := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-node-label",
+			Namespace: "podtrace-system",
+			Labels: map[string]string{
+				LabelManagedBy:   ManagedByValue,
+				LabelComponent:   ComponentSession,
+				LabelSessionName: "other",
+				LabelSessionNS:   ns,
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(labelled, unlabelled).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	over, err := r.nodesAtCapacity(context.Background(), []string{"n1"}, 1, ns, "self")
+	if err != nil {
+		t.Fatalf("nodesAtCapacity: %v", err)
+	}
+	if len(over) != 1 || over[0] != "n1" {
+		t.Errorf("expected n1 over capacity from the labelled Job only, got %v", over)
+	}
+}

--- a/internal/operator/podtracesession_job_optional_fields_test.go
+++ b/internal/operator/podtracesession_job_optional_fields_test.go
@@ -1,0 +1,80 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func minimalSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-opt"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+}
+
+func TestBuildSessionJobSpec_ImagePullPolicyOverride(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image:           "ghcr.io/gma1k/podtrace:test",
+			ImagePullPolicy: corev1.PullAlways,
+		},
+	}
+	spec := buildSessionJobSpec(minimalSession(), tc, "node-a", sessionTargets{})
+	if got := spec.Template.Spec.Containers[0].ImagePullPolicy; got != corev1.PullAlways {
+		t.Errorf("ImagePullPolicy = %q, want Always", got)
+	}
+}
+
+func TestBuildSessionJobSpec_MainContainerAgentEnvFromTracerConfig(t *testing.T) {
+	usdtOff := false
+	dnsOff := false
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image: "ghcr.io/gma1k/podtrace:test",
+			Agent: podtracev1alpha1.AgentSpec{
+				USDT:           &usdtOff,
+				DNSFullAnswers: &dnsOff,
+				LogLevel:       "debug",
+			},
+		},
+	}
+	spec := buildSessionJobSpec(minimalSession(), tc, "node-a", sessionTargets{})
+	env := spec.Template.Spec.Containers[0].Env
+
+	if v, ok := envValue(env, "PODTRACE_USDT_ENABLED"); !ok || v != "false" {
+		t.Errorf("PODTRACE_USDT_ENABLED=%q ok=%v want false", v, ok)
+	}
+	if v, ok := envValue(env, "PODTRACE_DNS_PAYLOAD_ENABLED"); !ok || v != "false" {
+		t.Errorf("PODTRACE_DNS_PAYLOAD_ENABLED=%q ok=%v want false", v, ok)
+	}
+	if v, ok := envValue(env, "PODTRACE_LOG_LEVEL"); !ok || v != "debug" {
+		t.Errorf("PODTRACE_LOG_LEVEL=%q ok=%v want debug", v, ok)
+	}
+}
+
+func TestBuildSessionJobSpec_AgentEnvDefaultsWhenUnset(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	spec := buildSessionJobSpec(minimalSession(), tc, "node-a", sessionTargets{})
+	env := spec.Template.Spec.Containers[0].Env
+
+	if v, ok := envValue(env, "PODTRACE_USDT_ENABLED"); !ok || v != "true" {
+		t.Errorf("PODTRACE_USDT_ENABLED=%q ok=%v want true (default)", v, ok)
+	}
+	if v, ok := envValue(env, "PODTRACE_DNS_PAYLOAD_ENABLED"); !ok || v != "true" {
+		t.Errorf("PODTRACE_DNS_PAYLOAD_ENABLED=%q ok=%v want true (default)", v, ok)
+	}
+	if _, ok := envValue(env, "PODTRACE_LOG_LEVEL"); ok {
+		t.Error("PODTRACE_LOG_LEVEL must be absent when LogLevel is unset")
+	}
+}

--- a/internal/operator/podtracesession_objectstore_harvest_test.go
+++ b/internal/operator/podtracesession_objectstore_harvest_test.go
@@ -1,0 +1,84 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func harvestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := podtracev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("podtrace scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestHarvestReportLocation_ListError(t *testing.T) {
+	scheme := harvestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+			return apierrors.NewInternalError(errors.New("synthetic list failure"))
+		},
+	}).Build()
+
+	if _, err := harvestReportLocation(context.Background(), c, sessionWithObjectStore(""), "podtrace-system"); err == nil {
+		t.Fatal("expected error when listing session pods fails")
+	}
+}
+
+func TestHarvestReportLocation_SkipsNonUploaderAndTracksRestarts(t *testing.T) {
+	scheme := harvestScheme(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "diag-pod",
+			Namespace: "podtrace-system",
+			Labels: map[string]string{
+				LabelSessionName: "diag",
+				LabelSessionNS:   "default",
+			},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "unrelated-init",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+				{
+					Name:         reportUploaderContainerName,
+					RestartCount: 3,
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	obs, err := harvestReportLocation(context.Background(), c, sessionWithObjectStore(""), "podtrace-system")
+	if err != nil {
+		t.Fatalf("harvest: %v", err)
+	}
+	if obs.Attempts != 3 {
+		t.Errorf("Attempts = %d, want 3 (highest restart count of the uploader)", obs.Attempts)
+	}
+	if obs.Terminated {
+		t.Error("Terminated must stay false while the uploader is still running")
+	}
+	if obs.Succeeded || obs.ResolvedURI != "" {
+		t.Errorf("running uploader must not report success: %+v", obs)
+	}
+}

--- a/internal/operator/podtracesession_reconcile_branches_test.go
+++ b/internal/operator/podtracesession_reconcile_branches_test.go
@@ -1,0 +1,125 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestSessionBranch_DeletionTracerConfigUnreadable(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	now := metav1.Now()
+	s := sessMoreSession(func(s *podtracev1alpha1.PodTraceSession) { s.DeletionTimestamp = &now })
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*podtracev1alpha1.TracerConfig); ok {
+					return errInternal()
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	if _, err := sessMoreReconcile(t, r); err != nil {
+		t.Fatalf("deletion must fall back to default system namespace when TracerConfig is unreadable, got %v", err)
+	}
+	var got podtracev1alpha1.PodTraceSession
+	err := c.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, &got)
+	if err == nil && len(got.Finalizers) != 0 {
+		t.Fatalf("finalizer should be cleared after cleanup, got %v", got.Finalizers)
+	}
+}
+
+func TestSessionBranch_SetFinalizerConflictRequeues(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", UID: "uid-s", Generation: 1},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.UpdateOption) error {
+				if _, ok := obj.(*podtracev1alpha1.PodTraceSession); ok {
+					return errConflict("podtracesessions", "s")
+				}
+				return nil
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	res, err := sessMoreReconcile(t, r)
+	if err != nil {
+		t.Fatalf("a conflict while adding the finalizer must requeue without error, got %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("expected a requeue after finalizer-set conflict, got %+v", res)
+	}
+}
+
+func TestSessionBranch_SecretToSessionsListError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{
+				Endpoint:          "otel:4318",
+				Protocol:          podtracev1alpha1.OTLPProtocolHTTP,
+				HeadersFromSecret: &podtracev1alpha1.LocalObjectReference{Name: "creds"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.PodTraceSessionList); ok {
+					return errInternal()
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	got := r.secretToPodTraceSessions(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "team-a"},
+	})
+	if got != nil {
+		t.Fatalf("a failed session list must yield no requeue requests, got %v", got)
+	}
+}
+
+func TestSessionBranch_EnsureJobsListOwnedError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return errInternal()
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "uid-s"},
+	}
+	if _, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: nil}, nil); err == nil {
+		t.Fatal("ensureJobs must surface the owned-Job list error")
+	}
+}

--- a/internal/operator/session_helpers_branches_test.go
+++ b/internal/operator/session_helpers_branches_test.go
@@ -1,0 +1,193 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func helperTestSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "sess-uid"},
+	}
+}
+
+func TestEnsureSessionExporterBundle_RenderError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := helperTestSession()
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
+		Spec:       podtracev1alpha1.ExporterConfigSpec{Type: podtracev1alpha1.ExporterTypeOTLP},
+	}
+	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err == nil {
+		t.Fatal("an OTLP ExporterConfig with a nil OTLP block must fail bundle rendering")
+	}
+}
+
+func TestEnsureSessionExporterBundle_PruneStaleSecretDeleteError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	s := helperTestSession()
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err == nil {
+		t.Fatal("a failing prune of the credential-less bundle Secret must be surfaced")
+	}
+}
+
+func TestEnsureSessionObjectStoreCredentials_GetError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	s := helperTestSession()
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{
+			URI:                  "s3://b/k",
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "creds"},
+		},
+	}
+	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, s, "podtrace-system"); err == nil {
+		t.Fatal("a non-NotFound Get of the credentials Secret must be surfaced")
+	}
+}
+
+func TestEnsureSessionObjectStoreCredentials_CreateError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "team-a"},
+		Data:       map[string][]byte{"access": []byte("k")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	s := helperTestSession()
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{
+			URI:                  "s3://b/k",
+			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "creds"},
+		},
+	}
+	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, s, "podtrace-system"); err == nil {
+		t.Fatal("a failing upsert of the copied credentials Secret must be surfaced")
+	}
+}
+
+func TestPopulateSessionSummaries_ReadError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*corev1.PodList); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	s := helperTestSession()
+	completed := metav1.Now()
+	jobs := []batchv1.Job{{
+		ObjectMeta: metav1.ObjectMeta{Name: "j1", Namespace: "podtrace-system"},
+		Status:     batchv1.JobStatus{CompletionTime: &completed},
+	}}
+	if err := populateSessionSummaries(context.Background(), c, s, jobs); err == nil {
+		t.Fatal("a failing pod list while reading a finished Job's summary must be surfaced")
+	}
+}
+
+func TestSessionJobName_EmptyNodeFallsBackToHashOnly(t *testing.T) {
+	name := SessionJobName("sess-uid", "")
+	if name == "" {
+		t.Fatal("empty node name must still yield a non-empty Job name")
+	}
+	if !strings.HasPrefix(name, "pts-") {
+		t.Fatalf("Job name %q must retain the pts- prefix", name)
+	}
+	if strings.HasSuffix(name, "-") {
+		t.Fatalf("Job name %q must not end in a dash", name)
+	}
+}
+
+func durationSampleCount(t *testing.T, backend, result string) uint64 {
+	t.Helper()
+	obs, err := reportUploadDuration.GetMetricWithLabelValues(backend, result)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	m, ok := obs.(prometheus.Metric)
+	if !ok {
+		t.Fatal("histogram observer is not a prometheus.Metric")
+	}
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return pb.GetHistogram().GetSampleCount()
+}
+
+func TestObserveReportUploadMetrics_ObservesDurationWhenStarted(t *testing.T) {
+	reset := func() {
+		forgetReportObservations("ns-dur", "s-dur")
+		reportUploadAttempts.Reset()
+		reportUploadDuration.Reset()
+	}
+	reset()
+	defer reset()
+
+	s := &podtracev1alpha1.PodTraceSession{}
+	s.Name, s.Namespace = "s-dur", "ns-dur"
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ObjectStore: &podtracev1alpha1.ObjectStoreReference{URI: "s3://b/k/"},
+	}
+	start := metav1.NewTime(time.Now().Add(-2 * time.Second))
+	s.Status.StartTime = &start
+
+	observeReportUploadMetrics(s, reportUploadObservation{
+		ResolvedURI: "s3://b/k/r.txt",
+		Terminated:  true,
+		Succeeded:   true,
+		Attempts:    1,
+	})
+
+	if got := durationSampleCount(t, "s3", "success"); got != 1 {
+		t.Errorf("duration histogram sample count = %d, want 1 once StartTime is set", got)
+	}
+}

--- a/internal/operator/session_rbac_cleanup_branches_test.go
+++ b/internal/operator/session_rbac_cleanup_branches_test.go
@@ -1,0 +1,95 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func rbacTestSession() *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "sess-uid"},
+	}
+}
+
+func TestCleanupPodReadRBAC_RoleBindingDeleteError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := rbacTestSession()
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SessionPodReadRoleBindingName(s.UID),
+			Namespace: "granted-ns",
+			Labels:    sessionRBACLabels(s),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(binding).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*rbacv1.RoleBinding); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+
+	if err := cleanupSessionPodReadRBAC(context.Background(), c, s); err == nil {
+		t.Fatal("pod-read RoleBinding delete failure must be surfaced")
+	}
+}
+
+func TestCleanupPodReadRBAC_RoleDeleteError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := rbacTestSession()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SessionPodReadRoleName(s.UID),
+			Namespace: "granted-ns",
+			Labels:    sessionRBACLabels(s),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(role).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+				if _, ok := obj.(*rbacv1.Role); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+
+	if err := cleanupSessionPodReadRBAC(context.Background(), c, s); err == nil {
+		t.Fatal("pod-read Role delete failure must be surfaced")
+	}
+}
+
+func TestEnsureSessionReportObject_InspectExistingError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := rbacTestSession()
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ConfigMap: &corev1.LocalObjectReference{Name: "report-cm"},
+	}
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "report-cm", Namespace: s.Namespace},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+
+	if err := ensureSessionReportObject(context.Background(), c, s); err == nil {
+		t.Fatal("failure to inspect the pre-existing report object must be surfaced")
+	}
+}

--- a/internal/operator/tracerconfig_cleanup_branches_test.go
+++ b/internal/operator/tracerconfig_cleanup_branches_test.go
@@ -1,0 +1,128 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func newTracerConfigCleanupReconciler(t *testing.T, stale client.Object) *TracerConfigReconciler {
+	t.Helper()
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return errInternal()
+			},
+		}).Build()
+	return &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+}
+
+func TestTCCleanupBranch_DaemonSetDeleteError(t *testing.T) {
+	labels := map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent}
+	r := newTracerConfigCleanupReconciler(t, &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: AgentDaemonSetName(), Namespace: "old-ns", Labels: labels},
+	})
+	if err := r.cleanupStaleAgentNamespaces(context.Background(), "podtrace-system"); err == nil {
+		t.Fatal("stale DaemonSet delete failure must be surfaced")
+	}
+}
+
+func TestTCCleanupBranch_ServiceAccountDeleteError(t *testing.T) {
+	labels := map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent}
+	r := newTracerConfigCleanupReconciler(t, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: AgentServiceAccountName(), Namespace: "old-ns", Labels: labels},
+	})
+	if err := r.cleanupStaleAgentNamespaces(context.Background(), "podtrace-system"); err == nil {
+		t.Fatal("stale ServiceAccount delete failure must be surfaced")
+	}
+}
+
+func TestTCCleanupBranch_RoleDeleteError(t *testing.T) {
+	labels := map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent}
+	r := newTracerConfigCleanupReconciler(t, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: AgentBundleRoleName(), Namespace: "old-ns", Labels: labels},
+	})
+	if err := r.cleanupStaleAgentNamespaces(context.Background(), "podtrace-system"); err == nil {
+		t.Fatal("stale Role delete failure must be surfaced")
+	}
+}
+
+func TestTCCleanupBranch_RoleBindingDeleteError(t *testing.T) {
+	labels := map[string]string{LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent}
+	r := newTracerConfigCleanupReconciler(t, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: AgentBundleRoleBindingName(), Namespace: "old-ns", Labels: labels},
+	})
+	if err := r.cleanupStaleAgentNamespaces(context.Background(), "podtrace-system"); err == nil {
+		t.Fatal("stale RoleBinding delete failure must be surfaced")
+	}
+}
+
+func TestTCReconcileBranch_RBACErrorStatusUpdateAlsoFails(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName, Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: DefaultTracerConfigName},
+	}); err == nil {
+		t.Fatal("RBAC failure must surface as a Reconcile error even when the status write also fails")
+	}
+}
+
+func TestTCReconcileBranch_DaemonSetErrorStatusUpdateAlsoFails(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName, Generation: 1},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.DaemonSet); ok {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: DefaultTracerConfigName},
+	}); err == nil {
+		t.Fatal("DaemonSet failure must surface as a Reconcile error even when the status write also fails")
+	}
+}

--- a/internal/operator/tracerconfig_daemonset_alerting_test.go
+++ b/internal/operator/tracerconfig_daemonset_alerting_test.go
@@ -1,0 +1,55 @@
+package operator
+
+import (
+	"testing"
+
+	podtracev1alpha1 "github.com/podtrace/podtrace/api/v1alpha1"
+)
+
+func TestBuildAgentDaemonSetSpec_AlertingWiresWebhookEnv(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.Agent.Alerting = &podtracev1alpha1.AgentAlertingSpec{
+			Enabled:              true,
+			WebhookURL:           "https://alerts.example.com/hook",
+			AllowInsecureWebhook: true,
+		}
+	}), "podtrace-system")
+
+	env := spec.Template.Spec.Containers[0].Env
+	if v, ok := envValue(env, "PODTRACE_ALERTING_ENABLED"); !ok || v != "true" {
+		t.Errorf("PODTRACE_ALERTING_ENABLED=%q ok=%v want true", v, ok)
+	}
+	if v, ok := envValue(env, "PODTRACE_ALERT_WEBHOOK_URL"); !ok || v != "https://alerts.example.com/hook" {
+		t.Errorf("PODTRACE_ALERT_WEBHOOK_URL=%q ok=%v want the webhook url", v, ok)
+	}
+	if v, ok := envValue(env, "PODTRACE_ALERT_WEBHOOK_ALLOW_HTTP"); !ok || v != "true" {
+		t.Errorf("PODTRACE_ALERT_WEBHOOK_ALLOW_HTTP=%q ok=%v want true", v, ok)
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_AlertingEnabledWithoutOptionalFields(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.Agent.Alerting = &podtracev1alpha1.AgentAlertingSpec{Enabled: true}
+	}), "podtrace-system")
+
+	env := spec.Template.Spec.Containers[0].Env
+	if v, ok := envValue(env, "PODTRACE_ALERTING_ENABLED"); !ok || v != "true" {
+		t.Errorf("PODTRACE_ALERTING_ENABLED=%q ok=%v want true", v, ok)
+	}
+	if _, ok := envValue(env, "PODTRACE_ALERT_WEBHOOK_URL"); ok {
+		t.Error("PODTRACE_ALERT_WEBHOOK_URL must be absent when WebhookURL is empty")
+	}
+	if _, ok := envValue(env, "PODTRACE_ALERT_WEBHOOK_ALLOW_HTTP"); ok {
+		t.Error("PODTRACE_ALERT_WEBHOOK_ALLOW_HTTP must be absent when AllowInsecureWebhook is false")
+	}
+}
+
+func TestBuildAgentDaemonSetSpec_AlertingDisabledOmitsEnv(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
+		x.Spec.Agent.Alerting = &podtracev1alpha1.AgentAlertingSpec{Enabled: false, WebhookURL: "https://x"}
+	}), "podtrace-system")
+
+	if _, ok := envValue(spec.Template.Spec.Containers[0].Env, "PODTRACE_ALERTING_ENABLED"); ok {
+		t.Error("PODTRACE_ALERTING_ENABLED must be absent when alerting is disabled")
+	}
+}

--- a/internal/profiling/fetchtext_test.go
+++ b/internal/profiling/fetchtext_test.go
@@ -1,0 +1,63 @@
+package profiling
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchText_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("heap profile body"))
+	}))
+	defer srv.Close()
+
+	p := NewPodProfiler("127.0.0.1", nil)
+	body, raw, err := p.fetchText(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchText: unexpected error %v", err)
+	}
+	if body != "heap profile body" {
+		t.Errorf("body=%q want %q", body, "heap profile body")
+	}
+	if string(raw) != body {
+		t.Errorf("raw=%q want %q", string(raw), body)
+	}
+}
+
+func TestFetchText_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := NewPodProfiler("127.0.0.1", nil)
+	_, _, err := p.fetchText(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected error on HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %q should mention status 500", err.Error())
+	}
+}
+
+func TestFetchText_BadURL(t *testing.T) {
+	p := NewPodProfiler("127.0.0.1", nil)
+	if _, _, err := p.fetchText(context.Background(), "://not-a-url"); err == nil {
+		t.Error("expected error building request for malformed URL")
+	}
+}
+
+func TestFetchText_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	p := NewPodProfiler("127.0.0.1", nil)
+	if _, _, err := p.fetchText(context.Background(), url); err == nil {
+		t.Error("expected transport error against closed server")
+	}
+}

--- a/internal/tracing/context/context_remote_parent_test.go
+++ b/internal/tracing/context/context_remote_parent_test.go
@@ -1,0 +1,56 @@
+package context
+
+import "testing"
+
+func TestTraceContext_HasRemoteParent(t *testing.T) {
+	cases := []struct {
+		name    string
+		traceID string
+		parent  string
+		want    bool
+	}{
+		{"both set", "abc", "def", true},
+		{"no parent", "abc", "", false},
+		{"no trace id", "", "def", false},
+		{"neither", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := &TraceContext{TraceID: c.traceID, ParentSpanID: c.parent}
+			if got := tc.HasRemoteParent(); got != c.want {
+				t.Errorf("HasRemoteParent()=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsLowerHex_Cases(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"00ff", true},
+		{"0123456789abcdef", true},
+		{"ABCD", false},
+		{"gg", false},
+		{"12 34", false},
+	}
+	for _, c := range cases {
+		if got := isLowerHex(c.in); got != c.want {
+			t.Errorf("isLowerHex(%q)=%v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseW3CTraceParent_AllZeroRejected(t *testing.T) {
+	zeroTrace := "00-00000000000000000000000000000000-0000000000000001-01"
+	if _, err := ParseW3CTraceParent(zeroTrace); err == nil {
+		t.Error("expected all-zero trace ID to be rejected")
+	}
+
+	zeroParent := "00-0000000000000000000000000000abcd-0000000000000000-01"
+	if _, err := ParseW3CTraceParent(zeroParent); err == nil {
+		t.Error("expected all-zero parent ID to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

Add focused unit tests that broaden coverage across the `cmd` and `internal` packages, targeting previously-untested pure-logic branches.

## What's covered

- `internal/ebpf/probes`: ELF/DWARF symbol resolution, gosym offset parsing, rustls/quiche symbol matching, and TLS debug-info handling, driven by a purpose-built fixture binary and hand-crafted ELF fixtures.
- `internal/ebpf/tracer`: circuit-breaker, sliding-window, error classification, and cgroup/probe-group helper branches.
- `internal/operator`: reconcile and reconcile-helper error paths for the schedule, session, tracer-config, application-trace, and finalizer controllers, using fake clients and interceptors.
- `cmd/podtrace`: CLI helpers for event filtering, target validation, tracing-flag wiring, and session-artifact aggregation.
- `internal/kubernetes`, `nodespawn`, `agent`, `tracing/context`, and `profiling`: assorted helper and error-path branches.