### PR TITLE
fix: give each event-tee consumer its own copy to end a data race

### DIFF
--- a/cmd/podtrace/event_tee.go
+++ b/cmd/podtrace/event_tee.go
@@ -39,8 +39,9 @@ func teeEvents(ctx context.Context, source <-chan *events.Event, auxiliary int) 
 					return
 				}
 				for _, c := range aux {
+					evCopy := *ev
 					select {
-					case c <- ev:
+					case c <- &evCopy:
 					default:
 					}
 				}

--- a/cmd/podtrace/event_tee_test.go
+++ b/cmd/podtrace/event_tee_test.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gma1k/podtrace/internal/events"
 )
 
-// TestTeeEvents_EveryConsumerSeesEveryEvent is a regression test: the
-// report loop, metrics handler, and tracing handler all used to receive from
-// the SAME channel, so each saw only a random disjoint subset of events.
 func TestTeeEvents_EveryConsumerSeesEveryEvent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -52,9 +50,75 @@ func TestTeeEvents_EveryConsumerSeesEveryEvent(t *testing.T) {
 	count("aux[1]", aux[1])
 }
 
-// TestTeeEvents_SlowAuxiliaryDoesNotStallPrimary: auxiliary sends are
-// non-blocking, so a consumer that never drains its channel must not stop
-// the report pipeline.
+func TestTeeEvents_AuxiliaryConsumersGetIndependentCopies(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan *events.Event, 1)
+	primary, aux := teeEvents(ctx, source, 2)
+
+	source <- &events.Event{PID: 1, TraceID: "original"}
+	close(source)
+
+	ev0 := <-aux[0]
+	ev0.TraceID = "mutated"
+	ev0.PID = 999
+
+	ev1 := <-aux[1]
+	evP := <-primary
+
+	if ev1.TraceID != "original" || ev1.PID != 1 {
+		t.Errorf("aux[1] observed aux[0]'s mutation: TraceID=%q PID=%d", ev1.TraceID, ev1.PID)
+	}
+	if evP.TraceID != "original" || evP.PID != 1 {
+		t.Errorf("primary observed aux[0]'s mutation: TraceID=%q PID=%d", evP.TraceID, evP.PID)
+	}
+	if ev0 == ev1 {
+		t.Error("aux consumers received the same pointer; each must get an independent copy")
+	}
+}
+
+func TestTeeEvents_ConcurrentAuxMutationIsRaceFree(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan *events.Event, 64)
+	primary, aux := teeEvents(ctx, source, 2)
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			source <- &events.Event{PID: uint32(i + 1), TraceID: "seed"}
+		}
+		close(source)
+	}()
+
+	go func() {
+		defer wg.Done()
+		for ev := range aux[0] {
+			ev.TraceID = "mutated"
+			ev.SpanID = "span"
+			ev.TraceFlags = 1
+		}
+	}()
+
+	drain := func(ch <-chan *events.Event) {
+		defer wg.Done()
+		for ev := range ch {
+			_ = ev.TraceID
+			_ = ev.SpanID
+			_ = ev.PID
+		}
+	}
+	go drain(aux[1])
+	go drain(primary)
+
+	wg.Wait()
+}
+
 func TestTeeEvents_SlowAuxiliaryDoesNotStallPrimary(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -755,13 +755,6 @@ func runNormalModeWithSource(ctx context.Context, eventChan <-chan *events.Event
 			} else {
 				diagnostician.AddEvent(event)
 			}
-			if tracingManager != nil && enableTracing {
-				var k8sCtxInterface interface{}
-				if k8sCtx != nil {
-					k8sCtxInterface = k8sCtx
-				}
-				tracingManager.ProcessEvent(event, k8sCtxInterface)
-			}
 
 		case <-ticker.C:
 			diagnostician.Finish()
@@ -841,13 +834,6 @@ func runDiagnoseModeWithSource(ctx context.Context, eventChan <-chan *events.Eve
 				}
 			} else {
 				diagnostician.AddEvent(e)
-			}
-			if tracingManager != nil && enableTracing {
-				var k8sCtxInterface interface{}
-				if k8sCtx != nil {
-					k8sCtxInterface = k8sCtx
-				}
-				tracingManager.ProcessEvent(e, k8sCtxInterface)
 			}
 		}
 		eventBatch = eventBatch[:0]


### PR DESCRIPTION
## Summary

`teeEvents` handed the same `*events.Event` to every consumer, and the tracing handler mutated it (`TraceID`/`SpanID`/…) while the report and metrics loops read it, a data race, plus duplicate span emission from a second `ProcessEvent` call in the report loop.

## Changes

- `teeEvents`: send each auxiliary consumer its own copy of the event.
- Remove the report-loop `ProcessEvent` calls (normal + diagnose); the dedicated aux tracing handler is now the single tracing path.