### PR TITLE
feat: surface agent, session and exporter config knobs in the Helm chart

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -29,11 +29,12 @@ podtrace specifically:
 - **Best-effort backward compatibility within a minor release line.** A
   patch release (e.g. `v0.11.0` → `v0.11.1`) will not break existing
   manifests. Minor releases (`v0.11.0` → `v0.12.0`) may.
-- **Reserved-but-rejected fields are forward-compatibility markers, not
-  promises.** Example: `PodTraceSession.spec.reportRef.objectStore` is
-  defined in the schema but rejected by the validating webhook today. It
-  will be enabled in a future version; the field name and shape may still
-  change before that happens.
+- **Reserved fields are forward-compatibility markers, not promises.** A
+  field may appear in the schema before its behavior is fully implemented.
+  Until it is, the validating webhook may reject it, the operator may
+  ignore it, and its name and shape may still change. Such fields are
+  called out as reserved in the reference docs for the resource that
+  defines them.
 - **Production use is allowed but not recommended without pinning.** Pin
   to a specific `v0.x.y` tag and read this changelog before each upgrade.
 

--- a/deploy/charts/podtrace/templates/cr-bootstrap.yaml
+++ b/deploy/charts/podtrace/templates/cr-bootstrap.yaml
@@ -91,6 +91,10 @@ data:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       agent:
         {{- with .Values.agent.resources }}
         resources:
@@ -105,6 +109,20 @@ data:
         {{- if .Values.agent.statusReportInterval }}
         statusReportInterval: {{ .Values.agent.statusReportInterval | quote }}
         {{- end }}
+        {{- with .Values.agent.logLevel }}
+        logLevel: {{ . | quote }}
+        {{- end }}
+        dnsPacketCapture: {{ .Values.agent.dnsPacketCapture }}
+        dnsFullAnswers: {{ .Values.agent.dnsFullAnswers }}
+        usdt: {{ .Values.agent.usdt }}
+        {{- if .Values.agent.alerting.enabled }}
+        alerting:
+          enabled: true
+          {{- with .Values.agent.alerting.webhookURL }}
+          webhookURL: {{ . | quote }}
+          {{- end }}
+          allowInsecureWebhook: {{ .Values.agent.alerting.allowInsecureWebhook }}
+        {{- end }}
       session:
         {{- with .Values.session.resources }}
         resources:
@@ -114,6 +132,9 @@ data:
         activeDeadlineSecondsOffset: {{ .Values.session.activeDeadlineSecondsOffset }}
         backoffLimit: {{ .Values.session.backoffLimit }}
         sidecarUploader: {{ .Values.tracerConfig.sidecarUploader }}
+        {{- with .Values.session.maxDuration }}
+        maxDuration: {{ . | quote }}
+        {{- end }}
       {{- if .Values.tracerConfig.redaction.enabled }}
       redaction:
         enabled: true
@@ -147,6 +168,12 @@ data:
         endpoint: {{ .Values.examples.exporterconfig.endpoint | quote }}
         protocol: {{ .Values.examples.exporterconfig.protocol | default "http" }}
         insecure: {{ .Values.examples.exporterconfig.insecure }}
+      {{- if .Values.examples.exporterconfig.samplePercent }}
+      samplePercent: {{ .Values.examples.exporterconfig.samplePercent }}
+      {{- end }}
+      {{- if .Values.examples.exporterconfig.synthesizeSpans }}
+      synthesizeSpans: true
+      {{- end }}
   {{- end }}
 ---
 apiVersion: v1

--- a/deploy/charts/podtrace/values.schema.json
+++ b/deploy/charts/podtrace/values.schema.json
@@ -7,17 +7,47 @@
         "agent": {
             "type": "object",
             "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "alerting": {
+                    "type": "object",
+                    "properties": {
+                        "allowInsecureWebhook": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "webhookURL": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "btfMode": {
                     "type": "string"
                 },
+                "dnsFullAnswers": {
+                    "type": "boolean"
+                },
+                "dnsPacketCapture": {
+                    "type": "boolean"
+                },
                 "eventBufferSize": {
                     "type": "integer"
+                },
+                "logLevel": {
+                    "type": "string",
+                    "enum": ["", "debug", "info", "warn", "error"]
                 },
                 "nodeSelector": {
                     "type": "object"
                 },
                 "priorityClassName": {
                     "type": "string"
+                },
+                "usdt": {
+                    "type": "boolean"
                 },
                 "resources": {
                     "type": "object",
@@ -105,6 +135,14 @@
                         },
                         "protocol": {
                             "type": "string"
+                        },
+                        "samplePercent": {
+                            "type": ["integer", "null"],
+                            "minimum": 0,
+                            "maximum": 100
+                        },
+                        "synthesizeSpans": {
+                            "type": "boolean"
                         }
                     }
                 }
@@ -258,6 +296,9 @@
                 },
                 "maxConcurrentSessionsPerNode": {
                     "type": "integer"
+                },
+                "maxDuration": {
+                    "type": "string"
                 },
                 "resources": {
                     "type": "object",

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -23,10 +23,6 @@ crds:
 
   adopt: true
 
-  # Image for the CRD-labeler / namespace / cr-bootstrap hook Jobs (kubectl).
-  # Empty uses a digest-pinned alpine/k8s default so these cluster-critical
-  # hooks are reproducible and cannot silently change when the upstream tag
-  # moves. Override with your own (ideally digest-pinned) mirror if needed.
   labelerImage: ""
 
   keep: true
@@ -72,16 +68,31 @@ agent:
   tolerations:
     - operator: Exists
       effect: NoSchedule
+  affinity: {}
   priorityClassName: system-node-critical
   eventBufferSize: 10000
   statusReportInterval: 30s
   btfMode: auto
+
+  logLevel: ""
+
+  dnsPacketCapture: true
+
+  dnsFullAnswers: true
+
+  usdt: true
+
+  alerting:
+    enabled: false
+    webhookURL: ""
+    allowInsecureWebhook: false
 
 session:
   ttlSecondsAfterFinished: 300
   activeDeadlineSecondsOffset: 30
   backoffLimit: 0
   maxConcurrentSessionsPerNode: 2
+  maxDuration: ""
   resources:
     requests:
       cpu: 100m
@@ -136,3 +147,5 @@ examples:
     endpoint: otel-collector.observability:4318
     protocol: http
     insecure: true
+    samplePercent: null
+    synthesizeSpans: false

--- a/docs/crd-exporterconfig.md
+++ b/docs/crd-exporterconfig.md
@@ -122,7 +122,7 @@ spec:
 | `otlp.protocol` | enum | `http` / `grpc`. Defaults to `http`. |
 | `otlp.insecure` | bool | Disables TLS. |
 | `otlp.headers[]` | list | Either literal `value` or `valueFrom: SecretKeySelector`. |
-| `otlp.headersFromSecret` | object | Reserved for "every Secret key becomes a header". |
+| `otlp.headersFromSecret` | object | `{name}` reference to a Secret in the same namespace; every key in that Secret becomes an OTLP header. Use for bulk or additional secret-backed headers beyond the single `headers[].valueFrom` credential. |
 | `jaeger.endpoint` | string | Required when `type=jaeger`. |
 | `zipkin.endpoint` | string | Required when `type=zipkin`. |
 | `splunk.endpoint` | string | Splunk HEC URL. |
@@ -143,7 +143,8 @@ operator creates two objects in `podtrace-system`:
    `sample_percent`, and a `bundle.yaml` blob the CLI consumes.
 2. **Secret** with the same name (created only when the exporter
    references credential material). Carries the resolved value under
-   the fixed `credential` key.
+   the fixed `credential` key, plus one `header.<name>` key for each
+   key of the Secret referenced by `otlp.headersFromSecret`.
 
 ## Credential rotation
 

--- a/docs/crd-podtrace.md
+++ b/docs/crd-podtrace.md
@@ -48,7 +48,7 @@ spec:
 | `selector` | LabelSelector | one of selector/podRefs/appSelector | Pods labeled to trace. Empty selector is rejected. |
 | `podRefs` | `[{namespace, name}]` | one of selector/podRefs/appSelector | Explicit pod list. Cross-namespace allowed. |
 | `appSelector` | `{matchSelectors: []LabelSelector}` | one of selector/podRefs/appSelector | Application of several workloads: a pod matching **any** selector is traced (union, de-duplicated). Exactly-one-of is enforced by CEL + webhook. |
-| `namespaceSelector` | LabelSelector | optional | Widens `selector` across namespaces. Field's expressions are not yet evaluated; presence alone enables cluster-wide search. |
+| `namespaceSelector` | LabelSelector | optional | Widens `selector` across namespaces. `matchLabels` and `matchExpressions` are both evaluated against namespace labels; an empty selector (`{}`) matches every namespace. A matched namespace is only traced if it consents via the `podtrace.io/allow-tracing-from` annotation. |
 | `filters` | `[dns,net,fs,cpu,proc,crypto]` | optional | Empty = all categories. Agents enforce the set per-event in userspace and only the listed categories reach the configured exporter. |
 | `exporterRef.name` | string | required | Names an `ExporterConfig` in the same namespace. |
 | `paused` | bool | optional | Stop emitting events without deleting the CR. |

--- a/docs/language-runtime-adapters.md
+++ b/docs/language-runtime-adapters.md
@@ -160,8 +160,11 @@ Via Helm, the same is exposed under `tracerConfig.redaction` in `values.yaml`. T
 
 Scans the container binary's ELF `.note.stapsdt` section to discover available userspace tracepoints (USDTs).
 
+USDT scanning is enabled by default. Disable it by setting the environment
+variable to `false` (or `agent.usdt: false` in the Helm chart):
+
 ```bash
-export PODTRACE_USDT_ENABLED=true
+export PODTRACE_USDT_ENABLED=false
 ./bin/podtrace -n production my-pod
 ```
 
@@ -177,7 +180,7 @@ When enabled, Podtrace logs all discovered USDT probes at startup:
 | Variable | Default | Description |
 |---|---|---|
 | `PODTRACE_GRPC_PORT` | `50051` | Destination port used to identify gRPC traffic |
-| `PODTRACE_USDT_ENABLED` | `false` | Enable USDT probe scanning on the container binary |
+| `PODTRACE_USDT_ENABLED` | `true` | Scan the container binary for USDT probes; set `false` to disable |
 | `PODTRACE_REDACT_PII` | `false` | Scrub PII from event Target/Details fields |
 | `PODTRACE_REDACT_CUSTOM_RULES` | `""` | JSON array of additional redaction rules |
 | `PODTRACE_CRITICAL_PATH` | `true` | Emit per-request latency breakdowns |

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -423,6 +423,71 @@ func TestChart_OperatorClusterRoleHasRoleAndRoleBindingVerbs(t *testing.T) {
 	}
 }
 
+func TestChart_AgentAndSessionKnobsPropagate(t *testing.T) {
+	out := renderChart(t,
+		"operator.enabled=true",
+		"agent.logLevel=warn",
+		"agent.usdt=false",
+		"agent.dnsFullAnswers=false",
+		"agent.dnsPacketCapture=false",
+		"agent.alerting.enabled=true",
+		"agent.alerting.webhookURL=https://alerts.example/hook",
+		"agent.alerting.allowInsecureWebhook=true",
+		"session.maxDuration=45m",
+	)
+	for _, marker := range []string{
+		`logLevel: "warn"`,
+		"usdt: false",
+		"dnsFullAnswers: false",
+		"dnsPacketCapture: false",
+		"alerting:",
+		"enabled: true",
+		`webhookURL: "https://alerts.example/hook"`,
+		"allowInsecureWebhook: true",
+		`maxDuration: "45m"`,
+	} {
+		if !bytes.Contains(out, []byte(marker)) {
+			t.Errorf("rendered TracerConfig missing %q", marker)
+		}
+	}
+}
+
+func TestChart_AgentTracingDefaultsOn(t *testing.T) {
+	out := renderChart(t, "operator.enabled=true")
+	for _, marker := range []string{
+		"usdt: true",
+		"dnsPacketCapture: true",
+		"dnsFullAnswers: true",
+	} {
+		if !bytes.Contains(out, []byte(marker)) {
+			t.Errorf("default TracerConfig missing %q", marker)
+		}
+	}
+	if bytes.Contains(out, []byte(`webhookURL: "`)) {
+		t.Error("default render must not emit an alerting webhookURL")
+	}
+	if bytes.Contains(out, []byte(`logLevel: "`)) {
+		t.Error("default render must not pin a logLevel (agent uses the binary default)")
+	}
+}
+
+func TestChart_ExporterExampleSamplingKnobs(t *testing.T) {
+	out := renderChart(t,
+		"operator.enabled=true",
+		"examples.exporterconfig.enabled=true",
+		"examples.exporterconfig.samplePercent=25",
+		"examples.exporterconfig.synthesizeSpans=true",
+	)
+	for _, marker := range []string{
+		"samplePercent: 25",
+		"synthesizeSpans: true",
+	} {
+		if !bytes.Contains(out, []byte(marker)) {
+			t.Errorf("example ExporterConfig missing %q", marker)
+		}
+	}
+}
+
 func parseKinds(t *testing.T, raw []byte) map[string]int {
 	t.Helper()
 	out := map[string]int{}


### PR DESCRIPTION
## Summary
Exposes TracerConfig and example ExporterConfig fields the operator already consumes but the chart never set, and fixes docs that still called shipped features unimplemented.

## Changes
- Helm: add `agent.alerting`, `agent.logLevel`, `agent.dnsPacketCapture`, `agent.dnsFullAnswers`, `agent.usdt`, `agent.affinity`, `session.maxDuration`, and `examples.exporterconfig.samplePercent`/`synthesizeSpans` (values.yaml + cr-bootstrap.yaml + values.schema.json).
- Docs: correct stale claims for `reportRef.objectStore`, USDT default, `otlp.headersFromSecret`, and `namespaceSelector`.
- Tests: chart render tests confirming the knobs land in the rendered TracerConfig.