### PR TITLE
fix: bound HPACK late-join window by bytes, cap field length

### DIFF
--- a/internal/ebpf/h2decode/hpack_bytes_bound_test.go
+++ b/internal/ebpf/h2decode/hpack_bytes_bound_test.go
@@ -1,0 +1,97 @@
+package h2decode
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+func appendHPACKInteger(dst []byte, i, prefixBits int) []byte {
+	max := (1 << uint(prefixBits)) - 1
+	if i < max {
+		return append(dst, byte(i))
+	}
+	dst = append(dst, byte(max))
+	i -= max
+	for i >= 128 {
+		dst = append(dst, byte(i%128+128))
+		i /= 128
+	}
+	return append(dst, byte(i))
+}
+
+func hpackStringLiteral(huffman bool, payload []byte) []byte {
+	buf := appendHPACKInteger(nil, len(payload), 7)
+	if huffman {
+		buf[0] |= 0x80
+	}
+	return append(buf, payload...)
+}
+
+func TestReadString_RawFieldExceedingLimitRejected(t *testing.T) {
+	buf := hpackStringLiteral(false, make([]byte, maxFieldLength+1))
+	if _, _, err := readString(buf); !errors.Is(err, errHPACKFieldTooLong) {
+		t.Fatalf("readString err = %v, want errHPACKFieldTooLong", err)
+	}
+}
+
+func TestReadString_HuffmanDecodedExceedingLimitRejected(t *testing.T) {
+	s := strings.Repeat("0", maxFieldLength+1)
+	huff := hpack.AppendHuffmanString(nil, s)
+	if len(huff) > maxFieldLength {
+		t.Fatalf("huffman payload %d bytes is itself over the raw cap; test premise broken", len(huff))
+	}
+	buf := hpackStringLiteral(true, huff)
+	if _, _, err := readString(buf); !errors.Is(err, errHPACKFieldTooLong) {
+		t.Fatalf("readString err = %v, want errHPACKFieldTooLong (decoded len %d)", err, len(s))
+	}
+}
+
+func TestReadString_AtLimitAccepted(t *testing.T) {
+	payload := []byte(strings.Repeat("a", maxFieldLength))
+	buf := hpackStringLiteral(false, payload)
+	s, _, err := readString(buf)
+	if err != nil {
+		t.Fatalf("field at the limit must decode: %v", err)
+	}
+	if len(s) != maxFieldLength {
+		t.Fatalf("decoded len = %d, want %d", len(s), maxFieldLength)
+	}
+}
+
+func TestInsert_WindowBoundedByBytes(t *testing.T) {
+	d := &lateJoinDecoder{}
+	big := strings.Repeat("x", maxFieldLength)
+	for i := 0; i < 200; i++ {
+		d.insert(tableEntry{field: hpack.HeaderField{Name: "n", Value: big}})
+	}
+
+	if d.trackedBytes > maxTrackedBytes {
+		t.Fatalf("trackedBytes = %d exceeds cap %d", d.trackedBytes, maxTrackedBytes)
+	}
+	if len(d.inserts) >= 200 {
+		t.Fatalf("window not byte-bounded: %d of 200 large entries retained", len(d.inserts))
+	}
+
+	sum := 0
+	for _, e := range d.inserts {
+		sum += entrySize(e)
+	}
+	if sum != d.trackedBytes {
+		t.Fatalf("trackedBytes accounting drift: tracked %d vs actual %d", d.trackedBytes, sum)
+	}
+}
+
+func TestInsert_ResetEpochClearsByteCount(t *testing.T) {
+	d := &lateJoinDecoder{}
+	d.insert(tableEntry{field: hpack.HeaderField{Name: "n", Value: "v"}})
+	if d.trackedBytes == 0 {
+		t.Fatal("trackedBytes should be non-zero after insert")
+	}
+	d.resetEpoch()
+	if d.trackedBytes != 0 || len(d.inserts) != 0 {
+		t.Fatalf("resetEpoch must clear window: bytes=%d len=%d", d.trackedBytes, len(d.inserts))
+	}
+}

--- a/internal/ebpf/h2decode/latejoin.go
+++ b/internal/ebpf/h2decode/latejoin.go
@@ -16,6 +16,12 @@ const (
 	maxDynamicIndex = hpackStaticTableSize + 8192
 
 	maxFieldsPerBlock = 256
+
+	maxFieldLength = 8192
+
+	maxTrackedBytes = 1 << 18
+
+	hpackEntryOverhead = 32
 )
 
 var (
@@ -24,6 +30,7 @@ var (
 	errHPACKZeroIndex       = errors.New("hpack: zero index")
 	errHPACKIndexRange      = errors.New("hpack: index out of range")
 	errHPACKTooManyFields   = errors.New("hpack: too many fields in block")
+	errHPACKFieldTooLong    = errors.New("hpack: field exceeds length limit")
 )
 
 // tableEntry is one observed dynamic-table insertion.
@@ -36,12 +43,14 @@ type tableEntry struct {
 // observed insertion window allows and skipping pre-attach references instead
 // of failing the block.
 type lateJoinDecoder struct {
-	inserts []tableEntry
+	inserts      []tableEntry
+	trackedBytes int
 }
 
 // resetEpoch discards the observed insertion window.
 func (d *lateJoinDecoder) resetEpoch() {
 	d.inserts = d.inserts[:0]
+	d.trackedBytes = 0
 }
 
 // decodeBlock decodes one complete header block. complete is false when one
@@ -160,10 +169,22 @@ func (d *lateJoinDecoder) resolveIndex(index int) (hpack.HeaderField, bool, erro
 	return entry.field, true, nil
 }
 
+// entrySize is the retained cost of one tracked insertion, mirroring the
+// RFC 7541 §4.1 dynamic-table entry size (name + value + 32).
+func entrySize(entry tableEntry) int {
+	return len(entry.field.Name) + len(entry.field.Value) + hpackEntryOverhead
+}
+
 func (d *lateJoinDecoder) insert(entry tableEntry) {
 	d.inserts = append(d.inserts, entry)
-	if len(d.inserts) > maxTrackedInserts {
-		n := copy(d.inserts, d.inserts[len(d.inserts)-maxTrackedInserts:])
+	d.trackedBytes += entrySize(entry)
+	drop := 0
+	for drop < len(d.inserts) && (len(d.inserts)-drop > maxTrackedInserts || d.trackedBytes > maxTrackedBytes) {
+		d.trackedBytes -= entrySize(d.inserts[drop])
+		drop++
+	}
+	if drop > 0 {
+		n := copy(d.inserts, d.inserts[drop:])
 		d.inserts = d.inserts[:n]
 	}
 }
@@ -209,6 +230,9 @@ func readString(buf []byte) (s string, consumed int, err error) {
 	if err != nil {
 		return "", 0, err
 	}
+	if length > maxFieldLength {
+		return "", 0, errHPACKFieldTooLong
+	}
 	if length > len(buf)-n {
 		return "", 0, errHPACKTruncated
 	}
@@ -220,6 +244,9 @@ func readString(buf []byte) (s string, consumed int, err error) {
 	s, err = hpack.HuffmanDecodeToString(raw)
 	if err != nil {
 		return "", 0, err
+	}
+	if len(s) > maxFieldLength {
+		return "", 0, errHPACKFieldTooLong
 	}
 	return s, consumed, nil
 }


### PR DESCRIPTION
## Summary

The late-join HPACK decoder bounded its tracked-insertion window by count (maxTrackedInserts = 1024) but not by bytes, and readString had no absolute field-length cap.

## Changes

- readString: reject a field whose raw or Huffman-decoded length exceeds maxFieldLength (8192), matching qpackdecode.
- insert: account for retained bytes (name + value + 32, the RFC 7541 §4.1 entry size) and evict the oldest entries until the window is under maxTrackedBytes (256 KB) as well as maxTrackedInserts. resetEpoch clears the byte count.