### PR TITLE
fix: mount host cgroupfs read-only to close release_agent escap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@
 # The same image serves the CLI, the agent DaemonSet, the operator
 # Deployment, and per-session Jobs, one binary, multiple subcommands.
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG DEBIAN_RELEASE=trixie
-ARG GO_IMAGE_DIGEST=sha256:f1a132429b98724a904e9b3bdbaed399d8f923203c3e5170e6def66d0a7cc04c
+ARG GO_IMAGE_DIGEST=sha256:ab563819a16cfe5faff0f96a8bb598fbb0e400ab2ac751996e60abcb23b106a3
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_RELEASE}@${GO_IMAGE_DIGEST} AS builder
 

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -97,7 +97,7 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 		{Name: "bpf", MountPath: "/sys/fs/bpf"},
 		{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
 		{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
-		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: true},
 		{Name: "cgroup", MountPath: "/host/sys/fs/cgroup", ReadOnly: true},
 		{Name: "containerd-sock", MountPath: "/run/containerd", ReadOnly: true},
 		{Name: "debug", MountPath: "/sys/kernel/debug"},

--- a/internal/kubernetes/nodespawn/pod_spec_test.go
+++ b/internal/kubernetes/nodespawn/pod_spec_test.go
@@ -145,8 +145,18 @@ func TestBuildPodSpec_HostMountsAndEnv(t *testing.T) {
 	}
 }
 
-// TestBuildPodSpec_SecurityFSHostPathHardenedAgainstSilentEmptyMount pins the
-// securityfs volume type to HostPathDirectory (not DirectoryOrCreate).
+func TestBuildPodSpec_CgroupMountsReadOnly(t *testing.T) {
+	got, err := BuildPodSpec(baseOpts())
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	for _, m := range got.Spec.Containers[0].VolumeMounts {
+		if m.Name == "cgroup" && !m.ReadOnly {
+			t.Errorf("cgroup mount at %q must be ReadOnly (writable host cgroupfs under root+CAP_SYS_ADMIN is a release_agent escape)", m.MountPath)
+		}
+	}
+}
+
 func TestBuildPodSpec_SecurityFSHostPathHardenedAgainstSilentEmptyMount(t *testing.T) {
 	got, err := BuildPodSpec(baseOpts())
 	if err != nil {

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -92,7 +92,7 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		{Name: "bpf", MountPath: "/sys/fs/bpf", MountPropagation: mountPropagationHostToContainer()},
 		{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
 		{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
-		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+		{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: true},
 		{Name: "debugfs", MountPath: "/sys/kernel/debug", ReadOnly: true},
 		{Name: "tracefs", MountPath: "/sys/kernel/tracing", ReadOnly: true},
 		{Name: "exporter", MountPath: "/etc/podtrace/exporter", ReadOnly: true},

--- a/internal/operator/podtracesession_job_test.go
+++ b/internal/operator/podtracesession_job_test.go
@@ -169,6 +169,20 @@ func TestBuildSessionJobSpec_CoreInvariants(t *testing.T) {
 	}
 }
 
+func TestBuildSessionJobSpec_CgroupMountReadOnly(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	spec := buildSessionJobSpec(newSession(nil), tc, "node-a", sessionTargets{})
+	for _, c := range spec.Template.Spec.Containers {
+		for _, m := range c.VolumeMounts {
+			if m.Name == "cgroup" && !m.ReadOnly {
+				t.Errorf("container %q cgroup mount at %q must be ReadOnly", c.Name, m.MountPath)
+			}
+		}
+	}
+}
+
 func TestBuildSessionJobSpec_SidecarOptedIn(t *testing.T) {
 	tc := &podtracev1alpha1.TracerConfig{
 		Spec: podtracev1alpha1.TracerConfigSpec{

--- a/internal/operator/tracerconfig_daemonset.go
+++ b/internal/operator/tracerconfig_daemonset.go
@@ -157,7 +157,7 @@ func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string)
 						{Name: "bpf", MountPath: "/sys/fs/bpf", MountPropagation: mountPropagationHostToContainer()},
 						{Name: "btf", MountPath: "/sys/kernel/btf", ReadOnly: true},
 						{Name: "proc", MountPath: "/host/proc", ReadOnly: true},
-						{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: false},
+						{Name: "cgroup", MountPath: "/sys/fs/cgroup", ReadOnly: true},
 						{Name: "debugfs", MountPath: "/sys/kernel/debug", ReadOnly: true},
 						{Name: "tracefs", MountPath: "/sys/kernel/tracing", ReadOnly: true},
 					},

--- a/internal/operator/tracerconfig_daemonset_test.go
+++ b/internal/operator/tracerconfig_daemonset_test.go
@@ -101,6 +101,19 @@ func TestBuildAgentDaemonSetSpec_HostMounts(t *testing.T) {
 	}
 }
 
+func TestBuildAgentDaemonSetSpec_HostSysMountsReadOnly(t *testing.T) {
+	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
+	ro := map[string]bool{}
+	for _, m := range spec.Template.Spec.Containers[0].VolumeMounts {
+		ro[m.Name] = m.ReadOnly
+	}
+	for _, name := range []string{"cgroup", "btf", "proc", "debugfs", "tracefs"} {
+		if !ro[name] {
+			t.Errorf("host mount %q must be ReadOnly (writable host cgroupfs under root+CAP_SYS_ADMIN is a release_agent escape)", name)
+		}
+	}
+}
+
 func TestBuildAgentDaemonSetSpec_NodeNameEnvInjected(t *testing.T) {
 	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
 	c := spec.Template.Spec.Containers[0]


### PR DESCRIPTION
## Summary

All three privileged pod specs, the agent DaemonSet, the per-session Job, and the node-local spawn pod, mounted the host `/sys/fs/cgroup` writable (`ReadOnly: false`) while running as UID 0 with `CAP_SYS_ADMIN`. On a cgroup v1 host that is the classic `release_agent` container escape: write a payload path into `release_agent`, empty a cgroup, and the kernel executes it on the host as root.

## Changes

- Set `ReadOnly: true` on the host `/sys/fs/cgroup` mount at all three sites: `internal/operator/tracerconfig_daemonset.go`, `internal/operator/podtracesession_job.go`, and `internal/kubernetes/nodespawn/pod_spec.go`.
- Add regression tests asserting the cgroup mount is read-only in each generated spec (the DaemonSet test also pins btf/proc/debugfs/tracefs as read-only), each proven to fail without the fix.