### PR TITLE
fix: stop the operator caching and cluster-wide-writing every Secret

### DIFF
--- a/deploy/charts/podtrace/templates/operator-rbac.yaml
+++ b/deploy/charts/podtrace/templates/operator-rbac.yaml
@@ -54,10 +54,12 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  # System-namespace infrastructure: SAs, bundles (ConfigMap+Secret)
   - apiGroups: [""]
-    resources: ["serviceaccounts", "configmaps", "secrets"]
+    resources: ["serviceaccounts", "configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "delete"]
   # Agent RBAC managed by TracerConfigReconciler
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles", "clusterrolebindings"]
@@ -85,6 +87,36 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "podtrace.fullname" . }}-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "podtrace.fullname" . }}-operator
+    namespace: {{ include "podtrace.systemNamespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator-secrets
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator-secrets
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "podtrace.fullname" . }}-operator-secrets
 subjects:
   - kind: ServiceAccount
     name: {{ include "podtrace.fullname" . }}-operator

--- a/deploy/olm/csv-template.yaml
+++ b/deploy/olm/csv-template.yaml
@@ -371,8 +371,11 @@ spec:
               resources: ["nodes"]
               verbs: ["get", "list", "watch"]
             - apiGroups: [""]
-              resources: ["serviceaccounts", "configmaps", "secrets"]
+              resources: ["serviceaccounts", "configmaps"]
               verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "list", "watch", "create", "delete"]
             - apiGroups: ["rbac.authorization.k8s.io"]
               resources: ["clusterroles", "clusterrolebindings"]
               verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -385,6 +388,12 @@ spec:
             - apiGroups: ["coordination.k8s.io"]
               resources: ["leases"]
               verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      permissions:
+        - serviceAccountName: podtrace-operator
+          rules:
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["update", "patch"]
 
       deployments:
         - name: podtrace-operator

--- a/internal/operator/exporter_bundle.go
+++ b/internal/operator/exporter_bundle.go
@@ -82,10 +82,6 @@ func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.Export
 			data["protocol"] = string(podtracev1alpha1.OTLPProtocolHTTP)
 		}
 		data["insecure"] = boolString(ec.Spec.OTLP.Insecure)
-		// The loop must visit every header: an early return on the first
-		// ValueFrom header used to drop all literal headers declared after
-		// it (and silently ignore further ValueFrom headers) while the
-		// readiness evaluator still reported the configuration healthy.
 		var credRef *podtracev1alpha1.SecretKeySelector
 		for _, h := range ec.Spec.OTLP.Headers {
 			if h.ValueFrom != nil {
@@ -153,15 +149,12 @@ func renderBundlePayload(policy *bundlePolicyInputs, ec *podtracev1alpha1.Export
 
 // buildBundleSecretData materializes the bundle Secret contents: the single
 // credential (bundle.CredentialKey) when credRef is set, plus one
-// "header.<name>" entry per key of the headersFromSecret Secret. The latter
-// used to be checked for existence by the readiness evaluator but never
-// rendered anywhere, so OTLP auth supplied exclusively via headersFromSecret
-// reported Ready=True while agents exported with no headers at all.
-func buildBundleSecretData(ctx context.Context, c client.Client, ecNamespace string, credRef *podtracev1alpha1.SecretKeySelector, headersFrom *podtracev1alpha1.LocalObjectReference) (map[string][]byte, error) {
+// "header.<name>" entry per key of the headersFromSecret Secret.
+func buildBundleSecretData(ctx context.Context, reader client.Reader, ecNamespace string, credRef *podtracev1alpha1.SecretKeySelector, headersFrom *podtracev1alpha1.LocalObjectReference) (map[string][]byte, error) {
 	out := map[string][]byte{}
 	if credRef != nil {
 		var src corev1.Secret
-		if err := c.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: credRef.Name}, &src); err != nil {
+		if err := reader.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: credRef.Name}, &src); err != nil {
 			return nil, fmt.Errorf("get credential Secret %s/%s: %w", ecNamespace, credRef.Name, err)
 		}
 		val, ok := src.Data[credRef.Key]
@@ -172,7 +165,7 @@ func buildBundleSecretData(ctx context.Context, c client.Client, ecNamespace str
 	}
 	if headersFrom != nil {
 		var src corev1.Secret
-		if err := c.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: headersFrom.Name}, &src); err != nil {
+		if err := reader.Get(ctx, types.NamespacedName{Namespace: ecNamespace, Name: headersFrom.Name}, &src); err != nil {
 			return nil, fmt.Errorf("get headersFromSecret Secret %s/%s: %w", ecNamespace, headersFrom.Name, err)
 		}
 		for k, v := range src.Data {
@@ -223,7 +216,7 @@ func policyFromSession(s *podtracev1alpha1.PodTraceSession) *bundlePolicyInputs 
 // effectiveSamplePercentFromPolicy returns the operator-side resolution
 // of the "minimum applies" sampling contract between the CR-owner intent
 // (PodTrace/Session.spec.samplePercent) and the platform-owner cap
-// (ExporterConfig.spec.samplePercent). Unset (nil) is treated as 100%.
+// (ExporterConfig.spec.samplePercent).
 func effectiveSamplePercentFromPolicy(p *bundlePolicyInputs, ec *podtracev1alpha1.ExporterConfig) *int32 {
 	var crVal *int32
 	if p != nil {

--- a/internal/operator/exporterconfig_controller.go
+++ b/internal/operator/exporterconfig_controller.go
@@ -30,7 +30,8 @@ import (
 //   - Referenced condition mirrors ReferencedBy > 0.
 type ExporterConfigReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
 }
 
 // Reason strings for the Ready / Referenced conditions. Stable
@@ -47,10 +48,6 @@ const (
 	ecMaxConditionMessageLen = 256
 )
 
-// Field-indexer keys. Registered against PodTrace and PodTraceSession
-// in registerExporterConfigIndexers — reverse lookup so the
-// reconciler can ask "which PT/PTS objects point at this EC name?"
-// without listing the entire namespace.
 const (
 	IndexFieldPodTraceExporterRef        = "spec.exporterRef.name"
 	IndexFieldPodTraceSessionExporterRef = "spec.exporterRef.name"
@@ -59,6 +56,13 @@ const (
 // +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+
+func (r *ExporterConfigReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
 
 func (r *ExporterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -134,7 +138,7 @@ func (r *ExporterConfigReconciler) evaluateReadiness(ctx context.Context, ec *po
 	for _, ref := range collectSecretRefs(ec.Spec) {
 		var sec corev1.Secret
 		key := types.NamespacedName{Namespace: ec.Namespace, Name: ref.Name}
-		if err := r.Get(ctx, key, &sec); err != nil {
+		if err := r.reader().Get(ctx, key, &sec); err != nil {
 			if apierrors.IsNotFound(err) {
 				logger.V(1).Info("secret missing", "secret", key.String())
 				return false, metav1.ConditionFalse, ecReasonSecretMissing,

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -32,6 +32,7 @@ import (
 //     that array is agent-owned and patched via merge.
 type PodTraceReconciler struct {
 	client.Client
+	APIReader       client.Reader
 	Scheme          *runtime.Scheme
 	SystemNamespace string
 }
@@ -40,8 +41,16 @@ type PodTraceReconciler struct {
 // +kubebuilder:rbac:groups=podtrace.io,resources=podtraces/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=podtrace.io,resources=podtraces/finalizers,verbs=update
 // +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=secrets;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+
+func (r *PodTraceReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
 
 func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var pt podtracev1alpha1.PodTrace
@@ -295,7 +304,7 @@ func (r *PodTraceReconciler) syncExporterBundle(ctx context.Context, pt *podtrac
 	}
 
 	if credSecretRef != nil || headersFrom != nil {
-		credData, err := buildBundleSecretData(ctx, r.Client, ec.Namespace, credSecretRef, headersFrom)
+		credData, err := buildBundleSecretData(ctx, r.reader(), ec.Namespace, credSecretRef, headersFrom)
 		if err != nil {
 			return fmt.Errorf("load credential Secret: %w", err)
 		}
@@ -344,7 +353,7 @@ func (r *PodTraceReconciler) effectiveSystemNamespace(ctx context.Context) strin
 // to re-parse the SecretKeySelector.
 func (r *PodTraceReconciler) loadCredentialSecret(ctx context.Context, namespace string, ref podtracev1alpha1.SecretKeySelector) (map[string][]byte, error) {
 	var src corev1.Secret
-	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref.Name}, &src); err != nil {
+	if err := r.reader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref.Name}, &src); err != nil {
 		return nil, fmt.Errorf("get Secret %s/%s: %w", namespace, ref.Name, err)
 	}
 	val, ok := src.Data[ref.Key]

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -28,6 +28,7 @@ import (
 // node hosting at least one matched pod.
 type PodTraceSessionReconciler struct {
 	client.Client
+	APIReader       client.Reader
 	Scheme          *runtime.Scheme
 	SystemNamespace string
 }
@@ -39,12 +40,20 @@ type PodTraceSessionReconciler struct {
 // +kubebuilder:rbac:groups=podtrace.io,resources=exporterconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile fans a PodTraceSession out into per-node Jobs, then rolls
 // Job status back into PodTraceSession.status.
+func (r *PodTraceSessionReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
 func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("podtracesession", req.String())
 
@@ -152,13 +161,13 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// assume a ServiceAccount, or exercise RBAC that lives somewhere else.
 	// Provision the full set in every namespace the resolution touches.
 	for _, ns := range resolved.namespaces {
-		if err := ensureSessionExporterBundle(ctx, r.Client, &session, &ec, ns); err != nil {
+		if err := ensureSessionExporterBundle(ctx, r.Client, r.reader(), &session, &ec, ns); err != nil {
 			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
 			_ = r.Status().Update(ctx, &session)
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 		}
 
-		if _, err := ensureSessionObjectStoreCredentials(ctx, r.Client, &session, ns); err != nil {
+		if _, err := ensureSessionObjectStoreCredentials(ctx, r.Client, r.reader(), &session, ns); err != nil {
 			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ObjectStoreCreds", err.Error())
 			_ = r.Status().Update(ctx, &session)
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil

--- a/internal/operator/reconcilers.go
+++ b/internal/operator/reconcilers.go
@@ -28,6 +28,7 @@ func registerReconcilers(mgr ctrl.Manager, opts Options) error {
 
 	ptsr := &PodTraceSessionReconciler{
 		Client:          mgr.GetClient(),
+		APIReader:       mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
 		SystemNamespace: opts.SystemNamespace,
 	}
@@ -37,6 +38,7 @@ func registerReconcilers(mgr ctrl.Manager, opts Options) error {
 
 	ptr := &PodTraceReconciler{
 		Client:          mgr.GetClient(),
+		APIReader:       mgr.GetAPIReader(),
 		Scheme:          mgr.GetScheme(),
 		SystemNamespace: opts.SystemNamespace,
 	}
@@ -45,8 +47,9 @@ func registerReconcilers(mgr ctrl.Manager, opts Options) error {
 	}
 
 	ecr := &ExporterConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
 	}
 	if err := ecr.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("ExporterConfigReconciler: %w", err)

--- a/internal/operator/reconcilers_deep_unit_test.go
+++ b/internal/operator/reconcilers_deep_unit_test.go
@@ -818,6 +818,7 @@ func TestDeepReconcile_SessionObjectStoreCreds(t *testing.T) {
 
 	if name, err := ensureSessionObjectStoreCredentials(context.Background(),
 		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
 		&podtracev1alpha1.PodTraceSession{}, sysNS); err != nil || name != "" {
 		t.Errorf("nil ReportRef: name=%q err=%v, want empty/nil", name, err)
 	}
@@ -831,7 +832,7 @@ func TestDeepReconcile_SessionObjectStoreCreds(t *testing.T) {
 		},
 	}
 	if name, err := ensureSessionObjectStoreCredentials(context.Background(),
-		fake.NewClientBuilder().WithScheme(scheme).Build(), sNoCreds, sysNS); err != nil || name != "" {
+		fake.NewClientBuilder().WithScheme(scheme).Build(), fake.NewClientBuilder().WithScheme(scheme).Build(), sNoCreds, sysNS); err != nil || name != "" {
 		t.Errorf("no creds ref: name=%q err=%v, want empty/nil", name, err)
 	}
 
@@ -847,7 +848,7 @@ func TestDeepReconcile_SessionObjectStoreCreds(t *testing.T) {
 		},
 	}
 	if _, err := ensureSessionObjectStoreCredentials(context.Background(),
-		fake.NewClientBuilder().WithScheme(scheme).Build(), sMissing, sysNS); err == nil {
+		fake.NewClientBuilder().WithScheme(scheme).Build(), fake.NewClientBuilder().WithScheme(scheme).Build(), sMissing, sysNS); err == nil {
 		t.Error("expected error when source Secret is missing")
 	}
 
@@ -867,7 +868,7 @@ func TestDeepReconcile_SessionObjectStoreCreds(t *testing.T) {
 		},
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(src).Build()
-	dstName, err := ensureSessionObjectStoreCredentials(context.Background(), c, sOK, sysNS)
+	dstName, err := ensureSessionObjectStoreCredentials(context.Background(), c, c, sOK, sysNS)
 	if err != nil {
 		t.Fatalf("happy path: %v", err)
 	}

--- a/internal/operator/runtime.go
+++ b/internal/operator/runtime.go
@@ -102,7 +102,8 @@ func Run(ctx context.Context, opts Options) error {
 		})
 	}
 	managerOpts.Cache.ByObject = map[client.Object]cache.ByObject{
-		&corev1.Node{}: {Transform: stripNodeStatus},
+		&corev1.Node{}:   {Transform: stripNodeStatus},
+		&corev1.Secret{}: {Transform: stripSecretData},
 	}
 	if opts.SyncPeriod > 0 {
 		managerOpts.Cache.SyncPeriod = &opts.SyncPeriod
@@ -144,6 +145,17 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	return mgr.Start(ctx)
+}
+
+func stripSecretData(obj any) (any, error) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return obj, nil
+	}
+	secret.Data = nil
+	secret.StringData = nil
+	secret.ManagedFields = nil
+	return secret, nil
 }
 
 // stripNodeStatus drops the bulk of a cached Node.

--- a/internal/operator/secret_cache_transform_test.go
+++ b/internal/operator/secret_cache_transform_test.go
@@ -1,0 +1,57 @@
+package operator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStripSecretData_RemovesPlaintextKeepsMetadata(t *testing.T) {
+	in := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "creds",
+			Namespace:     "team-a",
+			Labels:        map[string]string{"app": "billing"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+		},
+		Data:       map[string][]byte{"token": []byte("s3cr3t")},
+		StringData: map[string]string{"token": "s3cr3t"},
+		Type:       corev1.SecretTypeOpaque,
+	}
+
+	out, err := stripSecretData(in)
+	if err != nil {
+		t.Fatalf("stripSecretData error: %v", err)
+	}
+	s, ok := out.(*corev1.Secret)
+	if !ok {
+		t.Fatalf("stripSecretData returned %T, want *corev1.Secret", out)
+	}
+	if s.Data != nil {
+		t.Errorf("Data must be cleared, got %v", s.Data)
+	}
+	if s.StringData != nil {
+		t.Errorf("StringData must be cleared, got %v", s.StringData)
+	}
+	if s.ManagedFields != nil {
+		t.Error("ManagedFields must be cleared")
+	}
+	if s.Name != "creds" || s.Namespace != "team-a" || s.Labels["app"] != "billing" {
+		t.Error("metadata (name/namespace/labels) must be preserved for watches and label-scoped lists")
+	}
+	if s.Type != corev1.SecretTypeOpaque {
+		t.Error("Type must be preserved")
+	}
+}
+
+func TestStripSecretData_PassesThroughNonSecret(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}}
+	out, err := stripSecretData(cm)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if out != any(cm) {
+		t.Error("non-Secret object must pass through unchanged")
+	}
+}

--- a/internal/operator/secret_reader_test.go
+++ b/internal/operator/secret_reader_test.go
@@ -1,0 +1,97 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestReaderAccessors_OverrideAndFallback(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	cached := fake.NewClientBuilder().WithScheme(scheme).Build()
+	direct := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	checks := []struct {
+		name       string
+		withReader func(apiReader client.Reader) client.Reader
+	}{
+		{"podtrace", func(a client.Reader) client.Reader {
+			return (&PodTraceReconciler{Client: cached, APIReader: a}).reader()
+		}},
+		{"session", func(a client.Reader) client.Reader {
+			return (&PodTraceSessionReconciler{Client: cached, APIReader: a}).reader()
+		}},
+		{"exporterconfig", func(a client.Reader) client.Reader {
+			return (&ExporterConfigReconciler{Client: cached, APIReader: a}).reader()
+		}},
+	}
+	for _, c := range checks {
+		if got := c.withReader(direct); got != client.Reader(direct) {
+			t.Errorf("%s: reader() must return APIReader when set", c.name)
+		}
+		if got := c.withReader(nil); got != client.Reader(cached) {
+			t.Errorf("%s: reader() must fall back to the cached Client when APIReader is nil", c.name)
+		}
+	}
+}
+
+func TestEvaluateReadiness_ReadsCredentialViaAPIReaderNotStrippedCache(t *testing.T) {
+	scheme := newOperatorScheme(t)
+
+	strippedCache := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns"}},
+	).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "ns"},
+			Data:       map[string][]byte{"token": []byte("s3cr3t")},
+		},
+	).Build()
+
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "otlp", Namespace: "ns"},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{
+				Endpoint: "o:4317",
+				Headers: []podtracev1alpha1.OTLPHeader{
+					{Name: "X-Auth", ValueFrom: &podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"}},
+				},
+			},
+		},
+	}
+
+	r := &ExporterConfigReconciler{Client: strippedCache, APIReader: apiReader, Scheme: scheme}
+	ready, _, reason, msg := r.evaluateReadiness(context.Background(), ec)
+	if !ready {
+		t.Fatalf("readiness must resolve the key via the APIReader, got not-ready reason=%s msg=%q", reason, msg)
+	}
+	if reason != ecReasonSecretsResolved {
+		t.Errorf("reason = %q, want %q (reading the stripped cache would report SecretKeyMissing)", reason, ecReasonSecretsResolved)
+	}
+}
+
+func TestBuildBundleSecretData_ResolvesFromReader(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "team-a"},
+			Data:       map[string][]byte{"token": []byte("s3cr3t")},
+		},
+	).Build()
+
+	data, err := buildBundleSecretData(context.Background(), reader, "team-a",
+		&podtracev1alpha1.SecretKeySelector{Name: "auth", Key: "token"}, nil)
+	if err != nil {
+		t.Fatalf("buildBundleSecretData: %v", err)
+	}
+	if string(data["credential"]) != "s3cr3t" {
+		t.Errorf("credential = %q, want the plaintext read from the reader", data["credential"])
+	}
+}

--- a/internal/operator/session_bundle.go
+++ b/internal/operator/session_bundle.go
@@ -38,7 +38,7 @@ func SessionBundleName(sessionUID types.UID) string {
 
 // ensureSessionExporterBundle creates-or-updates the ConfigMap + optional
 // companion Secret the session Job mounts at /etc/podtrace/exporter/.
-func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string) error {
+func ensureSessionExporterBundle(ctx context.Context, c client.Client, reader client.Reader, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string) error {
 	name := SessionBundleName(s.UID)
 
 	payload, credSecretRef, headersFrom, err := renderBundlePayload(policyFromSession(s), ec, nil)
@@ -76,7 +76,7 @@ func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtra
 	}
 
 	if credSecretRef != nil || headersFrom != nil {
-		credData, err := buildBundleSecretData(ctx, c, ec.Namespace, credSecretRef, headersFrom)
+		credData, err := buildBundleSecretData(ctx, reader, ec.Namespace, credSecretRef, headersFrom)
 		if err != nil {
 			return fmt.Errorf("load session credential Secret: %w", err)
 		}
@@ -112,9 +112,9 @@ func ensureSessionExporterBundle(ctx context.Context, c client.Client, s *podtra
 // loadCredentialSecret fetches exactly the one SecretKeySelector an
 // ExporterConfig references and returns the value under the fixed
 // "credential" key.
-func loadCredentialSecret(ctx context.Context, c client.Client, namespace string, ref podtracev1alpha1.SecretKeySelector) (map[string][]byte, error) {
+func loadCredentialSecret(ctx context.Context, reader client.Reader, namespace string, ref podtracev1alpha1.SecretKeySelector) (map[string][]byte, error) {
 	var src corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref.Name}, &src); err != nil {
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ref.Name}, &src); err != nil {
 		return nil, fmt.Errorf("get Secret %s/%s: %w", namespace, ref.Name, err)
 	}
 	val, ok := src.Data[ref.Key]

--- a/internal/operator/session_bundle_errorpath_test.go
+++ b/internal/operator/session_bundle_errorpath_test.go
@@ -32,7 +32,7 @@ func TestEnsureSessionExporterBundle_ConfigMapCreateError(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-cm-err"},
 	}
-	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system")
 	if err == nil {
 		t.Fatal("expected error when ConfigMap reconcile fails")
 		return
@@ -71,7 +71,7 @@ func TestEnsureSessionExporterBundle_SecretCreateError(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-secret-err"},
 	}
-	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system")
 	if err == nil {
 		t.Fatal("expected error when companion Secret reconcile fails")
 		return
@@ -97,7 +97,7 @@ func TestEnsureSessionExporterBundle_MissingCredentialSecretErrors(t *testing.T)
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-missing-cred"},
 	}
-	err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system")
+	err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system")
 	if err == nil {
 		t.Fatal("expected error when credential Secret is absent")
 		return

--- a/internal/operator/session_bundle_test.go
+++ b/internal/operator/session_bundle_test.go
@@ -52,7 +52,7 @@ func TestEnsureSessionExporterBundle_CreatesConfigMap(t *testing.T) {
 		},
 	}
 
-	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err != nil {
+	if err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system"); err != nil {
 		t.Fatalf("ensureSessionExporterBundle: %v", err)
 	}
 
@@ -87,7 +87,7 @@ func TestEnsureSessionExporterBundle_UpdatesExisting(t *testing.T) {
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, existing).Build()
 
-	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err != nil {
+	if err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system"); err != nil {
 		t.Fatalf("ensureSessionExporterBundle: %v", err)
 	}
 
@@ -125,7 +125,7 @@ func TestEnsureSessionExporterBundle_WithCredentialCreatesSecret(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-xyz"},
 	}
-	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err != nil {
+	if err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system"); err != nil {
 		t.Fatalf("ensureSessionExporterBundle: %v", err)
 	}
 

--- a/internal/operator/session_helpers_branches_test.go
+++ b/internal/operator/session_helpers_branches_test.go
@@ -32,7 +32,7 @@ func TestEnsureSessionExporterBundle_RenderError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "team-a"},
 		Spec:       podtracev1alpha1.ExporterConfigSpec{Type: podtracev1alpha1.ExporterTypeOTLP},
 	}
-	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err == nil {
+	if err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system"); err == nil {
 		t.Fatal("an OTLP ExporterConfig with a nil OTLP block must fail bundle rendering")
 	}
 }
@@ -56,7 +56,7 @@ func TestEnsureSessionExporterBundle_PruneStaleSecretDeleteError(t *testing.T) {
 			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
 		},
 	}
-	if err := ensureSessionExporterBundle(context.Background(), c, s, ec, "podtrace-system"); err == nil {
+	if err := ensureSessionExporterBundle(context.Background(), c, c, s, ec, "podtrace-system"); err == nil {
 		t.Fatal("a failing prune of the credential-less bundle Secret must be surfaced")
 	}
 }
@@ -79,7 +79,7 @@ func TestEnsureSessionObjectStoreCredentials_GetError(t *testing.T) {
 			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "creds"},
 		},
 	}
-	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, s, "podtrace-system"); err == nil {
+	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, c, s, "podtrace-system"); err == nil {
 		t.Fatal("a non-NotFound Get of the credentials Secret must be surfaced")
 	}
 }
@@ -106,7 +106,7 @@ func TestEnsureSessionObjectStoreCredentials_CreateError(t *testing.T) {
 			CredentialsSecretRef: &corev1.LocalObjectReference{Name: "creds"},
 		},
 	}
-	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, s, "podtrace-system"); err == nil {
+	if _, err := ensureSessionObjectStoreCredentials(context.Background(), c, c, s, "podtrace-system"); err == nil {
 		t.Fatal("a failing upsert of the copied credentials Secret must be surfaced")
 	}
 }

--- a/internal/operator/session_objectstore_creds.go
+++ b/internal/operator/session_objectstore_creds.go
@@ -24,7 +24,7 @@ func SessionObjectStoreCredsName(sessionUID types.UID) string {
 // ensureSessionObjectStoreCredentials copies the user's
 // CredentialsSecretRef Secret from the session's namespace into
 // systemNS.
-func ensureSessionObjectStoreCredentials(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, systemNS string) (string, error) {
+func ensureSessionObjectStoreCredentials(ctx context.Context, c client.Client, reader client.Reader, s *podtracev1alpha1.PodTraceSession, systemNS string) (string, error) {
 	if s == nil || s.Spec.ReportRef == nil || s.Spec.ReportRef.ObjectStore == nil {
 		return "", nil
 	}
@@ -34,7 +34,7 @@ func ensureSessionObjectStoreCredentials(ctx context.Context, c client.Client, s
 	}
 
 	var src corev1.Secret
-	if err := c.Get(ctx, types.NamespacedName{Namespace: s.Namespace, Name: ref.Name}, &src); err != nil {
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: s.Namespace, Name: ref.Name}, &src); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", fmt.Errorf("objectstore credentials Secret %s/%s not found", s.Namespace, ref.Name)
 		}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -548,3 +548,70 @@ func TestChart_OperatorImageAllowlistEnv(t *testing.T) {
 		t.Error("allowlist must combine the chart's image.repository with agent.allowedImageRepos")
 	}
 }
+
+func TestChart_OperatorSecretRBACNarrowed(t *testing.T) {
+	out := renderChart(t, "operator.enabled=true")
+
+	type rbacRule struct {
+		APIGroups []string `json:"apiGroups"`
+		Resources []string `json:"resources"`
+		Verbs     []string `json:"verbs"`
+	}
+	type rbacDoc struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Rules []rbacRule `json:"rules"`
+	}
+
+	secretVerbs := func(kind, nameSuffix string) []string {
+		for _, doc := range bytes.Split(out, []byte("\n---\n")) {
+			var d rbacDoc
+			if err := yaml.Unmarshal(doc, &d); err != nil || d.Kind != kind {
+				continue
+			}
+			if !strings.HasSuffix(d.Metadata.Name, nameSuffix) {
+				continue
+			}
+			for _, r := range d.Rules {
+				for _, res := range r.Resources {
+					if res == "secrets" {
+						return r.Verbs
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	has := func(verbs []string, v string) bool {
+		for _, x := range verbs {
+			if x == v {
+				return true
+			}
+		}
+		return false
+	}
+
+	cw := secretVerbs("ClusterRole", "-operator")
+	if cw == nil {
+		t.Fatal("operator ClusterRole must have a secrets rule")
+	}
+	if has(cw, "update") || has(cw, "patch") {
+		t.Errorf("cluster-wide secrets rule must not grant update/patch, got %v", cw)
+	}
+	for _, v := range []string{"get", "list", "watch", "create", "delete"} {
+		if !has(cw, v) {
+			t.Errorf("cluster-wide secrets rule missing required verb %q, got %v", v, cw)
+		}
+	}
+
+	role := secretVerbs("Role", "-operator-secrets")
+	if role == nil {
+		t.Fatal("a system-namespace Role must grant in-place secret writes")
+	}
+	if !has(role, "update") || !has(role, "patch") {
+		t.Errorf("system-namespace Role must grant update+patch on secrets, got %v", role)
+	}
+}


### PR DESCRIPTION
## Summary

The operator held cluster-wide read/write on every Secret and cached all of them in plaintext. Its ClusterRole granted secrets at get/list/watch/create/update/patch/delete cluster-wide, annotated "System-namespace infrastructure" but applied everywhere, and three controllers installed unrestricted cluster-wide Secret informers, so the manager cache held the full plaintext of every Secret in the cluster; the same rule shipped to OperatorHub and OpenShift via the CSV. An RCE in the operator pod, or anyone able to bind a pod to its ServiceAccount, could read every Secret. This strips Secret plaintext out of the cache, moves in-place Secret writes to the operator's own namespace, and keeps only the cluster-wide read the design genuinely needs.

## Changes

- Add a cache `Transform` (`stripSecretData`) that clears `Data`, `StringData`, and `ManagedFields` from every Secret before it enters the informer cache, mirroring the existing `stripNodeStatus`. Object metadata (name, namespace, labels, resourceVersion) is preserved so the Secret watches still fire and label-scoped lists still work; only the plaintext is gone.
- Plumb the manager's uncached `APIReader` into the PodTrace, PodTraceSession, and ExporterConfig reconcilers (via a `reader()` accessor that falls back to the cached client when unset) and route every credential and objectstore-credential read through it, since those bytes are no longer cached.
- Split the Secret RBAC: the ClusterRole now grants secrets get/list/watch/create/delete (cluster-wide read for credentials in any namespace, plus create/delete of per-session and bundle Secrets), and a new system-namespace Role grants update/patch for the operator's own bundle Secrets, so a compromise can no longer rewrite Secrets in every namespace. Applied to the Helm chart, the OLM CSV (clusterPermissions narrowed, namespaced permissions added), and the kubebuilder RBAC markers.

## Risk notes

- Cluster-wide Secret read is intentionally retained: the operator resolves exporter credential Secrets that live in any namespace and must react to their rotation. What is removed is the passive plaintext cache and the cluster-wide in-place write.
- With the cache stripped, a Secret read now costs a direct API call rather than an in-memory hit; this is confined to the credential/objectstore read paths, which run per reconcile, not per event.
- The system-namespace Role assumes the operator's bundle Secrets live in its own namespace; an install that relocates them would need the Role's namespace adjusted, which the chart derives from the same systemNamespace value.