### PR TITLE
fix: constrain TracerConfig agent image to a trusted allowlist

### DIFF
--- a/api/v1alpha1/tracerconfig_types.go
+++ b/api/v1alpha1/tracerconfig_types.go
@@ -125,6 +125,9 @@ const MaxTracerConfigNameLength = 63
 
 type TracerConfigSpec struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	// +kubebuilder:validation:XValidation:rule="self.contains('/') && (self.split('/')[0].contains('.') || self.split('/')[0].contains(':') || self.split('/')[0] == 'localhost')",message="spec.image must be a fully-qualified image reference that includes a registry host, e.g. ghcr.io/org/app:tag"
 	Image string `json:"image"`
 
 	// +optional

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_tracerconfigs.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_tracerconfigs.yaml
@@ -1097,7 +1097,14 @@ spec:
                     type: array
                 type: object
               image:
+                maxLength: 512
+                minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.image must be a fully-qualified image reference that
+                    includes a registry host, e.g. ghcr.io/org/app:tag
+                  rule: self.contains('/') && (self.split('/')[0].contains('.') ||
+                    self.split('/')[0].contains(':') || self.split('/')[0] == 'localhost')
               imagePullPolicy:
                 description: PullPolicy describes a policy for if/when to pull a container
                   image

--- a/deploy/charts/podtrace/templates/operator-deployment.yaml
+++ b/deploy/charts/podtrace/templates/operator-deployment.yaml
@@ -62,6 +62,8 @@ spec:
               value: {{ include "podtrace.image" . | quote }}
             - name: PODTRACE_BOOTSTRAP_TC_NAME
               value: {{ .Values.tracerConfig.name | default "default" | quote }}
+            - name: PODTRACE_ALLOWED_AGENT_IMAGE_REPOS
+              value: {{ prepend (.Values.agent.allowedImageRepos | default list) .Values.image.repository | uniq | join "," | quote }}
             {{- with .Values.operator.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -57,6 +57,7 @@ operator:
   extraEnv: []
 
 agent:
+  allowedImageRepos: []
   resources:
     requests:
       cpu: 100m

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -483,6 +483,22 @@ var (
 	Image   = "ghcr.io/gma1k/podtrace"
 )
 
+// AllowedAgentImageRepos returns the repository prefixes the operator accepts
+// in TracerConfig.spec.image.
+func AllowedAgentImageRepos() []string {
+	raw, set := os.LookupEnv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS")
+	if !set {
+		return []string{Image}
+	}
+	var repos []string
+	for _, r := range strings.Split(raw, ",") {
+		if r = strings.TrimSpace(r); r != "" {
+			repos = append(repos, r)
+		}
+	}
+	return repos
+}
+
 var readVCSRevision = func() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {

--- a/internal/config/config_accessors_test.go
+++ b/internal/config/config_accessors_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -93,4 +94,30 @@ func TestCaptureHeaderList(t *testing.T) {
 			t.Errorf("CaptureHeaderList() = %v, want %v", got, want)
 		}
 	})
+}
+
+func TestAllowedAgentImageRepos_DefaultsToTrustedImage(t *testing.T) {
+	if _, set := os.LookupEnv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS"); set {
+		t.Skip("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS set in environment")
+	}
+	got := AllowedAgentImageRepos()
+	if len(got) != 1 || got[0] != Image {
+		t.Errorf("default AllowedAgentImageRepos = %v, want [%s]", got, Image)
+	}
+}
+
+func TestAllowedAgentImageRepos_WidenedViaEnv(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace, registry.internal:5000/mirror , ")
+	got := AllowedAgentImageRepos()
+	want := []string{"ghcr.io/gma1k/podtrace", "registry.internal:5000/mirror"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AllowedAgentImageRepos = %v, want %v", got, want)
+	}
+}
+
+func TestAllowedAgentImageRepos_ExplicitEmptyDisables(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "")
+	if got := AllowedAgentImageRepos(); len(got) != 0 {
+		t.Errorf("explicit empty must disable the policy, got %v", got)
+	}
 }

--- a/internal/imagepolicy/imagepolicy.go
+++ b/internal/imagepolicy/imagepolicy.go
@@ -1,0 +1,96 @@
+// Package imagepolicy validates container image references against an
+// admin-controlled allowlist of trusted repositories.
+//
+// TracerConfig.spec.image is copied by the operator into a DaemonSet that runs
+// as UID 0 with CAP_SYS_ADMIN, host PID, and host /proc mounted. Without a
+// gate, anyone able to write a (cluster-scoped) TracerConfig could point that
+// at an arbitrary image and get root on every node. The operator therefore
+// resolves spec.image against this allowlist and refuses to create the agent
+// when it does not match, defaulting the allowlist to the operator's own
+// trusted repository.
+package imagepolicy
+
+import (
+	"fmt"
+	"strings"
+)
+
+const dockerDefaultRegistry = "docker.io"
+
+// NormalizeRepository extracts the registry+repository portion of an image
+// reference, stripping any tag and digest and applying Docker Hub's implicit
+// normalization. It returns an error for a reference that has no repository.
+//
+//	ghcr.io/gma1k/podtrace:0.14.3      -> ghcr.io/gma1k/podtrace
+//	ghcr.io/gma1k/podtrace@sha256:...  -> ghcr.io/gma1k/podtrace
+//	registry:5000/team/app:latest      -> registry:5000/team/app
+//	attacker/x                         -> docker.io/attacker/x
+//	nginx                              -> docker.io/library/nginx
+func NormalizeRepository(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("image reference is empty")
+	}
+
+	if at := strings.IndexByte(ref, '@'); at >= 0 {
+		ref = ref[:at]
+	}
+
+	registry, remainder := splitRegistry(ref)
+
+	if colon := strings.LastIndexByte(remainder, ':'); colon >= 0 {
+		remainder = remainder[:colon]
+	}
+
+	if remainder == "" {
+		return "", fmt.Errorf("image reference %q has no repository path", ref)
+	}
+
+	if registry == "" {
+		registry = dockerDefaultRegistry
+		if !strings.Contains(remainder, "/") {
+			remainder = "library/" + remainder
+		}
+	}
+
+	return registry + "/" + remainder, nil
+}
+
+func splitRegistry(ref string) (registry, remainder string) {
+	slash := strings.IndexByte(ref, '/')
+	if slash < 0 {
+		return "", ref
+	}
+	first := ref[:slash]
+	if strings.ContainsAny(first, ".:") || first == "localhost" {
+		return first, ref[slash+1:]
+	}
+	return "", ref
+}
+
+func RepoAllowed(ref string, allowedRepos []string) error {
+	if len(allowedRepos) == 0 {
+		return nil
+	}
+
+	repo, err := NormalizeRepository(ref)
+	if err != nil {
+		return fmt.Errorf("spec.image %q is not a valid image reference: %w", ref, err)
+	}
+
+	for _, allowed := range allowedRepos {
+		norm, err := NormalizeRepository(allowed)
+		if err != nil {
+			continue
+		}
+		if repo == norm || strings.HasPrefix(repo, norm+"/") {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"spec.image %q resolves to repository %q, which is not in the operator's allowed set %v; "+
+			"the agent runs as root with CAP_SYS_ADMIN on every node, so its image must come from a trusted repository. "+
+			"Set an allowed repository via the operator's PODTRACE_ALLOWED_AGENT_IMAGE_REPOS if this image is trusted",
+		ref, repo, allowedRepos)
+}

--- a/internal/imagepolicy/imagepolicy_test.go
+++ b/internal/imagepolicy/imagepolicy_test.go
@@ -1,0 +1,110 @@
+package imagepolicy
+
+import "testing"
+
+func TestNormalizeRepository(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"ghcr.io/gma1k/podtrace:0.14.3", "ghcr.io/gma1k/podtrace"},
+		{"ghcr.io/gma1k/podtrace", "ghcr.io/gma1k/podtrace"},
+		{"ghcr.io/gma1k/podtrace@sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "ghcr.io/gma1k/podtrace"},
+		{"ghcr.io/gma1k/podtrace:0.14.3@sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "ghcr.io/gma1k/podtrace"},
+		{"registry:5000/team/app:latest", "registry:5000/team/app"},
+		{"registry:5000/team/app", "registry:5000/team/app"},
+		{"localhost/app:dev", "localhost/app"},
+		{"localhost:5000/app", "localhost:5000/app"},
+		{"attacker/x", "docker.io/attacker/x"},
+		{"attacker/x:latest", "docker.io/attacker/x"},
+		{"nginx", "docker.io/library/nginx"},
+		{"nginx:1.27", "docker.io/library/nginx"},
+		{"docker.io/library/nginx", "docker.io/library/nginx"},
+		{"  ghcr.io/gma1k/podtrace:tag  ", "ghcr.io/gma1k/podtrace"},
+	}
+	for _, c := range cases {
+		got, err := NormalizeRepository(c.in)
+		if err != nil {
+			t.Errorf("NormalizeRepository(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NormalizeRepository(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeRepository_Errors(t *testing.T) {
+	for _, in := range []string{"", "   ", "ghcr.io/", "ghcr.io/@sha256:abc"} {
+		if _, err := NormalizeRepository(in); err == nil {
+			t.Errorf("NormalizeRepository(%q) expected error, got nil", in)
+		}
+	}
+}
+
+func TestRepoAllowed_EmptyAllowlistAllowsEverything(t *testing.T) {
+	if err := RepoAllowed("attacker/evil:latest", nil); err != nil {
+		t.Errorf("empty allowlist must allow any image, got %v", err)
+	}
+}
+
+func TestRepoAllowed_ExactAndSubRepo(t *testing.T) {
+	allowed := []string{"ghcr.io/gma1k/podtrace"}
+	for _, ref := range []string{
+		"ghcr.io/gma1k/podtrace",
+		"ghcr.io/gma1k/podtrace:0.14.3",
+		"ghcr.io/gma1k/podtrace@sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	} {
+		if err := RepoAllowed(ref, allowed); err != nil {
+			t.Errorf("RepoAllowed(%q) should be allowed, got %v", ref, err)
+		}
+	}
+}
+
+func TestRepoAllowed_ParentPrefixAdmitsChildren(t *testing.T) {
+	allowed := []string{"ghcr.io/gma1k"}
+	if err := RepoAllowed("ghcr.io/gma1k/podtrace:tag", allowed); err != nil {
+		t.Errorf("child repo under an allowed parent should be allowed, got %v", err)
+	}
+}
+
+func TestRepoAllowed_RejectsBoundaryLookalike(t *testing.T) {
+	allowed := []string{"ghcr.io/gma1k/podtrace"}
+	for _, ref := range []string{
+		"ghcr.io/gma1k/podtrace-evil:latest",
+		"ghcr.io/gma1k-evil/podtrace:latest",
+		"attacker/x:latest",
+		"nginx",
+		"evil.example.com/gma1k/podtrace:latest",
+	} {
+		if err := RepoAllowed(ref, allowed); err == nil {
+			t.Errorf("RepoAllowed(%q) must be rejected against %v", ref, allowed)
+		}
+	}
+}
+
+func TestRepoAllowed_MultipleAllowedRepos(t *testing.T) {
+	allowed := []string{"ghcr.io/gma1k/podtrace", "registry.internal:5000/mirror/podtrace"}
+	if err := RepoAllowed("registry.internal:5000/mirror/podtrace:0.14.3", allowed); err != nil {
+		t.Errorf("mirror repo should be allowed, got %v", err)
+	}
+	if err := RepoAllowed("registry.internal:5000/other/thing", allowed); err == nil {
+		t.Error("non-listed repo on an allowed registry must still be rejected")
+	}
+}
+
+func TestRepoAllowed_InvalidReferenceRejected(t *testing.T) {
+	if err := RepoAllowed("", []string{"ghcr.io/gma1k/podtrace"}); err == nil {
+		t.Error("empty image reference must be rejected when a policy is set")
+	}
+}
+
+func TestRepoAllowed_SkipsMalformedAllowlistEntries(t *testing.T) {
+	allowed := []string{"", "  ", "ghcr.io/gma1k/podtrace"}
+	if err := RepoAllowed("ghcr.io/gma1k/podtrace:tag", allowed); err != nil {
+		t.Errorf("a valid allowlist entry must still match past malformed ones, got %v", err)
+	}
+	if err := RepoAllowed("attacker/x", []string{"", "  "}); err == nil {
+		t.Error("an allowlist of only malformed entries must reject a non-matching image")
+	}
+}

--- a/internal/operator/reconcilers_deep_unit_test.go
+++ b/internal/operator/reconcilers_deep_unit_test.go
@@ -570,7 +570,7 @@ func TestDeepReconcile_TracerConfig_CustomNamespace(t *testing.T) {
 	const customNS = "custom-sys"
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", UID: "tc-uid", Generation: 4},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: customNS},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: customNS, Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	scheme := newOperatorScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).

--- a/internal/operator/reconcilers_errorpaths_unit_test.go
+++ b/internal/operator/reconcilers_errorpaths_unit_test.go
@@ -596,7 +596,7 @@ func TestErrPath_TracerConfig_RBACCreateError(t *testing.T) {
 	s := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system", Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -624,7 +624,7 @@ func TestErrPath_TracerConfig_DaemonSetCreateError(t *testing.T) {
 	s := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system", Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -652,7 +652,7 @@ func TestErrPath_TracerConfig_DaemonSetConflictRequeues(t *testing.T) {
 	s := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system", Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -684,7 +684,7 @@ func TestErrPath_TracerConfig_FinalStatusUpdateConflictRequeues(t *testing.T) {
 	s := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system", Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).
@@ -713,7 +713,7 @@ func TestErrPath_TracerConfig_FinalStatusUpdateError(t *testing.T) {
 	s := newOperatorScheme(t)
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Generation: 1},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: "podtrace-system", Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(s).

--- a/internal/operator/reconcilers_unit_test.go
+++ b/internal/operator/reconcilers_unit_test.go
@@ -382,7 +382,7 @@ func TestTracerConfigReconciler_HappyPath(t *testing.T) {
 	const sysNS = "podtrace-system"
 	tc := &podtracev1alpha1.TracerConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", UID: "tc-uid"},
-		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: sysNS},
+		Spec:       podtracev1alpha1.TracerConfigSpec{SystemNamespace: sysNS, Image: "ghcr.io/gma1k/podtrace:test"},
 	}
 	scheme := newOperatorScheme(t)
 	c := fake.NewClientBuilder().WithScheme(scheme).

--- a/internal/operator/tracerconfig_controller.go
+++ b/internal/operator/tracerconfig_controller.go
@@ -28,7 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/fleet"
+	"github.com/gma1k/podtrace/internal/imagepolicy"
 	"github.com/gma1k/podtrace/internal/safeconv"
 )
 
@@ -66,6 +68,16 @@ func (r *TracerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err := validateTracerConfigName(tc.Name); err != nil {
 		r.setCondition(&tc, ConditionDegraded, metav1.ConditionTrue, "InvalidName", err.Error())
 		r.setCondition(&tc, ConditionReady, metav1.ConditionFalse, "InvalidName", err.Error())
+		if uerr := r.Status().Update(ctx, &tc); uerr != nil && !apierrors.IsConflict(uerr) {
+			return ctrl.Result{}, fmt.Errorf("update status: %w", uerr)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err := imagepolicy.RepoAllowed(tc.Spec.Image, config.AllowedAgentImageRepos()); err != nil {
+		logger.Info("refusing agent fleet: image not allowed", "image", tc.Spec.Image, "error", err.Error())
+		r.setCondition(&tc, ConditionDegraded, metav1.ConditionTrue, "ImageNotAllowed", err.Error())
+		r.setCondition(&tc, ConditionReady, metav1.ConditionFalse, "ImageNotAllowed", err.Error())
 		if uerr := r.Status().Update(ctx, &tc); uerr != nil && !apierrors.IsConflict(uerr) {
 			return ctrl.Result{}, fmt.Errorf("update status: %w", uerr)
 		}

--- a/internal/operator/tracerconfig_imagepolicy_test.go
+++ b/internal/operator/tracerconfig_imagepolicy_test.go
@@ -1,0 +1,99 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestReconcile_RejectsUntrustedImage_NoDaemonSet(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace")
+
+	c, r := reconcileFleets(t, []client.Object{
+		fleetConfig("default", podtracev1alpha1.TracerConfigSpec{Image: "evil.example.com/x:latest"}),
+	}, "default")
+
+	var ds appsv1.DaemonSet
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name: AgentDaemonSetName("default"), Namespace: r.SystemNamespace,
+	}, &ds)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("agent DaemonSet must not be created for an untrusted image; got err=%v", err)
+	}
+
+	var tc podtracev1alpha1.TracerConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "default"}, &tc); err != nil {
+		t.Fatal(err)
+	}
+	ready := meta.FindStatusCondition(tc.Status.Conditions, ConditionReady)
+	if ready == nil || ready.Status != "False" || ready.Reason != "ImageNotAllowed" {
+		t.Fatalf("expected Ready=False reason=ImageNotAllowed, got %+v", ready)
+	}
+}
+
+func TestReconcile_AcceptsTrustedImage_CreatesDaemonSet(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace")
+
+	c, r := reconcileFleets(t, []client.Object{
+		fleetConfig("default", podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:0.14.3"}),
+	}, "default")
+
+	var ds appsv1.DaemonSet
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: AgentDaemonSetName("default"), Namespace: r.SystemNamespace,
+	}, &ds); err != nil {
+		t.Fatalf("agent DaemonSet must be created for a trusted image: %v", err)
+	}
+}
+
+func TestReconcile_AllowsMirrorRepoViaEnv(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace,registry.internal:5000/mirror")
+
+	c, r := reconcileFleets(t, []client.Object{
+		fleetConfig("default", podtracev1alpha1.TracerConfigSpec{Image: "registry.internal:5000/mirror/podtrace:0.14.3"}),
+	}, "default")
+
+	var ds appsv1.DaemonSet
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: AgentDaemonSetName("default"), Namespace: r.SystemNamespace,
+	}, &ds); err != nil {
+		t.Fatalf("agent DaemonSet must be created for an admin-allowed mirror image: %v", err)
+	}
+}
+
+func TestReconcile_RecoversWhenImageCorrected(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace")
+
+	c, r := reconcileFleets(t, []client.Object{
+		fleetConfig("default", podtracev1alpha1.TracerConfigSpec{Image: "evil.example.com/x:latest"}),
+	}, "default")
+
+	var tc podtracev1alpha1.TracerConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "default"}, &tc); err != nil {
+		t.Fatal(err)
+	}
+	tc.Spec.Image = "ghcr.io/gma1k/podtrace:0.14.3"
+	if err := c.Update(context.Background(), &tc); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile after correcting image: %v", err)
+	}
+
+	var ds appsv1.DaemonSet
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: AgentDaemonSetName("default"), Namespace: r.SystemNamespace,
+	}, &ds); err != nil {
+		t.Fatalf("DaemonSet must be created once the image is corrected to a trusted repo: %v", err)
+	}
+}

--- a/internal/operator/tracerconfig_reconcile_test.go
+++ b/internal/operator/tracerconfig_reconcile_test.go
@@ -205,7 +205,10 @@ func TestTC_Reconcile_NonDefaultStatusUpdateError(t *testing.T) {
 
 func TestTC_Reconcile_RBACError(t *testing.T) {
 	scheme := newOperatorScheme(t)
-	tc := &podtracev1alpha1.TracerConfig{ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName}}
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
 	c := fake.NewClientBuilder().WithScheme(scheme).
 		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
 		WithObjects(tc).

--- a/internal/webhook/v1alpha1/tracerconfig_webhook.go
+++ b/internal/webhook/v1alpha1/tracerconfig_webhook.go
@@ -12,7 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/fleet"
+	"github.com/gma1k/podtrace/internal/imagepolicy"
 )
 
 // +kubebuilder:webhook:path=/validate-podtrace-io-v1alpha1-tracerconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=podtrace.io,resources=tracerconfigs,verbs=create;update,versions=v1alpha1,name=vtracerconfig.podtrace.io,admissionReviewVersions=v1
@@ -49,6 +51,9 @@ func (v *TracerConfigCustomValidator) ValidateDelete(_ context.Context, _ *podtr
 
 func (v *TracerConfigCustomValidator) validate(ctx context.Context, tc *podtracev1alpha1.TracerConfig) (admission.Warnings, error) {
 	if err := validateTracerConfigNameLength(tc.Name); err != nil {
+		return nil, err
+	}
+	if err := imagepolicy.RepoAllowed(tc.Spec.Image, config.AllowedAgentImageRepos()); err != nil {
 		return nil, err
 	}
 	if v.Client == nil {

--- a/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
+++ b/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
@@ -213,3 +213,29 @@ func TestResolveTracerConfigRefNilAndEmptyAreUnset(t *testing.T) {
 		t.Errorf("an empty ref name means resolve per node, got %v", err)
 	}
 }
+
+func TestTracerConfigRejectsUntrustedImage(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace")
+	v := tracerConfigValidator(t)
+
+	_, err := v.ValidateCreate(context.Background(), tracerConfig("default", podtracev1alpha1.TracerConfigSpec{
+		Image: "evil.example.com/x:latest",
+	}))
+	if err == nil {
+		t.Fatal("expected an untrusted image to be rejected at admission")
+	}
+	if !strings.Contains(err.Error(), "not in the operator's allowed set") {
+		t.Errorf("error should explain the allowlist, got %q", err)
+	}
+}
+
+func TestTracerConfigAcceptsTrustedImage(t *testing.T) {
+	t.Setenv("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS", "ghcr.io/gma1k/podtrace")
+	v := tracerConfigValidator(t)
+
+	if _, err := v.ValidateCreate(context.Background(), tracerConfig("default", podtracev1alpha1.TracerConfigSpec{
+		Image: "ghcr.io/gma1k/podtrace:0.14.3",
+	})); err != nil {
+		t.Errorf("trusted image must be admitted, got %v", err)
+	}
+}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -523,3 +523,28 @@ func containsAnyKind(doc []byte) bool {
 	}
 	return false
 }
+
+func TestChart_TracerConfigImageHasCELBackstop(t *testing.T) {
+	out := renderChart(t)
+	if !bytes.Contains(out, []byte("must be a fully-qualified image reference")) {
+		t.Error("TracerConfig CRD must carry the spec.image CEL validation backstop")
+	}
+	if !bytes.Contains(out, []byte("x-kubernetes-validations")) {
+		t.Error("TracerConfig CRD must declare x-kubernetes-validations for spec.image")
+	}
+}
+
+func TestChart_OperatorImageAllowlistEnv(t *testing.T) {
+	out := renderChart(t, "operator.enabled=true")
+	if !bytes.Contains(out, []byte("PODTRACE_ALLOWED_AGENT_IMAGE_REPOS")) {
+		t.Fatal("operator must receive PODTRACE_ALLOWED_AGENT_IMAGE_REPOS")
+	}
+	if !bytes.Contains(out, []byte("ghcr.io/gma1k/podtrace")) {
+		t.Error("default allowlist must include the chart's own image repository")
+	}
+
+	custom := renderChart(t, "operator.enabled=true", "image.repository=myreg.io/podtrace", "agent.allowedImageRepos={mirror.io/podtrace}")
+	if !bytes.Contains(custom, []byte("myreg.io/podtrace,mirror.io/podtrace")) {
+		t.Error("allowlist must combine the chart's image.repository with agent.allowedImageRepos")
+	}
+}


### PR DESCRIPTION
## Summary

Write access to the cluster-scoped TracerConfig CRD was equivalent to root on every node. Its `spec.image` was an unvalidated string that the operator copied straight into a DaemonSet running as UID 0 with `CAP_SYS_ADMIN`, `hostPID`, and host `/proc` mounted, so a principal granted `create/update` on `podtrace.io/tracerconfigs`, a grant that reads like "tracing configuration", could set `spec.image: attacker/x` and run their container as root on every node, control-plane included. The validating webhook inspected only name length and nodeSelector overlap, and is disabled by default, so a default install validated nothing. This constrains the agent image to a trusted, admin-controlled allowlist and enforces it in layers that hold even when the webhook is off.

## Changes

- Add `internal/imagepolicy`: a self-contained image-reference normalizer and repository allowlist check (no new dependency), matching Docker Hub's implicit normalization and honouring repository path boundaries so `ghcr.io/org` admits `ghcr.io/org/app` but not `ghcr.io/org-evil`.
- Add `config.AllowedAgentImageRepos()`: the trusted repository allowlist, defaulting to the operator's own build repository and widenable via `PODTRACE_ALLOWED_AGENT_IMAGE_REPOS` (an explicit empty value disables the check).
- Enforce the allowlist authoritatively in the TracerConfig reconciler before creating the fleet: an untrusted image sets `Ready=False, reason=ImageNotAllowed` and no DaemonSet is created. This runs whether or not the webhook is installed.
- Add a CEL `x-kubernetes-validations` backstop on `spec.image` in the CRD, enforced by the apiserver on every write, rejecting non-fully-qualified references (e.g. the implicit-Docker-Hub `attacker/x` shorthand) even with the webhook off.
- Check the allowlist in the validating webhook as well, for immediate admission-time feedback when it is enabled.
- Wire the operator's allowlist from the chart's `image.repository` plus a new `agent.allowedImageRepos` value, so a custom-registry or mirrored install automatically trusts its own image.

## Risk notes

- Existing TracerConfigs whose `spec.image` is outside the operator's allowlist stop reconciling their fleet and report `ImageNotAllowed`; on a default install the allowlist is the chart's own `image.repository`, which the bootstrapped default TracerConfig already uses, so a stock install is unaffected. Operators running a custom or mirrored image must set `agent.allowedImageRepos` (or `PODTRACE_ALLOWED_AGENT_IMAGE_REPOS`).
- The report also paired the image with `spec.tolerations: [{operator: Exists}]` to reach control-plane nodes; this is deliberately not constrained. Once the image is pinned to a trusted repository the tolerations only ever spread the trusted agent, and the chart's own default `agent.tolerations` uses that blanket toleration for intended full-cluster tracing, so restricting it would break a documented feature without adding security.
- `spec.image` moves from an unvalidated string to CEL-validated (fully-qualified references only) and MaxLength 512; a reference with no registry host is now rejected at the apiserver.