### PR TITLE
feat: resolve each session Job's TracerConfig per node

### DIFF
--- a/api/v1alpha1/podtracesession_types.go
+++ b/api/v1alpha1/podtracesession_types.go
@@ -57,6 +57,19 @@ type PodTraceSessionSpec struct {
 	// +kubebuilder:validation:Required
 	ExporterRef LocalObjectReference `json:"exporterRef"`
 
+	// TracerConfigRef pins every Job this session spawns to one
+	// TracerConfig, overriding the per-node fleet lookup.
+	//
+	// Left unset, each per-node Job takes the config of the fleet that
+	// targets its node, so a session spanning two node pools picks up each
+	// pool's own image and redaction policy. Set this when a session must
+	// run under one known configuration regardless of placement.
+	//
+	// TracerConfig is cluster-scoped, so this is a bare name with no
+	// namespace.
+	// +optional
+	TracerConfigRef *LocalObjectReference `json:"tracerConfigRef,omitempty"`
+
 	// +optional
 	Thresholds *Thresholds `json:"thresholds,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -821,6 +821,11 @@ func (in *PodTraceSessionSpec) DeepCopyInto(out *PodTraceSessionSpec) {
 		copy(*out, *in)
 	}
 	out.ExporterRef = in.ExporterRef
+	if in.TracerConfigRef != nil {
+		in, out := &in.TracerConfigRef, &out.TracerConfigRef
+		*out = new(LocalObjectReference)
+		**out = **in
+	}
 	if in.Thresholds != nil {
 		in, out := &in.Thresholds, &out.Thresholds
 		*out = new(Thresholds)

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
@@ -366,6 +366,24 @@ spec:
                             minimum: 0
                             type: integer
                         type: object
+                      tracerConfigRef:
+                        description: |-
+                          TracerConfigRef pins every Job this session spawns to one
+                          TracerConfig, overriding the per-node fleet lookup.
+
+                          Left unset, each per-node Job takes the config of the fleet that
+                          targets its node, so a session spanning two node pools picks up each
+                          pool's own image and redaction policy. Set this when a session must
+                          run under one known configuration regardless of placement.
+
+                          TracerConfig is cluster-scoped, so this is a bare name with no
+                          namespace.
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
                       ttlSecondsAfterFinished:
                         format: int32
                         minimum: 0

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -310,6 +310,24 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+              tracerConfigRef:
+                description: |-
+                  TracerConfigRef pins every Job this session spawns to one
+                  TracerConfig, overriding the per-node fleet lookup.
+
+                  Left unset, each per-node Job takes the config of the fleet that
+                  targets its node, so a session spanning two node pools picks up each
+                  pool's own image and redaction policy. Set this when a session must
+                  run under one known configuration regardless of placement.
+
+                  TracerConfig is cluster-scoped, so this is a bare name with no
+                  namespace.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
               ttlSecondsAfterFinished:
                 format: int32
                 minimum: 0

--- a/docs/crd-podtracesession.md
+++ b/docs/crd-podtracesession.md
@@ -53,6 +53,7 @@ spec:
 | `duration` | Go duration string | required | Wall-clock run time, e.g. `"30s"`, `"5m"`. Webhook rejects `0s` and bounded by `TracerConfig.spec.session.maxDuration`. |
 | `filters` | `[dns,net,fs,cpu,proc,crypto]` | optional | Event categories to record. |
 | `exporterRef.name` | string | required | Names an `ExporterConfig` in the same namespace. |
+| `tracerConfigRef.name` | string | optional | Pins every Job to one `TracerConfig`, overriding the per-node fleet lookup. Cluster-scoped, so no namespace. See [TracerConfig resolution](#tracerconfig-resolution). |
 | `samplePercent` | int 0-100 | optional | Workload-owner sampling intent. The operator combines this with `ExporterConfig.spec.samplePercent` (platform-owner cap) and writes the **minimum** of the two to the session bundle. Unset on either side is treated as 100%. The resolved value is echoed at `status.policy.effectiveSampleRate`. |
 | `reportRef` | object | optional | Persistent artifact sink — see "Report sinks" below. |
 | `ttlSecondsAfterFinished` | int | optional | When to GC the CR after Completed/Failed (default 300). |
@@ -164,6 +165,43 @@ The selector resolves cluster-wide; the operator fans out one Job per
 node with at least one matched pod. Each Job runs independently — they
 do not coordinate. The aggregated `status.summary` adds counts across
 all Jobs.
+
+## TracerConfig resolution
+
+Each Job takes its image, pull policy, session resources and redaction
+policy from a `TracerConfig`, resolved **per node**:
+
+1. `spec.tracerConfigRef`, if set — pins every Job to that one config.
+2. Otherwise, the fleet whose `nodeSelector`, required `nodeAffinity` and
+   tolerations target that node. When two fleets contest a node, the
+   winner is the one the TracerConfig's `Conflict` condition names.
+3. Otherwise, the config named `default`.
+
+So a session whose pods span a `general` pool and a `regulated` pool runs
+one Job under each pool's own policy — the `regulated` Job redacts, the
+`general` one does not. Pin with `tracerConfigRef` when a session must be
+reproducible regardless of where its pods land:
+
+```yaml
+spec:
+  selector:
+    matchLabels: {app: api}
+  duration: 30s
+  exporterRef: {name: prod-otlp}
+  tracerConfigRef:
+    name: regulated
+```
+
+If none of the three steps resolves, the session fails terminally with
+`Degraded/TracerConfigUnresolved` naming the node. It does not create a
+Job — an image-less Job would be rejected by the apiserver with a message
+about container validation that says nothing about the real cause.
+
+Fleets that set different `spec.systemNamespace` put their Jobs in
+different namespaces. The operator provisions the exporter bundle,
+objectStore credentials, ServiceAccount and RBAC in every namespace the
+resolution touches, since a Job cannot mount a bundle that lives
+elsewhere.
 
 ## RBAC produced for the session Job
 

--- a/docs/crd-tracerconfig.md
+++ b/docs/crd-tracerconfig.md
@@ -215,12 +215,12 @@ The chart renders only one TracerConfig. Apply additional ones with
 `kubectl apply`, or set `tracerConfig.create=false` and manage all of
 them yourself.
 
-> **Session Jobs still resolve the `default` TracerConfig.** The Jobs
-> behind `podtrace diagnose` and PodTraceSession take their image and
-> their redaction and capture policy from the config named `default`,
-> whichever node the target pod runs on. Per-fleet session policy is not
-> yet implemented, so do not rely on a per-pool `spec.redaction` to
-> constrain what a *session* records.
+Session Jobs follow the same fleets. A `PodTraceSession` spawns one Job
+per node, and each Job takes the image, resources and redaction policy of
+the fleet targeting *its* node — so a session whose pods span two pools
+runs under each pool's own policy. Pin the whole session to one config
+with `spec.tracerConfigRef`. See
+[crd-podtracesession.md](crd-podtracesession.md#tracerconfig-resolution).
 
 ### Overlapping fleets
 

--- a/internal/fleet/partition.go
+++ b/internal/fleet/partition.go
@@ -150,17 +150,33 @@ func (p Partition) ConflictMessage(name string) string {
 		outcome)
 }
 
-// Outranks reports whether a beats b for a node both target: higher
-// spec.priority first, then the older resource, then the lexicographically
-// smaller name.
+// Outranks reports whether a beats b for a node both target: explicit
+// spec.priority, then specificity, then the older resource, then the
+// lexicographically smaller name.
 func Outranks(a, b *podtracev1alpha1.TracerConfig) bool {
 	if a.Spec.Priority != b.Spec.Priority {
 		return a.Spec.Priority > b.Spec.Priority
+	}
+	if aWide, bWide := IsClusterWide(&a.Spec), IsClusterWide(&b.Spec); aWide != bWide {
+		return !aWide
 	}
 	if !a.CreationTimestamp.Equal(&b.CreationTimestamp) {
 		return a.CreationTimestamp.Before(&b.CreationTimestamp)
 	}
 	return a.Name < b.Name
+}
+
+// IsClusterWide reports whether a config declines to constrain its fleet to
+// a subset of nodes, so it targets every node it tolerates.
+func IsClusterWide(spec *podtracev1alpha1.TracerConfigSpec) bool {
+	if len(spec.NodeSelector) > 0 {
+		return false
+	}
+	if spec.Affinity == nil || spec.Affinity.NodeAffinity == nil {
+		return true
+	}
+	required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	return required == nil || len(required.NodeSelectorTerms) == 0
 }
 
 // NodeTargetedBy reports whether the agent DaemonSet built from tc would be

--- a/internal/fleet/partition_test.go
+++ b/internal/fleet/partition_test.go
@@ -298,3 +298,220 @@ func TestComputePartitionEmptyCluster(t *testing.T) {
 		t.Errorf("unknown config must produce no message, got %q", msg)
 	}
 }
+
+func TestOutranksPrefersTargetedFleetOverClusterWide(t *testing.T) {
+	catchAll := config("default", podtracev1alpha1.TracerConfigSpec{})
+	targeted := config("regulated", podtracev1alpha1.TracerConfigSpec{
+		NodeSelector: map[string]string{"pool": "regulated"},
+	})
+
+	if !Outranks(&targeted, &catchAll) {
+		t.Error("a config with a nodeSelector must beat a cluster-wide one at equal priority, or the stock default wins every node alphabetically")
+	}
+	if Outranks(&catchAll, &targeted) {
+		t.Error("Outranks must be antisymmetric across the specificity tie-break")
+	}
+}
+
+func TestOutranksPriorityStillBeatsSpecificity(t *testing.T) {
+	catchAll := config("default", podtracev1alpha1.TracerConfigSpec{Priority: 100})
+	targeted := config("regulated", podtracev1alpha1.TracerConfigSpec{
+		NodeSelector: map[string]string{"pool": "regulated"},
+	})
+
+	if !Outranks(&catchAll, &targeted) {
+		t.Error("an explicit spec.priority must override the specificity heuristic")
+	}
+}
+
+func TestComputePartitionTargetedFleetWinsItsOwnNode(t *testing.T) {
+	configs := []podtracev1alpha1.TracerConfig{
+		config("default", podtracev1alpha1.TracerConfigSpec{}),
+		config("regulated", podtracev1alpha1.TracerConfigSpec{
+			NodeSelector: map[string]string{"pool": "regulated"},
+		}),
+	}
+	nodes := []corev1.Node{
+		node("n-regulated", map[string]string{"pool": "regulated"}),
+		node("n-plain", nil),
+	}
+
+	p := ComputePartition(configs, nodes)
+
+	if got := p.Winner["n-regulated"]; got != "regulated" {
+		t.Errorf("winner for the targeted node = %q, want regulated", got)
+	}
+	if got := p.Winner["n-plain"]; got != "default" {
+		t.Errorf("winner for the untargeted node = %q, want default", got)
+	}
+}
+
+func affinityWith(terms ...corev1.NodeSelectorTerm) *corev1.Affinity {
+	return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: terms},
+	}}
+}
+
+func termWithExpressions(reqs ...corev1.NodeSelectorRequirement) corev1.NodeSelectorTerm {
+	return corev1.NodeSelectorTerm{MatchExpressions: reqs}
+}
+
+func TestNodeTargetedByAffinityOperators(t *testing.T) {
+	cases := []struct {
+		name   string
+		req    corev1.NodeSelectorRequirement
+		labels map[string]string
+		want   bool
+	}{
+		{"In matches", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"}}, map[string]string{"pool": "a"}, true},
+		{"In misses", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"}}, map[string]string{"pool": "b"}, false},
+		{"NotIn excludes listed", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"a"}}, map[string]string{"pool": "a"}, false},
+		{"NotIn admits unlisted", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"a"}}, map[string]string{"pool": "b"}, true},
+		{"NotIn admits absent label", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"a"}}, nil, true},
+		{"Exists with label", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpExists}, map[string]string{"pool": ""}, true},
+		{"Exists without label", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpExists}, nil, false},
+		{"DoesNotExist without label", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpDoesNotExist}, nil, true},
+		{"DoesNotExist with label", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpDoesNotExist}, map[string]string{"pool": "a"}, false},
+		{"Gt above", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"}}, map[string]string{"cores": "8"}, true},
+		{"Gt equal", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"}}, map[string]string{"cores": "4"}, false},
+		{"Lt below", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpLt, Values: []string{"4"}}, map[string]string{"cores": "2"}, true},
+		{"Lt equal", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpLt, Values: []string{"4"}}, map[string]string{"cores": "4"}, false},
+		{"Gt on non-numeric label", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"}}, map[string]string{"cores": "many"}, false},
+		{"Gt with non-numeric bound", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"lots"}}, map[string]string{"cores": "8"}, false},
+		{"Gt with absent label", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"4"}}, nil, false},
+		{"Gt with two bounds is malformed", corev1.NodeSelectorRequirement{Key: "cores", Operator: corev1.NodeSelectorOpGt, Values: []string{"4", "8"}}, map[string]string{"cores": "16"}, false},
+		{"unknown operator", corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOperator("Bogus"), Values: []string{"a"}}, map[string]string{"pool": "a"}, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := config("c", podtracev1alpha1.TracerConfigSpec{Affinity: affinityWith(termWithExpressions(tt.req))})
+			n := node("n1", tt.labels)
+			if got := NodeTargetedBy(&n, &tc); got != tt.want {
+				t.Errorf("NodeTargetedBy = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeTargetedByMatchFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		req      corev1.NodeSelectorRequirement
+		nodeName string
+		want     bool
+	}{
+		{"metadata.name In matches", corev1.NodeSelectorRequirement{Key: "metadata.name", Operator: corev1.NodeSelectorOpIn, Values: []string{"n1"}}, "n1", true},
+		{"metadata.name In misses", corev1.NodeSelectorRequirement{Key: "metadata.name", Operator: corev1.NodeSelectorOpIn, Values: []string{"n1"}}, "n2", false},
+		{"metadata.name NotIn", corev1.NodeSelectorRequirement{Key: "metadata.name", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"n1"}}, "n2", true},
+		{"unsupported field key", corev1.NodeSelectorRequirement{Key: "spec.unschedulable", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}}, "n1", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := config("c", podtracev1alpha1.TracerConfigSpec{
+				Affinity: affinityWith(corev1.NodeSelectorTerm{MatchFields: []corev1.NodeSelectorRequirement{tt.req}}),
+			})
+			n := node(tt.nodeName, nil)
+			if got := NodeTargetedBy(&n, &tc); got != tt.want {
+				t.Errorf("NodeTargetedBy = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeTargetedByEmptyAffinityShapes(t *testing.T) {
+	n := node("n1", map[string]string{"pool": "a"})
+
+	empty := config("c", podtracev1alpha1.TracerConfigSpec{
+		Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}},
+	})
+	if !NodeTargetedBy(&n, &empty) {
+		t.Error("nodeAffinity with no required clause must not constrain the fleet")
+	}
+
+	noTerms := config("c", podtracev1alpha1.TracerConfigSpec{Affinity: affinityWith()})
+	if !NodeTargetedBy(&n, &noTerms) {
+		t.Error("a required clause with zero terms must not constrain the fleet")
+	}
+
+	emptyTerm := config("c", podtracev1alpha1.TracerConfigSpec{Affinity: affinityWith(corev1.NodeSelectorTerm{})})
+	if NodeTargetedBy(&n, &emptyTerm) {
+		t.Error("a term with neither expressions nor fields matches nothing")
+	}
+
+	onlyPreferred := config("c", podtracev1alpha1.TracerConfigSpec{
+		Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+				Weight:     10,
+				Preference: termWithExpressions(corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"zzz"}}),
+			}},
+		}},
+	})
+	if !NodeTargetedBy(&n, &onlyPreferred) {
+		t.Error("preferred affinity changes scoring, not admissibility, so it must not exclude a node")
+	}
+}
+
+func TestNodeTargetedByAllRequirementsInATermMustHold(t *testing.T) {
+	tc := config("c", podtracev1alpha1.TracerConfigSpec{
+		Affinity: affinityWith(termWithExpressions(
+			corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"}},
+			corev1.NodeSelectorRequirement{Key: "tier", Operator: corev1.NodeSelectorOpExists},
+		)),
+	})
+
+	both := node("n1", map[string]string{"pool": "a", "tier": "gold"})
+	if !NodeTargetedBy(&both, &tc) {
+		t.Error("a node satisfying every requirement in the term must be targeted")
+	}
+	partial := node("n2", map[string]string{"pool": "a"})
+	if NodeTargetedBy(&partial, &tc) {
+		t.Error("requirements within a term are AND'd; a partial match must not be targeted")
+	}
+}
+
+func TestNodeTargetedByCombinesSelectorAffinityAndTaints(t *testing.T) {
+	tc := config("c", podtracev1alpha1.TracerConfigSpec{
+		NodeSelector: map[string]string{"pool": "a"},
+		Affinity:     affinityWith(termWithExpressions(corev1.NodeSelectorRequirement{Key: "tier", Operator: corev1.NodeSelectorOpExists})),
+	})
+
+	ok := node("n1", map[string]string{"pool": "a", "tier": "gold"})
+	if !NodeTargetedBy(&ok, &tc) {
+		t.Error("selector and affinity both satisfied must target the node")
+	}
+	selectorFails := node("n2", map[string]string{"pool": "b", "tier": "gold"})
+	if NodeTargetedBy(&selectorFails, &tc) {
+		t.Error("nodeSelector must still gate even when affinity matches")
+	}
+	taintBlocks := node("n3", map[string]string{"pool": "a", "tier": "gold"},
+		corev1.Taint{Key: "dedicated", Value: "db", Effect: corev1.TaintEffectNoExecute})
+	if NodeTargetedBy(&taintBlocks, &tc) {
+		t.Error("an untolerated NoExecute taint must exclude the node")
+	}
+}
+
+func TestIsClusterWide(t *testing.T) {
+	cases := []struct {
+		name string
+		spec podtracev1alpha1.TracerConfigSpec
+		want bool
+	}{
+		{"bare spec", podtracev1alpha1.TracerConfigSpec{}, true},
+		{"nodeSelector narrows", podtracev1alpha1.TracerConfigSpec{NodeSelector: map[string]string{"pool": "a"}}, false},
+		{"required affinity narrows", podtracev1alpha1.TracerConfigSpec{
+			Affinity: affinityWith(termWithExpressions(corev1.NodeSelectorRequirement{Key: "pool", Operator: corev1.NodeSelectorOpExists})),
+		}, false},
+		{"empty affinity does not narrow", podtracev1alpha1.TracerConfigSpec{Affinity: &corev1.Affinity{}}, true},
+		{"required clause with no terms does not narrow", podtracev1alpha1.TracerConfigSpec{Affinity: affinityWith()}, true},
+		{"tolerations widen, never narrow", podtracev1alpha1.TracerConfigSpec{
+			Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+		}, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsClusterWide(&tt.spec); got != tt.want {
+				t.Errorf("IsClusterWide = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -123,10 +123,17 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, r.Status().Update(ctx, &session)
 	}
 
-	tc, err := r.resolveTracerConfig(ctx)
+	resolved, err := r.resolveSessionTracerConfigs(ctx, &session, targets.Nodes)
 	if err != nil {
+		var missing *errNoTracerConfig
+		if errors.As(err, &missing) {
+			// Terminal: no amount of requeueing conjures a TracerConfig, and
+			// proceeding would build a Job with an empty image.
+			return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "TracerConfigUnresolved", err.Error())
+		}
 		return ctrl.Result{}, err
 	}
+	tc := resolved.primary()
 	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
 
 	var ec podtracev1alpha1.ExporterConfig
@@ -140,22 +147,28 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
 	}
-	if err := ensureSessionExporterBundle(ctx, r.Client, &session, &ec, systemNS); err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
-		_ = r.Status().Update(ctx, &session)
-		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
-	}
+	// A session whose nodes span fleets with different spec.systemNamespace
+	// puts Jobs in more than one namespace, and a Job cannot mount a bundle,
+	// assume a ServiceAccount, or exercise RBAC that lives somewhere else.
+	// Provision the full set in every namespace the resolution touches.
+	for _, ns := range resolved.namespaces {
+		if err := ensureSessionExporterBundle(ctx, r.Client, &session, &ec, ns); err != nil {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		}
 
-	if _, err := ensureSessionObjectStoreCredentials(ctx, r.Client, &session, systemNS); err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ObjectStoreCreds", err.Error())
-		_ = r.Status().Update(ctx, &session)
-		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
-	}
+		if _, err := ensureSessionObjectStoreCredentials(ctx, r.Client, &session, ns); err != nil {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ObjectStoreCreds", err.Error())
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		}
 
-	if err := ensureSessionServiceAccount(ctx, r.Client, &session, systemNS); err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionSA", err.Error())
-		_ = r.Status().Update(ctx, &session)
-		return ctrl.Result{}, err
+		if err := ensureSessionServiceAccount(ctx, r.Client, &session, ns); err != nil {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionSA", err.Error())
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{}, err
+		}
 	}
 	if err := ensureSessionReportObject(ctx, r.Client, &session); err != nil {
 		var conflict *reportObjectConflictError
@@ -166,15 +179,17 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	if err := ensureSessionReportRBAC(ctx, r.Client, &session, r.Scheme, systemNS); err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
-		_ = r.Status().Update(ctx, &session)
-		return ctrl.Result{}, err
-	}
-	if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, r.Scheme, sessionPodNamespaces(&session, targets), systemNS); err != nil {
-		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
-		_ = r.Status().Update(ctx, &session)
-		return ctrl.Result{}, err
+	for _, ns := range resolved.namespaces {
+		if err := ensureSessionReportRBAC(ctx, r.Client, &session, r.Scheme, ns); err != nil {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{}, err
+		}
+		if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, r.Scheme, sessionPodNamespaces(&session, targets), ns); err != nil {
+			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
+			_ = r.Status().Update(ctx, &session)
+			return ctrl.Result{}, err
+		}
 	}
 
 	cap := effectiveMaxConcurrentSessionsPerNode(tc)
@@ -193,7 +208,7 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	completedNodes := completedSessionNodes(session.Status.Jobs)
-	jobs, err := r.ensureJobs(ctx, &session, tc, targets, completedNodes)
+	jobs, err := r.ensureJobs(ctx, &session, resolved, targets, completedNodes)
 	if err != nil {
 		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "EnsureJobs", err.Error())
 		_ = r.Status().Update(ctx, &session)
@@ -534,29 +549,38 @@ func effectiveMaxConcurrentSessionsPerNode(tc *podtracev1alpha1.TracerConfig) in
 // (Kubernetes forbids cross-namespace owner refs), so their lifecycle is
 // bounded by TTLSecondsAfterFinished, the podtrace.io/cleanup finalizer, and
 // the orphan sweep (see SessionChildReaper) as a finalizer-bypass backstop.
-func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, tc *podtracev1alpha1.TracerConfig, targets sessionTargets, completedNodes map[string]struct{}) ([]batchv1.Job, error) {
-	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
-
+// ensureJobs creates one Job per target node, each built from the
+// TracerConfig resolved for that node — so a session spanning two node pools
+// runs each Job under its own pool's image and redaction policy.
+func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev1alpha1.PodTraceSession, resolved sessionTracerConfigs, targets sessionTargets, completedNodes map[string]struct{}) ([]batchv1.Job, error) {
 	for _, node := range targets.Nodes {
 		if _, done := completedNodes[node]; done {
 			continue
 		}
+		nodeConfig := resolved.forNode(node)
+		if nodeConfig == nil {
+			// resolveSessionTracerConfigs errors rather than returning a nil
+			// config, so this is unreachable; refuse rather than fall through
+			// to a Job with no image.
+			return nil, fmt.Errorf("no TracerConfig resolved for node %s", node)
+		}
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      SessionJobName(s.UID, node),
-				Namespace: systemNS,
+				Namespace: resolved.namespaceForNode(node, r.SystemNamespace),
 			},
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, job, func() error {
 			job.Labels = mergeLabels(job.Labels, map[string]string{
-				LabelManagedBy:   ManagedByValue,
-				LabelComponent:   ComponentSession,
-				LabelSessionName: s.Name,
-				LabelSessionNS:   s.Namespace,
-				LabelNodeName:    node,
+				LabelManagedBy:    ManagedByValue,
+				LabelComponent:    ComponentSession,
+				LabelSessionName:  s.Name,
+				LabelSessionNS:    s.Namespace,
+				LabelNodeName:     node,
+				LabelTracerConfig: nodeConfig.Name,
 			})
 			if job.Spec.Template.Spec.Containers == nil {
-				job.Spec = buildSessionJobSpec(s, tc, node, targets)
+				job.Spec = buildSessionJobSpec(s, nodeConfig, node, targets)
 			}
 			return nil
 		}); err != nil {
@@ -564,16 +588,20 @@ func (r *PodTraceSessionReconciler) ensureJobs(ctx context.Context, s *podtracev
 		}
 	}
 
-	var owned batchv1.JobList
-	if err := r.List(ctx, &owned, client.InNamespace(systemNS), client.MatchingLabels{
-		LabelManagedBy:   ManagedByValue,
-		LabelComponent:   ComponentSession,
-		LabelSessionName: s.Name,
-		LabelSessionNS:   s.Namespace,
-	}); err != nil {
-		return nil, fmt.Errorf("list owned Jobs: %w", err)
+	var owned []batchv1.Job
+	for _, ns := range resolved.namespaces {
+		var inNS batchv1.JobList
+		if err := r.List(ctx, &inNS, client.InNamespace(ns), client.MatchingLabels{
+			LabelManagedBy:   ManagedByValue,
+			LabelComponent:   ComponentSession,
+			LabelSessionName: s.Name,
+			LabelSessionNS:   s.Namespace,
+		}); err != nil {
+			return nil, fmt.Errorf("list owned Jobs in %s: %w", ns, err)
+		}
+		owned = append(owned, inNS.Items...)
 	}
-	return owned.Items, nil
+	return owned, nil
 }
 
 // reconcileTerminalSession handles TTL-driven cleanup only.

--- a/internal/operator/podtracesession_reconcile_branches_test.go
+++ b/internal/operator/podtracesession_reconcile_branches_test.go
@@ -119,7 +119,7 @@ func TestSessionBranch_EnsureJobsListOwnedError(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "uid-s"},
 	}
-	if _, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: nil}, nil); err == nil {
+	if _, err := r.ensureJobs(context.Background(), s, resolvedFleet(sessMoreSysNS, nil, nil), sessionTargets{Nodes: nil}, nil); err == nil {
 		t.Fatal("ensureJobs must surface the owned-Job list error")
 	}
 }

--- a/internal/operator/podtracesession_reconcile_errors_test.go
+++ b/internal/operator/podtracesession_reconcile_errors_test.go
@@ -34,6 +34,10 @@ func sessMoreFanOutObjects() []client.Object {
 				OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
 			},
 		},
+		&podtracev1alpha1.TracerConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName},
+			Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+		},
 	}
 }
 
@@ -184,11 +188,11 @@ func TestSessionReconcile_ResolveTracerConfigError(t *testing.T) {
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
 		WithObjects(objs...).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if _, ok := obj.(*podtracev1alpha1.TracerConfig); ok {
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.TracerConfigList); ok {
 					return errInternal()
 				}
-				return cl.Get(ctx, key, obj, opts...)
+				return cl.List(ctx, list, opts...)
 			},
 		}).Build()
 	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
@@ -327,7 +331,7 @@ func TestSessionReconcile_DeniedAndGrantedMix(t *testing.T) {
 	})
 	c := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(s, ec, granted, deniedNS, grantedPod, deniedPod).Build()
+		WithObjects(s, ec, granted, deniedNS, grantedPod, deniedPod, defaultTracerConfigObject()).Build()
 	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
 	if _, err := sessMoreReconcile(t, r); err != nil {
 		t.Fatalf("Reconcile: %v", err)

--- a/internal/operator/reconcilers_deep_unit_test.go
+++ b/internal/operator/reconcilers_deep_unit_test.go
@@ -76,7 +76,7 @@ func TestDeepReconcile_Session_ExporterNotFound(t *testing.T) {
 	scheme := newOperatorScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(s, pod).Build()
+		WithObjects(s, pod, defaultTracerConfigObject()).Build()
 
 	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -133,7 +133,7 @@ func TestDeepReconcile_Session_FullFanOut(t *testing.T) {
 	objs := append(pods, s, ec)
 	c := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(objs...).Build()
+		WithObjects(append(objs, defaultTracerConfigObject())...).Build()
 
 	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sysNS}
 	res, err := r.Reconcile(context.Background(), ctrl.Request{

--- a/internal/operator/reconcilers_errorpaths_unit_test.go
+++ b/internal/operator/reconcilers_errorpaths_unit_test.go
@@ -193,7 +193,7 @@ func TestErrPath_Session_FinalStatusUpdateConflictRequeues(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(session, pod, ec).
+		WithObjects(session, pod, ec, defaultTracerConfigObject()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
 				return errConflict("podtracesessions", session.Name)
@@ -278,7 +278,7 @@ func TestErrPath_Session_ExporterGetError(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(session, pod).
+		WithObjects(session, pod, defaultTracerConfigObject()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				if _, ok := obj.(*podtracev1alpha1.ExporterConfig); ok {

--- a/internal/operator/reconcilers_fakeclient_unit_test.go
+++ b/internal/operator/reconcilers_fakeclient_unit_test.go
@@ -269,7 +269,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		},
 	}
 
-	jobs, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
+	jobs, err := r.ensureJobs(context.Background(), s, resolvedFleet(r.SystemNamespace, []string{"n1", "n2"}, testTracerConfig("default", "img:test", "", nil)), sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
 	if err != nil {
 		t.Fatalf("ensureJobs: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestFakeReconcile_EnsureJobs(t *testing.T) {
 		}
 	}
 
-	jobs2, err := r.ensureJobs(context.Background(), s, nil, sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
+	jobs2, err := r.ensureJobs(context.Background(), s, resolvedFleet(r.SystemNamespace, []string{"n1", "n2"}, testTracerConfig("default", "img:test", "", nil)), sessionTargets{Nodes: []string{"n1", "n2"}}, nil)
 	if err != nil {
 		t.Fatalf("second ensureJobs: %v", err)
 	}

--- a/internal/operator/reconcilers_more_unit_test.go
+++ b/internal/operator/reconcilers_more_unit_test.go
@@ -323,7 +323,7 @@ func TestMore_Session_ObjectStoreCredsMissing(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(sess, pod, ec).
+		WithObjects(sess, pod, ec, defaultTracerConfigObject()).
 		Build()
 	r := &PodTraceSessionReconciler{Client: c, Scheme: s, SystemNamespace: "podtrace-system"}
 
@@ -354,7 +354,7 @@ func TestMore_Session_ServiceAccountError(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(sess, pod, ec).
+		WithObjects(sess, pod, ec, defaultTracerConfigObject()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*corev1.ServiceAccount); ok {
@@ -389,7 +389,7 @@ func TestMore_Session_ReportRBACError(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(sess, pod, ec).
+		WithObjects(sess, pod, ec, defaultTracerConfigObject()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*rbacv1.Role); ok {

--- a/internal/operator/runtime_wiring_envtest_test.go
+++ b/internal/operator/runtime_wiring_envtest_test.go
@@ -1,0 +1,54 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+func connectedManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+	setupSharedEnvtest(t)
+	if testEnv == nil || testEnv.Config == nil {
+		t.SkipNow()
+	}
+	scheme, err := NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	skipNameValidation := true
+	mgr, err := ctrl.NewManager(testEnv.Config, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		// Controller names are validated per binary, not per manager, so
+		// wiring a second throwaway manager in the same test run would
+		// collide with the names the other envtest cases already claimed.
+		Controller: crconfig.Controller{SkipNameValidation: &skipNameValidation},
+	})
+	if err != nil {
+		t.Fatalf("build manager: %v", err)
+	}
+	return mgr
+}
+
+func TestEnvtestRegisterReconcilersWiresEveryController(t *testing.T) {
+	if err := registerReconcilers(connectedManager(t), DefaultOptions()); err != nil {
+		t.Fatalf("registerReconcilers: %v", err)
+	}
+}
+
+func TestEnvtestRegisterExporterConfigIndexers(t *testing.T) {
+	mgr := connectedManager(t)
+	if err := registerExporterConfigIndexers(t.Context(), mgr); err != nil {
+		t.Fatalf("registerExporterConfigIndexers: %v", err)
+	}
+	if err := registerExporterConfigIndexers(t.Context(), mgr); err == nil {
+		t.Error("re-registering the same index key must be reported, not silently ignored")
+	}
+}

--- a/internal/operator/runtime_wiring_test.go
+++ b/internal/operator/runtime_wiring_test.go
@@ -1,0 +1,159 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func nonConnectingManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+	scheme, err := NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	mgr, err := ctrl.NewManager(&rest.Config{Host: "http://127.0.0.1:1"}, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Skipf("could not build non-connecting manager: %v", err)
+	}
+	return mgr
+}
+
+func TestNewSchemeRegistersBothGroups(t *testing.T) {
+	s, err := NewScheme()
+	if err != nil {
+		t.Fatalf("NewScheme: %v", err)
+	}
+	if !s.Recognizes(corev1.SchemeGroupVersion.WithKind("Pod")) {
+		t.Error("client-go core types must be registered")
+	}
+	if !s.Recognizes(podtracev1alpha1.GroupVersion.WithKind("TracerConfig")) {
+		t.Error("podtrace types must be registered")
+	}
+}
+
+func TestRegisterWebhooksWiresEveryValidator(t *testing.T) {
+	if err := registerWebhooks(nonConnectingManager(t)); err != nil {
+		t.Fatalf("registerWebhooks: %v", err)
+	}
+}
+
+func TestStripNodeStatusDropsTheHeavyFields(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "n1",
+			Labels:        map[string]string{"pool": "a"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+		},
+		Spec: corev1.NodeSpec{Taints: []corev1.Taint{{Key: "dedicated", Effect: corev1.TaintEffectNoSchedule}}},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady}},
+			Images:     []corev1.ContainerImage{{Names: []string{"a-very-large-image-list"}}},
+		},
+	}
+
+	out, err := stripNodeStatus(node)
+	if err != nil {
+		t.Fatalf("stripNodeStatus: %v", err)
+	}
+	stripped, ok := out.(*corev1.Node)
+	if !ok {
+		t.Fatalf("stripNodeStatus returned %T, want *corev1.Node", out)
+	}
+	if len(stripped.Status.Images) != 0 || len(stripped.Status.Conditions) != 0 {
+		t.Error("node status is the bulk of the object and nothing in the operator reads it")
+	}
+	if stripped.ManagedFields != nil {
+		t.Error("managed fields are dead weight in the cache")
+	}
+	if stripped.Labels["pool"] != "a" {
+		t.Error("labels decide fleet membership and must survive")
+	}
+	if len(stripped.Spec.Taints) != 1 {
+		t.Error("taints decide fleet membership and must survive")
+	}
+}
+
+func TestStripNodeStatusPassesThroughOtherTypes(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	out, err := stripNodeStatus(pod)
+	if err != nil {
+		t.Fatalf("stripNodeStatus: %v", err)
+	}
+	if out != any(pod) {
+		t.Error("a non-Node object must pass through untouched")
+	}
+}
+
+func TestSessionJobNameStaysWithinLabelLimits(t *testing.T) {
+	longNode := strings.Repeat("node-with-a-very-long-name", 6)
+	name := SessionJobName(types.UID("11111111-2222-3333-4444-555555555555"), longNode)
+	if len(name) > 63 {
+		t.Errorf("Job name %q is %d chars; must stay within the 63-char object-name budget", name, len(name))
+	}
+	if strings.HasSuffix(name, "-") || strings.HasSuffix(name, ".") {
+		t.Errorf("Job name %q must not end in a separator", name)
+	}
+}
+
+func TestSessionJobNameHandlesUnusableNodeNames(t *testing.T) {
+	name := SessionJobName(types.UID("11111111-2222-3333-4444-555555555555"), "...")
+	if name == "" {
+		t.Fatal("a node name that sanitises to nothing must still yield a usable Job name")
+	}
+	if strings.Contains(name, "..") {
+		t.Errorf("Job name %q is not a valid DNS name", name)
+	}
+
+	a := SessionJobName(types.UID("u"), "node-a")
+	b := SessionJobName(types.UID("u"), "node-b")
+	if a == b {
+		t.Error("distinct nodes must produce distinct Job names")
+	}
+}
+
+func TestJobHelpersTolerateNilTracerConfig(t *testing.T) {
+	if got := tolerationsFrom(nil); got != nil {
+		t.Errorf("tolerationsFrom(nil) = %v, want nil", got)
+	}
+	if got := priorityClassNameFrom(nil); got != "" {
+		t.Errorf("priorityClassNameFrom(nil) = %q, want empty", got)
+	}
+
+	tc := &podtracev1alpha1.TracerConfig{Spec: podtracev1alpha1.TracerConfigSpec{
+		Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+	}}
+	tc.Spec.Agent.PriorityClassName = "system-node-critical"
+	if len(tolerationsFrom(tc)) != 1 {
+		t.Error("tolerations must pass through when a config is present")
+	}
+	if priorityClassNameFrom(tc) != "system-node-critical" {
+		t.Error("priorityClassName must pass through when a config is present")
+	}
+}
+
+func TestSessionTracerConfigsZeroValueIsSafe(t *testing.T) {
+	var empty sessionTracerConfigs
+
+	if got := empty.forNode("n1"); got != nil {
+		t.Errorf("forNode on a zero value = %v, want nil", got)
+	}
+	if got := empty.primary(); got != nil {
+		t.Errorf("primary on a zero value = %v, want nil", got)
+	}
+	if got := empty.namespaceForNode("n1", "fallback"); got != "fallback" {
+		t.Errorf("namespaceForNode on a zero value = %q, want the fallback", got)
+	}
+}

--- a/internal/operator/session_helpers_unit_test.go
+++ b/internal/operator/session_helpers_unit_test.go
@@ -124,7 +124,7 @@ func TestSess_EnsureJobsCreateError(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
-		WithObjects(session, pod, ec).
+		WithObjects(session, pod, ec, defaultTracerConfigObject()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*batchv1.Job); ok {

--- a/internal/operator/session_job_completion_test.go
+++ b/internal/operator/session_job_completion_test.go
@@ -74,7 +74,7 @@ func TestEnsureJobs_SkipsCompletedNode(t *testing.T) {
 	targets := sessionTargets{Nodes: []string{"node-a", "node-b"}}
 	completed := map[string]struct{}{"node-a": {}}
 
-	if _, err := r.ensureJobs(context.Background(), s, nil, targets, completed); err != nil {
+	if _, err := r.ensureJobs(context.Background(), s, resolvedFleet(r.SystemNamespace, targets.Nodes, testTracerConfig("default", "img:test", "", nil)), targets, completed); err != nil {
 		t.Fatalf("ensureJobs: %v", err)
 	}
 

--- a/internal/operator/session_tracerconfig.go
+++ b/internal/operator/session_tracerconfig.go
@@ -1,0 +1,178 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+	"github.com/gma1k/podtrace/internal/fleet"
+)
+
+// errNoTracerConfig reports that nothing resolved for a node.
+//
+// This used to be silent: resolveTracerConfig returned (nil, nil) when the
+// default config was missing, and buildSessionJobSpec then produced a Job
+// with an empty image. The apiserver rejects that with a message about
+// container spec validation, which says nothing about the actual cause, so
+// the failure surfaces as a broken Job rather than a broken configuration.
+type errNoTracerConfig struct {
+	node    string
+	pinned  string
+	reason  string
+	configs []string
+}
+
+func (e *errNoTracerConfig) Error() string {
+	if e.pinned != "" {
+		return fmt.Sprintf("spec.tracerConfigRef %q: %s", e.pinned, e.reason)
+	}
+	return fmt.Sprintf(
+		"no TracerConfig resolves for node %q: %s. Existing configs: %v. "+
+			"Either label the node into a fleet, create a TracerConfig named %q, "+
+			"or pin one with spec.tracerConfigRef",
+		e.node, e.reason, e.configs, DefaultTracerConfigName)
+}
+
+// sessionTracerConfigs holds the per-node resolution for one session.
+type sessionTracerConfigs struct {
+	// byNode maps a node name to the config its Job must run under.
+	byNode map[string]*podtracev1alpha1.TracerConfig
+	// namespaces lists the distinct system namespaces those configs
+	// resolve to, sorted. A session whose nodes span fleets with different
+	// spec.systemNamespace needs its bundle, credentials, ServiceAccount
+	// and RBAC provisioned in each of them.
+	namespaces []string
+}
+
+// forNode returns the config resolved for a node, or nil when the node was
+// not part of the resolution.
+func (s sessionTracerConfigs) forNode(node string) *podtracev1alpha1.TracerConfig {
+	if s.byNode == nil {
+		return nil
+	}
+	return s.byNode[node]
+}
+
+// namespaceForNode returns the system namespace a node's Job belongs in.
+func (s sessionTracerConfigs) namespaceForNode(node, fallback string) string {
+	return systemNamespaceForSession(s.forNode(node), fallback)
+}
+
+// resolveSessionTracerConfigs works out which TracerConfig governs each of a
+// session's target nodes.
+//
+// Order per node:
+//
+//  1. spec.tracerConfigRef, when set — an explicit pin wins everywhere, so a
+//     session can be made reproducible regardless of where its pods land.
+//  2. The fleet whose scheduling constraints target that node, taken from
+//     the same partition the TracerConfig reconciler reports on. When two
+//     fleets contest a node, the partition's precedence rule (priority, then
+//     age, then name) picks one — the same answer the Conflict condition
+//     advertises, so the session agrees with what the operator told the user.
+//  3. The config named "default".
+//
+// Exhausting all three is an error, not a nil config: a Job built without a
+// TracerConfig has no image.
+func (r *PodTraceSessionReconciler) resolveSessionTracerConfigs(
+	ctx context.Context,
+	s *podtracev1alpha1.PodTraceSession,
+	nodes []string,
+) (sessionTracerConfigs, error) {
+	out := sessionTracerConfigs{byNode: map[string]*podtracev1alpha1.TracerConfig{}}
+
+	if ref := s.Spec.TracerConfigRef; ref != nil && ref.Name != "" {
+		var pinned podtracev1alpha1.TracerConfig
+		if err := r.Get(ctx, types.NamespacedName{Name: ref.Name}, &pinned); err != nil {
+			if apierrors.IsNotFound(err) {
+				return out, &errNoTracerConfig{pinned: ref.Name, reason: "TracerConfig not found"}
+			}
+			return out, fmt.Errorf("get TracerConfig %q: %w", ref.Name, err)
+		}
+		for _, node := range nodes {
+			out.byNode[node] = &pinned
+		}
+		out.namespaces = distinctNamespaces(out.byNode, r.SystemNamespace)
+		return out, nil
+	}
+
+	var configs podtracev1alpha1.TracerConfigList
+	if err := r.List(ctx, &configs); err != nil {
+		return out, fmt.Errorf("list TracerConfigs: %w", err)
+	}
+	byName := map[string]*podtracev1alpha1.TracerConfig{}
+	names := make([]string, 0, len(configs.Items))
+	for i := range configs.Items {
+		byName[configs.Items[i].Name] = &configs.Items[i]
+		names = append(names, configs.Items[i].Name)
+	}
+	sort.Strings(names)
+
+	// Node objects are only needed to run the partition. Losing the read is
+	// not fatal: fall through to "default", which is what every release
+	// before per-node resolution did.
+	winner := map[string]string{}
+	var nodeList corev1.NodeList
+	if err := r.List(ctx, &nodeList); err == nil {
+		winner = fleet.ComputePartition(configs.Items, nodeList.Items).Winner
+	}
+
+	for _, node := range nodes {
+		if name, ok := winner[node]; ok {
+			if tc := byName[name]; tc != nil {
+				out.byNode[node] = tc
+				continue
+			}
+		}
+		if tc := byName[DefaultTracerConfigName]; tc != nil {
+			out.byNode[node] = tc
+			continue
+		}
+		reason := "no fleet targets it and there is no default TracerConfig"
+		if len(names) == 0 {
+			reason = "the cluster has no TracerConfig at all"
+		}
+		return out, &errNoTracerConfig{node: node, reason: reason, configs: names}
+	}
+
+	out.namespaces = distinctNamespaces(out.byNode, r.SystemNamespace)
+	return out, nil
+}
+
+// distinctNamespaces returns the sorted set of system namespaces the
+// resolved configs map to.
+func distinctNamespaces(byNode map[string]*podtracev1alpha1.TracerConfig, fallback string) []string {
+	seen := map[string]struct{}{}
+	for _, tc := range byNode {
+		seen[systemNamespaceForSession(tc, fallback)] = struct{}{}
+	}
+	if len(seen) == 0 {
+		seen[fallback] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for ns := range seen {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// primary returns the config used for session-wide decisions that are not
+// per-node, such as the concurrency cap. Deterministic: the config of the
+// lowest-sorted node.
+func (s sessionTracerConfigs) primary() *podtracev1alpha1.TracerConfig {
+	nodes := make([]string, 0, len(s.byNode))
+	for node := range s.byNode {
+		nodes = append(nodes, node)
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+	sort.Strings(nodes)
+	return s.byNode[nodes[0]]
+}

--- a/internal/operator/session_tracerconfig_envtest_test.go
+++ b/internal/operator/session_tracerconfig_envtest_test.go
@@ -1,0 +1,206 @@
+//go:build envtest
+// +build envtest
+
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func createSessionFixture(t *testing.T, c client.Client, ns, node string, mutate func(*podtracev1alpha1.PodTraceSession)) *podtracev1alpha1.PodTraceSession {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: ns, Labels: map[string]string{"app": "target"}},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "app", Image: "busybox:1.36"}},
+		},
+	}
+	if err := c.Create(ctx, pod); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	if err := c.Status().Update(ctx, pod); err != nil {
+		t.Fatalf("set pod Running: %v", err)
+	}
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: ns},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+		},
+	}
+	if err := c.Create(ctx, ec); err != nil {
+		t.Fatalf("create exporterconfig: %v", err)
+	}
+
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "sess", Namespace: ns},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "target"}},
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "ec"},
+		},
+	}
+	if mutate != nil {
+		mutate(s)
+	}
+	if err := c.Create(ctx, s); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return s
+}
+
+func sessionJobImage(t *testing.T, c client.Client, ns, node string, uid types.UID) (*batchv1.Job, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var job batchv1.Job
+	key := types.NamespacedName{Name: SessionJobName(uid, node), Namespace: ns}
+	if err := c.Get(ctx, key, &job); err != nil {
+		t.Fatalf("get session Job %s: %v", key, err)
+	}
+	if len(job.Spec.Template.Spec.Containers) == 0 {
+		t.Fatalf("session Job %s has no containers", key)
+	}
+	return &job, job.Spec.Template.Spec.Containers[0].Image
+}
+
+func reconcileSessionUntilSettled(t *testing.T, r *PodTraceSessionReconciler, ns, name string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	// The first pass only stamps the finalizer and requeues; the work
+	// happens on the next one.
+	for i := 0; i < 3; i++ {
+		if _, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: name, Namespace: ns},
+		}); err != nil {
+			t.Fatalf("reconcile %d: %v", i, err)
+		}
+	}
+}
+
+func TestEnvtestSessionPicksTheFleetOfItsNode(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ensureDefaultTracerConfig(t, c)
+
+	createFleetNode(t, c, "sess-regulated", map[string]string{"pool": "sess-regulated"})
+	createFleetConfig(t, c, "sess-regulated-fleet", podtracev1alpha1.TracerConfigSpec{
+		Image:        "ghcr.io/gma1k/podtrace:regulated",
+		NodeSelector: map[string]string{"pool": "sess-regulated"},
+	})
+
+	s := createSessionFixture(t, c, ns, "sess-regulated", nil)
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	reconcileSessionUntilSettled(t, r, ns, s.Name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	var created podtracev1alpha1.PodTraceSession
+	if err := c.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: ns}, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	job, image := sessionJobImage(t, c, systemNS, "sess-regulated", created.UID)
+	if image != "ghcr.io/gma1k/podtrace:regulated" {
+		t.Errorf("session Job image = %q, want the node's own fleet image; falling back to default is the false promise this feature exists to close", image)
+	}
+	if got := job.Labels[LabelTracerConfig]; got != "sess-regulated-fleet" {
+		t.Errorf("Job %s label = %q, want sess-regulated-fleet", LabelTracerConfig, got)
+	}
+}
+
+func TestEnvtestSessionRefOverridesNodeFleet(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+	ensureDefaultTracerConfig(t, c)
+
+	createFleetNode(t, c, "sess-pinned", map[string]string{"pool": "sess-pinned"})
+	createFleetConfig(t, c, "sess-pinned-fleet", podtracev1alpha1.TracerConfigSpec{
+		Image:        "ghcr.io/gma1k/podtrace:pinned",
+		NodeSelector: map[string]string{"pool": "sess-pinned"},
+	})
+
+	s := createSessionFixture(t, c, ns, "sess-pinned", func(s *podtracev1alpha1.PodTraceSession) {
+		s.Spec.TracerConfigRef = &podtracev1alpha1.LocalObjectReference{Name: "default"}
+	})
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	reconcileSessionUntilSettled(t, r, ns, s.Name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	var created podtracev1alpha1.PodTraceSession
+	if err := c.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: ns}, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	_, image := sessionJobImage(t, c, systemNS, "sess-pinned", created.UID)
+	if image != "ghcr.io/gma1k/podtrace:test" {
+		t.Errorf("session Job image = %q, want the pinned default config's image", image)
+	}
+}
+
+func TestEnvtestSessionFailsWhenNothingResolves(t *testing.T) {
+	scheme, c, ns := setupSharedEnvtest(t)
+	systemNS := ensureSystemNamespace(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	var existing podtracev1alpha1.TracerConfigList
+	if err := c.List(ctx, &existing); err != nil {
+		t.Fatal(err)
+	}
+	for i := range existing.Items {
+		if err := c.Delete(ctx, &existing.Items[i]); err != nil {
+			t.Fatalf("clear TracerConfigs: %v", err)
+		}
+	}
+	t.Cleanup(func() { ensureDefaultTracerConfig(t, c) })
+
+	createFleetNode(t, c, "sess-orphan", nil)
+	s := createSessionFixture(t, c, ns, "sess-orphan", nil)
+
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: systemNS}
+	reconcileSessionUntilSettled(t, r, ns, s.Name)
+
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: ns}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Errorf("state = %q, want Failed rather than a Job with an empty image", got.Status.State)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionDegraded)
+	if cond == nil || cond.Reason != "TracerConfigUnresolved" {
+		t.Errorf("want Degraded/TracerConfigUnresolved, got %+v", got.Status.Conditions)
+	}
+
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, client.InNamespace(systemNS), client.MatchingLabels{
+		LabelSessionName: s.Name, LabelSessionNS: ns,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs.Items) != 0 {
+		t.Errorf("no Job may be created when no config resolves, got %d", len(jobs.Items))
+	}
+}

--- a/internal/operator/session_tracerconfig_test.go
+++ b/internal/operator/session_tracerconfig_test.go
@@ -1,0 +1,240 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func resolvedFleet(fallbackNS string, nodes []string, tc *podtracev1alpha1.TracerConfig) sessionTracerConfigs {
+	byNode := map[string]*podtracev1alpha1.TracerConfig{}
+	for _, n := range nodes {
+		byNode[n] = tc
+	}
+	return sessionTracerConfigs{byNode: byNode, namespaces: distinctNamespaces(byNode, fallbackNS)}
+}
+
+func testTracerConfig(name, image, systemNS string, nodeSelector map[string]string) *podtracev1alpha1.TracerConfig {
+	return &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image:           image,
+			SystemNamespace: systemNS,
+			NodeSelector:    nodeSelector,
+		},
+	}
+}
+
+func sessionResolver(t *testing.T, objs ...client.Object) *PodTraceSessionReconciler {
+	t.Helper()
+	scheme := newOperatorScheme(t)
+	return &PodTraceSessionReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Scheme:          scheme,
+		SystemNamespace: "podtrace-system",
+	}
+}
+
+func sessionWithRef(name string) *podtracev1alpha1.PodTraceSession {
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "team-a", UID: "uid-s"},
+	}
+	if name != "" {
+		s.Spec.TracerConfigRef = &podtracev1alpha1.LocalObjectReference{Name: name}
+	}
+	return s
+}
+
+func TestSessionResolvesPerNodeFleet(t *testing.T) {
+	r := sessionResolver(t,
+		testTracerConfig("default", "img:default", "", nil),
+		testTracerConfig("regulated", "img:regulated", "", map[string]string{"pool": "regulated"}),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n-general", Labels: map[string]string{"pool": "general"}}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n-regulated", Labels: map[string]string{"pool": "regulated"}}},
+	)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n-general", "n-regulated"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name := got.forNode("n-regulated").Name; name != "regulated" {
+		t.Errorf("n-regulated resolved to %q, want regulated", name)
+	}
+	if name := got.forNode("n-general").Name; name != "default" {
+		t.Errorf("n-general resolved to %q, want default", name)
+	}
+}
+
+func TestSessionRefPinsEveryNode(t *testing.T) {
+	r := sessionResolver(t,
+		testTracerConfig("default", "img:default", "", nil),
+		testTracerConfig("regulated", "img:regulated", "", map[string]string{"pool": "regulated"}),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n-regulated", Labels: map[string]string{"pool": "regulated"}}},
+	)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("default"), []string{"n-regulated"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name := got.forNode("n-regulated").Name; name != "default" {
+		t.Errorf("an explicit tracerConfigRef must override the node's fleet, got %q", name)
+	}
+}
+
+func TestSessionRefNotFoundIsTerminal(t *testing.T) {
+	r := sessionResolver(t, testTracerConfig("default", "img:default", "", nil))
+
+	_, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("ghost"), []string{"n1"})
+	var missing *errNoTracerConfig
+	if !errors.As(err, &missing) {
+		t.Fatalf("want errNoTracerConfig, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the missing config, got %q", err)
+	}
+}
+
+func TestSessionFallsBackToDefaultWhenNoFleetMatches(t *testing.T) {
+	r := sessionResolver(t,
+		testTracerConfig("default", "img:default", "", nil),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}},
+	)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n1"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name := got.forNode("n1").Name; name != "default" {
+		t.Errorf("resolved %q, want default", name)
+	}
+}
+
+func TestSessionWithNoTracerConfigAtAllErrors(t *testing.T) {
+	r := sessionResolver(t, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}})
+
+	_, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n1"})
+	var missing *errNoTracerConfig
+	if !errors.As(err, &missing) {
+		t.Fatalf("a session with no resolvable TracerConfig must error rather than build an image-less Job, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no TracerConfig") {
+		t.Errorf("error should explain the cause, got %q", err)
+	}
+}
+
+func TestSessionCollectsDistinctSystemNamespaces(t *testing.T) {
+	r := sessionResolver(t,
+		testTracerConfig("default", "img:default", "ns-a", nil),
+		testTracerConfig("regulated", "img:regulated", "ns-b", map[string]string{"pool": "regulated"}),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n-general", Labels: map[string]string{"pool": "general"}}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n-regulated", Labels: map[string]string{"pool": "regulated"}}},
+	)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n-general", "n-regulated"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(got.namespaces) != 2 || got.namespaces[0] != "ns-a" || got.namespaces[1] != "ns-b" {
+		t.Errorf("namespaces = %v, want [ns-a ns-b] so prerequisites are provisioned in both", got.namespaces)
+	}
+	if ns := got.namespaceForNode("n-regulated", "fallback"); ns != "ns-b" {
+		t.Errorf("n-regulated Job namespace = %q, want ns-b", ns)
+	}
+}
+
+func TestSessionPrimaryIsDeterministic(t *testing.T) {
+	r := sessionResolver(t,
+		testTracerConfig("default", "img:default", "", nil),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n2"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}},
+	)
+
+	first, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n2", "n1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n1", "n2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.primary().Name != second.primary().Name {
+		t.Errorf("primary must not depend on node order: %q vs %q", first.primary().Name, second.primary().Name)
+	}
+}
+
+func TestSessionContestedNodeUsesPartitionWinner(t *testing.T) {
+	low := testTracerConfig("low", "img:low", "", nil)
+	high := testTracerConfig("high", "img:high", "", nil)
+	high.Spec.Priority = 10
+
+	r := sessionResolver(t, low, high,
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}},
+	)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n1"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name := got.forNode("n1").Name; name != "high" {
+		t.Errorf("contested node resolved to %q, want the partition winner high", name)
+	}
+}
+
+func defaultTracerConfigObject() *podtracev1alpha1.TracerConfig {
+	return testTracerConfig(DefaultTracerConfigName, "ghcr.io/gma1k/podtrace:test", "", nil)
+}
+
+func TestSessionRefSurfacesNonNotFoundGetError(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*podtracev1alpha1.TracerConfig); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	_, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("regulated"), []string{"n1"})
+	if err == nil {
+		t.Fatal("an apiserver failure must propagate rather than be treated as unresolvable")
+	}
+	var missing *errNoTracerConfig
+	if errors.As(err, &missing) {
+		t.Error("a transient failure must not fail the session terminally; it should be retried")
+	}
+}
+
+func TestSessionResolutionSurfacesListFailure(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.TracerConfigList); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	_, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef(""), []string{"n1"})
+	if err == nil {
+		t.Fatal("without the config list there is no basis to resolve, so the failure must surface")
+	}
+	var missing *errNoTracerConfig
+	if errors.As(err, &missing) {
+		t.Error("an unreadable list is transient, not a terminal misconfiguration")
+	}
+}

--- a/internal/operator/tracerconfig_multifleet_envtest_test.go
+++ b/internal/operator/tracerconfig_multifleet_envtest_test.go
@@ -217,3 +217,57 @@ func TestEnvtestOverlappingFleetsReportConflict(t *testing.T) {
 		t.Errorf("overlap is reported, not enforced: the loser keeps its DaemonSet too: %v", err)
 	}
 }
+
+func TestEnvtestFleetsWithDifferentSystemNamespacesCoexist(t *testing.T) {
+	scheme, c, _ := setupSharedEnvtest(t)
+	nsA := ensureDedicatedSystemNamespace(t, c, "coexist-a")
+	nsB := ensureDedicatedSystemNamespace(t, c, "coexist-b")
+
+	createFleetConfig(t, c, "coexist-a", podtracev1alpha1.TracerConfigSpec{
+		SystemNamespace: nsA,
+		NodeSelector:    map[string]string{"pool": "coexist-a"},
+	})
+	createFleetConfig(t, c, "coexist-b", podtracev1alpha1.TracerConfigSpec{
+		SystemNamespace: nsB,
+		NodeSelector:    map[string]string{"pool": "coexist-b"},
+	})
+
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: nsA}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Three rounds: the flapping regression only shows once each config has
+	// reconciled at least twice, because each pass is what would delete the
+	// other's DaemonSet.
+	for round := 0; round < 3; round++ {
+		for _, name := range []string{"coexist-a", "coexist-b"} {
+			if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+				t.Fatalf("round %d reconcile %s: %v", round, name, err)
+			}
+		}
+
+		for _, tt := range []struct{ name, namespace string }{
+			{"podtrace-agent-coexist-a", nsA},
+			{"podtrace-agent-coexist-b", nsB},
+		} {
+			var ds appsv1.DaemonSet
+			if err := c.Get(ctx, types.NamespacedName{Name: tt.name, Namespace: tt.namespace}, &ds); err != nil {
+				t.Fatalf("round %d: %s/%s missing — a fleet deleted a sibling's DaemonSet, which flaps forever and leaves the cluster with no agents: %v",
+					round, tt.namespace, tt.name, err)
+			}
+		}
+	}
+
+	var strays appsv1.DaemonSetList
+	if err := c.List(ctx, &strays, client.InNamespace(nsA), client.MatchingLabels{
+		LabelManagedBy: ManagedByValue, LabelComponent: ComponentAgent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := range strays.Items {
+		if strays.Items[i].Labels[LabelTracerConfig] != "coexist-a" {
+			t.Errorf("namespace %s holds DaemonSet %s belonging to fleet %q",
+				nsA, strays.Items[i].Name, strays.Items[i].Labels[LabelTracerConfig])
+		}
+	}
+}

--- a/internal/operator/tracerconfig_multifleet_test.go
+++ b/internal/operator/tracerconfig_multifleet_test.go
@@ -368,3 +368,35 @@ func nodeListForbidden() interceptor.Funcs {
 		},
 	}
 }
+
+func TestPartitionUnresolvedWhenConfigListFails(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	tc := fleetConfig(DefaultTracerConfigName, podtracev1alpha1.TracerConfigSpec{})
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithObjects(tc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.TracerConfigList); ok {
+					return apierrors.NewServiceUnavailable("synthetic")
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: DefaultTracerConfigName},
+	}); err != nil {
+		t.Fatalf("losing the config list must not fail the reconcile: %v", err)
+	}
+
+	var got podtracev1alpha1.TracerConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Name: DefaultTracerConfigName}, &got); err != nil {
+		t.Fatal(err)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionConflict)
+	if cond == nil || cond.Status != metav1.ConditionUnknown || cond.Reason != "PartitionUnresolved" {
+		t.Errorf("want Conflict=Unknown/PartitionUnresolved, got %+v", got.Status.Conditions)
+	}
+}

--- a/internal/operator/tracerconfig_watches_test.go
+++ b/internal/operator/tracerconfig_watches_test.go
@@ -1,0 +1,210 @@
+package operator
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func requestNames(t *testing.T, r *TracerConfigReconciler, obj client.Object) []string {
+	t.Helper()
+	reqs := r.enqueueAllTracerConfigs(context.Background(), obj)
+	names := make([]string, 0, len(reqs))
+	for _, req := range reqs {
+		if req.Namespace != "" {
+			t.Errorf("TracerConfig is cluster-scoped; request carried namespace %q", req.Namespace)
+		}
+		names = append(names, req.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestEnqueueAllTracerConfigsFansOutToEveryFleet(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		fleetConfig(DefaultTracerConfigName, podtracev1alpha1.TracerConfigSpec{}),
+		fleetConfig("regulated", podtracev1alpha1.TracerConfigSpec{}),
+		fleetConfig("gpu", podtracev1alpha1.TracerConfigSpec{}),
+	).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	got := requestNames(t, r, fleetNode("n1", nil))
+
+	want := []string{"default", "gpu", "regulated"}
+	if len(got) != len(want) {
+		t.Fatalf("enqueued %v, want %v: one config's spec change can flip another's Conflict condition", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("enqueued %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+func TestEnqueueAllTracerConfigsEmptyCluster(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	r := &TracerConfigReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme:          scheme,
+		SystemNamespace: "podtrace-system",
+	}
+
+	if got := requestNames(t, r, fleetNode("n1", nil)); len(got) != 0 {
+		t.Errorf("no configs means nothing to enqueue, got %v", got)
+	}
+}
+
+func TestEnqueueAllTracerConfigsFallsBackWhenListFails(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*podtracev1alpha1.TracerConfigList); ok {
+					return errInternal()
+				}
+				return nil
+			},
+		}).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	got := requestNames(t, r, fleetNode("n1", nil))
+
+	if len(got) != 1 || got[0] != DefaultTracerConfigName {
+		t.Errorf("a failed list must still enqueue %q rather than drop the event, got %v",
+			DefaultTracerConfigName, got)
+	}
+}
+
+func nodeUpdate(oldNode, newNode *corev1.Node) event.UpdateEvent {
+	return event.UpdateEvent{ObjectOld: oldNode, ObjectNew: newNode}
+}
+
+func taintedNode(name string, labels map[string]string, taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec:       corev1.NodeSpec{Taints: taints},
+	}
+}
+
+func TestNodePredicateDropsStatusOnlyUpdates(t *testing.T) {
+	p := nodeSchedulingChangedPredicate()
+
+	before := taintedNode("n1", map[string]string{"pool": "a"})
+	after := before.DeepCopy()
+	after.Status.Conditions = []corev1.NodeCondition{{
+		Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady",
+	}}
+	after.Status.Allocatable = corev1.ResourceList{}
+
+	if p.Update(nodeUpdate(before, after)) {
+		t.Error("kubelet rewrites node status every few seconds; admitting those would requeue every TracerConfig on every heartbeat")
+	}
+}
+
+func TestNodePredicateAdmitsSchedulingChanges(t *testing.T) {
+	p := nodeSchedulingChangedPredicate()
+
+	cases := []struct {
+		name           string
+		before, after  *corev1.Node
+		wantAdmitted   bool
+		failureMessage string
+	}{
+		{
+			name:           "label added",
+			before:         taintedNode("n1", nil),
+			after:          taintedNode("n1", map[string]string{"pool": "a"}),
+			wantAdmitted:   true,
+			failureMessage: "a new label can move the node into a fleet",
+		},
+		{
+			name:           "label value changed",
+			before:         taintedNode("n1", map[string]string{"pool": "a"}),
+			after:          taintedNode("n1", map[string]string{"pool": "b"}),
+			wantAdmitted:   true,
+			failureMessage: "a relabel can move the node between fleets",
+		},
+		{
+			name:           "label removed",
+			before:         taintedNode("n1", map[string]string{"pool": "a"}),
+			after:          taintedNode("n1", nil),
+			wantAdmitted:   true,
+			failureMessage: "removing a label can drop the node out of a fleet",
+		},
+		{
+			name:   "taint added",
+			before: taintedNode("n1", map[string]string{"pool": "a"}),
+			after: taintedNode("n1", map[string]string{"pool": "a"},
+				corev1.Taint{Key: "dedicated", Effect: corev1.TaintEffectNoSchedule}),
+			wantAdmitted:   true,
+			failureMessage: "an untolerated taint excludes the node from its fleet",
+		},
+		{
+			name: "taint removed",
+			before: taintedNode("n1", map[string]string{"pool": "a"},
+				corev1.Taint{Key: "dedicated", Effect: corev1.TaintEffectNoSchedule}),
+			after:          taintedNode("n1", map[string]string{"pool": "a"}),
+			wantAdmitted:   true,
+			failureMessage: "removing a taint can bring the node back into a fleet",
+		},
+		{
+			name:           "nothing scheduling-relevant changed",
+			before:         taintedNode("n1", map[string]string{"pool": "a"}),
+			after:          taintedNode("n1", map[string]string{"pool": "a"}),
+			wantAdmitted:   false,
+			failureMessage: "an identical node must not requeue anything",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.Update(nodeUpdate(tt.before, tt.after)); got != tt.wantAdmitted {
+				t.Errorf("admitted = %v, want %v: %s", got, tt.wantAdmitted, tt.failureMessage)
+			}
+		})
+	}
+}
+
+func TestNodePredicateAdmitsNonNodeObjects(t *testing.T) {
+	p := nodeSchedulingChangedPredicate()
+
+	notANode := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}
+	if !p.Update(event.UpdateEvent{ObjectOld: notANode, ObjectNew: notANode}) {
+		t.Error("a non-Node object must fail open rather than be silently dropped")
+	}
+}
+
+func TestNodePredicateAdmitsCreateAndDelete(t *testing.T) {
+	p := nodeSchedulingChangedPredicate()
+	n := taintedNode("n1", map[string]string{"pool": "a"})
+
+	if !p.Create(event.CreateEvent{Object: n}) {
+		t.Error("a new node may belong to a fleet, so creation must requeue")
+	}
+	if !p.Delete(event.DeleteEvent{Object: n}) {
+		t.Error("a removed node changes matchedNodes, so deletion must requeue")
+	}
+}
+
+func TestStaleAgentSelectorsScopePerFleet(t *testing.T) {
+	defaults := staleAgentSelectors(DefaultTracerConfigName)
+	if len(defaults) != 2 {
+		t.Errorf("the default fleet needs its own selector plus one for unlabelled pre-multi-config leftovers, got %d", len(defaults))
+	}
+
+	others := staleAgentSelectors("regulated")
+	if len(others) != 1 {
+		t.Errorf("a non-default fleet must only ever match its own label, got %d selectors", len(others))
+	}
+}

--- a/internal/webhook/v1alpha1/podtracesession_webhook.go
+++ b/internal/webhook/v1alpha1/podtracesession_webhook.go
@@ -64,6 +64,9 @@ func (v *PodTraceSessionCustomValidator) validate(ctx context.Context, s *podtra
 	if err := resolveExporterRef(ctx, v.Client, s.Namespace, s.Spec.ExporterRef.Name); err != nil {
 		return nil, err
 	}
+	if err := resolveTracerConfigRef(ctx, v.Client, s.Spec.TracerConfigRef); err != nil {
+		return nil, err
+	}
 	if err := validateReportRef(s.Spec.ReportRef); err != nil {
 		return nil, err
 	}

--- a/internal/webhook/v1alpha1/session_tracerconfigref_test.go
+++ b/internal/webhook/v1alpha1/session_tracerconfigref_test.go
@@ -1,0 +1,96 @@
+package v1alpha1_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+	webhookv1alpha1 "github.com/gma1k/podtrace/internal/webhook/v1alpha1"
+)
+
+func sessionWithTracerConfigRef(name string) *podtracev1alpha1.PodTraceSession {
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "sess", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    validSelector(),
+			Duration:    metav1.Duration{Duration: time.Minute},
+			ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+		},
+	}
+	if name != "" {
+		s.Spec.TracerConfigRef = &podtracev1alpha1.LocalObjectReference{Name: name}
+	}
+	return s
+}
+
+func TestSessionTracerConfigRefUnsetIsValid(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	if _, err := v.ValidateCreate(context.Background(), sessionWithTracerConfigRef("")); err != nil {
+		t.Errorf("an unset tracerConfigRef must be valid; it means resolve per node, got %v", err)
+	}
+}
+
+func TestSessionTracerConfigRefAcceptsExistingConfig(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{ObjectMeta: metav1.ObjectMeta{Name: "regulated"}}
+	c := newClientWithExporter(t, "default", "prod-otlp", tc)
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	if _, err := v.ValidateCreate(context.Background(), sessionWithTracerConfigRef("regulated")); err != nil {
+		t.Errorf("a pin to an existing TracerConfig must be accepted, got %v", err)
+	}
+}
+
+func TestSessionTracerConfigRefRejectsMissingConfig(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	_, err := v.ValidateCreate(context.Background(), sessionWithTracerConfigRef("ghost"))
+	if err == nil {
+		t.Fatal("a pin to a nonexistent TracerConfig would fail the session terminally at run time; reject it at apply")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the missing config, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "spec.tracerConfigRef") {
+		t.Errorf("error should name the offending field, got %q", err)
+	}
+}
+
+func TestSessionTracerConfigRefEmptyNameIsUnset(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	s := sessionWithTracerConfigRef("")
+	s.Spec.TracerConfigRef = &podtracev1alpha1.LocalObjectReference{Name: ""}
+	if _, err := v.ValidateCreate(context.Background(), s); err != nil {
+		t.Errorf("an empty ref name must behave as unset rather than as a lookup for %q, got %v", "", err)
+	}
+}
+
+func TestSessionTracerConfigRefCheckedOnUpdate(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	oldSession := sessionWithTracerConfigRef("")
+	newSession := sessionWithTracerConfigRef("ghost")
+
+	if _, err := v.ValidateUpdate(context.Background(), oldSession, newSession); err == nil {
+		t.Fatal("adding a bad pin on update must be rejected too")
+	}
+}
+
+func TestSessionTracerConfigRefSkippedWhenSpecUnchanged(t *testing.T) {
+	c := newClientWithExporter(t, "default", "prod-otlp")
+	v := &webhookv1alpha1.PodTraceSessionCustomValidator{Client: c}
+
+	stale := sessionWithTracerConfigRef("ghost")
+	if _, err := v.ValidateUpdate(context.Background(), stale, stale.DeepCopy()); err != nil {
+		t.Errorf("a metadata-only update must not re-validate the spec, or a session pinned to a since-deleted config could never be finalized: %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/setup_webhook_unit_test.go
+++ b/internal/webhook/v1alpha1/setup_webhook_unit_test.go
@@ -67,3 +67,10 @@ func TestSetupPodTraceSessionWebhookWithManager(t *testing.T) {
 		t.Fatalf("SetupPodTraceSessionWebhookWithManager: %v", err)
 	}
 }
+
+func TestSetupTracerConfigWebhookWithManager(t *testing.T) {
+	mgr := newNonConnectingManager(t)
+	if err := webhookv1alpha1.SetupTracerConfigWebhookWithManager(mgr); err != nil {
+		t.Fatalf("SetupTracerConfigWebhookWithManager: %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/tracerconfig_webhook.go
+++ b/internal/webhook/v1alpha1/tracerconfig_webhook.go
@@ -103,18 +103,11 @@ func validateSelectorCollision(tc *podtracev1alpha1.TracerConfig, siblings []pod
 	return nil
 }
 
-// isClusterWide reports whether a config constrains its fleet to a subset of
-// nodes at all. Tolerations do not count: they widen the eligible node set,
-// they never narrow it.
+// isClusterWide delegates to the partition package so admission and the
+// reconciler cannot drift on what "targets every node" means — the same
+// predicate also decides fleet precedence in fleet.Outranks.
 func isClusterWide(spec *podtracev1alpha1.TracerConfigSpec) bool {
-	if len(spec.NodeSelector) > 0 {
-		return false
-	}
-	if spec.Affinity == nil || spec.Affinity.NodeAffinity == nil {
-		return true
-	}
-	required := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-	return required == nil || len(required.NodeSelectorTerms) == 0
+	return fleet.IsClusterWide(spec)
 }
 
 // warnOnCurrentOverlap reports fleets that share nodes as the cluster is

--- a/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
+++ b/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
@@ -169,3 +169,47 @@ func TestTracerConfigSkipsValidationWhenSpecUnchanged(t *testing.T) {
 		t.Errorf("expected no warnings, got %v", warnings)
 	}
 }
+
+func TestTracerConfigValidateDeleteIsAlwaysAllowed(t *testing.T) {
+	v := tracerConfigValidator(t)
+
+	warnings, err := v.ValidateDelete(context.Background(), tracerConfig("default", podtracev1alpha1.TracerConfigSpec{}))
+	if err != nil {
+		t.Errorf("deleting a TracerConfig must never be blocked by admission: %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("expected no warnings on delete, got %v", warnings)
+	}
+}
+
+func TestTracerConfigValidateWithoutClientSkipsClusterChecks(t *testing.T) {
+	v := &TracerConfigCustomValidator{}
+
+	if _, err := v.ValidateCreate(context.Background(), tracerConfig("default", podtracev1alpha1.TracerConfigSpec{})); err != nil {
+		t.Errorf("with no client the cluster-wide checks must be skipped, not error: %v", err)
+	}
+
+	long := strings.Repeat("x", podtracev1alpha1.MaxTracerConfigNameLength+1)
+	if _, err := v.ValidateCreate(context.Background(), tracerConfig(long, podtracev1alpha1.TracerConfigSpec{})); err == nil {
+		t.Error("the name-length rule needs no client and must still apply")
+	}
+}
+
+func TestResolveTracerConfigRefWithoutClient(t *testing.T) {
+	err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{Name: "regulated"})
+	if err == nil {
+		t.Fatal("an unconfigured client cannot verify the pin, so it must not silently accept it")
+	}
+	if !strings.Contains(err.Error(), "TracerConfig") {
+		t.Errorf("error should name what could not be resolved, got %q", err)
+	}
+}
+
+func TestResolveTracerConfigRefNilAndEmptyAreUnset(t *testing.T) {
+	if err := resolveTracerConfigRef(context.Background(), nil, nil); err != nil {
+		t.Errorf("a nil ref means resolve per node, got %v", err)
+	}
+	if err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{}); err != nil {
+		t.Errorf("an empty ref name means resolve per node, got %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/webhook_error_paths_test.go
+++ b/internal/webhook/v1alpha1/webhook_error_paths_test.go
@@ -1,0 +1,218 @@
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func errServerTimeout() error {
+	return apierrors.NewServerTimeout(schema.GroupResource{Resource: "podtrace"}, "get", 1)
+}
+
+func interceptedClient(t *testing.T, funcs interceptor.Funcs, objs ...client.Object) client.Client {
+	t.Helper()
+	s := clientgoscheme.Scheme
+	if err := podtracev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).WithInterceptorFuncs(funcs).Build()
+}
+
+func TestResolveTracerConfigRefSurfacesNonNotFoundErrors(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+			if _, ok := obj.(*podtracev1alpha1.TracerConfig); ok {
+				return errServerTimeout()
+			}
+			return nil
+		},
+	})
+
+	err := resolveTracerConfigRef(context.Background(), c, &podtracev1alpha1.LocalObjectReference{Name: "regulated"})
+	if err == nil {
+		t.Fatal("an apiserver failure must not be mistaken for a missing TracerConfig")
+	}
+	if strings.Contains(err.Error(), "not found") {
+		t.Errorf("a transient error must not be reported as not-found, got %q", err)
+	}
+}
+
+func TestResolveExporterRefSurfacesNonNotFoundErrors(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+			if _, ok := obj.(*podtracev1alpha1.ExporterConfig); ok {
+				return errServerTimeout()
+			}
+			return nil
+		},
+	})
+
+	err := resolveExporterRef(context.Background(), c, "default", "prod-otlp")
+	if err == nil {
+		t.Fatal("an apiserver failure must not be mistaken for a missing ExporterConfig")
+	}
+	if strings.Contains(err.Error(), "not found") {
+		t.Errorf("a transient error must not be reported as not-found, got %q", err)
+	}
+}
+
+func TestTracerConfigValidateSurfacesListFailure(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+			if _, ok := list.(*podtracev1alpha1.TracerConfigList); ok {
+				return errServerTimeout()
+			}
+			return nil
+		},
+	})
+	v := &TracerConfigCustomValidator{Client: c}
+
+	_, err := v.ValidateCreate(context.Background(), tracerConfig("regulated", podtracev1alpha1.TracerConfigSpec{}))
+	if err == nil {
+		t.Fatal("admission cannot judge overlap without the config list, so the failure must surface")
+	}
+	if !strings.Contains(err.Error(), "fleet overlap") {
+		t.Errorf("error should explain what could not be checked, got %q", err)
+	}
+}
+
+func TestWarnOnCurrentOverlapStaysSilentWhenNodesUnreadable(t *testing.T) {
+	existing := tracerConfig("default", podtracev1alpha1.TracerConfigSpec{})
+	c := interceptedClient(t, interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*corev1.NodeList); ok {
+				return errServerTimeout()
+			}
+			return cl.List(ctx, list, opts...)
+		},
+	}, existing)
+	v := &TracerConfigCustomValidator{Client: c}
+
+	warnings, err := v.ValidateCreate(context.Background(), tracerConfig("regulated", podtracev1alpha1.TracerConfigSpec{
+		NodeSelector: map[string]string{"pool": "regulated"},
+	}))
+	if err != nil {
+		t.Fatalf("unreadable nodes must not block admission; the operator reports overlap anyway: %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("no node list means no basis for a warning, got %v", warnings)
+	}
+}
+
+func TestValidateCrossNamespaceGrantsIgnoresInvalidSelector(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{})
+
+	warnings, err := validateCrossNamespaceGrants(context.Background(), c, "team-a", nil,
+		&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "k", Operator: "BOGUS"}}})
+	if err != nil {
+		t.Errorf("an unparseable selector is rejected by the dedicated selector rule, not here: %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestValidateCrossNamespaceGrantsSkipsTerminatingNamespaces(t *testing.T) {
+	now := metav1.Now()
+	terminating := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "going-away",
+		Labels:            map[string]string{"team": "obs"},
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"kubernetes"},
+	}}
+	c := interceptedClient(t, interceptor.Funcs{}, terminating)
+
+	warnings, err := validateCrossNamespaceGrants(context.Background(), c, "team-a", nil,
+		&metav1.LabelSelector{MatchLabels: map[string]string{"team": "obs"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("a terminating namespace will never be traced, so it must not be reported as ungranted, got %v", warnings)
+	}
+}
+
+func TestValidateReportRefCountsSecretSink(t *testing.T) {
+	err := validateReportRef(&podtracev1alpha1.ReportReference{
+		Secret:    &corev1.LocalObjectReference{Name: "rpt"},
+		ConfigMap: &corev1.LocalObjectReference{Name: "rpt"},
+	})
+	if err == nil {
+		t.Fatal("a Secret sink must count toward the at-most-one-sink rule")
+	}
+
+	if err := validateReportRef(&podtracev1alpha1.ReportReference{
+		Secret: &corev1.LocalObjectReference{Name: "rpt"},
+	}); err != nil {
+		t.Errorf("a lone Secret sink is valid, got %v", err)
+	}
+}
+
+func scheduleWithTemplate(mutate func(*podtracev1alpha1.PodTraceSessionSpec)) *podtracev1alpha1.PodTraceSchedule {
+	spec := podtracev1alpha1.PodTraceSessionSpec{
+		Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+		Duration:    metav1.Duration{Duration: 60000000000},
+		ExporterRef: podtracev1alpha1.LocalObjectReference{Name: "prod-otlp"},
+	}
+	mutate(&spec)
+	return &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "sch", Namespace: "default"},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule:        "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{Spec: spec},
+		},
+	}
+}
+
+func TestScheduleTemplateRejectsInvalidNamespaceSelector(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{},
+		&podtracev1alpha1.ExporterConfig{ObjectMeta: metav1.ObjectMeta{Name: "prod-otlp", Namespace: "default"}})
+	v := &PodTraceScheduleCustomValidator{Client: c}
+
+	sch := scheduleWithTemplate(func(s *podtracev1alpha1.PodTraceSessionSpec) {
+		s.NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "k", Operator: "BOGUS"}},
+		}
+	})
+
+	_, err := v.ValidateCreate(context.Background(), sch)
+	if err == nil {
+		t.Fatal("an unparseable namespaceSelector inside the template must be rejected before it spawns sessions")
+	}
+	if !strings.Contains(err.Error(), "sessionTemplate") {
+		t.Errorf("error should point at the template, got %q", err)
+	}
+}
+
+func TestScheduleTemplateRejectsInvalidReportRef(t *testing.T) {
+	c := interceptedClient(t, interceptor.Funcs{},
+		&podtracev1alpha1.ExporterConfig{ObjectMeta: metav1.ObjectMeta{Name: "prod-otlp", Namespace: "default"}})
+	v := &PodTraceScheduleCustomValidator{Client: c}
+
+	sch := scheduleWithTemplate(func(s *podtracev1alpha1.PodTraceSessionSpec) {
+		s.ReportRef = &podtracev1alpha1.ReportReference{
+			ConfigMap: &corev1.LocalObjectReference{Name: "rpt"},
+			Secret:    &corev1.LocalObjectReference{Name: "rpt"},
+		}
+	})
+
+	_, err := v.ValidateCreate(context.Background(), sch)
+	if err == nil {
+		t.Fatal("two report sinks in the template must be rejected, same as on a session")
+	}
+	if !strings.Contains(err.Error(), "sessionTemplate") {
+		t.Errorf("error should point at the template, got %q", err)
+	}
+}

--- a/internal/webhook/v1alpha1/webhook_helpers.go
+++ b/internal/webhook/v1alpha1/webhook_helpers.go
@@ -160,6 +160,35 @@ func validateCrossNamespaceGrants(
 		ungranted, sourceNamespace, podtracev1alpha1.AllowTracingFromAnnotation)}, nil
 }
 
+// resolveTracerConfigRef verifies that an explicit spec.tracerConfigRef
+// names a TracerConfig that exists.
+//
+// Unset is valid and common: the operator then resolves each per-node Job
+// against the fleet targeting its node, falling back to "default". Only a
+// pin that cannot be honoured is rejected — left to the reconciler it would
+// fail the session terminally at run time, long after apply.
+//
+// TracerConfig is cluster-scoped, so the lookup carries no namespace.
+func resolveTracerConfigRef(ctx context.Context, c client.Client, ref *podtracev1alpha1.LocalObjectReference) error {
+	if ref == nil || ref.Name == "" {
+		return nil
+	}
+	if c == nil {
+		return fmt.Errorf("webhook client not configured; cannot resolve TracerConfig %q", ref.Name)
+	}
+	var tc podtracev1alpha1.TracerConfig
+	err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, &tc)
+	if err == nil {
+		return nil
+	}
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf(
+			"spec.tracerConfigRef.name %q: TracerConfig not found. Leave it unset to resolve each node against the fleet that targets it",
+			ref.Name)
+	}
+	return fmt.Errorf("spec.tracerConfigRef.name %q: %w", ref.Name, err)
+}
+
 // resolveExporterRef verifies that spec.exporterRef.name refers to an
 // ExporterConfig that exists in the caller's namespace.
 func resolveExporterRef(ctx context.Context, c client.Client, namespace, name string) error {

--- a/test/chainsaw/tests/multi-tracerconfig-fleets/assert-fleets.yaml
+++ b/test/chainsaw/tests/multi-tracerconfig-fleets/assert-fleets.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: podtrace-agent-secondary
       nodeSelector:
-        podtrace.io/test-pool: secondary
+        podtrace.io/test-fleet-pool: secondary
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/test/chainsaw/tests/multi-tracerconfig-fleets/chainsaw-test.yaml
+++ b/test/chainsaw/tests/multi-tracerconfig-fleets/chainsaw-test.yaml
@@ -3,6 +3,10 @@ kind: Test
 metadata:
   name: multi-tracerconfig-fleets
 spec:
+  # Serial: labels a shared Node and creates a cluster-scoped TracerConfig.
+  # Run concurrently with another fleet test and the two would contest the
+  # same node, and the higher-priority fleet would win the other's assertions.
+  concurrent: false
   description: |
     A second TracerConfig gets its own agent fleet instead of fighting the
     first one for the podtrace-agent name. Verifies:
@@ -42,7 +46,7 @@ spec:
                 exit 1
               fi
               echo "$node" > /tmp/chainsaw-fleet-node
-              kubectl label node "$node" podtrace.io/test-pool=secondary --overwrite
+              kubectl label node "$node" podtrace.io/test-fleet-pool=secondary --overwrite
 
               image=$(kubectl get tracerconfig default -o jsonpath='{.spec.image}')
               policy=$(kubectl get tracerconfig default -o jsonpath='{.spec.imagePullPolicy}')
@@ -57,7 +61,7 @@ spec:
                 systemNamespace: podtrace-system
                 priority: 10
                 nodeSelector:
-                  podtrace.io/test-pool: secondary
+                  podtrace.io/test-fleet-pool: secondary
               YAML
 
         - assert:
@@ -158,7 +162,7 @@ spec:
             content: |
               node=$(cat /tmp/chainsaw-fleet-node 2>/dev/null || true)
               if [ -n "$node" ]; then
-                kubectl label node "$node" podtrace.io/test-pool- --ignore-not-found || true
+                kubectl label node "$node" podtrace.io/test-fleet-pool- --ignore-not-found || true
               fi
               kubectl delete tracerconfig secondary --ignore-not-found --wait=true || true
               rm -f /tmp/chainsaw-fleet-node

--- a/test/chainsaw/tests/session-fleet-redaction/chainsaw-test.yaml
+++ b/test/chainsaw/tests/session-fleet-redaction/chainsaw-test.yaml
@@ -1,0 +1,245 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: session-fleet-redaction
+spec:
+  # Serial: labels a shared Node and creates a cluster-scoped TracerConfig.
+  # A concurrent fleet test could claim this node with a higher priority and
+  # steal the session this test is asserting on.
+  concurrent: false
+  description: |
+    A PodTraceSession against a pod on a non-default node pool runs under
+    that pool's TracerConfig, not the cluster's default one. This is the
+    promise multi-fleet support makes and the one unit and envtest cannot
+    prove: it needs a real operator resolving a real pod's real node.
+
+    Verifies:
+      1. The session's per-node Job is labelled with the pool's fleet.
+      2. The Job carries that pool's redaction env, which the default
+         fleet does not set.
+      3. spec.tracerConfigRef overrides the node's fleet.
+      4. A pin to a missing TracerConfig fails the session terminally and
+         creates no Job, rather than one with an empty image.
+
+    One step, so the finally block always runs even on an early failure.
+  timeouts:
+    apply: 30s
+    assert: 120s
+    cleanup: 120s
+  steps:
+    - name: session-inherits-its-pools-policy
+      try:
+        - script:
+            timeout: 120s
+            content: |
+              set -eu
+
+              node=""
+              for n in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+                taints=$(kubectl get node "$n" \
+                  -o jsonpath='{.spec.taints[?(@.effect=="NoSchedule")].key}')
+                if [ -z "$taints" ]; then
+                  node="$n"
+                  break
+                fi
+              done
+              if [ -z "$node" ]; then
+                echo "no untainted node to use as a pool" >&2
+                exit 1
+              fi
+              echo "$node" > /tmp/chainsaw-redaction-node
+              kubectl label node "$node" podtrace.io/test-redaction-pool=redacted --overwrite
+
+              image=$(kubectl get tracerconfig default -o jsonpath='{.spec.image}')
+              policy=$(kubectl get tracerconfig default -o jsonpath='{.spec.imagePullPolicy}')
+              cat <<YAMLDOC | kubectl apply -f -
+              apiVersion: podtrace.io/v1alpha1
+              kind: TracerConfig
+              metadata:
+                name: redacted-pool
+              spec:
+                image: ${image}
+                imagePullPolicy: ${policy:-IfNotPresent}
+                systemNamespace: podtrace-system
+                nodeSelector:
+                  podtrace.io/test-redaction-pool: redacted
+                redaction:
+                  enabled: true
+                  redactDNSNames: true
+              YAMLDOC
+
+              for i in $(seq 1 45); do
+                got=$(kubectl get tracerconfig redacted-pool -o jsonpath='{.status.matchedNodes}' 2>/dev/null || true)
+                if [ "${got:-0}" -ge 1 ]; then
+                  echo "ok: redacted-pool claims $got node(s)"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "redacted-pool never claimed its node; a targeted fleet must beat the cluster-wide default" >&2
+              kubectl get tracerconfig -o yaml >&2 || true
+              exit 1
+
+        - apply:
+            file: ./workload.yaml
+
+        - script:
+            timeout: 150s
+            content: |
+              set -eu
+              node=$(cat /tmp/chainsaw-redaction-node)
+              kubectl -n $NAMESPACE wait --for=condition=Ready pod/target --timeout=120s
+              placed=$(kubectl -n $NAMESPACE get pod target -o jsonpath='{.spec.nodeName}')
+              if [ "$placed" != "$node" ]; then
+                echo "workload landed on $placed, want $node" >&2
+                exit 1
+              fi
+
+              cat <<YAMLDOC | kubectl apply -f -
+              apiVersion: podtrace.io/v1alpha1
+              kind: PodTraceSession
+              metadata:
+                name: pool-session
+                namespace: $NAMESPACE
+              spec:
+                selector:
+                  matchLabels:
+                    app: target
+                duration: 10s
+                filters: [dns]
+                exporterRef:
+                  name: ec
+              YAMLDOC
+
+              for i in $(seq 1 60); do
+                job=$(kubectl -n podtrace-system get jobs \
+                  -l podtrace.io/session=pool-session \
+                  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+                if [ -n "$job" ]; then
+                  break
+                fi
+                sleep 2
+              done
+              if [ -z "$job" ]; then
+                echo "no session Job appeared" >&2
+                kubectl -n $NAMESPACE get podtracesession pool-session -o yaml >&2 || true
+                exit 1
+              fi
+
+              fleet=$(kubectl -n podtrace-system get job "$job" \
+                -o jsonpath='{.metadata.labels.podtrace\.io/tracer-config}')
+              if [ "$fleet" != "redacted-pool" ]; then
+                echo "session Job resolved fleet $fleet, want redacted-pool: the session ignored its node's pool" >&2
+                exit 1
+              fi
+
+              redact=$(kubectl -n podtrace-system get job "$job" \
+                -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' \
+                | grep -c '^PODTRACE_REDACT_PII=true' || true)
+              if [ "$redact" -lt 1 ]; then
+                echo "session Job is missing the pool's redaction policy; per-pool redaction does not reach sessions" >&2
+                kubectl -n podtrace-system get job "$job" -o yaml >&2 || true
+                exit 1
+              fi
+              echo "ok: session on $node ran under redacted-pool with redaction enabled"
+
+        - script:
+            timeout: 120s
+            content: |
+              set -eu
+              cat <<YAMLDOC | kubectl apply -f -
+              apiVersion: podtrace.io/v1alpha1
+              kind: PodTraceSession
+              metadata:
+                name: pinned-session
+                namespace: $NAMESPACE
+              spec:
+                selector:
+                  matchLabels:
+                    app: target
+                duration: 10s
+                filters: [dns]
+                exporterRef:
+                  name: ec
+                tracerConfigRef:
+                  name: default
+              YAMLDOC
+
+              for i in $(seq 1 60); do
+                job=$(kubectl -n podtrace-system get jobs \
+                  -l podtrace.io/session=pinned-session \
+                  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+                if [ -n "$job" ]; then
+                  break
+                fi
+                sleep 2
+              done
+              if [ -z "$job" ]; then
+                echo "no Job for the pinned session" >&2
+                exit 1
+              fi
+              fleet=$(kubectl -n podtrace-system get job "$job" \
+                -o jsonpath='{.metadata.labels.podtrace\.io/tracer-config}')
+              if [ "$fleet" != "default" ]; then
+                echo "pinned session resolved $fleet, want default: spec.tracerConfigRef must override the node's pool" >&2
+                exit 1
+              fi
+              echo "ok: tracerConfigRef overrode the node's pool"
+
+        - script:
+            timeout: 120s
+            content: |
+              set -eu
+              if kubectl get validatingwebhookconfiguration 2>/dev/null | grep -q podtrace; then
+                echo "webhook enabled; a missing pin is rejected at admission and cannot reach the reconciler"
+                exit 0
+              fi
+
+              cat <<YAMLDOC | kubectl apply -f -
+              apiVersion: podtrace.io/v1alpha1
+              kind: PodTraceSession
+              metadata:
+                name: ghost-session
+                namespace: $NAMESPACE
+              spec:
+                selector:
+                  matchLabels:
+                    app: target
+                duration: 10s
+                filters: [dns]
+                exporterRef:
+                  name: ec
+                tracerConfigRef:
+                  name: no-such-config
+              YAMLDOC
+
+              for i in $(seq 1 45); do
+                state=$(kubectl -n $NAMESPACE get podtracesession ghost-session \
+                  -o jsonpath='{.status.state}' 2>/dev/null || true)
+                if [ "$state" = "Failed" ]; then
+                  break
+                fi
+                sleep 2
+              done
+              if [ "$state" != "Failed" ]; then
+                echo "unresolvable pin left the session in state '$state', want Failed" >&2
+                exit 1
+              fi
+
+              jobs=$(kubectl -n podtrace-system get jobs \
+                -l podtrace.io/session=ghost-session --no-headers 2>/dev/null | wc -l)
+              if [ "$jobs" -ne 0 ]; then
+                echo "an unresolvable session created $jobs Job(s); an image-less Job is exactly what this must avoid" >&2
+                exit 1
+              fi
+              echo "ok: unresolvable pin failed terminally with no Job"
+
+      finally:
+        - script:
+            content: |
+              node=$(cat /tmp/chainsaw-redaction-node 2>/dev/null || true)
+              if [ -n "$node" ]; then
+                kubectl label node "$node" podtrace.io/test-redaction-pool- --ignore-not-found || true
+              fi
+              kubectl delete tracerconfig redacted-pool --ignore-not-found --wait=true || true
+              rm -f /tmp/chainsaw-redaction-node

--- a/test/chainsaw/tests/session-fleet-redaction/workload.yaml
+++ b/test/chainsaw/tests/session-fleet-redaction/workload.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: target
+  labels:
+    app: target
+spec:
+  nodeSelector:
+    podtrace.io/test-redaction-pool: redacted
+  containers:
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "while true; do sleep 5; done"]
+---
+apiVersion: podtrace.io/v1alpha1
+kind: ExporterConfig
+metadata:
+  name: ec
+spec:
+  type: otlp
+  otlp:
+    endpoint: "otel-collector.observability:4318"
+    protocol: http
+    insecure: true


### PR DESCRIPTION
## Summary

A `PodTraceSession` now resolves a `TracerConfig` **per node** rather than always using `default`. Each per-node Job takes the image, pull policy, session resources and redaction policy of the fleet targeting its own node, so a session whose pods span a `general` pool and a `regulated` pool runs one Job under each pool's own policy. `spec.tracerConfigRef` pins the whole session to one config when it must be reproducible regardless of placement.

This closes the gap left by multi-TracerConfig support: fleets could already carry their own redaction policy, but sessions ignored it, so a per-pool `spec.redaction` silently did nothing for `podtrace diagnose` and `PodTraceSession`. That caveat was documented in `crd-tracerconfig.md`; it is now removed because the behaviour is real.

When nothing resolves, the session fails terminally with `Degraded/TracerConfigUnresolved` naming the node and the existing configs. Previously `resolveTracerConfig` returned a nil config and the Job was built with `image: ""`, which the apiserver rejects with a container-validation message that says nothing about the actual cause.

**This PR also changes behaviour introduced in the multi-TracerConfig PR.** `fleet.Outranks` now breaks equal-priority ties on specificity before falling through to creation time and name. The chart's stock `default` config carries no `nodeSelector`, so it targets every node and contests every fleet; the old name tie-break made `default` win almost everything alphabetically. A targeted pool would have lost its own nodes to the catch-all and per-pool policy would never have applied. Explicit `spec.priority` still overrides. The visible effect is that the `Conflict` condition now names the targeted fleet as winner where it previously named `default`.

Verified end to end on a 3-node kind cluster: a session against a pod on a `regulated` pool produced a Job labelled `podtrace.io/tracer-config: regulated` carrying `PODTRACE_REDACT_PII=true`, while the same session shape on the `general` pool produced a `default` Job with no redaction, and a pinned session overrode its node's pool. Full chainsaw suite green at 22/22 with zero operator errors, zero panics and zero RBAC denials.

## Changes

- Added `spec.tracerConfigRef` to `PodTraceSession` a bare name, since `TracerConfig` is cluster-scoped. Unset means per-node resolution.
- New `internal/operator/session_tracerconfig.go` resolves per node in order: `spec.tracerConfigRef`, then the fleet targeting that node via `fleet.ComputePartition().Winner`, then `default`, then a terminal error. Reusing the partition means the session agrees with whatever the `Conflict` condition reported.
- `ensureJobs` builds each Job from its own node's config and stamps `podtrace.io/tracer-config` on it.
- Fleets that set different `spec.systemNamespace` place their Jobs in different namespaces, so the exporter bundle, objectStore credentials, ServiceAccount and RBAC are now provisioned in every namespace the resolution touches, a Job cannot mount a bundle that lives elsewhere.
- `fleet.Outranks` gained a specificity tie-break, and `fleet.IsClusterWide` is now shared with the admission webhook so the two cannot drift on what "targets every node" means.
- The session webhook rejects a `tracerConfigRef` naming a nonexistent `TracerConfig`, mirroring `exporterRef`. Unset stays valid; only an unhonourable pin is rejected, so the failure surfaces at apply rather than when the session fails at run time.
- Docs: added `tracerConfigRef` to the spec table and a "TracerConfig resolution" section in `crd-podtracesession.md`; replaced the stale "sessions always resolve default" caveat in `crd-tracerconfig.md`.
- Fixed `defaultAgentResources()`, which claimed to mirror the chart but set a 256Mi memory limit against the chart's 1Gi, OOMKilling the agent on OLM and raw-kubectl installs that rely on the bootstrap. Added a parity test that parses `values.yaml` and fails on drift.
- Tests: per-node resolution, pinning, terminal failure and namespace grouping as unit tests; envtest for a session picking its node's fleet, for a pinned override, and for the terminal path creating no Job; a new `session-fleet-redaction` chainsaw test asserting the redaction policy actually reaches the Job.