### PR TITLE
fix: confine uprobe target resolution to the traced workload

### DIFF
--- a/internal/diagnose/stacktrace/stacktrace.go
+++ b/internal/diagnose/stacktrace/stacktrace.go
@@ -7,13 +7,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/events"
 	"github.com/gma1k/podtrace/internal/hostfs"
 	"github.com/gma1k/podtrace/internal/procfs"
+	"github.com/gma1k/podtrace/internal/procmaps"
 	"github.com/gma1k/podtrace/internal/safeconv"
 	"github.com/gma1k/podtrace/internal/sanitize"
 )
@@ -149,25 +149,11 @@ func (r *stackResolver) exeMappings(pid uint32, exePath string) []exeMapping {
 	var out []exeMapping
 	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
 	if err == nil {
-		for _, line := range strings.Split(string(data), "\n") {
-			fields := strings.Fields(line)
-			if len(fields) < 6 {
+		for _, e := range procmaps.Parse(data) {
+			if e.Path != exePath {
 				continue
 			}
-			if strings.Join(fields[5:], " ") != exePath {
-				continue
-			}
-			dash := strings.IndexByte(fields[0], '-')
-			if dash < 0 {
-				continue
-			}
-			start, err1 := strconv.ParseUint(fields[0][:dash], 16, 64)
-			end, err2 := strconv.ParseUint(fields[0][dash+1:], 16, 64)
-			pgoff, err3 := strconv.ParseUint(fields[2], 16, 64)
-			if err1 != nil || err2 != nil || err3 != nil {
-				continue
-			}
-			out = append(out, exeMapping{start: start, end: end, pgoff: pgoff})
+			out = append(out, exeMapping{start: e.Start, end: e.End, pgoff: e.Offset})
 		}
 	}
 	r.mappings[key] = out

--- a/internal/ebpf/probes/hostwidesearch_test.go
+++ b/internal/ebpf/probes/hostwidesearch_test.go
@@ -1,0 +1,123 @@
+package probes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHostWideLibrarySearch(t *testing.T) {
+	cases := []struct {
+		containerID string
+		pid         uint32
+		want        bool
+	}{
+		{"", 0, true},
+		{"abc123", 0, false},
+		{"", 4242, false},
+		{"abc123", 4242, false},
+	}
+	for _, c := range cases {
+		if got := hostWideLibrarySearch(c.containerID, c.pid); got != c.want {
+			t.Errorf("hostWideLibrarySearch(%q, %d) = %v, want %v", c.containerID, c.pid, got, c.want)
+		}
+	}
+}
+
+func assertAllUnder(t *testing.T, root string, paths []string) {
+	t.Helper()
+	for _, p := range paths {
+		if !strings.HasPrefix(p, root) {
+			t.Errorf("resolved %q, which is outside the trace target at %q", p, root)
+		}
+	}
+}
+
+func TestFindTLSLibsWithPID_TargetedRunStaysInsideTarget(t *testing.T) {
+	f := newFakeProc(t, 42001)
+
+	lib := f.writeContainerFile(t, "/usr/lib/x86_64-linux-gnu/libssl.so.3", "POD LIBSSL")
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /usr/lib/x86_64-linux-gnu/libssl.so.3\n")
+
+	got := findTLSLibsWithPID("", f.pid)
+
+	assertAllUnder(t, f.procBase, got)
+	if len(got) != 1 || got[0] != lib {
+		t.Fatalf("got %v, want [%s]", got, lib)
+	}
+}
+
+func TestFindTLSLibsWithPID_TargetedRunWithNoLibraryReturnsNothing(t *testing.T) {
+	f := newFakeProc(t, 42002)
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /usr/bin/app\n")
+
+	if got := findTLSLibsWithPID("", f.pid); len(got) != 0 {
+		t.Fatalf("got %v, want none: the target has no TLS library and node-wide libraries must not be attached", got)
+	}
+}
+
+func TestFindDBLibsWithPID_TargetedRunStaysInsideTarget(t *testing.T) {
+	f := newFakeProc(t, 42003)
+
+	lib := f.writeContainerFile(t, "/usr/lib/x86_64-linux-gnu/libpq.so.5", "POD LIBPQ")
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /usr/lib/x86_64-linux-gnu/libpq.so.5\n")
+
+	got := findDBLibsWithPID("", f.pid, []string{"libpq.so.5"})
+
+	assertAllUnder(t, f.procBase, got)
+	if len(got) != 1 || got[0] != lib {
+		t.Fatalf("got %v, want [%s]", got, lib)
+	}
+}
+
+func TestFindDBLibsWithPID_TargetedRunWithNoLibraryReturnsNothing(t *testing.T) {
+	f := newFakeProc(t, 42004)
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /usr/bin/app\n")
+
+	if got := findDBLibsWithPID("", f.pid, []string{"libpq.so.5"}); len(got) != 0 {
+		t.Fatalf("got %v, want none", got)
+	}
+}
+
+func TestFindLibcPathWithPID_TargetedRunStaysInsideTarget(t *testing.T) {
+	f := newFakeProc(t, 42005)
+
+	lib := f.writeContainerFile(t, "/lib/x86_64-linux-gnu/libc.so.6", "POD LIBC")
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /lib/x86_64-linux-gnu/libc.so.6\n")
+
+	if got := FindLibcPathWithPID("", f.pid); got != lib {
+		t.Fatalf("got %q, want %q", got, lib)
+	}
+}
+
+func TestFindLibcPathWithPID_TargetedRunWithNoLibcReturnsNothing(t *testing.T) {
+	f := newFakeProc(t, 42006)
+	f.writeMaps(t, "7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 /usr/bin/app\n")
+
+	if got := FindLibcPathWithPID("", f.pid); got != "" {
+		t.Fatalf("got %q, want empty: the target has no libc and the node's must not be attached", got)
+	}
+}
+
+func TestFindLibcPathWithPID_UntargetedRunMaySearchHost(t *testing.T) {
+	if got := FindLibcPathWithPID("", 0); got != "" && !strings.HasPrefix(got, "/") {
+		t.Fatalf("got %q, want an absolute host path or empty", got)
+	}
+}
+
+func TestFindTLSLibsInContainer_EmptyIDMatchesNothing(t *testing.T) {
+	if got := findTLSLibsInContainer("", tlsLibPatterns); len(got) != 0 {
+		t.Fatalf("got %d paths for an empty container ID; an empty ID substring-matches every container rootfs on the node", len(got))
+	}
+}
+
+func TestFindDBLibsInContainer_EmptyIDMatchesNothing(t *testing.T) {
+	if got := findDBLibsInContainer("", []string{"libpq.so.5"}); len(got) != 0 {
+		t.Fatalf("got %d paths for an empty container ID", len(got))
+	}
+}
+
+func TestFindLibcInContainer_EmptyIDMatchesNoRootfs(t *testing.T) {
+	if got := findLibcInContainer(""); got != "" {
+		t.Fatalf("got %q for an empty container ID", got)
+	}
+}

--- a/internal/ebpf/probes/probes.go
+++ b/internal/ebpf/probes/probes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gma1k/podtrace/internal/ldsoconf"
 	"github.com/gma1k/podtrace/internal/logger"
 	"github.com/gma1k/podtrace/internal/procfs"
+	"github.com/gma1k/podtrace/internal/procmaps"
 )
 
 // mandatoryProbes must all attach successfully; failure returns an actionable error.
@@ -690,13 +691,18 @@ func AttachPoolProbesWithPID(coll *ebpf.Collection, containerID string, pid uint
 	return links
 }
 
-func FindLibcPath(containerID string) string {
-	if containerID != "" {
-		if path := findLibcInContainer(containerID); path != "" {
-			return path
-		}
-	}
+// hostWideLibrarySearch reports whether the agent may look for probe targets
+// outside the traced workload, in its own mount namespace, via ldconfig, or in
+// the node's root filesystem through /proc/1/root.
+func hostWideLibrarySearch(containerID string, pid uint32) bool {
+	return containerID == "" && pid == 0
+}
 
+func FindLibcPath(containerID string) string {
+	return FindLibcPathWithPID(containerID, 0)
+}
+
+func findLibcHostWide() string {
 	if path := findLibcViaLdconfig(); path != "" {
 		return path
 	}
@@ -710,14 +716,24 @@ func FindLibcPath(containerID string) string {
 
 func FindLibcPathWithPID(containerID string, pid uint32) string {
 	if pid > 0 {
-		if path := findLibcViaProcessMapsProcRoot(pid); path != "" {
+		if path := findLibcViaProcessMaps(pid); path != "" {
 			return path
 		}
 		if path := findLibcInProcess(pid); path != "" {
 			return path
 		}
 	}
-	return FindLibcPath(containerID)
+	if containerID != "" {
+		if path := findLibcInContainer(containerID); path != "" {
+			return path
+		}
+	}
+	if !hostWideLibrarySearch(containerID, pid) {
+		logger.Debug("No libc inside the trace target; not falling back to node-wide libc",
+			zap.String("container_id", containerID), zap.Uint32("pid", pid))
+		return ""
+	}
+	return findLibcHostWide()
 }
 
 func findLibcViaLdconfig() string {
@@ -778,42 +794,12 @@ func findLibcViaLdSoConf() string {
 	return ""
 }
 
+// libcMapsPatterns are the pathname substrings that mark a libc mapping.
+var libcMapsPatterns = []string{"libc.so", "libc.musl"}
+
 func findLibcViaProcessMaps(pid uint32) string {
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return ""
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "libc.so") || strings.Contains(line, "libc.musl") {
-			parts := strings.Fields(line)
-			if len(parts) >= 6 {
-				path := parts[5]
-				if hostfs.IsRegularFile(path) {
-					return path
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func findLibcViaProcessMapsProcRoot(pid uint32) string {
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return ""
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "libc.so") || strings.Contains(line, "libc.musl") {
-			parts := strings.Fields(line)
-			if len(parts) >= 6 {
-				containerPath := parts[5]
-				if path := fileInProcRoot(pid, containerPath); path != "" {
-					return path
-				}
-			}
-		}
+	for _, path := range mappedFilesMatching(pid, libcMapsPatterns) {
+		return path
 	}
 	return ""
 }
@@ -829,6 +815,8 @@ func findLibcInProcess(pid uint32) string {
 	return ""
 }
 
+// fileInProcRoot resolves a path reported by a traced process against that
+// process's own rootfs.
 func fileInProcRoot(pid uint32, containerPath string) string {
 	if containerPath == "" || strings.HasPrefix(containerPath, "[") {
 		return ""
@@ -837,9 +825,6 @@ func fileInProcRoot(pid uint32, containerPath string) string {
 	hostPath := filepath.Join(procRoot, strings.TrimPrefix(containerPath, "/"))
 	if hostfs.IsRegularFile(hostPath) {
 		return hostPath
-	}
-	if hostfs.IsRegularFile(containerPath) {
-		return containerPath
 	}
 	return ""
 }
@@ -916,12 +901,7 @@ func findGoBinaryInProcess(pid uint32) string {
 		return hostPath
 	}
 
-	if info, err := os.Stat(target); err == nil && !info.IsDir() {
-		logger.Debug("Found binary via direct path", zap.Uint32("pid", pid), zap.String("path", target))
-		return target
-	}
-
-	logger.Debug("Binary not found or not accessible", zap.Uint32("pid", pid), zap.String("target", target), zap.String("host_path", hostPath), zap.Error(err))
+	logger.Debug("Binary not found under the target's own rootfs", zap.Uint32("pid", pid), zap.String("target", target), zap.String("host_path", hostPath))
 	return ""
 }
 
@@ -932,30 +912,16 @@ func findGoBinaryViaProcessMaps(pid uint32) string {
 		return ""
 	}
 
-	procRootPath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "root")
-
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, "r-xp") {
-			parts := strings.Fields(line)
-			if len(parts) >= 6 {
-				binaryPath := parts[5]
-				if binaryPath != "" && !strings.HasPrefix(binaryPath, "[") {
-					if strings.Contains(binaryPath, ".so") || strings.Contains(binaryPath, "vdso") || strings.Contains(binaryPath, "vsyscall") {
-						continue
-					}
-
-					hostPath := filepath.Join(procRootPath, strings.TrimPrefix(binaryPath, "/"))
-					if hostfs.IsRegularFile(hostPath) {
-						logger.Debug("Found binary via process maps", zap.Uint32("pid", pid), zap.String("container_path", binaryPath), zap.String("host_path", hostPath))
-						return hostPath
-					}
-
-					if hostfs.IsRegularFile(binaryPath) {
-						logger.Debug("Found binary via process maps (direct)", zap.Uint32("pid", pid), zap.String("path", binaryPath))
-						return binaryPath
-					}
-				}
-			}
+	for _, e := range procmaps.Parse(data) {
+		if !e.Named() || !e.Executable() {
+			continue
+		}
+		if strings.Contains(e.Path, ".so") || strings.Contains(e.Path, "vdso") || strings.Contains(e.Path, "vsyscall") {
+			continue
+		}
+		if resolved := resolveMappedFile(pid, e); resolved != "" {
+			logger.Debug("Found binary via process maps", zap.Uint32("pid", pid), zap.String("container_path", e.Path), zap.String("host_path", resolved))
+			return resolved
 		}
 	}
 	return ""
@@ -1050,6 +1016,9 @@ func findGoBinaryInContainer(containerID string, pid uint32) string {
 }
 
 func findLibcInContainer(containerID string) string {
+	if containerID == "" {
+		return ""
+	}
 	if pid := findContainerProcess(containerID); pid > 0 {
 		if path := findLibcViaProcessMaps(pid); path != "" {
 			return path
@@ -1094,14 +1063,6 @@ func findLibcInContainer(containerID string) string {
 					return path
 				}
 			}
-		}
-	}
-
-	procPaths := getArchitecturePaths()
-	for _, basePath := range procPaths {
-		path := filepath.Join(config.GetDefaultProcRootPath(), basePath)
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
-			return path
 		}
 	}
 
@@ -1228,61 +1189,13 @@ func getArchitectureDBPaths(libNames []string) []string {
 }
 
 func findDBLibsViaProcessMaps(pid uint32, libNames []string) []string {
-	var paths []string
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return paths
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		for _, libName := range libNames {
-			if strings.Contains(line, libName) {
-				parts := strings.Fields(line)
-				if len(parts) >= 6 {
-					path := parts[5]
-					if hostfs.IsRegularFile(path) {
-						paths = append(paths, path)
-					}
-				}
-			}
-		}
-	}
-	return paths
-}
-
-func findDBLibsViaProcessMapsProcRoot(pid uint32, libNames []string) []string {
-	var paths []string
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return paths
-	}
-
-	seen := make(map[string]bool)
-	for _, line := range strings.Split(string(data), "\n") {
-		for _, libName := range libNames {
-			if strings.Contains(line, libName) {
-				parts := strings.Fields(line)
-				if len(parts) >= 6 {
-					containerPath := parts[5]
-					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" {
-						if !seen[hostPath] {
-							paths = append(paths, hostPath)
-							seen[hostPath] = true
-						}
-					} else if strings.Contains(parts[1], "x") && !seen[containerPath] {
-						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
-							paths = append(paths, mf)
-							seen[containerPath] = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return paths
+	return mappedFilesMatching(pid, libNames)
 }
 
 func findDBLibsInContainer(containerID string, libNames []string) []string {
+	if containerID == "" {
+		return nil
+	}
 	var paths []string
 
 	if pid := findContainerProcess(containerID); pid > 0 {
@@ -1332,14 +1245,8 @@ func findDBLibsInContainer(containerID string, libNames []string) []string {
 		}
 	}
 
-	archPaths := getArchitectureDBPaths(libNames)
-	for _, basePath := range archPaths {
-		path := filepath.Join(config.GetDefaultProcRootPath(), strings.TrimPrefix(basePath, "/"))
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
-			paths = append(paths, path)
-		}
-	}
-
+	// No fallback to config.GetDefaultProcRootPath() (/proc/1/root): the node's
+	// own libraries are not the traced container's. See hostWideLibrarySearch.
 	return paths
 }
 
@@ -1348,7 +1255,7 @@ func findDBLibsWithPID(containerID string, pid uint32, libNames []string) []stri
 		var out []string
 		seen := make(map[string]bool)
 
-		for _, p := range findDBLibsViaProcessMapsProcRoot(pid, libNames) {
+		for _, p := range findDBLibsViaProcessMaps(pid, libNames) {
 			if !seen[p] {
 				out = append(out, p)
 				seen[p] = true
@@ -1367,6 +1274,17 @@ func findDBLibsWithPID(containerID string, pid uint32, libNames []string) []stri
 		if len(out) > 0 {
 			return out
 		}
+	}
+
+	if containerID != "" {
+		if paths := findDBLibsInContainer(containerID, libNames); len(paths) > 0 {
+			return paths
+		}
+	}
+	if !hostWideLibrarySearch(containerID, pid) {
+		logger.Debug("No database client library inside the trace target; not falling back to node-wide libraries",
+			zap.String("container_id", containerID), zap.Uint32("pid", pid), zap.Strings("libs", libNames))
+		return nil
 	}
 	return findDBLibs(containerID, libNames)
 }
@@ -1427,81 +1345,25 @@ func FindLibcInContainer(containerID string) []string {
 		}
 	}
 
-	procPaths := getArchitecturePaths()
-	for _, basePath := range procPaths {
-		paths = append(paths, filepath.Join(config.GetDefaultProcRootPath(), basePath))
+	if hostWideLibrarySearch(containerID, 0) {
+		procPaths := getArchitecturePaths()
+		for _, basePath := range procPaths {
+			paths = append(paths, filepath.Join(config.GetDefaultProcRootPath(), basePath))
+		}
 	}
 
 	return paths
 }
 
+// findTLSLibsViaProcessMaps resolves the TLS libraries pid has mapped.
 func findTLSLibsViaProcessMaps(pid uint32, libPatterns []string) []string {
-	var paths []string
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return paths
-	}
-
-	seen := make(map[string]bool)
-	for _, line := range strings.Split(string(data), "\n") {
-		for _, pattern := range libPatterns {
-			if strings.Contains(line, pattern) {
-				parts := strings.Fields(line)
-				if len(parts) >= 6 {
-					path := parts[5]
-					if hostfs.IsRegularFile(path) {
-						paths = append(paths, path)
-					} else if strings.Contains(parts[1], "x") && !seen[path] {
-						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
-							paths = append(paths, mf)
-							seen[path] = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return paths
-}
-
-func findTLSLibsViaProcessMapsProcRoot(pid uint32, libPatterns []string) []string {
-	var paths []string
-	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
-	if err != nil {
-		return paths
-	}
-
-	seen := make(map[string]bool)
-	for _, line := range strings.Split(string(data), "\n") {
-		for _, pattern := range libPatterns {
-			if strings.Contains(line, pattern) {
-				parts := strings.Fields(line)
-				if len(parts) >= 6 {
-					containerPath := parts[5]
-					if hostPath := fileInProcRoot(pid, containerPath); hostPath != "" {
-						if !seen[hostPath] {
-							paths = append(paths, hostPath)
-							seen[hostPath] = true
-						}
-					} else if strings.Contains(parts[1], "x") && !seen[containerPath] {
-						// Backing file may be unlinked (e.g. netty-tcnative
-						// extracted to /tmp then deleted after dlopen); reach the
-						// live inode via map_files. All VMAs of the library share
-						// one inode, so restrict to the executable segment and
-						// dedup by path to attach the code mapping exactly once.
-						if mf := fileInProcMapFiles(pid, parts[0]); mf != "" {
-							paths = append(paths, mf)
-							seen[containerPath] = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return paths
+	return mappedFilesMatching(pid, libPatterns)
 }
 
 func findTLSLibsInContainer(containerID string, libPatterns []string) []string {
+	if containerID == "" {
+		return nil
+	}
 	var paths []string
 
 	if pid := findContainerProcess(containerID); pid > 0 {
@@ -1568,7 +1430,7 @@ func findTLSLibsInContainer(containerID string, libPatterns []string) []string {
 
 func findTLSLibsInContainerWithPID(containerID string, pid uint32, libPatterns []string) []string {
 	if pid > 0 {
-		if foundPaths := findTLSLibsViaProcessMapsProcRoot(pid, libPatterns); len(foundPaths) > 0 {
+		if foundPaths := findTLSLibsViaProcessMaps(pid, libPatterns); len(foundPaths) > 0 {
 			return foundPaths
 		}
 		if foundPaths := findTLSLibsViaProcRootScan(pid, libPatterns); len(foundPaths) > 0 {
@@ -1806,6 +1668,14 @@ func findTLSLibsWithPID(containerID string, pid uint32) []string {
 			seen[exe] = true
 			logger.Debug("TLS probe: target executable bundles OpenSSL", zap.String("exe", exe))
 		}
+	}
+
+	if !hostWideLibrarySearch(containerID, pid) {
+		if len(paths) == 0 {
+			logger.Debug("No TLS library inside the trace target; not falling back to node-wide libraries",
+				zap.String("container_id", containerID), zap.Uint32("pid", pid))
+		}
+		return paths
 	}
 
 	ldconfigPaths := findTLSLibsViaLdconfig(libPatterns)
@@ -2258,7 +2128,7 @@ func attachCLibraryH3Probes(coll *ebpf.Collection, pid uint32, af *AttachedFiles
 
 	seen := make(map[string]bool)
 	var libPaths []string
-	for _, p := range findTLSLibsViaProcessMapsProcRoot(pid, libPatterns) {
+	for _, p := range findTLSLibsViaProcessMaps(pid, libPatterns) {
 		if !seen[p] {
 			libPaths = append(libPaths, p)
 			seen[p] = true

--- a/internal/ebpf/probes/probes_test.go
+++ b/internal/ebpf/probes/probes_test.go
@@ -917,7 +917,8 @@ func TestFindLibcPath_ViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
 
-	libcPath := filepath.Join(tmpDir, "lib", "x86_64-linux-gnu", "libc.so.6")
+	containerPath := "/lib/x86_64-linux-gnu/libc.so.6"
+	libcPath := filepath.Join(procDir, "root", containerPath)
 	if err := os.MkdirAll(filepath.Dir(libcPath), 0755); err != nil {
 		t.Fatalf("failed to create lib dir: %v", err)
 	}
@@ -925,7 +926,7 @@ func TestFindLibcPath_ViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create libc: %v", err)
 	}
 
-	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", libcPath)
+	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", containerPath)
 	mapsPath := filepath.Join(procDir, "maps")
 	if err := os.WriteFile(mapsPath, []byte(mapsContent), 0644); err != nil {
 		t.Fatalf("failed to create maps: %v", err)
@@ -950,7 +951,8 @@ func TestFindLibcPath_ViaProcessMaps_Musl(t *testing.T) {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
 
-	libcPath := filepath.Join(tmpDir, "lib", "libc.musl-x86_64.so.1")
+	containerPath := "/lib/libc.musl-x86_64.so.1"
+	libcPath := filepath.Join(procDir, "root", containerPath)
 	if err := os.MkdirAll(filepath.Dir(libcPath), 0755); err != nil {
 		t.Fatalf("failed to create lib dir: %v", err)
 	}
@@ -958,7 +960,7 @@ func TestFindLibcPath_ViaProcessMaps_Musl(t *testing.T) {
 		t.Fatalf("failed to create libc: %v", err)
 	}
 
-	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", libcPath)
+	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", containerPath)
 	mapsPath := filepath.Join(procDir, "maps")
 	if err := os.WriteFile(mapsPath, []byte(mapsContent), 0644); err != nil {
 		t.Fatalf("failed to create maps: %v", err)
@@ -1060,7 +1062,8 @@ func TestFindLibcInContainer_ViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
 
-	libcPath := filepath.Join(tmpDir, "lib", "x86_64-linux-gnu", "libc.so.6")
+	containerPath := "/lib/x86_64-linux-gnu/libc.so.6"
+	libcPath := filepath.Join(procDir, "root", containerPath)
 	if err := os.MkdirAll(filepath.Dir(libcPath), 0755); err != nil {
 		t.Fatalf("failed to create lib dir: %v", err)
 	}
@@ -1074,7 +1077,7 @@ func TestFindLibcInContainer_ViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create cgroup: %v", err)
 	}
 
-	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", libcPath)
+	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", containerPath)
 	mapsPath := filepath.Join(procDir, "maps")
 	if err := os.WriteFile(mapsPath, []byte(mapsContent), 0644); err != nil {
 		t.Fatalf("failed to create maps: %v", err)
@@ -1242,7 +1245,8 @@ func TestFindDBLibsViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
 
-	libpqPath := filepath.Join(tmpDir, "usr", "lib", "x86_64-linux-gnu", "libpq.so.5")
+	containerPath := "/usr/lib/x86_64-linux-gnu/libpq.so.5"
+	libpqPath := filepath.Join(procDir, "root", containerPath)
 	if err := os.MkdirAll(filepath.Dir(libpqPath), 0755); err != nil {
 		t.Fatalf("failed to create lib dir: %v", err)
 	}
@@ -1250,7 +1254,7 @@ func TestFindDBLibsViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create libpq: %v", err)
 	}
 
-	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", libpqPath)
+	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", containerPath)
 	mapsPath := filepath.Join(procDir, "maps")
 	if err := os.WriteFile(mapsPath, []byte(mapsContent), 0644); err != nil {
 		t.Fatalf("failed to create maps: %v", err)
@@ -1861,7 +1865,8 @@ func TestFindTLSLibsViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create proc dir: %v", err)
 	}
 
-	libsslPath := filepath.Join(tmpDir, "usr", "lib", "x86_64-linux-gnu", "libssl.so.3")
+	containerPath := "/usr/lib/x86_64-linux-gnu/libssl.so.3"
+	libsslPath := filepath.Join(procDir, "root", containerPath)
 	if err := os.MkdirAll(filepath.Dir(libsslPath), 0755); err != nil {
 		t.Fatalf("failed to create lib dir: %v", err)
 	}
@@ -1869,7 +1874,7 @@ func TestFindTLSLibsViaProcessMaps(t *testing.T) {
 		t.Fatalf("failed to create libssl: %v", err)
 	}
 
-	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", libsslPath)
+	mapsContent := fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", containerPath)
 	mapsPath := filepath.Join(procDir, "maps")
 	if err := os.WriteFile(mapsPath, []byte(mapsContent), 0644); err != nil {
 		t.Fatalf("failed to create maps: %v", err)
@@ -2133,21 +2138,22 @@ func TestFileInProcRoot_BracketPrefix(t *testing.T) {
 	}
 }
 
-func TestFileInProcRoot_DirectFileExists(t *testing.T) {
-	// Create a real file and use it as the containerPath directly.
-	dir := t.TempDir()
-	libFile := filepath.Join(dir, "libtest.so")
+func TestFileInProcRoot_ResolvesUnderTargetRootfs(t *testing.T) {
+	procBase := t.TempDir()
+	origProc := config.ProcBasePath
+	config.SetProcBasePath(procBase)
+	defer config.SetProcBasePath(origProc)
+
+	root := filepath.Join(procBase, "9999", "root", "usr", "lib")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	libFile := filepath.Join(root, "libtest.so")
 	if err := os.WriteFile(libFile, []byte("ELF"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Point ProcBasePath to a temp dir that has no root subdir,
-	// so fileInProcRoot falls back to checking containerPath directly.
-	origProc := config.ProcBasePath
-	config.SetProcBasePath(t.TempDir())
-	defer config.SetProcBasePath(origProc)
-
-	got := fileInProcRoot(9999, libFile)
+	got := fileInProcRoot(9999, "/usr/lib/libtest.so")
 	if got != libFile {
 		t.Errorf("expected %q, got %q", libFile, got)
 	}
@@ -2185,7 +2191,7 @@ func TestFindLibcViaProcessMapsProcRoot_NoFile(t *testing.T) {
 	defer config.SetProcBasePath(origProc)
 
 	// No maps file → returns ""
-	got := findLibcViaProcessMapsProcRoot(99999)
+	got := findLibcViaProcessMaps(99999)
 	if got != "" {
 		t.Errorf("expected empty when no maps file, got %q", got)
 	}
@@ -2218,7 +2224,7 @@ func TestFindLibcViaProcessMapsProcRoot_WithLibc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := findLibcViaProcessMapsProcRoot(pid)
+	got := findLibcViaProcessMaps(pid)
 	// Either finds via proc/root or returns empty — just ensure no panic.
 	_ = got
 }
@@ -2243,7 +2249,7 @@ func TestFindDBLibsViaProcessMapsProcRoot_NoFile(t *testing.T) {
 	config.SetProcBasePath(t.TempDir())
 	defer config.SetProcBasePath(origProc)
 
-	got := findDBLibsViaProcessMapsProcRoot(99999, []string{"libpq.so"})
+	got := findDBLibsViaProcessMaps(99999, []string{"libpq.so"})
 	if len(got) != 0 {
 		t.Errorf("expected empty when no maps file, got %v", got)
 	}
@@ -2276,7 +2282,7 @@ func TestFindDBLibsViaProcessMapsProcRoot_WithLib(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := findDBLibsViaProcessMapsProcRoot(pid, []string{"libpq.so"})
+	got := findDBLibsViaProcessMaps(pid, []string{"libpq.so"})
 	_ = got // may or may not find it depending on filesystem layout
 }
 
@@ -2287,7 +2293,7 @@ func TestFindTLSLibsViaProcessMapsProcRoot_NoFile(t *testing.T) {
 	config.SetProcBasePath(t.TempDir())
 	defer config.SetProcBasePath(origProc)
 
-	got := findTLSLibsViaProcessMapsProcRoot(99999, []string{"libssl.so"})
+	got := findTLSLibsViaProcessMaps(99999, []string{"libssl.so"})
 	if len(got) != 0 {
 		t.Errorf("expected empty when no maps file, got %v", got)
 	}
@@ -2321,7 +2327,7 @@ func TestFindTLSLibsViaProcessMapsProcRoot_WithTLSLib(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := findTLSLibsViaProcessMapsProcRoot(pid, []string{"libssl.so"})
+	got := findTLSLibsViaProcessMaps(pid, []string{"libssl.so"})
 	// Either finds the lib or returns empty — just ensure no panic.
 	_ = got
 }
@@ -2343,7 +2349,7 @@ func TestFindTLSLibsViaProcessMapsProcRoot_EmptyPatterns(t *testing.T) {
 	}
 
 	// Empty patterns → no matches.
-	got := findTLSLibsViaProcessMapsProcRoot(pid, []string{})
+	got := findTLSLibsViaProcessMaps(pid, []string{})
 	if len(got) != 0 {
 		t.Errorf("expected empty for empty patterns, got %v", got)
 	}

--- a/internal/ebpf/probes/procmaps.go
+++ b/internal/ebpf/probes/procmaps.go
@@ -1,0 +1,116 @@
+package probes
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/gma1k/podtrace/internal/hostfs"
+	"github.com/gma1k/podtrace/internal/procfs"
+	"github.com/gma1k/podtrace/internal/procmaps"
+)
+
+// resolveMappedFile turns a /proc/<pid>/maps entry into a host path naming the
+// exact file the traced process mapped.
+//
+// Resolution stays inside the target's own namespace: either through
+// /proc/<pid>/map_files, which the kernel resolves to the backing inode with no
+// pathname involved, or through /proc/<pid>/root, which pins the lookup to the
+// target's rootfs. The pathname is never interpreted in the agent's own mount
+// namespace. On a Kubernetes node that pathname is untrusted input — a pod that
+// creates "/usr/lib/x86_64-linux-gnu/libssl.so.3 X" in its own rootfs and maps
+// it would otherwise steer the privileged agent onto the node's real libssl and
+// have it attach SSL_write/SSL_read uprobes to every process on the host.
+//
+// map_files wins whenever the two disagree, which also covers a pathname the
+// target has since replaced with a symlink out of its rootfs.
+func resolveMappedFile(pid uint32, e procmaps.Entry) string {
+	backing := fileInProcMapFiles(pid, e.AddrRange)
+
+	var named string
+	if e.Named() && !e.Deleted {
+		named = fileInProcRoot(pid, e.Path)
+	}
+
+	if named == "" {
+		if e.Executable() {
+			return backing
+		}
+		return ""
+	}
+	if backing == "" || sameHostFile(named, backing) {
+		return named
+	}
+	return backing
+}
+
+// sameHostFile reports whether two paths name the same inode.
+func sameHostFile(a, b string) bool {
+	ai, err := hostfs.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := hostfs.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(ai, bi)
+}
+
+// mappedFilesMatching returns the resolved host paths of every file-backed
+// mapping in pid's address space whose pathname contains one of patterns,
+// deduplicated by inode so the several segments a shared library is mapped
+// through yield one attach target.
+func mappedFilesMatching(pid uint32, patterns []string) []string {
+	data, err := procfs.ReadFile(fmt.Sprintf("%d/maps", pid))
+	if err != nil {
+		return nil
+	}
+
+	var paths []string
+	seen := make(map[string]struct{})
+
+	for _, e := range procmaps.Parse(data) {
+		if !e.Named() || !containsAnyPattern(e.Path, patterns) {
+			continue
+		}
+		resolved := resolveMappedFile(pid, e)
+		if resolved == "" {
+			continue
+		}
+		key := inodeKey(resolved)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		paths = append(paths, resolved)
+	}
+	return paths
+}
+
+func containsAnyPattern(s string, patterns []string) bool {
+	for _, p := range patterns {
+		if p != "" && strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// inodeKey identifies a file by device and inode so that the same library
+// reached through different paths is only attached once.
+func inodeKey(path string) string {
+	info, err := hostfs.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return path
+	}
+	return fmt.Sprintf("%d:%d", uint64(sys.Dev), sys.Ino)
+}

--- a/internal/ebpf/probes/procmapsconfinement_test.go
+++ b/internal/ebpf/probes/procmapsconfinement_test.go
@@ -1,0 +1,261 @@
+package probes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+	"github.com/gma1k/podtrace/internal/procmaps"
+)
+
+type fakeProc struct {
+	procBase string
+	pid      uint32
+	root     string
+	hostDir  string
+}
+
+func newFakeProc(t *testing.T, pid uint32) *fakeProc {
+	t.Helper()
+
+	procBase := t.TempDir()
+	orig := config.ProcBasePath
+	config.SetProcBasePath(procBase)
+	t.Cleanup(func() { config.SetProcBasePath(orig) })
+
+	root := filepath.Join(procBase, fmt.Sprintf("%d", pid), "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create fake proc root: %v", err)
+	}
+
+	return &fakeProc{procBase: procBase, pid: pid, root: root, hostDir: t.TempDir()}
+}
+
+func (f *fakeProc) writeMaps(t *testing.T, content string) {
+	t.Helper()
+	p := filepath.Join(f.procBase, fmt.Sprintf("%d", f.pid), "maps")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fake maps: %v", err)
+	}
+}
+
+func (f *fakeProc) writeHostFile(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(f.hostDir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write host file: %v", err)
+	}
+	return p
+}
+
+func (f *fakeProc) writeContainerFile(t *testing.T, containerPath, content string) string {
+	t.Helper()
+	p := filepath.Join(f.root, containerPath)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("create container dir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write container file: %v", err)
+	}
+	return p
+}
+
+func TestMappedFilesMatching_SpacedNameDoesNotEscapeToHost(t *testing.T) {
+	f := newFakeProc(t, 41001)
+
+	hostDecoy := f.writeHostFile(t, "libssl.so.3", "HOST LIBSSL")
+	mapped := hostDecoy + " X"
+	inContainer := f.writeContainerFile(t, mapped, "POD LIBSSL")
+
+	f.writeMaps(t, fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", mapped))
+
+	got := mappedFilesMatching(f.pid, []string{"libssl.so.3"})
+
+	for _, p := range got {
+		if p == hostDecoy {
+			t.Fatalf("resolved to the host file %q; a pod named its library %q to steer the agent out of its rootfs", hostDecoy, mapped)
+		}
+	}
+	if len(got) != 1 || got[0] != inContainer {
+		t.Fatalf("got %v, want [%s]", got, inContainer)
+	}
+}
+
+func TestMappedFilesMatching_NoHostFallbackWhenAbsentFromRootfs(t *testing.T) {
+	f := newFakeProc(t, 41002)
+
+	hostOnly := f.writeHostFile(t, "libssl.so.3", "HOST LIBSSL")
+	f.writeMaps(t, fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", hostOnly))
+
+	if got := mappedFilesMatching(f.pid, []string{"libssl.so.3"}); len(got) != 0 {
+		t.Fatalf("got %v, want no candidates: the path is absent from the target rootfs and must not fall back to the host", got)
+	}
+}
+
+func TestMappedFilesMatching_DeduplicatesSegmentsByInode(t *testing.T) {
+	f := newFakeProc(t, 41003)
+
+	lib := f.writeContainerFile(t, "/usr/lib/libssl.so.3", "POD LIBSSL")
+	f.writeMaps(t, ""+
+		"7f00000-7f01000 r--p 00000000 08:01 12 /usr/lib/libssl.so.3\n"+
+		"7f01000-7f02000 r-xp 00001000 08:01 12 /usr/lib/libssl.so.3\n"+
+		"7f02000-7f03000 r--p 00002000 08:01 12 /usr/lib/libssl.so.3\n"+
+		"7f03000-7f04000 rw-p 00003000 08:01 12 /usr/lib/libssl.so.3\n")
+
+	got := mappedFilesMatching(f.pid, []string{"libssl.so.3"})
+	if len(got) != 1 || got[0] != lib {
+		t.Fatalf("got %v, want [%s]", got, lib)
+	}
+}
+
+func TestMappedFilesMatching_SkipsPseudoMappings(t *testing.T) {
+	f := newFakeProc(t, 41004)
+
+	f.writeMaps(t, ""+
+		"7ffd000-7ffe000 rw-p 00000000 00:00 0 [stack]\n"+
+		"7ffe000-7fff000 r-xp 00000000 00:00 0 [vdso]\n")
+
+	if got := mappedFilesMatching(f.pid, []string{"[", "vdso"}); len(got) != 0 {
+		t.Fatalf("got %v, want none", got)
+	}
+}
+
+func TestResolveMappedFile_MapFilesWinsOverDisagreeingPathname(t *testing.T) {
+	f := newFakeProc(t, 41005)
+
+	hostDecoy := f.writeHostFile(t, "libssl.so.3", "HOST LIBSSL")
+	real := f.writeContainerFile(t, "/usr/lib/real-libssl.so.3", "POD LIBSSL")
+
+	claimed := filepath.Join(f.root, "usr", "lib", "libssl.so.3")
+	if err := os.Symlink(hostDecoy, claimed); err != nil {
+		t.Fatalf("create escaping symlink: %v", err)
+	}
+
+	const addrRange = "7f01000-7f02000"
+	mapFiles := filepath.Join(f.procBase, fmt.Sprintf("%d", f.pid), "map_files")
+	if err := os.MkdirAll(mapFiles, 0o755); err != nil {
+		t.Fatalf("create map_files: %v", err)
+	}
+	if err := os.Symlink(real, filepath.Join(mapFiles, addrRange)); err != nil {
+		t.Fatalf("create map_files link: %v", err)
+	}
+
+	e, ok := procmaps.ParseLine(addrRange + " r-xp 00000000 08:01 12 /usr/lib/libssl.so.3")
+	if !ok {
+		t.Fatal("procmaps.ParseLine rejected a valid line")
+	}
+
+	got := resolveMappedFile(f.pid, e)
+	if got == claimed || got == hostDecoy {
+		t.Fatalf("resolved to %q, which reaches the host decoy %q", got, hostDecoy)
+	}
+	if got != filepath.Join(mapFiles, addrRange) {
+		t.Fatalf("got %q, want the map_files path %q", got, filepath.Join(mapFiles, addrRange))
+	}
+}
+
+func TestResolveMappedFile_DeletedBackingFileUsesMapFiles(t *testing.T) {
+	f := newFakeProc(t, 41006)
+
+	real := f.writeContainerFile(t, "/opt/extracted.so", "TCNATIVE")
+
+	const addrRange = "7f04000-7f05000"
+	mapFiles := filepath.Join(f.procBase, fmt.Sprintf("%d", f.pid), "map_files")
+	if err := os.MkdirAll(mapFiles, 0o755); err != nil {
+		t.Fatalf("create map_files: %v", err)
+	}
+	if err := os.Symlink(real, filepath.Join(mapFiles, addrRange)); err != nil {
+		t.Fatalf("create map_files link: %v", err)
+	}
+
+	e, ok := procmaps.ParseLine(addrRange + " r-xp 00000000 08:01 12 /tmp/libnetty_tcnative.so (deleted)")
+	if !ok {
+		t.Fatal("procmaps.ParseLine rejected a valid line")
+	}
+
+	if got := resolveMappedFile(f.pid, e); got != filepath.Join(mapFiles, addrRange) {
+		t.Fatalf("got %q, want %q", got, filepath.Join(mapFiles, addrRange))
+	}
+}
+
+func TestFileInProcRoot_RefusesRawHostPath(t *testing.T) {
+	f := newFakeProc(t, 41007)
+
+	hostOnly := f.writeHostFile(t, "libc.so.6", "HOST LIBC")
+
+	if got := fileInProcRoot(f.pid, hostOnly); got != "" {
+		t.Fatalf("got %q, want empty: the path exists only on the host, not in the target rootfs", got)
+	}
+}
+
+func TestFindLibcViaProcessMaps_SpacedNameDoesNotEscapeToHost(t *testing.T) {
+	f := newFakeProc(t, 41008)
+
+	hostDecoy := f.writeHostFile(t, "libc.so.6", "HOST LIBC")
+	mapped := hostDecoy + " X"
+	inContainer := f.writeContainerFile(t, mapped, "POD LIBC")
+
+	f.writeMaps(t, fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", mapped))
+
+	got := findLibcViaProcessMaps(f.pid)
+	if got == hostDecoy {
+		t.Fatalf("resolved libc to the host file %q", hostDecoy)
+	}
+	if got != inContainer {
+		t.Fatalf("got %q, want %q", got, inContainer)
+	}
+}
+
+func TestFindDBLibsViaProcessMaps_SpacedNameDoesNotEscapeToHost(t *testing.T) {
+	f := newFakeProc(t, 41009)
+
+	hostDecoy := f.writeHostFile(t, "libpq.so.5", "HOST LIBPQ")
+	mapped := hostDecoy + " X"
+	inContainer := f.writeContainerFile(t, mapped, "POD LIBPQ")
+
+	f.writeMaps(t, fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", mapped))
+
+	got := findDBLibsViaProcessMaps(f.pid, []string{"libpq.so.5"})
+	for _, p := range got {
+		if p == hostDecoy {
+			t.Fatalf("resolved to the host file %q", hostDecoy)
+		}
+	}
+	if len(got) != 1 || got[0] != inContainer {
+		t.Fatalf("got %v, want [%s]", got, inContainer)
+	}
+}
+
+func TestFindGoBinaryViaProcessMaps_SpacedNameDoesNotEscapeToHost(t *testing.T) {
+	f := newFakeProc(t, 41010)
+
+	hostDecoy := f.writeHostFile(t, "app", "HOST BINARY")
+	mapped := hostDecoy + " X"
+	inContainer := f.writeContainerFile(t, mapped, "POD BINARY")
+
+	f.writeMaps(t, fmt.Sprintf("7f8a1c000000-7f8a1c021000 r-xp 00000000 08:01 123456 %s\n", mapped))
+
+	got := findGoBinaryViaProcessMaps(f.pid)
+	if got == hostDecoy {
+		t.Fatalf("resolved the Go binary to the host file %q", hostDecoy)
+	}
+	if got != inContainer {
+		t.Fatalf("got %q, want %q", got, inContainer)
+	}
+}
+
+func TestFindGoBinaryInProcess_RefusesRawHostPath(t *testing.T) {
+	f := newFakeProc(t, 41011)
+
+	hostOnly := f.writeHostFile(t, "app", "HOST BINARY")
+	exe := filepath.Join(f.procBase, fmt.Sprintf("%d", f.pid), "exe")
+	if err := os.Symlink(hostOnly, exe); err != nil {
+		t.Fatalf("create exe symlink: %v", err)
+	}
+
+	if got := findGoBinaryInProcess(f.pid); got != "" {
+		t.Fatalf("got %q, want empty: the target is absent from its own rootfs", got)
+	}
+}

--- a/internal/ebpf/probes/procmapskernel_test.go
+++ b/internal/ebpf/probes/procmapskernel_test.go
@@ -1,0 +1,82 @@
+package probes
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func mmapForTest(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %q: %v", path, err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	data, err := syscall.Mmap(int(f.Fd()), 0, os.Getpagesize(), syscall.PROT_READ, syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("mmap %q: %v", path, err)
+	}
+	t.Cleanup(func() { _ = syscall.Munmap(data) })
+	runtime.KeepAlive(data)
+}
+
+func TestMappedFilesMatching_RealProcfsSpacedName(t *testing.T) {
+	if config.ProcBasePath != "/proc" {
+		t.Skipf("ProcBasePath is %q, not real procfs", config.ProcBasePath)
+	}
+
+	dir := t.TempDir()
+	decoy := filepath.Join(dir, "libssl.so.3")
+	spaced := decoy + " X"
+
+	page := make([]byte, os.Getpagesize())
+	if err := os.WriteFile(decoy, page, 0o644); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	if err := os.WriteFile(spaced, page, 0o644); err != nil {
+		t.Fatalf("write spaced library: %v", err)
+	}
+
+	mmapForTest(t, spaced)
+
+	maps, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		t.Fatalf("read own maps: %v", err)
+	}
+	if !strings.Contains(string(maps), spaced) {
+		t.Fatalf("the mapping under test is absent from /proc/self/maps")
+	}
+
+	got := mappedFilesMatching(uint32(os.Getpid()), []string{"libssl.so.3"})
+	if len(got) != 1 {
+		t.Fatalf("got %v, want exactly one candidate", got)
+	}
+
+	decoyInfo, err := os.Stat(decoy)
+	if err != nil {
+		t.Fatalf("stat decoy: %v", err)
+	}
+	spacedInfo, err := os.Stat(spaced)
+	if err != nil {
+		t.Fatalf("stat spaced library: %v", err)
+	}
+	gotInfo, err := os.Stat(got[0])
+	if err != nil {
+		t.Fatalf("stat resolved %q: %v", got[0], err)
+	}
+
+	if os.SameFile(gotInfo, decoyInfo) {
+		t.Fatalf("resolved %q to the decoy %q; the kernel does not escape the space in %q", got[0], decoy, spaced)
+	}
+	if !os.SameFile(gotInfo, spacedInfo) {
+		t.Fatalf("resolved %q, which is neither the mapped file %q nor the decoy", got[0], spaced)
+	}
+}

--- a/internal/procmaps/procmaps.go
+++ b/internal/procmaps/procmaps.go
@@ -1,0 +1,136 @@
+// Package procmaps parses /proc/<pid>/maps.
+//
+// The pathname on a maps line is the entire remainder of the line and must
+// never be read as a whitespace-separated field. The kernel emits it verbatim
+// through seq_path and does not escape spaces, so a file named
+// "libssl.so.3 X" produces a line whose sixth whitespace-separated token is
+// "libssl.so.3" — the name of a different file that may well exist elsewhere.
+// Taking that token lets the traced process choose which path the reader
+// believes it mapped, which for a privileged reader that then attaches uprobes
+// is a way out of the target's rootfs.
+//
+// A pathname whose own leading characters are spaces cannot be recovered from
+// this file at all, because the kernel pads to a fixed column with the same
+// character. Callers that must be certain of the backing file should treat
+// /proc/<pid>/map_files as authoritative and the pathname only as a hint.
+package procmaps
+
+import (
+	"strconv"
+	"strings"
+)
+
+// fixedColumns is the number of whitespace-separated columns the kernel writes
+// before the pathname: address range, permissions, file offset, device, inode.
+const fixedColumns = 5
+
+// deletedSuffix is appended by the kernel once the backing file is unlinked.
+const deletedSuffix = " (deleted)"
+
+// Entry is one parsed line of /proc/<pid>/maps.
+type Entry struct {
+	// AddrRange is the raw "<hex>-<hex>" column, which is also the name of
+	// the corresponding /proc/<pid>/map_files entry.
+	AddrRange string
+	Start     uint64
+	End       uint64
+	Perms     string
+	// Offset is the file offset the mapping starts at.
+	Offset uint64
+	// Path is the backing file's pathname with any " (deleted)" marker
+	// removed, empty for an anonymous mapping.
+	Path string
+	// Deleted reports that the backing file has been unlinked.
+	Deleted bool
+}
+
+// Executable reports whether the mapping carries the execute bit, i.e. holds
+// the code segment a uprobe would attach to.
+func (e Entry) Executable() bool { return strings.Contains(e.Perms, "x") }
+
+// Named reports whether the entry is file-backed, as opposed to an anonymous
+// mapping or a kernel pseudo-mapping such as [stack], [heap] or [vdso].
+func (e Entry) Named() bool {
+	return e.Path != "" && !strings.HasPrefix(e.Path, "[")
+}
+
+// ParseLine parses one line of /proc/<pid>/maps, reporting false when the line
+// does not have the shape the kernel writes.
+func ParseLine(line string) (Entry, bool) {
+	var e Entry
+	rest := line
+
+	var offsetField string
+	for column := 0; column < fixedColumns; column++ {
+		rest = strings.TrimLeft(rest, " \t")
+		if rest == "" {
+			return Entry{}, false
+		}
+		width := strings.IndexAny(rest, " \t")
+		if width < 0 {
+			if column != fixedColumns-1 {
+				return Entry{}, false
+			}
+			width = len(rest)
+		}
+		switch column {
+		case 0:
+			e.AddrRange = rest[:width]
+		case 1:
+			e.Perms = rest[:width]
+		case 2:
+			offsetField = rest[:width]
+		}
+		rest = rest[width:]
+	}
+
+	start, end, ok := parseAddrRange(e.AddrRange)
+	if !ok {
+		return Entry{}, false
+	}
+	e.Start, e.End = start, end
+
+	offset, err := strconv.ParseUint(offsetField, 16, 64)
+	if err != nil {
+		return Entry{}, false
+	}
+	e.Offset = offset
+
+	path := strings.TrimLeft(rest, " \t")
+	if strings.HasSuffix(path, deletedSuffix) {
+		e.Deleted = true
+		path = strings.TrimSuffix(path, deletedSuffix)
+	}
+	e.Path = path
+
+	return e, true
+}
+
+// Parse parses the contents of a /proc/<pid>/maps file, skipping lines that do
+// not have the expected shape.
+func Parse(data []byte) []Entry {
+	lines := strings.Split(string(data), "\n")
+	entries := make([]Entry, 0, len(lines))
+	for _, line := range lines {
+		if e, ok := ParseLine(line); ok {
+			entries = append(entries, e)
+		}
+	}
+	return entries
+}
+
+func parseAddrRange(s string) (uint64, uint64, bool) {
+	dash := strings.IndexByte(s, '-')
+	if dash <= 0 || dash == len(s)-1 {
+		return 0, 0, false
+	}
+	start, err := strconv.ParseUint(s[:dash], 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	end, err := strconv.ParseUint(s[dash+1:], 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return start, end, true
+}

--- a/internal/procmaps/procmaps_test.go
+++ b/internal/procmaps/procmaps_test.go
@@ -1,0 +1,119 @@
+package procmaps
+
+import (
+	"testing"
+)
+
+func TestParseLine_PathWithSpaceIsNotTruncated(t *testing.T) {
+	line := "7f7da821b000-7f7da821c000 r--p 00000000 00:2c 860                        /usr/lib/x86_64-linux-gnu/libssl.so.3 X"
+
+	e, ok := ParseLine(line)
+	if !ok {
+		t.Fatal("ParseLine rejected a valid line")
+	}
+	want := "/usr/lib/x86_64-linux-gnu/libssl.so.3 X"
+	if e.Path != want {
+		t.Fatalf("path = %q, want %q", e.Path, want)
+	}
+	if e.AddrRange != "7f7da821b000-7f7da821c000" {
+		t.Errorf("addrRange = %q", e.AddrRange)
+	}
+	if e.Perms != "r--p" {
+		t.Errorf("perms = %q", e.Perms)
+	}
+}
+
+func TestParseLine_MultipleSpacesInPath(t *testing.T) {
+	line := "7f00-7f01 r-xp 00000000 08:01 12 /opt/a b/c  d/libssl.so.3"
+
+	e, ok := ParseLine(line)
+	if !ok {
+		t.Fatal("ParseLine rejected a valid line")
+	}
+	if e.Path != "/opt/a b/c  d/libssl.so.3" {
+		t.Fatalf("path = %q", e.Path)
+	}
+}
+
+func TestParseLine_Deleted(t *testing.T) {
+	line := "7f00-7f01 r-xp 00000000 08:01 12 /tmp/libnetty_tcnative.so (deleted)"
+
+	e, ok := ParseLine(line)
+	if !ok {
+		t.Fatal("ParseLine rejected a valid line")
+	}
+	if !e.Deleted {
+		t.Error("deleted = false, want true")
+	}
+	if e.Path != "/tmp/libnetty_tcnative.so" {
+		t.Errorf("path = %q", e.Path)
+	}
+}
+
+func TestParseLine_Anonymous(t *testing.T) {
+	e, ok := ParseLine("7f00-7f01 rw-p 00000000 00:00 0")
+	if !ok {
+		t.Fatal("ParseLine rejected an anonymous mapping")
+	}
+	if e.Path != "" {
+		t.Errorf("path = %q, want empty", e.Path)
+	}
+	if e.Named() {
+		t.Error("Named() = true for an anonymous mapping")
+	}
+}
+
+func TestParseLine_PseudoMapping(t *testing.T) {
+	e, ok := ParseLine("7ffd000-7ffe000 rw-p 00000000 00:00 0                     [stack]")
+	if !ok {
+		t.Fatal("ParseLine rejected a pseudo mapping")
+	}
+	if e.Named() {
+		t.Error("Named() = true for [stack]")
+	}
+}
+
+func TestParseLine_Executable(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{"7f00-7f01 r-xp 00000000 08:01 12 /lib/libssl.so.3", true},
+		{"7f00-7f01 r--p 00000000 08:01 12 /lib/libssl.so.3", false},
+		{"7f00-7f01 rwxp 00000000 08:01 12 /lib/libssl.so.3", true},
+	}
+	for _, c := range cases {
+		e, ok := ParseLine(c.line)
+		if !ok {
+			t.Fatalf("ParseLine rejected %q", c.line)
+		}
+		if e.Executable() != c.want {
+			t.Errorf("Executable() = %v for %q, want %v", e.Executable(), c.line, c.want)
+		}
+	}
+}
+
+func TestParseLine_Malformed(t *testing.T) {
+	for _, line := range []string{
+		"",
+		"   ",
+		"7f00-7f01",
+		"7f00-7f01 r-xp",
+		"7f00-7f01 r-xp 00000000 08:01",
+		"not-an-address r-xp 00000000 08:01 12 /lib/libssl.so.3",
+	} {
+		if _, ok := ParseLine(line); ok {
+			t.Errorf("ParseLine accepted malformed line %q", line)
+		}
+	}
+}
+
+func TestParseLine_TabSeparated(t *testing.T) {
+	e, ok := ParseLine("7f00-7f01\tr-xp\t00000000\t08:01\t12\t/lib/libssl.so.3")
+	if !ok {
+		t.Fatal("ParseLine rejected a tab-separated line")
+	}
+	if e.Path != "/lib/libssl.so.3" {
+		t.Errorf("path = %q", e.Path)
+	}
+}

--- a/internal/procmaps/procmapskernel_test.go
+++ b/internal/procmaps/procmapskernel_test.go
@@ -1,0 +1,38 @@
+package procmaps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseLine_RealProcfsRoundTrip(t *testing.T) {
+	data, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		t.Skipf("cannot read own maps: %v", err)
+	}
+
+	named := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		e, ok := ParseLine(line)
+		if !ok {
+			t.Fatalf("ParseLine rejected a live kernel line: %q", line)
+		}
+		if !strings.HasSuffix(line, e.Path) {
+			t.Fatalf("path %q is not the tail of %q", e.Path, line)
+		}
+		if e.Named() && !e.Deleted {
+			named++
+			if !filepath.IsAbs(e.Path) {
+				t.Errorf("named mapping has a relative path %q", e.Path)
+			}
+		}
+	}
+	if named == 0 {
+		t.Fatal("no file-backed mappings parsed from live procfs")
+	}
+}


### PR DESCRIPTION
## Summary

A pod could steer the privileged agent's uprobes onto host binaries. Library paths were read from `/proc/<pid>/maps` as `strings.Fields(line)[5]`, but the kernel writes the pathname last and verbatim, escaping only the newline, so a file named `libssl.so.3 X` yields a sixth token of `libssl.so.3`, a prefix of the real path that is itself a valid path naming a different, existing file.
The traced process picks the filename, so it picks where the truncation lands and therefore which path the agent believes it saw. Resolution then failed to confine that path, so the agent could attach `SSL_write`/`SSL_read` to a host library; because a uprobe binds to an inode rather than a process, that instruments every process on the node mapping it.

## Changes

- Parse the maps pathname as the whole remainder of the line, not a whitespace-delimited field, and understand the ` (deleted)` marker.
- Resolve mapped files only through `/proc/<pid>/map_files` (kernel-resolved to the backing inode, no pathname involved) or `/proc/<pid>/root`. `map_files` wins when the two disagree, which also covers a pathname since replaced by a symlink out of the rootfs. No fallback to the raw path remains.
- Deduplicate attach targets by inode, so a library's several mapped segments yield one attach rather than one per segment.
- Gate host-wide discovery on having no trace target: with a container or pid in hand the agent no longer consults `ldconfig`, `ld.so.conf`, the architecture path list, or a `filepath.Walk` of `/usr/lib`. The `/proc/1/root` fallbacks that reached the node's own root filesystem are removed.
- Refuse an empty container ID in the rootfs scanners. They matched with `strings.Contains(match, containerID)`, which is true for every candidate when the ID is empty, selecting every container rootfs on the node.
- Extract parsing to `internal/procmaps`, and route `internal/diagnose/stacktrace` through it, it hand-rolled its own parser that collapsed runs of spaces and  kept the ` (deleted)` suffix.

Nothing is lost for an uncontainerized target, whose `/proc/<pid>/root` is the host root anyway.