### PR TITLE
fix: publish tracer cgroup paths atomically to end read race

### DIFF
--- a/internal/ebpf/tracer/cgroup_paths_test.go
+++ b/internal/ebpf/tracer/cgroup_paths_test.go
@@ -1,0 +1,76 @@
+package tracer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/ebpf/filter"
+)
+
+func TestCgroupPathAccessors_RoundTripAndEdges(t *testing.T) {
+	tr := &Tracer{}
+
+	if got := tr.primaryCgroupPath(); got != "" {
+		t.Errorf("primaryCgroupPath on fresh tracer = %q, want empty", got)
+	}
+	if got := tr.currentCgroupPaths(); got != nil {
+		t.Errorf("currentCgroupPaths on fresh tracer = %v, want nil", got)
+	}
+
+	tr.setCgroupPaths([]string{"/sys/fs/cgroup/a", "/sys/fs/cgroup/b"})
+	if got := tr.primaryCgroupPath(); got != "/sys/fs/cgroup/a" {
+		t.Errorf("primaryCgroupPath = %q, want /sys/fs/cgroup/a", got)
+	}
+	if got := tr.currentCgroupPaths(); len(got) != 2 || got[1] != "/sys/fs/cgroup/b" {
+		t.Errorf("currentCgroupPaths = %v, want [/sys/fs/cgroup/a /sys/fs/cgroup/b]", got)
+	}
+
+	tr.setCgroupPaths(nil)
+	if got := tr.primaryCgroupPath(); got != "" {
+		t.Errorf("primaryCgroupPath after clear = %q, want empty", got)
+	}
+	if got := tr.currentCgroupPaths(); got != nil {
+		t.Errorf("currentCgroupPaths after clear = %v, want nil", got)
+	}
+
+	tr.setCgroupPaths([]string{})
+	if got := tr.primaryCgroupPath(); got != "" {
+		t.Errorf("primaryCgroupPath on empty slice = %q, want empty", got)
+	}
+}
+
+func TestCgroupPaths_ConcurrentWriteVsLockFreeRead(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	const iters = 3000
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%8 == 0 {
+				_ = tr.SetCgroups(nil)
+				continue
+			}
+			_ = tr.AttachToCgroups([]string{fmt.Sprintf("/sys/fs/cgroup/pod-%d", i)})
+		}
+	}()
+
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = tr.primaryCgroupPath()
+				for _, p := range tr.currentCgroupPaths() {
+					_ = p
+				}
+				_ = tr.pidsForContainer("deadbeefdeadbeef", nil)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/ebpf/tracer/multibinary_discovery_test.go
+++ b/internal/ebpf/tracer/multibinary_discovery_test.go
@@ -75,7 +75,8 @@ func TestPidsForContainer_DedupesByExecutableInode(t *testing.T) {
 			104: "",
 		})
 
-	tr := &Tracer{cgroupPaths: []string{cgroupDir}}
+	tr := &Tracer{}
+	tr.setCgroupPaths([]string{cgroupDir})
 	pids := tr.pidsForContainer(cid, nil)
 	if len(pids) != 2 || pids[0] != 101 || pids[1] != 103 {
 		t.Fatalf("pidsForContainer = %v, want [101 103] (one PID per distinct executable)", pids)
@@ -93,7 +94,8 @@ func TestPidsForContainer_CapsDistinctBinaries(t *testing.T) {
 	}
 	cgroupDir := fakeContainerProc(t, cid, pids, exeOf)
 
-	tr := &Tracer{cgroupPaths: []string{cgroupDir}}
+	tr := &Tracer{}
+	tr.setCgroupPaths([]string{cgroupDir})
 	got := tr.pidsForContainer(cid, nil)
 	if len(got) != maxDistinctBinariesPerContainer {
 		t.Fatalf("pidsForContainer returned %d PIDs, want cap %d", len(got), maxDistinctBinariesPerContainer)

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -114,9 +114,8 @@ type Tracer struct {
 	attributionCorrelatorDisabled bool
 	pathCache                     *cache.PathCache
 	resourceMgr                   *resourceMonitorManager
-	cgroupPath                    string
 	lastDNSDrops                  uint64
-	cgroupPaths                   []string
+	cgroupPaths                   atomic.Pointer[[]string]
 	useUserspaceCgroupFilter      atomic.Bool
 	denyWhenNoTargets             atomic.Bool
 	targetCgroupIDs               atomic.Pointer[map[uint64]struct{}]
@@ -165,15 +164,11 @@ type ContainerProbeTarget struct {
 	PIDs []uint32
 }
 
-// containerUprobeSet holds one container's uprobe links keyed by probe group
-// so DisableProbeGroup/EnableProbeGroup can detach and re-attach a group for
-// every targeted container.
 type containerUprobeSet struct {
 	pids  []uint32
 	links map[probes.ProbeGroup][]link.Link
 }
 
-// samePIDSet compares two sorted PID slices.
 func samePIDSet(a, b []uint32) bool {
 	if len(a) != len(b) {
 		return false
@@ -301,10 +296,7 @@ func (t *Tracer) attachContainerUprobes(id string, pids []uint32) map[probes.Pro
 }
 
 // SetContainerTargets reconciles container-scoped uprobes against the full set
-// of currently-targeted containers. Each target's PIDs are expanded to one
-// representative PID per distinct executable in the container (the caller's
-// PIDs act as seeds), so a container is re-attached whenever its binary set
-// changes, not just when a single PID changes.
+// of currently-targeted containers.
 func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 	t.attachGlobalProtocolProbesOnce()
 
@@ -358,8 +350,7 @@ func (t *Tracer) SetContainerTargets(targets []ContainerProbeTarget) error {
 }
 
 // attachGroupUprobes re-attaches the probes of a group that are NOT
-// container-scoped. Container-scoped uprobes are re-attached per container by
-// reattachContainerGroupUprobes.
+// container-scoped.
 func (t *Tracer) attachGroupUprobes(g probes.ProbeGroup) []link.Link {
 	coll := t.collection
 	if coll == nil {
@@ -843,11 +834,30 @@ func (t *Tracer) idleDeny() bool {
 
 // SetCgroups replaces the tracer's entire cgroup filter set with the
 // given paths.
+// setCgroupPaths atomically publishes the current cgroup target set. Callers
+// hold cgroupWriteMu to serialize writers.
+func (t *Tracer) setCgroupPaths(paths []string) {
+	t.cgroupPaths.Store(&paths)
+}
+
+func (t *Tracer) currentCgroupPaths() []string {
+	if p := t.cgroupPaths.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func (t *Tracer) primaryCgroupPath() string {
+	if p := t.cgroupPaths.Load(); p != nil && len(*p) > 0 {
+		return (*p)[0]
+	}
+	return ""
+}
+
 func (t *Tracer) SetCgroups(cgroupPaths []string) error {
 	if len(cgroupPaths) == 0 {
 		t.cgroupWriteMu.Lock()
-		t.cgroupPaths = nil
-		t.cgroupPath = ""
+		t.setCgroupPaths(nil)
 		t.storeCgroupIDs(map[uint64]struct{}{})
 		t.filter.SetCgroupPaths(nil)
 		if err := t.syncTargetCgroupMap(); err != nil {
@@ -907,8 +917,9 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		allPaths = normalized
 		newIDs = make(map[uint64]struct{}, len(normalized))
 	} else {
-		seen := make(map[string]struct{}, len(t.cgroupPaths)+len(normalized))
-		for _, p := range t.cgroupPaths {
+		existing := t.currentCgroupPaths()
+		seen := make(map[string]struct{}, len(existing)+len(normalized))
+		for _, p := range existing {
 			if _, dup := seen[p]; dup {
 				continue
 			}
@@ -928,10 +939,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		}
 	}
 
-	t.cgroupPaths = allPaths
-	if len(allPaths) > 0 {
-		t.cgroupPath = allPaths[0]
-	}
+	t.setCgroupPaths(allPaths)
 	t.filter.SetCgroupPaths(allPaths)
 
 	if !pidInCgroupPaths(t.containerPID, allPaths) {
@@ -977,7 +985,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 		t.storeCgroupIDs(newIDs)
 		logger.Debug("Cgroup v2 not detected, using userspace filtering only", zap.String("cgroup_base", config.CgroupBasePath))
 	}
-	currentPaths := append([]string(nil), t.cgroupPaths...)
+	currentPaths := allPaths
 	t.syncDNSPacketProbes(currentPaths)
 	t.syncHTTP3Probes(currentPaths)
 
@@ -986,7 +994,7 @@ func (t *Tracer) attachCgroups(cgroupPaths []string, replace bool) error {
 	}
 
 	logger.Debug("Attached to cgroups",
-		zap.Int("cgroup_count", len(t.cgroupPaths)),
+		zap.Int("cgroup_count", len(allPaths)),
 		zap.Uint32("container_pid", t.containerPID),
 		zap.Int("target_cgroup_id_count", len(newIDs)),
 		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()),
@@ -1007,7 +1015,7 @@ func (t *Tracer) syncTargetCgroupMap() error {
 	t.warnOnCgroupCapacity(len(ids), targetMap.MaxEntries())
 
 	if len(ids) == 0 {
-		deny := t.denyWhenNoTargets.Load() && len(t.cgroupPaths) == 0
+		deny := t.denyWhenNoTargets.Load() && len(t.currentCgroupPaths()) == 0
 		if err := t.setCgroupFilterEnabled(deny); err != nil {
 			return err
 		}
@@ -1225,7 +1233,7 @@ func (t *Tracer) pidsForContainer(id string, seeds []uint32) []uint32 {
 		short = short[:12]
 	}
 	var procs []uint32
-	for _, p := range t.cgroupPaths {
+	for _, p := range t.currentCgroupPaths() {
 		if strings.Contains(p, id) || (short != "" && strings.Contains(p, short)) {
 			if procs = readPIDsFromCgroupProcs(p); len(procs) > 0 {
 				break
@@ -1248,7 +1256,7 @@ func (t *Tracer) pidsForContainer(id string, seeds []uint32) []uint32 {
 		}
 		logger.Warn("No attached cgroup path matched container ID; uprobe attachment will fall back to scanning /proc for the container",
 			zap.String("container_id", id),
-			zap.Strings("cgroup_paths", t.cgroupPaths))
+			zap.Strings("cgroup_paths", t.currentCgroupPaths()))
 		return []uint32{0}
 	}
 
@@ -1299,7 +1307,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 	stackMap := t.collection.Maps["stack_traces"]
 
 	t.cgroupWriteMu.Lock()
-	dnsCgroups := append([]string(nil), t.cgroupPaths...)
+	dnsCgroups := t.currentCgroupPaths()
 	if err := t.syncTargetCgroupMap(); err != nil {
 		logger.Warn("Failed initial target cgroup map sync", zap.Error(err))
 	}
@@ -1350,7 +1358,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 	startTime := time.Now()
 
 	logger.Info("Starting event collection",
-		zap.String("cgroup_path", t.cgroupPath),
+		zap.String("cgroup_path", t.primaryCgroupPath()),
 		zap.Uint32("container_pid", t.containerPID),
 		zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
 		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
@@ -1375,7 +1383,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 							zap.Int64("events_filtered", eventsFiltered.Load()),
 							zap.Int64("events_collected", eventsCollected.Load()),
 							zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
-							zap.String("cgroup_path", t.cgroupPath),
+							zap.String("cgroup_path", t.primaryCgroupPath()),
 							zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
 						filteringDisabled.Store(true)
 						t.cgroupWriteMu.Lock()
@@ -1391,12 +1399,12 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 							zap.Int64("events_parsed", eventsParsed.Load()),
 							zap.Int64("events_filtered", eventsFiltered.Load()),
 							zap.Int64("events_collected", eventsCollected.Load()),
-							zap.String("cgroup_path", t.cgroupPath))
+							zap.String("cgroup_path", t.primaryCgroupPath()))
 					}
 				} else if eventsParsed.Load() == 0 && elapsed > 15*time.Second {
 					logger.Warn("No events parsed from ring buffer after 15 seconds - check eBPF program attachment",
 						zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
-						zap.String("cgroup_path", t.cgroupPath),
+						zap.String("cgroup_path", t.primaryCgroupPath()),
 						zap.Duration("elapsed", elapsed),
 						zap.Int("links_attached", t.linkCount()))
 					logger.Warn("If running in a container (e.g. DaemonSet), ensure host /sys/fs/cgroup and /proc are mounted and PODTRACE_CGROUP_BASE / PODTRACE_PROC_BASE point at them; see installation doc 'Running as a DaemonSet'")
@@ -1405,7 +1413,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 						zap.Int64("events_parsed", eventsParsed.Load()),
 						zap.Int64("events_filtered", eventsFiltered.Load()),
 						zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
-						zap.String("cgroup_path", t.cgroupPath),
+						zap.String("cgroup_path", t.primaryCgroupPath()),
 						zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()),
 						zap.Duration("elapsed", elapsed))
 					if t.useUserspaceCgroupFilter.Load() {
@@ -1611,7 +1619,7 @@ func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 				logger.Debug("Event filtered by userspace PID cgroup check",
 					zap.Uint32("pid", event.PID),
 					zap.String("process", event.ProcessName),
-					zap.String("cgroup_path", t.cgroupPath))
+					zap.String("cgroup_path", t.primaryCgroupPath()))
 			}
 		}
 	} else {

--- a/internal/ebpf/tracer/tracer_test.go
+++ b/internal/ebpf/tracer/tracer_test.go
@@ -60,11 +60,11 @@ func TestTracer_AttachToCgroup_IsAdditive(t *testing.T) {
 		}
 	}
 
-	if got := len(tr.cgroupPaths); got != 3 {
+	if got := len(tr.currentCgroupPaths()); got != 3 {
 		t.Errorf("cgroupPaths len = %d, want 3 (additive across calls)", got)
 	}
 	seen := map[string]struct{}{}
-	for _, p := range tr.cgroupPaths {
+	for _, p := range tr.currentCgroupPaths() {
 		seen[p] = struct{}{}
 	}
 	for _, want := range []string{"/sys/fs/cgroup/a", "/sys/fs/cgroup/b", "/sys/fs/cgroup/c"} {
@@ -82,7 +82,7 @@ func TestTracer_AttachToCgroup_IdempotentOnRepeat(t *testing.T) {
 			t.Fatalf("AttachToCgroup(%q) attempt %d: %v", p, i, err)
 		}
 	}
-	if got := len(tr.cgroupPaths); got != 1 {
+	if got := len(tr.currentCgroupPaths()); got != 1 {
 		t.Errorf("cgroupPaths len = %d, want 1 (idempotent on repeat)", got)
 	}
 }
@@ -95,10 +95,10 @@ func TestTracer_AttachToCgroups_Replaces(t *testing.T) {
 	if err := tr.AttachToCgroups([]string{"/sys/fs/cgroup/new1", "/sys/fs/cgroup/new2"}); err != nil {
 		t.Fatalf("AttachToCgroups: %v", err)
 	}
-	if got := len(tr.cgroupPaths); got != 2 {
+	if got := len(tr.currentCgroupPaths()); got != 2 {
 		t.Errorf("cgroupPaths len = %d, want 2 (bulk = replace)", got)
 	}
-	for _, p := range tr.cgroupPaths {
+	for _, p := range tr.currentCgroupPaths() {
 		if p == "/sys/fs/cgroup/old" {
 			t.Errorf("bulk AttachToCgroups should have dropped the earlier path, still see %q", p)
 		}
@@ -1338,10 +1338,10 @@ func TestTracer_GetProcessNameQuick_CmdlineRootPath(t *testing.T) {
 func TestTracer_Start_WithCgroupPath_NoMaps(t *testing.T) {
 	tracer := &Tracer{
 		filter:     filter.NewCgroupFilter(),
-		cgroupPath: "/sys/fs/cgroup/test",
 		collection: nil,
 		reader:     nil,
 	}
+	tracer.setCgroupPaths([]string{"/sys/fs/cgroup/test"})
 
 	eventChan := make(chan *events.Event, config.EventChannelBufferSize)
 	ctx := context.Background()
@@ -1361,10 +1361,10 @@ func TestTracer_Start_WithCgroupPath_NoMaps(t *testing.T) {
 func TestTracer_Start_WithCgroupPath_NoLimitsMap(t *testing.T) {
 	tracer := &Tracer{
 		filter:     filter.NewCgroupFilter(),
-		cgroupPath: "/sys/fs/cgroup/test",
 		collection: nil,
 		reader:     nil,
 	}
+	tracer.setCgroupPaths([]string{"/sys/fs/cgroup/test"})
 
 	eventChan := make(chan *events.Event, config.EventChannelBufferSize)
 	ctx := context.Background()
@@ -1414,10 +1414,10 @@ func TestTracer_Start_WithResourceMonitorError(t *testing.T) {
 
 	tracer := &Tracer{
 		filter:     filter.NewCgroupFilter(),
-		cgroupPath: cgroupPath,
 		collection: nil,
 		reader:     nil,
 	}
+	tracer.setCgroupPaths([]string{cgroupPath})
 
 	eventChan := make(chan *events.Event, config.EventChannelBufferSize)
 	ctx := context.Background()
@@ -1673,10 +1673,10 @@ func TestTracer_Start_WithCgroupPath_ResourceMonitorMapsMissing(t *testing.T) {
 
 	tracer := &Tracer{
 		filter:     filter.NewCgroupFilter(),
-		cgroupPath: cgroupPath,
 		collection: nil,
 		reader:     nil,
 	}
+	tracer.setCgroupPaths([]string{cgroupPath})
 
 	eventChan := make(chan *events.Event, config.EventChannelBufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1699,7 +1699,6 @@ func TestTracer_Start_WithCgroupPath_ResourceMonitorMapsMissing(t *testing.T) {
 func TestTracer_Start_WithoutCgroupPath(t *testing.T) {
 	tracer := &Tracer{
 		filter:     filter.NewCgroupFilter(),
-		cgroupPath: "",
 		collection: nil,
 		reader:     nil,
 	}
@@ -1941,8 +1940,8 @@ func TestAttachToCgroup_CRIOSubfolder(t *testing.T) {
 	if tr.containerPID != 777 {
 		t.Errorf("expected containerPID=777 (from CRI-O subfolder), got %d", tr.containerPID)
 	}
-	if !strings.HasSuffix(tr.cgroupPath, "container") {
-		t.Errorf("expected cgroupPath to end with 'container', got %q", tr.cgroupPath)
+	if !strings.HasSuffix(tr.primaryCgroupPath(), "container") {
+		t.Errorf("expected cgroupPath to end with 'container', got %q", tr.primaryCgroupPath())
 	}
 }
 

--- a/internal/ebpf/tracer/uprobe_target_hygiene_test.go
+++ b/internal/ebpf/tracer/uprobe_target_hygiene_test.go
@@ -12,8 +12,8 @@ import (
 func TestPidForContainer_NoCgroupMatchReturnsZero(t *testing.T) {
 	tr := &Tracer{
 		containerPID: 42,
-		cgroupPaths:  []string{"/sys/fs/cgroup/kubepods/poduid/othercontainerid"},
 	}
+	tr.setCgroupPaths([]string{"/sys/fs/cgroup/kubepods/poduid/othercontainerid"})
 	if pids := tr.pidsForContainer("deadbeefdeadbeef", nil); len(pids) != 1 || pids[0] != 0 {
 		t.Fatalf("pidsForContainer = %v, want [0] (must not borrow another container's PID)", pids)
 	}


### PR DESCRIPTION
## Summary

`cgroupPath`/`cgroupPaths` were written under `cgroupWriteMu` but read lock-free from `processAndDispatch`, the monitor goroutine, and `pidsForContainer`. `zap.String` reads eagerly regardless of log level, so a torn header races the writers on pod churn, a data race, with OOB-read risk. Now published atomically so readers are lock-free.

## Changes

- `cgroupPaths []string` `atomic.Pointer[[]string]`; remove the redundant `cgroupPath` field (derived from `cgroupPaths[0]`).
- Add `setCgroupPaths` (writers Store under `cgroupWriteMu`) and `currentCgroupPaths` / `primaryCgroupPath` (readers Load lock-free); route all sites through them.