### PR TITLE
fix: guard tracer map writers against a concurrent Stop

### DIFF
--- a/internal/ebpf/tracer/stop_probe_race_test.go
+++ b/internal/ebpf/tracer/stop_probe_race_test.go
@@ -1,0 +1,162 @@
+package tracer
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/gma1k/podtrace/internal/ebpf/probes"
+)
+
+func TestSetContainerTargets_StopDuringAttach_NoPanicNoLeak(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	var attached []*fakeLink
+
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
+		once.Do(func() { close(started) })
+		<-release
+		l := &fakeLink{}
+		attached = append(attached, l)
+		return []link.Link{l}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1}}})
+	}()
+
+	<-started
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("SetContainerTargets: %v", err)
+	}
+
+	tr.probeGroupsMu.Lock()
+	cu := tr.containerUprobes
+	tr.probeGroupsMu.Unlock()
+	if cu != nil {
+		t.Errorf("containerUprobes must stay nil after Stop raced the attach, got %v", cu)
+	}
+
+	if len(attached) == 0 {
+		t.Fatal("expected the raced attach to have produced links")
+	}
+	for i, l := range attached {
+		if got := l.closes.Load(); got != 1 {
+			t.Errorf("attached link %d closes = %d, want 1 (links attached after Stop must be closed, not leaked)", i, got)
+		}
+	}
+}
+
+func TestSetContainerTargets_AfterStop_NoResurrection(t *testing.T) {
+	var attachCalls atomic.Int32
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+	tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
+		attachCalls.Add(1)
+		return []link.Link{&fakeLink{}}
+	}
+
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := tr.SetContainerTargets([]ContainerProbeTarget{{ID: "containeraaaa", PIDs: []uint32{1}}}); err != nil {
+		t.Fatalf("SetContainerTargets: %v", err)
+	}
+
+	tr.probeGroupsMu.Lock()
+	cu := tr.containerUprobes
+	tr.probeGroupsMu.Unlock()
+	if cu != nil {
+		t.Errorf("containerUprobes must stay nil after Stop, got %v", cu)
+	}
+	if got := attachCalls.Load(); got != 0 {
+		t.Errorf("no probes should be attached after Stop, got %d attach calls", got)
+	}
+}
+
+func TestSyncDNSPacketProbes_AfterStop_NoResurrection(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}, collection: &ebpf.Collection{}}
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	tr.syncDNSPacketProbes([]string{"/sys/fs/cgroup/kubepods/podx/containery"})
+
+	tr.probeGroupsMu.Lock()
+	m := tr.dnsPacketLinks
+	tr.probeGroupsMu.Unlock()
+	if m != nil {
+		t.Errorf("dnsPacketLinks must stay nil after Stop, got %v", m)
+	}
+}
+
+func TestSyncHTTP3Probes_AfterStop_NoResurrection(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}, collection: &ebpf.Collection{}}
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	tr.syncHTTP3Probes([]string{"/sys/fs/cgroup/kubepods/podx/containery"})
+
+	tr.probeGroupsMu.Lock()
+	m := tr.http3Links
+	tr.probeGroupsMu.Unlock()
+	if m != nil {
+		t.Errorf("http3Links must stay nil after Stop, got %v", m)
+	}
+}
+
+func TestRegisterGroupLinks_AfterStop_ClosesInsteadOfRegistering(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	l := &fakeLink{}
+	tr.registerGroupLinks(probes.GroupTLS, []link.Link{l})
+
+	if got := l.closes.Load(); got != 1 {
+		t.Errorf("link closes = %d, want 1 (registerGroupLinks must close, not register, after Stop)", got)
+	}
+	tr.probeGroupsMu.Lock()
+	groupLen := len(tr.probeGroups[probes.GroupTLS])
+	flatLen := len(tr.links)
+	tr.probeGroupsMu.Unlock()
+	if groupLen != 0 {
+		t.Errorf("probeGroups[TLS] gained %d links after Stop, want 0", groupLen)
+	}
+	if flatLen != 0 {
+		t.Errorf("links registry gained %d handles after Stop, want 0", flatLen)
+	}
+}
+
+func TestProbe_RealStopVsSetContainerTargets(t *testing.T) {
+	for i := 0; i < 300; i++ {
+		tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+		tr.attachContainerGroupFn = func(g probes.ProbeGroup, id string, pids []uint32) []link.Link {
+			runtime.Gosched()
+			return []link.Link{&fakeLink{}}
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = tr.Stop()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = tr.SetContainerIDs([]string{"containeraaaa"})
+		}()
+		wg.Wait()
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -84,6 +84,8 @@ type Tracer struct {
 	dnsPacketLinks map[string][]link.Link
 	http3Links     map[string][]link.Link
 
+	probesClosed bool
+
 	intentionallyDisabled map[probes.ProbeGroup]struct{}
 	detachWarned          map[probes.ProbeGroup]struct{}
 
@@ -133,6 +135,11 @@ func (t *Tracer) registerGroupLinks(g probes.ProbeGroup, ls []link.Link) {
 		return
 	}
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		closeLinks(ls)
+		return
+	}
 	defer t.probeGroupsMu.Unlock()
 	t.probeGroups[g] = append(t.probeGroups[g], ls...)
 	t.links = append(t.links, ls...)
@@ -187,6 +194,12 @@ func (s *containerUprobeSet) allLinks() []link.Link {
 	return out
 }
 
+func closeLinks(ls []link.Link) {
+	for _, l := range ls {
+		_ = l.Close()
+	}
+}
+
 // containerUprobeGroups lists the probe groups that carry container-scoped
 // uprobes, in attach order.
 var containerUprobeGroups = []probes.ProbeGroup{
@@ -203,6 +216,10 @@ var containerUprobeGroups = []probes.ProbeGroup{
 // exactly once.
 func (t *Tracer) attachGlobalProtocolProbesOnce() {
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		return
+	}
 	already := t.globalProtocolAttached
 	t.globalProtocolAttached = true
 	t.probeGroupsMu.Unlock()
@@ -299,6 +316,10 @@ func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	}
 
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		return nil
+	}
 	if t.containerUprobes == nil {
 		t.containerUprobes = map[string]*containerUprobeSet{}
 	}
@@ -325,6 +346,11 @@ func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	for _, ct := range toAttach {
 		links := t.attachContainerUprobes(ct.ID, ct.PIDs)
 		t.probeGroupsMu.Lock()
+		if t.probesClosed {
+			t.probeGroupsMu.Unlock()
+			closeLinks((&containerUprobeSet{links: links}).allLinks())
+			continue
+		}
 		t.containerUprobes[ct.ID] = &containerUprobeSet{pids: ct.PIDs, links: links}
 		t.probeGroupsMu.Unlock()
 	}
@@ -406,6 +432,10 @@ func (t *Tracer) syncDNSPacketProbes(paths []string) {
 	}
 
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		return
+	}
 	if t.dnsPacketLinks == nil {
 		t.dnsPacketLinks = map[string][]link.Link{}
 	}
@@ -429,6 +459,11 @@ func (t *Tracer) syncDNSPacketProbes(paths []string) {
 	for _, p := range missing {
 		ls := probes.AttachDNSPacketProbes(t.collection, []string{p})
 		t.probeGroupsMu.Lock()
+		if t.probesClosed {
+			t.probeGroupsMu.Unlock()
+			closeLinks(ls)
+			continue
+		}
 		t.dnsPacketLinks[p] = ls
 		t.probeGroupsMu.Unlock()
 	}
@@ -448,6 +483,10 @@ func (t *Tracer) syncHTTP3Probes(paths []string) {
 	}
 
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		return
+	}
 	if t.http3Links == nil {
 		t.http3Links = map[string][]link.Link{}
 	}
@@ -471,6 +510,11 @@ func (t *Tracer) syncHTTP3Probes(paths []string) {
 	for _, p := range missing {
 		ls := probes.AttachHTTP3Probes(t.collection, []string{p})
 		t.probeGroupsMu.Lock()
+		if t.probesClosed {
+			t.probeGroupsMu.Unlock()
+			closeLinks(ls)
+			continue
+		}
 		t.http3Links[p] = ls
 		t.probeGroupsMu.Unlock()
 	}
@@ -2191,6 +2235,7 @@ func (t *Tracer) Stop() error {
 	}
 
 	t.probeGroupsMu.Lock()
+	t.probesClosed = true
 	closing := t.links
 	t.links = nil
 	t.probeGroups = map[probes.ProbeGroup][]link.Link{}
@@ -2431,6 +2476,11 @@ func (t *Tracer) EnableProbeGroup(g probes.ProbeGroup) error {
 	newLinks = append(newLinks, t.attachGroupUprobes(g)...)
 
 	t.probeGroupsMu.Lock()
+	if t.probesClosed {
+		t.probeGroupsMu.Unlock()
+		closeLinks(newLinks)
+		return nil
+	}
 	t.probeGroups[g] = append(t.probeGroups[g], newLinks...)
 	t.links = append(t.links, newLinks...)
 	delete(t.intentionallyDisabled, g)


### PR DESCRIPTION
## Summary

The tracer attaches container/DNS/HTTP3 probes with `probeGroupsMu` released (ELF parsing and `/proc` scans take seconds), then re-acquires the lock to register the freshly-attached links into `containerUprobes`, `dnsPacketLinks`, and `http3Links`. `Stop()` nils those same maps under the same mutex. The map nil-check only ran in the first critical section, so a `Stop()` landing during the attach window makes the second critical section write to a nil map and panic (`assignment to entry in nil map`), and the same window leaks links Stop already drained.

## Changes

- Add a `probesClosed` flag set once by `Stop()` under `probeGroupsMu`, establishing the invariant that once the tracer has stopped no site registers freshly-attached links, it closes them instead.
- Re-check the flag after re-acquiring the lock in every attach-then-register site: `SetContainerTargets`, `syncDNSPacketProbes`, `syncHTTP3Probes` (both critical sections), plus `registerGroupLinks` and `EnableProbeGroup`. When stopped, these now close the just-attached links via a new `closeLinks` helper instead of writing to a nil-ed map (panic) or a drained slice (leak). `reattachContainerGroupUprobes` was already safe and is unchanged.