### PR TITLE
fix: size QUIC CRYPTO reassembly from received data, not claimed offset

### DIFF
--- a/internal/ebpf/quicinitial/quicinitial.go
+++ b/internal/ebpf/quicinitial/quicinitial.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"sort"
 )
 
 // QUIC version numbers.
@@ -326,7 +327,6 @@ func reassembleCrypto(plains ...[]byte) []byte {
 		data []byte
 	}
 	var chunks []chunk
-	maxEnd := 0
 	for _, plain := range plains {
 		i := 0
 		for i < len(plain) {
@@ -358,31 +358,34 @@ func reassembleCrypto(plains ...[]byte) []byte {
 				break
 			}
 			chunks = append(chunks, chunk{off: off, data: plain[i : i+l]})
-			if off+l > maxEnd {
-				maxEnd = off + l
-			}
 			i += l
 		}
 	}
-	if maxEnd == 0 || maxEnd > 1<<20 {
+	if len(chunks) == 0 {
 		return nil
 	}
-	out := make([]byte, maxEnd)
-	covered := make([]bool, maxEnd)
+	sort.Slice(chunks, func(i, j int) bool { return chunks[i].off < chunks[j].off })
+
+	end := 0
 	for _, c := range chunks {
-		copy(out[c.off:], c.data)
-		for j := c.off; j < c.off+len(c.data) && j < maxEnd; j++ {
-			covered[j] = true
+		if c.off > end {
+			break
+		}
+		if e := c.off + len(c.data); e > end {
+			end = e
 		}
 	}
-	contiguous := 0
-	for contiguous < maxEnd && covered[contiguous] {
-		contiguous++
-	}
-	if contiguous == 0 {
+	if end == 0 || end > 1<<20 {
 		return nil
 	}
-	return out[:contiguous]
+	out := make([]byte, end)
+	for _, c := range chunks {
+		if c.off >= end {
+			break
+		}
+		copy(out[c.off:], c.data)
+	}
+	return out
 }
 
 // parseClientHelloSNI parses a TLS ClientHello handshake message and returns the

--- a/internal/ebpf/quicinitial/reassemble_crypto_offset_test.go
+++ b/internal/ebpf/quicinitial/reassemble_crypto_offset_test.go
@@ -1,0 +1,56 @@
+package quicinitial
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestReassembleCrypto_HugeOffsetDoesNotAmplify(t *testing.T) {
+	frame := []byte{0x06, 0x80, 0x0f, 0xff, 0xff, 0x01, 0xaa}
+
+	if got := reassembleCrypto(frame); got != nil {
+		t.Fatalf("huge-offset gap-only frame: got %x, want nil", got)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	const iters = 2000
+	for i := 0; i < iters; i++ {
+		_ = reassembleCrypto(frame)
+	}
+	runtime.ReadMemStats(&after)
+	if perCall := (after.TotalAlloc - before.TotalAlloc) / iters; perCall > 4096 {
+		t.Fatalf("reassembleCrypto allocated %d bytes/call for a %d-byte frame; offset amplification regressed (was ~2MB)", perCall, len(frame))
+	}
+}
+
+func TestReassembleCrypto_DropsChunkPastGap(t *testing.T) {
+	crypto := func(off int, data []byte) []byte {
+		return append([]byte{0x06, byte(off), byte(len(data))}, data...)
+	}
+	plain := append(crypto(0, []byte{0xaa}), crypto(10, []byte{0xbb})...)
+	if got := reassembleCrypto(plain); string(got) != string([]byte{0xaa}) {
+		t.Fatalf("chunk past a gap must be dropped: got %x, want aa", got)
+	}
+}
+
+func TestReassembleCrypto_ContiguousAcrossFrames(t *testing.T) {
+	crypto := func(off int, data []byte) []byte {
+		return append([]byte{0x06, byte(off), byte(len(data))}, data...)
+	}
+	plain := append(crypto(0, []byte{0xaa, 0xbb}), crypto(2, []byte{0xcc})...)
+	if got := reassembleCrypto(plain); string(got) != string([]byte{0xaa, 0xbb, 0xcc}) {
+		t.Fatalf("adjacent frames must join: got %x, want aabbcc", got)
+	}
+}
+
+func TestReassembleCrypto_OutOfOrderContiguous(t *testing.T) {
+	crypto := func(off int, data []byte) []byte {
+		return append([]byte{0x06, byte(off), byte(len(data))}, data...)
+	}
+	plain := append(crypto(2, []byte{0xcc}), crypto(0, []byte{0xaa, 0xbb})...)
+	if got := reassembleCrypto(plain); string(got) != string([]byte{0xaa, 0xbb, 0xcc}) {
+		t.Fatalf("frames given out of offset order must sort and join: got %x, want aabbcc", got)
+	}
+}


### PR DESCRIPTION
## Summary

`reassembleCrypto` sized its buffers from `off + l`, where `off` is the attacker-controlled CRYPTO-frame offset. A 42-byte packet declaring `off=0xFFFFF, len=1` allocated a `[]byte` plus a `[]bool` of ~1 MB each (~2 MB) before checking contiguity, a ~50,000x amplification. Initial keys derive from the attacker's DCID, so the parser is reachable, and it runs per packet; varying the destination port mints unlimited flows. Sustained load drives multi-GB/s allocation churn in a privileged DaemonSet.

## Changes

- Size the reassembly buffer from the CRYPTO run contiguous from offset 0 (bounded by bytes actually received): sort chunks by offset, walk to the first gap, allocate only that. Drop the `covered []bool` array. A tiny packet with a huge offset yields no data at offset 0 and returns `nil` with ~0 allocation.