### PR TITLE
fix: skip merge commits in the DCO sign-off check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -45,7 +45,7 @@ jobs:
 
           failed=0
 
-          for sha in $(git rev-list "${BASE_SHA}..${HEAD_SHA}"); do
+          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
             short=$(git rev-parse --short "${sha}")
             subject=$(git show -s --format='%s' "${sha}")
             author=$(git show -s --format='%ae' "${sha}" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Signed-off-by: Ghassan Malke <ghassan+github@malke.nl>
