### PR TITLE
fix: stop paired-map leak that silently disables the eBPF tracer

### DIFF
--- a/bpf/cpu.c
+++ b/bpf/cpu.c
@@ -163,12 +163,14 @@ int kretprobe_do_futex(struct pt_regs *ctx) {
 	}
 	u64 latency = calc_latency(*start_ts);
 	if (latency < MIN_LATENCY_NS) {
+		bpf_map_delete_elem(&lock_targets, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
 	long ret = PT_REGS_RC(ctx);
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&lock_targets, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -240,12 +242,14 @@ int uretprobe_pthread_mutex_lock(struct pt_regs *ctx) {
 	}
 	u64 latency = calc_latency(*start_ts);
 	if (latency < MIN_LATENCY_NS) {
+		bpf_map_delete_elem(&lock_targets, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
 	long ret = PT_REGS_RC(ctx);
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&lock_targets, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}

--- a/bpf/filesystem.c
+++ b/bpf/filesystem.c
@@ -57,6 +57,7 @@ int kretprobe_vfs_read(struct pt_regs *ctx) {
 	
 	u64 latency = calc_latency(*start_ts);
 	if (latency < MIN_LATENCY_NS) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -69,6 +70,7 @@ int kretprobe_vfs_read(struct pt_regs *ctx) {
 	
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -106,6 +108,7 @@ int kretprobe_vfs_write(struct pt_regs *ctx) {
 	
 	u64 latency = calc_latency(*start_ts);
 	if (latency < MIN_LATENCY_NS) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -118,6 +121,7 @@ int kretprobe_vfs_write(struct pt_regs *ctx) {
 	
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -174,12 +178,14 @@ int kretprobe_vfs_fsync(struct pt_regs *ctx) {
 	
 	u64 latency = calc_latency(*start_ts);
 	if (latency < MIN_LATENCY_NS) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
 	
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -56,7 +56,7 @@ struct pair_key {
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, struct pair_key);
 	__type(value, u64);
@@ -207,8 +207,8 @@ struct {
 } stack_traces SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
 	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } lock_targets SEC(".maps");
@@ -279,8 +279,8 @@ struct {
 } quic_initial_events SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
 	__type(key, struct pair_key);
 	__type(value, char[MAX_STRING_LEN]);
 } syscall_paths SEC(".maps");

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -118,6 +118,8 @@ int kretprobe_do_sys_openat2(struct pt_regs *ctx) {
 
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
+		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
 	e->timestamp = bpf_ktime_get_ns();
@@ -182,6 +184,7 @@ int kretprobe_vfs_unlink(struct pt_regs *ctx) {
 
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}
@@ -260,6 +263,7 @@ int kretprobe_vfs_rename(struct pt_regs *ctx) {
 
 	struct event *e = get_event_buf();
 	if (!e) {
+		bpf_map_delete_elem(&syscall_paths, &key);
 		bpf_map_delete_elem(&start_times, &key);
 		return 0;
 	}

--- a/internal/ebpf/bpf_paired_map_cleanup_test.go
+++ b/internal/ebpf/bpf_paired_map_cleanup_test.go
@@ -1,0 +1,142 @@
+package ebpf
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var pairedLifetimeMaps = []string{"start_times", "syscall_paths", "lock_targets"}
+
+var earlyReturnRe = regexp.MustCompile(`if\s*\([^)]*\)\s*\{[^{}]*?return[^;]*;[^{}]*\}`)
+
+func TestPairedLifetimeMapsAreLRU(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join(locateBPFDir(t), "maps.h"))
+	if err != nil {
+		t.Fatalf("read maps.h: %v", err)
+	}
+	text := string(src)
+
+	for _, name := range pairedLifetimeMaps {
+		end := strings.Index(text, "} "+name+" SEC(")
+		if end < 0 {
+			t.Errorf("map %q not found in maps.h", name)
+			continue
+		}
+		start := strings.LastIndex(text[:end], "struct {")
+		if start < 0 {
+			t.Errorf("map %q: no struct opener before its declaration", name)
+			continue
+		}
+		if !strings.Contains(text[start:end], "BPF_MAP_TYPE_LRU_HASH") {
+			t.Errorf("map %q must be BPF_MAP_TYPE_LRU_HASH so an entry whose return probe never "+
+				"fires (kretprobe miss, thread death) is evicted rather than pinned; a plain HASH "+
+				"fills and silently disables every probe sharing it", name)
+		}
+	}
+}
+
+func TestReturnProbesCleanUpPairedMapsOnEarlyReturn(t *testing.T) {
+	bpfDir := locateBPFDir(t)
+
+	entries, err := os.ReadDir(bpfDir)
+	if err != nil {
+		t.Fatalf("read bpf dir %q: %v", bpfDir, err)
+	}
+
+	var violations []string
+	fnRe := regexp.MustCompile(`\nint\s+(\w+)\s*\([^)]*\)\s*\{`)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".c") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(bpfDir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		text := string(src)
+
+		for _, m := range fnRe.FindAllStringSubmatchIndex(text, -1) {
+			name := text[m[2]:m[3]]
+			body, ok := braceBody(text, m[1]-1)
+			if !ok || !strings.Contains(body, "get_event_buf()") {
+				continue
+			}
+
+			var owned []string
+			for _, mp := range pairedLifetimeMaps {
+				if strings.Contains(body, "bpf_map_delete_elem(&"+mp+",") {
+					owned = append(owned, mp)
+				}
+			}
+			if len(owned) < 2 {
+				continue
+			}
+
+			for _, blk := range earlyReturnRe.FindAllString(body, -1) {
+				cond := strings.TrimSpace(strings.SplitN(blk, "{", 2)[0])
+				if strings.Contains(cond, "start_ts") {
+					continue
+				}
+				for _, mp := range owned {
+					if !strings.Contains(blk, "bpf_map_delete_elem(&"+mp+",") {
+						violations = append(violations,
+							e.Name()+":"+name+" early return `"+cond+"` on the consume path leaks "+mp)
+					}
+				}
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("BPF return probes leak paired maps on an early-return path:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func braceBody(text string, openIdx int) (string, bool) {
+	for openIdx < len(text) && text[openIdx] != '{' {
+		openIdx++
+	}
+	if openIdx >= len(text) {
+		return "", false
+	}
+	depth := 0
+	for i := openIdx; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[openIdx : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+func locateBPFDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			bpfDir := filepath.Join(dir, "bpf")
+			if _, err := os.Stat(bpfDir); err != nil {
+				t.Fatalf("bpf dir not found at module root %q: %v", dir, err)
+			}
+			return bpfDir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("module root (go.mod) not found walking up from working directory")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary

A single missing `bpf_map_delete_elem` silently disabled the entire eBPF tracer. `kretprobe_do_sys_openat2` returned on the filtered-event path (`!e`, taken for every cgroup outside the target set, essentially every process on the node) without deleting from `start_times`. That map is a preallocated hash shared by ~30 probe pairs, so on a busy node it filled within minutes; once full, every kretprobe found no start timestamp and no latency-bearing event (TCP, DNS, HTTP, database, file I/O, lock contention) was ever emitted again, while the agent kept reporting healthy. A co-tenant could force it in seconds with a fork/openat loop.

## Changes

- Delete every owned paired map (`start_times`, `syscall_paths`, `lock_targets`) on every early return of every return probe, both the filtered-event branch (`if (!e)`) and the sub-threshold branch (`if (latency < MIN_LATENCY_NS)`), across openat/unlink/rename, vfs_read/write/fsync, and futex/pthread_mutex.
- Make `start_times`, `syscall_paths`, and `lock_targets` `BPF_MAP_TYPE_LRU_HASH` (already the codebase norm). This is the backstop for entries whose return probe never fires, a kretprobe return-instance miss under high concurrency, or a thread that dies mid-syscall. LRU evicts on insert instead of failing, so the shared map can never permanently wedge the whole pipeline. `syscall_paths` and `lock_targets` are sized to 4096 to preserve their previous effective capacity.
- Add a source-invariant regression test asserting every return probe frees all its paired maps on every early return, and that the three maps stay LRU.