### PR TITLE
fix: restore systemd cgroup walk and stop stale h2/h3 record bytes

### DIFF
--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -108,6 +108,7 @@ static long h2_frames_cb(u32 idx, void *vctx)
 			if (frag > 0 &&
 			    bpf_probe_read_user(s->frag, frag, (u8 *)c->base + off) == 0) {
 				u8 completes = (fs->remaining - frag) == 0;
+				__builtin_memset(&s->rec, 0, sizeof(s->rec));
 				s->rec.conn_id = c->conn_id;
 				s->rec.timestamp = c->ts;
 				s->rec.cgroup_id = c->cgroup_id;

--- a/bpf/http3.c
+++ b/bpf/http3.c
@@ -51,8 +51,9 @@ static __always_inline void quic_ship(struct __sk_buff *skb, u8 is_v6,
 		bpf_map_update_elem(&quic_seen, &k, &one, BPF_ANY);
 	}
 
+	u32 zero = 0;
 	struct quic_initial_record *rec =
-		bpf_ringbuf_reserve(&quic_initial_events, sizeof(*rec), 0);
+		bpf_map_lookup_elem(&quic_initial_scratch, &zero);
 	if (!rec)
 		return;
 	rec->timestamp = bpf_ktime_get_ns();
@@ -68,12 +69,11 @@ static __always_inline void quic_ship(struct __sk_buff *skb, u8 is_v6,
 	u32 caplen = skb->len > off ? skb->len - off : 0;
 	if (caplen > QUIC_PKT_CAP)
 		caplen = QUIC_PKT_CAP;
-	if (caplen < 20 || bpf_skb_load_bytes(skb, off, rec->pkt, caplen) < 0) {
-		bpf_ringbuf_discard(rec, 0);
+	if (caplen < 20 || bpf_skb_load_bytes(skb, off, rec->pkt, caplen) < 0)
 		return;
-	}
 	rec->pktlen = (u16)caplen;
-	bpf_ringbuf_submit(rec, 0);
+	bpf_ringbuf_output(&quic_initial_events, rec,
+			   __builtin_offsetof(struct quic_initial_record, pkt) + caplen, 0);
 }
 
 SEC("cgroup_skb/egress")

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -279,6 +279,13 @@ struct {
 } quic_initial_events SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct quic_initial_record);
+} quic_initial_scratch SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, struct pair_key);

--- a/bpf/nghttp3.c
+++ b/bpf/nghttp3.c
@@ -276,7 +276,8 @@ static __always_inline void h3_capture_stream_bytes(u64 conn, u64 stream_id,
 	c->offset = captured;
 	if (bpf_probe_read_user(c->data, n, (void *)src) != 0)
 		return;
-	bpf_ringbuf_output(&h3_stream_chunks, c, sizeof(*c), 0);
+	bpf_ringbuf_output(&h3_stream_chunks, c,
+			   __builtin_offsetof(struct h3_stream_chunk, data) + n, 0);
 	captured += n;
 	bpf_map_update_elem(&h3_stream_captured, &k, &captured, BPF_ANY);
 }

--- a/internal/ebpf/h2decode/peer_test.go
+++ b/internal/ebpf/h2decode/peer_test.go
@@ -29,3 +29,20 @@ func TestParseRecordPeer(t *testing.T) {
 		t.Errorf("peer ports = %d -> %d, want 54321 -> 8443", r.PeerSrcPort, r.PeerDstPort)
 	}
 }
+
+func TestParseRecordUnresolvedPeerIsEmpty(t *testing.T) {
+	data := make([]byte, recordHeaderSize)
+	binary.LittleEndian.PutUint16(data[36:38], 0)
+	data[38] = DirIngress
+
+	r, ok := ParseRecord(data)
+	if !ok {
+		t.Fatal("ParseRecord failed")
+	}
+	if r.PeerSrcIP != "" || r.PeerDstIP != "" {
+		t.Errorf("unresolved peer IPs = %q -> %q, want empty", r.PeerSrcIP, r.PeerDstIP)
+	}
+	if r.PeerSrcPort != 0 || r.PeerDstPort != 0 {
+		t.Errorf("unresolved peer ports = %d -> %d, want 0 -> 0", r.PeerSrcPort, r.PeerDstPort)
+	}
+}

--- a/internal/ebpf/h3stream/h3stream_test.go
+++ b/internal/ebpf/h3stream/h3stream_test.go
@@ -214,6 +214,14 @@ func TestParseChunkRawLayout(t *testing.T) {
 	}
 }
 
+func TestParseChunkRejectsCopiedLenOverrun(t *testing.T) {
+	raw := make([]byte, chunkHeaderSize+4)
+	binary.LittleEndian.PutUint32(raw[28:32], 64)
+	if _, ok := ParseChunk(raw); ok {
+		t.Fatal("chunk with copied_len beyond sample parsed")
+	}
+}
+
 func TestSectionStash(t *testing.T) {
 	s := NewSectionStash(time.Hour, 4)
 	key := SectionKey{TGID: 1, Conn: 2, Stream: 3}

--- a/internal/kubernetes/cgroup_v2_nested_test.go
+++ b/internal/kubernetes/cgroup_v2_nested_test.go
@@ -1,0 +1,63 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestFindCgroupPathV2_ResolvesSystemdNestedContainer(t *testing.T) {
+	origBase := config.CgroupBasePath
+	base := t.TempDir()
+	config.SetCgroupBasePath(base)
+	defer config.SetCgroupBasePath(origBase)
+
+	cid := "3efb8417ec5becbd398719f2fbedc3bb13c6c121abeb4909b6a6842439634041"
+	scope := filepath.Join(base,
+		"kubelet.slice",
+		"kubelet-kubepods.slice",
+		"kubelet-kubepods-besteffort.slice",
+		"kubelet-kubepods-besteffort-pod11111111_2222_3333_4444_555555555555.slice",
+		"cri-containerd-"+cid+".scope",
+	)
+	if err := os.MkdirAll(scope, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scope, "cgroup.procs"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findCgroupPathV2(cid)
+	if err != nil {
+		t.Fatalf("findCgroupPathV2: %v", err)
+	}
+	if got != scope {
+		t.Fatalf("resolved %q, want %q", got, scope)
+	}
+}
+
+func TestFindCgroupPathV2_DepthBoundStopsDeepWalk(t *testing.T) {
+	origBase := config.CgroupBasePath
+	base := t.TempDir()
+	config.SetCgroupBasePath(base)
+	defer config.SetCgroupBasePath(origBase)
+
+	cid := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbef0"
+	parts := []string{base}
+	for i := 0; i < maxCgroupWalkDepth+2; i++ {
+		parts = append(parts, "kubelet.slice")
+	}
+	deep := filepath.Join(append(parts, "cri-containerd-"+cid+".scope")...)
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "cgroup.procs"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findCgroupPathV2(cid); err == nil {
+		t.Fatal("expected depth-bounded walk to miss a cgroup nested beyond the cap")
+	}
+}

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -512,9 +512,39 @@ func isCgroupV2(basePath string) (bool, error) {
 	return false, nil
 }
 
+const maxCgroupWalkDepth = 8
+
+// walkCgroupForContainer scans basePath for containerID's cgroup directory.
+func walkCgroupForContainer(basePath, containerID, shortID string) (string, bool) {
+	base := filepath.Clean(basePath)
+	found := ""
+	_ = filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		name := filepath.Base(path)
+		if strings.Contains(path, containerID) || strings.Contains(path, shortID) ||
+			strings.Contains(name, containerID) || strings.Contains(name, shortID) {
+			if _, err := os.Stat(filepath.Join(path, "cgroup.procs")); err == nil {
+				found = path
+				return filepath.SkipAll
+			}
+		}
+		if path != base {
+			if rel, rerr := filepath.Rel(base, path); rerr == nil &&
+				strings.Count(rel, string(os.PathSeparator))+1 >= maxCgroupWalkDepth {
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	})
+	return found, found != ""
+}
+
 func findCgroupPathV2(containerID string) (string, error) {
+	roots := cgroupRootCandidates()
 	var basePaths []string
-	for _, root := range cgroupRootCandidates() {
+	for _, root := range roots {
 		basePaths = append(basePaths,
 			filepath.Join(root, "kubepods"),
 			filepath.Join(root, "kubepods.slice"),
@@ -528,8 +558,8 @@ func findCgroupPathV2(containerID string) (string, error) {
 			filepath.Join(root, "user.slice"),
 		)
 	}
+	basePaths = append(basePaths, roots...)
 
-	var errFound = errors.New("podtrace: cgroup found")
 	shortID := containerID
 	if len(containerID) >= 12 {
 		shortID = containerID[:12]
@@ -539,31 +569,8 @@ func findCgroupPathV2(containerID string) (string, error) {
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
 			continue
 		}
-
-		var foundPath string
-		found := false
-		_ = filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return nil
-			}
-			if !info.IsDir() {
-				return nil
-			}
-			baseName := filepath.Base(path)
-			pathStr := path
-			if strings.Contains(pathStr, containerID) || strings.Contains(pathStr, shortID) || strings.Contains(baseName, containerID) || strings.Contains(baseName, shortID) {
-				cgroupProcsPath := filepath.Join(path, "cgroup.procs")
-				if _, err := os.Stat(cgroupProcsPath); err == nil {
-					foundPath = path
-					found = true
-					return errFound
-				}
-			}
-			return nil
-		})
-
-		if found && foundPath != "" {
-			return foundPath, nil
+		if p, ok := walkCgroupForContainer(basePath, containerID, shortID); ok {
+			return p, nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

### 1. Restore cgroup resolution on the systemd driver (regression from #419)

#419 hardened cgroup-root selection but also dropped the bare-root walk fallback from findCgroupPathV2. On the systemd cgroup driver (Kubernetes' default, and kind's), cgroup v2 pod cgroups are nested under /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/…/…-pod<uid>.slice/…scope, which is not one of the enumerated kubepods*/system*/user* subdirectories. With no walk base above kubelet.slice, the session Job could not resolve any container cgroup ("cgroup path not found" -> "failed to attach to cgroups: no valid cgroup paths provided"), so every PodTraceSession diagnose failed with state=Failed. This affects all systemd-driver clusters, not just kind.

The bare root is safe to walk again because #419's own containment guard (cgroupRootCandidates rejects any root outside the cgroup base via sysfs.CgroupRelative) already prevents the spoofed-comm attack from producing a root of / or /proc. The threat is contained at the root level, independent of which subdirectories the walk descends into.

- findCgroupPathV2 appends the contained roots themselves as a last-resort walk base, after the cheap targeted subdirs (so kubeadm/cgroupfs layouts still short-circuit).
- The scan moves to a shared helper that uses filepath.WalkDir (never follows symlinks) and is depth-bounded (maxCgroupWalkDepth=8), so the restored walk is strictly tighter than the pre-#419 unbounded one.

### 2. Stop h2/h3 trace records from carrying stale bytes

Three L7 emit paths shipped bytes they never wrote. The HTTP/2 emit path filled the per-CPU scratch record field by field but, unlike both CLOSE paths, never zeroed it; on a fill_h2_record_peer miss the peer 4-tuple kept the previous record's values, which can belong to another container, and ParseRecord reads those offsets unconditionally. The QUIC-initial and HTTP/3-stream paths submitted a whole fixed-size record while filling only caplen/n payload bytes, shipping the uninitialized ring/per-CPU tail to userspace.

- h2.c: memset the scratch record at the top of the emit block, matching the CLOSE paths.
- http3.c: build the QUIC-initial record in a new quic_initial_scratch PERCPU_ARRAY and ship it with bpf_ringbuf_output at offsetof(pkt)+caplen (reserve/submit cannot ship a dynamic length, and a 1500-byte __builtin_memset does not compile for the BPF target).
- nghttp3.c: ship offsetof(data)+n instead of sizeof(*c).
- maps.h: add the quic_initial_scratch map.