### PR TITLE
fix: cap tracked traces and spans-per-trace to bound the trace map

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,8 @@ var (
 	ResourceMonitorInterval   = getDurationEnvOrDefault("PODTRACE_RESOURCE_MONITOR_INTERVAL", DefaultResourceMonitorInterval)
 	MetricsLabelLimit         = getIntEnvOrDefault("PODTRACE_METRICS_LABEL_LIMIT", 200)
 	MetricsPodLabelLimit      = getIntEnvOrDefault("PODTRACE_METRICS_POD_LABEL_LIMIT", 500)
+	MaxTrackedTraces          = getIntEnvOrDefault("PODTRACE_MAX_TRACKED_TRACES", 10000)
+	MaxSpansPerTrace          = getIntEnvOrDefault("PODTRACE_MAX_SPANS_PER_TRACE", 1000)
 	ProcessCacheEvictionRatio = getFloatEnvOrDefault("PODTRACE_PROCESS_CACHE_EVICTION_RATIO", DefaultProcessCacheEvictionRatio)
 	PIDCacheEvictionRatio     = getFloatEnvOrDefault("PODTRACE_PID_CACHE_EVICTION_RATIO", DefaultPIDCacheEvictionRatio)
 	CacheEvictionThreshold    = getFloatEnvOrDefault("PODTRACE_CACHE_EVICTION_THRESHOLD", DefaultCacheEvictionThreshold)

--- a/internal/diagnose/tracker/trace_tracker.go
+++ b/internal/diagnose/tracker/trace_tracker.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/events"
 )
 
@@ -63,6 +64,10 @@ func (tt *TraceTracker) ProcessEvent(event *events.Event, k8sContext interface{}
 	tt.mu.Lock()
 	trace, exists := tt.traces[event.TraceID]
 	if !exists {
+		if len(tt.traces) >= config.MaxTrackedTraces {
+			tt.mu.Unlock()
+			return
+		}
 		trace = &Trace{
 			TraceID:   event.TraceID,
 			Spans:     make([]*Span, 0),
@@ -106,6 +111,10 @@ func (tt *TraceTracker) findOrCreateSpan(trace *Trace, event *events.Event) *Spa
 		if span.SpanID == event.SpanID {
 			return span
 		}
+	}
+
+	if len(trace.Spans) >= config.MaxSpansPerTrace {
+		return nil
 	}
 
 	span := &Span{
@@ -327,7 +336,7 @@ func (tt *TraceTracker) CleanupOldTraces(maxAge time.Duration) {
 	now := time.Now()
 	for traceID, trace := range tt.traces {
 		trace.mu.RLock()
-		age := now.Sub(trace.EndTime)
+		age := now.Sub(trace.lastUpdate)
 		trace.mu.RUnlock()
 		if age > maxAge {
 			delete(tt.traces, traceID)

--- a/internal/diagnose/tracker/trace_tracker_cap_test.go
+++ b/internal/diagnose/tracker/trace_tracker_cap_test.go
@@ -1,0 +1,63 @@
+package tracker
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/clock"
+	"github.com/gma1k/podtrace/internal/config"
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestProcessEvent_CapsTrackedTraces(t *testing.T) {
+	tt := NewTraceTracker()
+	now := clock.WallToBPFTimestamp(time.Now())
+	for i := 0; i < config.MaxTrackedTraces+500; i++ {
+		tt.ProcessEvent(&events.Event{
+			TraceID:   fmt.Sprintf("%032x", i),
+			SpanID:    "s",
+			Timestamp: now,
+			Type:      events.EventHTTPReq,
+		}, nil)
+	}
+	if got := tt.GetTraceCount(); got != config.MaxTrackedTraces {
+		t.Fatalf("tracked traces = %d, want exactly the cap %d (a flood of distinct trace IDs must not grow the map)", got, config.MaxTrackedTraces)
+	}
+}
+
+func TestProcessEvent_CapsSpansPerTrace(t *testing.T) {
+	tt := NewTraceTracker()
+	now := clock.WallToBPFTimestamp(time.Now())
+	for i := 0; i < config.MaxSpansPerTrace+50; i++ {
+		tt.ProcessEvent(&events.Event{
+			TraceID:   "one-trace",
+			SpanID:    fmt.Sprintf("%016x", i),
+			Timestamp: now,
+			Type:      events.EventHTTPReq,
+		}, nil)
+	}
+	tr := tt.GetTrace("one-trace")
+	if tr == nil {
+		t.Fatal("trace missing after span flood")
+	}
+	if got := len(tr.Spans); got != config.MaxSpansPerTrace {
+		t.Fatalf("spans = %d, want exactly the cap %d (a span-ID flood under one trace must not grow unbounded)", got, config.MaxSpansPerTrace)
+	}
+}
+
+func TestCleanupOldTraces_KeepsRecentlyUpdated(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.ProcessEvent(&events.Event{
+		TraceID:   "fresh",
+		SpanID:    "s",
+		Timestamp: clock.WallToBPFTimestamp(time.Now()),
+		Type:      events.EventHTTPReq,
+	}, nil)
+
+	tt.CleanupOldTraces(1 * time.Minute)
+
+	if tt.GetTraceCount() != 1 {
+		t.Fatalf("recently-updated trace was evicted; count = %d, want 1", tt.GetTraceCount())
+	}
+}

--- a/internal/diagnose/tracker/trace_tracker_test.go
+++ b/internal/diagnose/tracker/trace_tracker_test.go
@@ -124,15 +124,16 @@ func TestTraceTracker_GetAllTraces(t *testing.T) {
 func TestTraceTracker_CleanupOldTraces(t *testing.T) {
 	tt := NewTraceTracker()
 
-	oldTime := time.Now().Add(-2 * time.Second)
 	event := &events.Event{
 		TraceID:   "old-trace",
 		SpanID:    "span1",
-		Timestamp: clock.WallToBPFTimestamp(oldTime),
+		Timestamp: clock.WallToBPFTimestamp(time.Now()),
 		Type:      events.EventHTTPReq,
 	}
 
 	tt.ProcessEvent(event, nil)
+
+	tt.traces["old-trace"].lastUpdate = time.Now().Add(-2 * time.Second)
 
 	tt.CleanupOldTraces(1 * time.Second)
 


### PR DESCRIPTION
## Summary

The diagnose trace tracker keyed its `traces` map on the 32-hex trace ID from the inbound traceparent header, caller-chosen from the full 2^128 space, with no cap. Time-based eviction (CleanupOldTraces, 10m) bounds age but not size, so a client sending distinct traceparents faster than they age grows the map without limit; each entry retains spans, events, and attribute maps, and SnapshotForExport deep-copies the whole set every 5s.

## Changes

- Cap the trace map at `config.MaxTrackedTraces` (default 10000, `PODTRACE_MAX_TRACKED_TRACES`): once full, new trace IDs are dropped (best-effort), bounding both the map and the 5s deep-copy.
- Cap spans per trace at `config.MaxSpansPerTrace` (default 1000, `PODTRACE_MAX_SPANS_PER_TRACE`): `findOrCreateSpan` returns nil at the cap, and the existing `span == nil` guard drops the event — closing the one-trace-many-spans vector.
- Evict on the wall-clock `lastUpdate` field (already recorded per event) instead of the event-timestamp-derived `EndTime`, so eviction does not depend on the BPF-to-wall clock conversion.