### PR TITLE
fix: clamp gRPC status and bound the error_code metric label

### DIFF
--- a/internal/ebpf/h2decode/decode.go
+++ b/internal/ebpf/h2decode/decode.go
@@ -39,6 +39,8 @@ const (
 	defaultMaxStreams       = 8192
 	defaultTTL              = 60 * time.Second
 	defaultGapTimeout       = 2 * time.Second
+
+	maxGrpcStatusCode = 16
 )
 
 // unknownPathPlaceholder stands in for a request :path that was HPACK-indexed
@@ -316,7 +318,7 @@ func (d *Decoder) decodeBlockLocked(st *dirState, rec *RawRecord, block []byte) 
 		}
 		ev := d.buildResponseLocked(rec, status, traceparent, extra)
 		if ev != nil && ev.Error == 0 {
-			if code, err := strconv.Atoi(grpcStatus); err == nil && code > 0 {
+			if code, err := strconv.Atoi(grpcStatus); err == nil && code > 0 && code <= maxGrpcStatusCode {
 				ev.Error = safeconv.IntToInt32(code)
 			}
 		}
@@ -440,7 +442,7 @@ func (d *Decoder) buildGrpcTrailerLocked(rec *RawRecord, grpcStatus string) *eve
 	ev.Type = events.EventHTTPResp
 	ev.TCPState = uint32(rec.Transport)
 	ev.Details = "grpc-status: " + grpcStatus
-	if code, err := strconv.Atoi(grpcStatus); err == nil && code > 0 {
+	if code, err := strconv.Atoi(grpcStatus); err == nil && code > 0 && code <= maxGrpcStatusCode {
 		ev.Error = safeconv.IntToInt32(code)
 	}
 

--- a/internal/ebpf/h2decode/grpc_status_clamp_test.go
+++ b/internal/ebpf/h2decode/grpc_status_clamp_test.go
@@ -1,0 +1,47 @@
+package h2decode
+
+import "testing"
+
+func TestGrpcTrailerStatus_ClampedToCanonicalRange(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    string
+		wantError int32
+	}{
+		{"internal", "13", 13},
+		{"unauthenticated_highest_valid", "16", 16},
+		{"one_past_range", "17", 0},
+		{"hostile_large", "999999", 0},
+		{"hostile_maxint", "2147483647", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := New()
+			enc := newBlockEncoder()
+			block := enc.encode(hf("grpc-status", c.status))
+			ev := singleEvent(t, d.Ingest(rec(4, DirIngress, 0, 1, block)))
+			if ev.Error != c.wantError {
+				t.Fatalf("trailer grpc-status %q: Error = %d, want %d", c.status, ev.Error, c.wantError)
+			}
+		})
+	}
+}
+
+func TestGrpcStatusInResponseHeaders_ClampedToCanonicalRange(t *testing.T) {
+	cases := []struct {
+		status    string
+		wantError int32
+	}{
+		{"13", 13},
+		{"999999", 0},
+	}
+	for _, c := range cases {
+		d := New()
+		enc := newBlockEncoder()
+		block := enc.encode(hf(":status", "200"), hf("grpc-status", c.status))
+		ev := singleEvent(t, d.Ingest(rec(4, DirIngress, 0, 1, block)))
+		if ev.Error != c.wantError {
+			t.Fatalf(":status 200 + grpc-status %q: Error = %d, want %d", c.status, ev.Error, c.wantError)
+		}
+	}
+}

--- a/internal/metricsexporter/error_code_cardinality_test.go
+++ b/internal/metricsexporter/error_code_cardinality_test.go
@@ -1,0 +1,19 @@
+package metricsexporter
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestRecordError_BoundsErrorCodeCardinality(t *testing.T) {
+	const eventType = "grpc-cardinality-test"
+	for i := 1; i <= config.MetricsLabelLimit+50; i++ {
+		RecordError(eventType, int32(i))
+	}
+	if testutil.ToFloat64(errorRateCounter.WithLabelValues(eventType, "other")) == 0 {
+		t.Fatal("a flood of distinct error codes must collapse into the 'other' label, not mint one series each")
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -541,14 +541,15 @@ func (l *labelCardinalityLimiter) bound(value string) string {
 }
 
 var (
-	commandCardinality = newLabelCardinalityLimiter(config.MetricsLabelLimit)
-	methodCardinality  = newLabelCardinalityLimiter(config.MetricsLabelLimit)
-	topicCardinality   = newLabelCardinalityLimiter(config.MetricsLabelLimit)
-	podCardinality     = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
-	serviceCardinality = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
-	podIPCardinality   = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
-	poolCardinality    = newLabelCardinalityLimiter(config.MetricsLabelLimit)
-	processCardinality = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	commandCardinality   = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	methodCardinality    = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	topicCardinality     = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	podCardinality       = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+	serviceCardinality   = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+	podIPCardinality     = newLabelCardinalityLimiter(config.MetricsPodLabelLimit)
+	poolCardinality      = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	processCardinality   = newLabelCardinalityLimiter(config.MetricsLabelLimit)
+	errorCodeCardinality = newLabelCardinalityLimiter(config.MetricsLabelLimit)
 )
 
 func HandleEventWithContext(e *events.Event, k8sContext map[string]interface{}) {
@@ -790,7 +791,7 @@ func RecordEventProcessingLatency(duration time.Duration) {
 }
 
 func RecordError(eventType string, errorCode int32) {
-	errorRateCounter.WithLabelValues(eventType, fmt.Sprintf("%d", errorCode)).Inc()
+	errorRateCounter.WithLabelValues(eventType, errorCodeCardinality.bound(fmt.Sprintf("%d", errorCode))).Inc()
 }
 
 // RecordAttribution counts one process-identity attribution outcome at

--- a/internal/metricsexporter/resource_limit_coverage_test.go
+++ b/internal/metricsexporter/resource_limit_coverage_test.go
@@ -1,0 +1,20 @@
+package metricsexporter
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestExportResourceLimitMetric_NilEventIgnored(t *testing.T) {
+	ExportResourceLimitMetricWithContext(nil, "ns")
+}
+
+func TestExportResourceLimitMetric_UnknownResourceType(t *testing.T) {
+	ExportResourceLimitMetricWithContext(&events.Event{TCPState: 99, Error: 85, Bytes: 100}, "unknown-type-ns")
+	if got := testutil.ToFloat64(resourceUtilizationPercentGauge.WithLabelValues("unknown", "unknown-type-ns")); got != 85 {
+		t.Fatalf("unknown resource type utilization = %v, want 85 (exported under the 'unknown' label)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`podtrace_errors_total{error_code}` was the only traffic-derived metric label with no cardinality bound. The HTTP `:status` path clamps to 500-599, but both gRPC paths accepted any grpc-status wire value > 0 up to MaxInt32 straight into `ev.Error`, and `RecordError` stringified it into the label with no limiter (unlike the ~14 sibling labels).

## Changes

- h2decode: clamp gRPC status at both decode sites to the canonical range (1..16), mirroring the HTTP :status 5xx clamp. Values outside the range are not recorded as errors, so `ev.Error` stays bounded everywhere it is consumed (metric, report, exporter).
- metricsexporter: route the `error_code` label through the existing `labelCardinalityLimiter` (overflow collapses to "other"), giving the metric the same bound its siblings have regardless of source.