### PR TITLE
ci: require DCO sign-off on every commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Thanks for opening a PR! A few quick conventions before you submit:
         docs: ...        docs only
         test: ...        test-only
   • Subject ≤ 72 chars, imperative present tense, no trailing period.
+  • Sign off every commit: git commit -s (DCO, enforced by CI).
   • Avoid Co-Authored-By trailers (project convention).
 -->
 
@@ -28,6 +29,7 @@ Thanks for opening a PR! A few quick conventions before you submit:
 <!-- Tick every box that applies. Strike-through (~~text~~) the ones
      that genuinely don't, with a one-line reason. -->
 
+- [ ] All commits signed off (`git commit -s`)
 - [ ] `make test` (unit) green
 - [ ] `make test-integration` green (or n/a for docs/chore)
 - [ ] `make chainsaw` green on a local kind cluster (or n/a)

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,93 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dco-check:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${BASE_SHA}" ] || [ -z "${HEAD_SHA}" ]; then
+            echo "Not a pull_request event, nothing to verify."
+            exit 0
+          fi
+
+          failed=0
+
+          for sha in $(git rev-list "${BASE_SHA}..${HEAD_SHA}"); do
+            short=$(git rev-parse --short "${sha}")
+            subject=$(git show -s --format='%s' "${sha}")
+            author=$(git show -s --format='%ae' "${sha}" | tr '[:upper:]' '[:lower:]')
+
+            case "${author}" in
+              *'[bot]@users.noreply.github.com')
+                echo "skip     ${short}  ${subject}"
+                continue
+                ;;
+            esac
+
+            matched=0
+            trailers=$(git show -s --format='%B' "${sha}" |
+              sed -n 's/^[Ss]igned-off-by:[[:space:]]*//p')
+
+            while IFS= read -r trailer; do
+              [ -n "${trailer}" ] || continue
+              email=${trailer##*<}
+              email=${email%%>*}
+              email=$(printf '%s' "${email}" | tr '[:upper:]' '[:lower:]')
+              if [ "${email}" = "${author}" ]; then
+                matched=1
+              fi
+            done <<TRAILERS
+          ${trailers}
+          TRAILERS
+
+            if [ "${matched}" -eq 1 ]; then
+              echo "ok       ${short}  ${subject}"
+            else
+              echo "MISSING  ${short}  ${subject}"
+              echo "         needs: Signed-off-by: Your Name <${author}>"
+              failed=1
+            fi
+          done
+
+          if [ "${failed}" -ne 0 ]; then
+            echo
+            echo "One or more commits are missing a Developer Certificate of Origin"
+            echo "sign-off matching the commit author. See CONTRIBUTING.md, section"
+            echo "'Developer Certificate of Origin'."
+            echo
+            echo "Fix the most recent commit:"
+            echo "  git commit --amend -s --no-edit && git push --force-with-lease"
+            echo
+            echo "Fix every commit on this branch:"
+            echo "  git rebase --signoff origin/main && git push --force-with-lease"
+            exit 1
+          fi
+
+          echo
+          echo "All commits carry a DCO sign-off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,7 @@ them locally and you will not be surprised by CI.
 | Shell portability | `checkbashisms $(git ls-files '*.sh')` | `bash-checks.yml` (blocks merge) |
 | Helm chart | `make helm-lint` | Chart changes |
 | Whitespace / EOL | `.editorconfig` | Your editor |
+| DCO sign-off | `git commit -s` | `dco.yml` (blocks merge) |
 
 ### Go
 
@@ -268,6 +269,60 @@ mapping kicks in (`feat:` → minor, `BREAKING CHANGE:` → major). See
 [STABILITY.md](STABILITY.md) for the full versioning policy and the
 graduation criteria from `v0.x` to `v1.0.0`.
 
+## Developer Certificate of Origin
+
+Every commit must carry a Developer Certificate of Origin (DCO) sign-off.
+The DCO is a short assertion, reproduced in full at
+[developercertificate.org](https://developercertificate.org/), that you have
+the right to submit the code under this project's Apache-2.0 licence. There
+is no CLA, no account to create, and nothing to sign out of band: the
+sign-off lives in the commit message itself.
+
+Add it with `-s`:
+
+```bash
+git commit -s -m "fix(loader): handle missing BTF file gracefully"
+```
+
+Git appends a trailer built from your `user.name` and `user.email`:
+
+```
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+By adding it you are asserting three things:
+
+- You wrote the code, or you have the right to submit it under Apache-2.0
+- If your employer owns the copyright in your work, you have their
+  permission to contribute it
+- You understand the commit, including the name and email in the trailer,
+  is public and permanent
+
+So make sure your identity is set before you start:
+
+```bash
+git config user.name "Jane Developer"
+git config user.email "jane@example.com"
+```
+
+### Forgot the sign-off
+
+The trailer must match the commit author's email, so amend rather than add a
+separate commit:
+
+```bash
+git commit --amend -s --no-edit          # most recent commit
+git rebase --signoff origin/main         # every commit on the branch
+git push --force-with-lease
+```
+
+`dco.yml` checks every commit in a pull request and blocks the merge until
+they all pass. Sign-offs survive the squash merge, because squash commit
+bodies are built from the individual commit messages. Machine-generated
+commits from bot accounts (renovate, `github-actions`) are exempt: a bot
+cannot make the DCO assertion, and release-please branches skip the job
+entirely.
+
 ## How releases happen
 
 The release pipeline is fully automated once a release-worthy commit
@@ -342,6 +397,7 @@ test tags.
 
 Before opening a PR:
 
+- [ ] Every commit is signed off (`git commit -s`) per the DCO section above
 - [ ] Commit message follows Conventional Commits (drives release-please)
 - [ ] Tests pass: at minimum `make test-unit`; `make chainsaw` for BPF/operator/agent changes
 - [ ] Updated relevant docs in `docs/` if you changed user-visible behavior


### PR DESCRIPTION
## Summary

Adds a Developer Certificate of Origin gate so every contributor asserts they are legally authorised to submit their changes under Apache-2.0.

## Changes

- `dco.yml`: new workflow checking every commit in a PR for a `Signed-off-by` trailer whose email matches the commit author. Fails with the exact `git commit --amend -s` / `git rebase --signoff` remediation commands.
- Bot-authored commits (`*[bot]@users.noreply.github.com`) are exempt, since a bot cannot make the DCO assertion, and `release-please--*` branches skip the job entirely, matching the existing guard in `chainsaw.yml`.
- `CONTRIBUTING.md`: new "Developer Certificate of Origin" section covering what the sign-off asserts, how to add it, and how to fix a branch that is missing it. Also adds a row to the enforced-tooling table and an item to the PR checklist.
- `PULL_REQUEST_TEMPLATE.md`: sign-off reminder in the conventions comment plus a test-plan checkbox.