### PR TITLE
chore: trigger release 0.14.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -91,7 +91,8 @@
           "type": "style",
           "section": "Maintenance"
         }
-      ]
+      ],
+      "release-as": "0.14.0"
     }
   }
 }


### PR DESCRIPTION
Sets `release-as: 0.14.0` in [release-please-config.json](../blob/main/release-please-config.json) so the next release-please run cuts `v0.14.0`.

## What happens after this PR merges

1. Release-please picks up the `release-as` field on its next run (triggered by any push to `main`).
2. It opens a separate PR titled `chore(release): release 0.14.0` that bumps CHANGELOG / Chart.yaml / manifest.
3. When that PR is merged, the `v0.14.0` tag is created and the release pipeline runs (image, chart, Krew, OLM bundle).
4. Release-please clears `release-as` from the config as part of its own commit, so subsequent commits resume normal patch-bump behaviour.

Any merge strategy works for this PR — the version override is in a file diff, not a commit-message footer.