### PR TITLE
fix: bound QPACK dynamic table and sweep idle HTTP/3 connections

### DIFF
--- a/internal/ebpf/h3stream/h3stream.go
+++ b/internal/ebpf/h3stream/h3stream.go
@@ -6,6 +6,7 @@ package h3stream
 import (
 	"encoding/binary"
 	"errors"
+	"time"
 
 	"github.com/gma1k/podtrace/internal/ebpf/qpackdecode"
 	"github.com/gma1k/podtrace/internal/safeconv"
@@ -71,6 +72,9 @@ const (
 	maxBlockedSections   = 16
 	maxHeadersPayload    = 8192
 	maxSettingsPayload   = 1024
+
+	connIdleTTL   = 2 * time.Minute
+	sweepInterval = 15 * time.Second
 )
 
 // HTTP/3 wire constants (RFC 9114).
@@ -115,7 +119,7 @@ type connState struct {
 	streams      map[uint64]*streamState
 	blocked      []blockedSection
 	settingsDone bool
-	lastSeen     uint64
+	lastSeen     time.Time
 }
 
 // Assembler turns chunks into decoded sections. It is not safe for
@@ -123,7 +127,8 @@ type connState struct {
 type Assembler struct {
 	onSection func(ConnKey, Section)
 	conns     map[ConnKey]*connState
-	seq       uint64
+	now       func() time.Time
+	lastSweep time.Time
 }
 
 // NewAssembler returns an assembler that calls onSection for every decoded
@@ -132,6 +137,7 @@ func NewAssembler(onSection func(ConnKey, Section)) *Assembler {
 	return &Assembler{
 		onSection: onSection,
 		conns:     make(map[ConnKey]*connState),
+		now:       time.Now,
 	}
 }
 
@@ -140,6 +146,8 @@ func (a *Assembler) Feed(c Chunk) {
 	if len(c.Data) == 0 {
 		return
 	}
+	now := a.now()
+	a.sweepIdle(now)
 	key := ConnKey{TGID: c.TGID, Conn: c.Conn}
 	cs := a.conns[key]
 	if cs == nil {
@@ -152,8 +160,7 @@ func (a *Assembler) Feed(c Chunk) {
 		}
 		a.conns[key] = cs
 	}
-	a.seq++
-	cs.lastSeen = a.seq
+	cs.lastSeen = now
 
 	st := cs.streams[c.StreamID]
 	if st == nil {
@@ -189,14 +196,29 @@ func (st *streamState) markBroken() {
 
 func (a *Assembler) evictOldest() {
 	var oldestKey ConnKey
-	oldest := uint64(1<<64 - 1)
+	var oldest time.Time
+	first := true
 	for k, cs := range a.conns {
-		if cs.lastSeen < oldest {
+		if first || cs.lastSeen.Before(oldest) {
 			oldest = cs.lastSeen
 			oldestKey = k
+			first = false
 		}
 	}
 	delete(a.conns, oldestKey)
+}
+
+// sweepIdle drops connections with no activity for connIdleTTL.
+func (a *Assembler) sweepIdle(now time.Time) {
+	if now.Sub(a.lastSweep) < sweepInterval {
+		return
+	}
+	a.lastSweep = now
+	for k, cs := range a.conns {
+		if now.Sub(cs.lastSeen) > connIdleTTL {
+			delete(a.conns, k)
+		}
+	}
 }
 
 func (a *Assembler) process(key ConnKey, cs *connState, streamID uint64, st *streamState) {

--- a/internal/ebpf/h3stream/sweep_idle_test.go
+++ b/internal/ebpf/h3stream/sweep_idle_test.go
@@ -1,0 +1,60 @@
+package h3stream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAssembler_SweepIdleEvictsStaleConnections(t *testing.T) {
+	a := NewAssembler(func(ConnKey, Section) {})
+	base := time.Unix(1000, 0)
+	a.conns[ConnKey{TGID: 1}] = &connState{lastSeen: base}
+	a.conns[ConnKey{TGID: 2}] = &connState{lastSeen: base.Add(90 * time.Second)}
+
+	a.sweepIdle(base.Add(3 * time.Minute))
+
+	if _, ok := a.conns[ConnKey{TGID: 1}]; ok {
+		t.Error("connection idle for 3m (> TTL) must be swept")
+	}
+	if _, ok := a.conns[ConnKey{TGID: 2}]; !ok {
+		t.Error("connection active 90s ago (< TTL) must be kept")
+	}
+}
+
+func TestAssembler_SweepIdleThrottledToInterval(t *testing.T) {
+	a := NewAssembler(func(ConnKey, Section) {})
+	base := time.Unix(1000, 0)
+	a.sweepIdle(base)
+	a.conns[ConnKey{TGID: 1}] = &connState{lastSeen: base.Add(-time.Hour)}
+
+	a.sweepIdle(base.Add(sweepInterval - time.Second))
+	if _, ok := a.conns[ConnKey{TGID: 1}]; !ok {
+		t.Error("a sweep within sweepInterval must be a no-op")
+	}
+
+	a.sweepIdle(base.Add(sweepInterval + time.Second))
+	if _, ok := a.conns[ConnKey{TGID: 1}]; ok {
+		t.Error("a sweep past sweepInterval must evict the idle connection")
+	}
+}
+
+func TestAssembler_FeedSweepsViaInjectedClock(t *testing.T) {
+	a := NewAssembler(func(ConnKey, Section) {})
+	clock := time.Unix(1000, 0)
+	a.now = func() time.Time { return clock }
+
+	a.conns[ConnKey{TGID: 9, Conn: 9}] = &connState{
+		lastSeen: clock,
+		streams:  map[uint64]*streamState{},
+	}
+
+	clock = clock.Add(5 * time.Minute)
+	a.Feed(Chunk{TGID: 1, Conn: 1, StreamID: 0, StreamLen: 1, CopiedLen: 1, Data: []byte{0x00}})
+
+	if _, ok := a.conns[ConnKey{TGID: 9, Conn: 9}]; ok {
+		t.Error("Feed must sweep the stale connection using the injected clock")
+	}
+	if _, ok := a.conns[ConnKey{TGID: 1, Conn: 1}]; !ok {
+		t.Error("Feed must retain the freshly-active connection")
+	}
+}

--- a/internal/ebpf/qpackdecode/capacity_guard_test.go
+++ b/internal/ebpf/qpackdecode/capacity_guard_test.go
@@ -1,0 +1,60 @@
+package qpackdecode
+
+import "testing"
+
+func TestSetCapacity_RejectedWithoutNegotiation(t *testing.T) {
+	d := NewDecoder(0)
+	if err := d.ParseEncoderStream(mustHex(t, "3fbd01")); err == nil {
+		t.Fatal("capacity 220 with an un-negotiated (0) SETTINGS max must be rejected (RFC 9204 3.2.3)")
+	}
+}
+
+func TestSetCapacity_ZeroAllowedWithoutNegotiation(t *testing.T) {
+	d := NewDecoder(0)
+	if err := d.ParseEncoderStream([]byte{0x20}); err != nil {
+		t.Fatalf("capacity 0 must be allowed with no SETTINGS: %v", err)
+	}
+}
+
+func TestSetCapacity_ExceedingNegotiatedRejected(t *testing.T) {
+	d := NewDecoder(100)
+	if err := d.ParseEncoderStream(mustHex(t, "3fbd01")); err == nil {
+		t.Fatal("capacity 220 exceeding negotiated SETTINGS max 100 must be rejected")
+	}
+}
+
+func TestSetMaxTableCapacity_RejectsAboveLimit(t *testing.T) {
+	d := NewDecoder(0)
+	d.SetMaxTableCapacity(1 << 30)
+	if d.settingsCapacity > maxTableCapacity {
+		t.Fatalf("settingsCapacity %d exceeds cap %d after an absurd SETTINGS value", d.settingsCapacity, maxTableCapacity)
+	}
+	d.SetMaxTableCapacity(maxTableCapacity)
+	if d.settingsCapacity != maxTableCapacity {
+		t.Fatalf("settingsCapacity = %d, want %d (a valid SETTINGS at the cap must raise it)", d.settingsCapacity, maxTableCapacity)
+	}
+}
+
+func TestSetCapacity_BoundedByMaxTableCapacity(t *testing.T) {
+	d := NewDecoder(1 << 30)
+	if err := d.setCapacity(maxTableCapacity + 1); err == nil {
+		t.Fatal("capacity above maxTableCapacity must be rejected")
+	}
+	if err := d.setCapacity(maxTableCapacity); err != nil {
+		t.Fatalf("capacity at maxTableCapacity must be allowed: %v", err)
+	}
+}
+
+func TestDuplicate_RejectsEntryExceedingCapacity(t *testing.T) {
+	d := NewDecoder(220)
+	if err := d.setCapacity(220); err != nil {
+		t.Fatalf("set capacity: %v", err)
+	}
+	if err := d.insert("aa", "bb"); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	d.capacity = 1
+	if err := d.ParseEncoderStream([]byte{0x00}); err == nil {
+		t.Fatal("duplicating an entry larger than the current capacity must be rejected")
+	}
+}

--- a/internal/ebpf/qpackdecode/qpackdecode.go
+++ b/internal/ebpf/qpackdecode/qpackdecode.go
@@ -20,12 +20,11 @@ type HeaderField struct {
 const (
 	entryOverhead          = 32
 	maxFieldLength         = 8192
-	maxTableCapacity       = 1 << 24
+	maxTableCapacity       = 1 << 18
 	maxEncoderRemainder    = 64 * 1024
 	maxPrefixedIntegerBits = 62
 )
 
-// errIncomplete signals that the buffer ends mid-instruction.
 var errIncomplete = errors.New("qpackdecode: truncated input")
 
 // BlockedError reports a field section that references dynamic table state
@@ -58,12 +57,10 @@ type Decoder struct {
 	remainder        []byte
 }
 
-// NewDecoder returns a decoder for one connection direction.
 func NewDecoder(maxTableCapacity uint64) *Decoder {
 	return &Decoder{settingsCapacity: maxTableCapacity}
 }
 
-// InsertCount returns the total number of dynamic table insertions observed.
 func (d *Decoder) InsertCount() uint64 {
 	return d.evicted + uint64(len(d.entries))
 }
@@ -199,7 +196,7 @@ func (d *Decoder) setCapacity(capacity uint64) error {
 	if capacity > maxTableCapacity {
 		return fmt.Errorf("qpackdecode: dynamic table capacity %d exceeds limit %d", capacity, maxTableCapacity)
 	}
-	if d.settingsCapacity > 0 && capacity > d.settingsCapacity {
+	if capacity > d.settingsCapacity {
 		return fmt.Errorf("qpackdecode: capacity %d exceeds SETTINGS maximum %d", capacity, d.settingsCapacity)
 	}
 	if capacity > d.largestCapacity {

--- a/internal/ebpf/qpackdecode/qpackdecode_test.go
+++ b/internal/ebpf/qpackdecode/qpackdecode_test.go
@@ -34,7 +34,7 @@ func expectFields(t *testing.T, got []HeaderField, want ...HeaderField) {
 // end to end: field sections B.1, B.2 and B.4 plus the encoder stream
 // instructions of B.2, B.3, B.4 and B.5.
 func TestRFC9204AppendixB(t *testing.T) {
-	d := NewDecoder(0)
+	d := NewDecoder(220)
 
 	fields, err := d.DecodeFieldSection(mustHex(t, "0000 510b 2f69 6e64 6578 2e68 746d 6c"))
 	if err != nil {
@@ -131,7 +131,7 @@ func TestBlockedSection(t *testing.T) {
 // TestEncoderStreamByteAtATime feeds the B.2+B.3 encoder stream one byte at
 // a time; instructions split across chunks must decode identically.
 func TestEncoderStreamByteAtATime(t *testing.T) {
-	d := NewDecoder(0)
+	d := NewDecoder(220)
 	stream := mustHex(t,
 		"3fbd01 c00f 7777 772e 6578 616d 706c 652e 636f 6d c10c 2f73 616d 706c 652f 7061 7468"+
 			"4a 6375 7374 6f6d 2d6b 6579 0c63 7573 746f 6d2d 7661 6c75 65")


### PR DESCRIPTION
## Summary

Three related bounds on QPACK/HTTP-3 state a hostile peer could grow without limit:

- The QPACK capacity guard read `settingsCapacity > 0 && capacity > settingsCapacity`, so before a SETTINGS frame (settingsCapacity 0) it was disabled, a peer could set a 16 MB dynamic table with no negotiation. RFC 9204 3.2.3: an un-negotiated max of 0 means no capacity may be set.
- `maxTableCapacity` was 16 MB, absurd for QPACK (real tables are 4-64 KB) and the true per-connection ceiling even with the guard fixed.
- Connection state was dropped only when a 513th connection arrived; there was no idle sweep, so up to 512 hostile connections stayed resident.

## Changes

- qpackdecode: drop the `> 0` short-circuit so capacity is rejected whenever it exceeds the negotiated max (0 by default).
- qpackdecode: lower `maxTableCapacity` from 1<<24 (16 MB) to 1<<18 (256 KB); this caps both the accepted SETTINGS max and the set capacity, and since entries are >=32 bytes it bounds entry count.
- h3stream: add a TTL sweep. Inject a clock (default time.Now), track per-connection lastSeen as a timestamp, and drop connections idle longer than 2 minutes, throttled to at most once per 15 seconds so the scan stays off the per-chunk path.
- Update two tests that modeled the old (un-negotiated) behavior to use a negotiated capacity.