### PR TITLE
fix: confine kubelet-derived cgroup walk roots to the cgroup base

### DIFF
--- a/internal/kubernetes/cgroup_kubelet_test.go
+++ b/internal/kubernetes/cgroup_kubelet_test.go
@@ -8,47 +8,44 @@ import (
 	"github.com/gma1k/podtrace/internal/config"
 )
 
-// TestCgroupRootCandidates_KubeletAbsPath covers the `filepath.IsAbs(kcp)` true
-// branch and `full = kcp` in cgroupRootCandidates.
 func TestCgroupRootCandidates_KubeletAbsPath(t *testing.T) {
-	// Ensure the once has already fired (call detectKubeletCgroupParent once first
-	// so the sync.Once is exhausted, then set kubeletCgroupParent directly).
 	_ = detectKubeletCgroupParent()
 
-	// Create a real temp dir to use as the absolute kubelet cgroup path.
-	absDir := t.TempDir()
-
-	// Directly set the cached value since Once has already run.
-	origKCP := kubeletCgroupParent
-	kubeletCgroupParent = absDir
-	defer func() { kubeletCgroupParent = origKCP }()
-
-	// Set a different base so absDir is not the base itself.
 	origBase := config.CgroupBasePath
 	baseDir := t.TempDir()
 	config.SetCgroupBasePath(baseDir)
 	defer config.SetCgroupBasePath(origBase)
 
-	candidates := cgroupRootCandidates()
+	origKCP := kubeletCgroupParent
+	defer func() { kubeletCgroupParent = origKCP }()
 
+	outOfBase := t.TempDir()
+	kubeletCgroupParent = outOfBase
+	for _, c := range cgroupRootCandidates() {
+		if c == outOfBase {
+			t.Errorf("out-of-base kubelet cgroup dir %q must not be admitted", outOfBase)
+		}
+	}
+
+	inBase := filepath.Join(baseDir, "kubepods")
+	if err := os.MkdirAll(inBase, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	kubeletCgroupParent = inBase
 	found := false
-	for _, c := range candidates {
-		if c == absDir {
+	for _, c := range cgroupRootCandidates() {
+		if c == inBase {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected absolute kubelet cgroup dir %q in candidates %v", absDir, candidates)
+		t.Errorf("in-base kubelet cgroup dir %q should be admitted", inBase)
 	}
 }
 
-// TestCgroupRootCandidates_KubeletRelPath covers the `full = filepath.Join(base, kcp)`
-// branch (non-absolute kubelet cgroup path).
 func TestCgroupRootCandidates_KubeletRelPath(t *testing.T) {
-	// Ensure once has already fired.
 	_ = detectKubeletCgroupParent()
 
-	// Set up a base dir with a "kubepods" subdir.
 	baseDir := t.TempDir()
 	kubepods := filepath.Join(baseDir, "kubepods")
 	if err := os.MkdirAll(kubepods, 0o755); err != nil {
@@ -59,7 +56,6 @@ func TestCgroupRootCandidates_KubeletRelPath(t *testing.T) {
 	config.SetCgroupBasePath(baseDir)
 	defer config.SetCgroupBasePath(origBase)
 
-	// Set relative kubelet cgroup parent.
 	origKCP := kubeletCgroupParent
 	kubeletCgroupParent = "kubepods"
 	defer func() { kubeletCgroupParent = origKCP }()
@@ -77,8 +73,6 @@ func TestCgroupRootCandidates_KubeletRelPath(t *testing.T) {
 	}
 }
 
-// TestCgroupRootCandidates_KubeletPathNotExist covers the `dirExists(full)` false
-// branch — kubelet cgroup dir set but doesn't exist on disk.
 func TestCgroupRootCandidates_KubeletPathNotExist(t *testing.T) {
 	_ = detectKubeletCgroupParent()
 

--- a/internal/kubernetes/cgroup_resolve_unit_test.go
+++ b/internal/kubernetes/cgroup_resolve_unit_test.go
@@ -70,6 +70,7 @@ func TestBuildPodInfoFromPreResolved_Success(t *testing.T) {
 	if err := os.MkdirAll(target, 0o755); err != nil {
 		t.Fatalf("mkdir target: %v", err)
 	}
+	_ = os.WriteFile(filepath.Join(target, "cgroup.procs"), nil, 0o644)
 
 	info, err := BuildPodInfoFromPreResolved(PreResolvedRef{
 		Namespace:     "ns",

--- a/internal/kubernetes/cgroup_walk_containment_test.go
+++ b/internal/kubernetes/cgroup_walk_containment_test.go
@@ -1,0 +1,144 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestValidCgroupFlagValue(t *testing.T) {
+	origBase := config.CgroupBasePath
+	base := t.TempDir()
+	config.SetCgroupBasePath(base)
+	defer config.SetCgroupBasePath(origBase)
+
+	cases := []struct {
+		v    string
+		want bool
+	}{
+		{"", false},
+		{"kubepods", true},
+		{"kubepods.slice", true},
+		{"../../../..", false},
+		{"foo/../bar", false},
+		{"/proc", false},
+		{"/", false},
+		{filepath.Join(base, "kubepods"), true},
+	}
+	for _, c := range cases {
+		if got := validCgroupFlagValue(c.v); got != c.want {
+			t.Errorf("validCgroupFlagValue(%q) = %v, want %v", c.v, got, c.want)
+		}
+	}
+}
+
+func TestCgroupRootCandidates_RejectsPoisonedKubeletRoot(t *testing.T) {
+	_ = detectKubeletCgroupParent()
+
+	origBase := config.CgroupBasePath
+	base := t.TempDir()
+	config.SetCgroupBasePath(base)
+	defer config.SetCgroupBasePath(origBase)
+
+	origKCP := kubeletCgroupParent
+	defer func() { kubeletCgroupParent = origKCP }()
+
+	for _, poison := range []string{"../../../..", "/proc", "/", "../../../../../.."} {
+		kubeletCgroupParent = poison
+		for _, c := range cgroupRootCandidates() {
+			if c == "/" || c == "/proc" || !strings.HasPrefix(c, base) {
+				t.Errorf("poisoned kubelet root %q produced out-of-base walk root %q", poison, c)
+			}
+		}
+	}
+}
+
+func TestReadKubeletCgroupFlag_SkipsSpoofedInvalidValue(t *testing.T) {
+	procDir := t.TempDir()
+	origProc := config.ProcBasePath
+	config.SetProcBasePath(procDir)
+	defer config.SetProcBasePath(origProc)
+
+	origBase := config.CgroupBasePath
+	config.SetCgroupBasePath(t.TempDir())
+	defer config.SetCgroupBasePath(origBase)
+
+	writeFakeKubelet(t, procDir, "10001", "kubelet\x00--cgroup-root\x00../../../..\x00")
+	writeFakeKubelet(t, procDir, "2345", "kubelet\x00--cgroup-root\x00kubepods\x00")
+
+	if got := readKubeletCgroupFlag(); got != "kubepods" {
+		t.Fatalf("readKubeletCgroupFlag()=%q, want %q (a spoofed first-match with an escaping value must be skipped)", got, "kubepods")
+	}
+}
+
+func TestFindCgroupPathV1_RequiresDirWithCgroupProcs(t *testing.T) {
+	origBase := config.CgroupBasePath
+	base := t.TempDir()
+	config.SetCgroupBasePath(base)
+	defer config.SetCgroupBasePath(origBase)
+
+	kubepods := filepath.Join(base, "kubepods.slice")
+	if err := os.MkdirAll(kubepods, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cid := "abcdef1234567890abcdef12"
+	if err := os.WriteFile(filepath.Join(kubepods, "pod_"+cid+".txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(kubepods, "nodir_"+cid), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findCgroupPathV1(cid); err == nil {
+		t.Fatal("v1 must not match a file, nor a dir lacking cgroup.procs")
+	}
+
+	leaf := filepath.Join(kubepods, "pod_"+cid)
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "cgroup.procs"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findCgroupPathV1(cid)
+	if err != nil || got != leaf {
+		t.Fatalf("v1 should match the leaf dir with cgroup.procs: got %q err %v", got, err)
+	}
+}
+
+func TestReadKubeletCgroupFlag_SkipsKubeletWithoutCmdline(t *testing.T) {
+	procDir := t.TempDir()
+	origProc := config.ProcBasePath
+	config.SetProcBasePath(procDir)
+	defer config.SetProcBasePath(origProc)
+
+	d := filepath.Join(procDir, "4242")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "comm"), []byte("kubelet\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readKubeletCgroupFlag(); got != "" {
+		t.Fatalf("readKubeletCgroupFlag()=%q, want empty (kubelet with unreadable cmdline is skipped)", got)
+	}
+}
+
+func writeFakeKubelet(t *testing.T, procDir, pid, cmdline string) {
+	t.Helper()
+	d := filepath.Join(procDir, pid)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "comm"), []byte("kubelet\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "cmdline"), []byte(cmdline), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -267,7 +267,7 @@ func cgroupRootCandidates() []string {
 		} else {
 			full = filepath.Join(base, kcp)
 		}
-		if dirExists(full) && !seen[full] {
+		if _, ok := sysfs.CgroupRelative(full); ok && dirExists(full) && !seen[full] {
 			seen[full] = true
 			candidates = append(candidates, full)
 		}
@@ -320,16 +320,15 @@ func readKubeletCgroupFlag() string {
 			for _, flag := range []string{"--cgroup-root", "--cgroup-parent"} {
 				if arg == flag && i+1 < len(args) {
 					v := strings.TrimSpace(args[i+1])
-					if v != "" {
+					if validCgroupFlagValue(v) {
 						logger.Debug("Detected kubelet cgroup flag",
 							zap.String("flag", flag), zap.String("value", v))
 						return v
 					}
 				}
 				if strings.HasPrefix(arg, flag+"=") {
-					v := strings.TrimPrefix(arg, flag+"=")
-					v = strings.TrimSpace(v)
-					if v != "" {
+					v := strings.TrimSpace(strings.TrimPrefix(arg, flag+"="))
+					if validCgroupFlagValue(v) {
 						logger.Debug("Detected kubelet cgroup flag",
 							zap.String("flag", flag), zap.String("value", v))
 						return v
@@ -337,9 +336,21 @@ func readKubeletCgroupFlag() string {
 				}
 			}
 		}
-		break
 	}
 	return ""
+}
+
+// validCgroupFlagValue rejects a kubelet cgroup flag value that would escape
+// the cgroup base — any ".." traversal or an absolute path outside the base.
+func validCgroupFlagValue(v string) bool {
+	if v == "" || strings.Contains(v, "..") {
+		return false
+	}
+	if filepath.IsAbs(v) {
+		_, ok := sysfs.CgroupRelative(v)
+		return ok
+	}
+	return true
 }
 
 func dirExists(path string) bool {
@@ -515,7 +526,6 @@ func findCgroupPathV2(containerID string) (string, error) {
 			filepath.Join(root, "system.slice"),
 			filepath.Join(root, "user"),
 			filepath.Join(root, "user.slice"),
-			root,
 		)
 	}
 
@@ -594,10 +604,15 @@ func findCgroupPathV1(containerID string) (string, error) {
 			if err != nil {
 				return nil
 			}
+			if !info.IsDir() {
+				return nil
+			}
 			if strings.Contains(path, containerID) || strings.Contains(path, shortID) {
-				foundPath = path
-				found = true
-				return errFound
+				if _, err := os.Stat(filepath.Join(path, "cgroup.procs")); err == nil {
+					foundPath = path
+					found = true
+					return errFound
+				}
 			}
 			return nil
 		})

--- a/internal/kubernetes/pod_test.go
+++ b/internal/kubernetes/pod_test.go
@@ -45,6 +45,7 @@ func TestFindCgroupPath_Found(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("failed to create target dir: %v", err)
 	}
+	_ = os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644)
 
 	if path, err := findCgroupPath(containerID); err != nil || path == "" {
 		t.Fatalf("expected to find cgroup path, got path=%q err=%v", path, err)
@@ -73,8 +74,7 @@ func TestFindCgroupPath_SystemdDriver(t *testing.T) {
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("failed to create target dir: %v", err)
 	}
-	// cgroup v1 may not have cgroup.procs in every hierarchy; findCgroupPathV1 just matches path.
-	// For v2 we'd need cgroup.procs. This test uses v1 layout (no cgroup.controllers at root).
+	_ = os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644)
 	path, err := findCgroupPath(containerID)
 	if err != nil {
 		t.Fatalf("expected to find cgroup path under systemd/, got err=%v", err)
@@ -197,6 +197,7 @@ func TestResolvePod_Success_WithoutContainerName(t *testing.T) {
 	shortID := "abcdef1234567890abcdef1234567890abcdef12"
 	targetDir := filepath.Join(kubepodsSlice, "pod_"+shortID)
 	_ = os.MkdirAll(targetDir, 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,6 +262,7 @@ func TestResolvePod_Success_WithContainerName(t *testing.T) {
 	shortID := "abcdef1234567890abcdef1234567890abcdef12"
 	targetDir := filepath.Join(kubepodsSlice, "pod_"+shortID)
 	_ = os.MkdirAll(targetDir, 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -568,6 +570,7 @@ func TestFindCgroupPath_ShortIDMatch(t *testing.T) {
 	shortID := fullID[:12]
 	targetDir := filepath.Join(kubepodsSlice, "pod_"+shortID)
 	_ = os.MkdirAll(targetDir, 0755)
+	_ = os.WriteFile(filepath.Join(targetDir, "cgroup.procs"), nil, 0o644)
 
 	path, err := findCgroupPath(fullID)
 	if err != nil {
@@ -1337,8 +1340,7 @@ func buildFakeProc(t *testing.T, comm, cmdlineArgs string) string {
 }
 
 func TestReadKubeletCgroupFlag_SeparateArg(t *testing.T) {
-	// --cgroup-root /mycgrouproot  (flag and value as separate NUL-separated args)
-	args := "kubelet\x00--cgroup-root\x00/mycgrouproot\x00"
+	args := "kubelet\x00--cgroup-root\x00mycgrouproot\x00"
 	dir := buildFakeProc(t, "kubelet", args)
 
 	origProc := config.ProcBasePath
@@ -1346,14 +1348,13 @@ func TestReadKubeletCgroupFlag_SeparateArg(t *testing.T) {
 	defer func() { config.SetProcBasePath(origProc) }()
 
 	got := readKubeletCgroupFlag()
-	if got != "/mycgrouproot" {
-		t.Errorf("readKubeletCgroupFlag()=%q, want %q", got, "/mycgrouproot")
+	if got != "mycgrouproot" {
+		t.Errorf("readKubeletCgroupFlag()=%q, want %q", got, "mycgrouproot")
 	}
 }
 
 func TestReadKubeletCgroupFlag_EqualSign(t *testing.T) {
-	// --cgroup-parent=/kubepods  (flag=value syntax)
-	args := "kubelet\x00--other-flag=foo\x00--cgroup-parent=/kubepods\x00"
+	args := "kubelet\x00--other-flag=foo\x00--cgroup-parent=kubepods\x00"
 	dir := buildFakeProc(t, "kubelet", args)
 
 	origProc := config.ProcBasePath
@@ -1361,8 +1362,8 @@ func TestReadKubeletCgroupFlag_EqualSign(t *testing.T) {
 	defer func() { config.SetProcBasePath(origProc) }()
 
 	got := readKubeletCgroupFlag()
-	if got != "/kubepods" {
-		t.Errorf("readKubeletCgroupFlag()=%q, want %q", got, "/kubepods")
+	if got != "kubepods" {
+		t.Errorf("readKubeletCgroupFlag()=%q, want %q", got, "kubepods")
 	}
 }
 
@@ -1586,15 +1587,14 @@ func TestReadKubeletCgroupFlag_SeparateArgFormat(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(pidDir, "comm"), []byte("kubelet\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Use --cgroup-parent <value> as separate NUL-separated arg.
-	cmdline := "kubelet\x00--cgroup-parent\x00/custom/cgroup\x00"
+	cmdline := "kubelet\x00--cgroup-parent\x00custom/cgroup\x00"
 	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(cmdline), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	got := readKubeletCgroupFlag()
-	if got != "/custom/cgroup" {
-		t.Errorf("expected '/custom/cgroup', got %q", got)
+	if got != "custom/cgroup" {
+		t.Errorf("expected 'custom/cgroup', got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Container cgroup resolution took its walk roots from the kubelet's --cgroup-root flag, read from /proc and trusted without bounds. Since comm is spoofable (prctl) and os.ReadDir is lexicographic, a hostile PID can pass its own value as the "kubelet" one, and a ".." value resolved to "/", guarded only by dirExists. Result: an unbounded filepath.Walk("/") in a privileged agent with hostPath /proc, on startup and every pod-informer update.

## Changes

- cgroupRootCandidates admits the kubelet-derived root only when sysfs.CgroupRelative(full) succeeds, so any ".."/absolute path outside the cgroup base (/, /proc, ../../../..) is rejected regardless of the spoofed comm.
- validCgroupFlagValue rejects a kubelet flag value containing ".." or an absolute path outside the base at read time, and readKubeletCgroupFlag no longer breaks on the first "kubelet" comm match, so a spoofed process cannot shadow the real kubelet.
- findCgroupPathV1 gains the IsDir() and cgroup.procs checks findCgroupPathV2 already has.
- Removed the bare-root fallback from findCgroupPathV2's walk bases; it walks only kubepods*/system*/user*.