### PR TITLE
fix: surface kernel event drops in agent metrics and status

### DIFF
--- a/internal/agent/kernel_drop_test.go
+++ b/internal/agent/kernel_drop_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestMetricsObserver_OnEventsDropped(t *testing.T) {
+	m := NewMetrics()
+	obs := m.EngineObserver()
+
+	obs.OnEventsDropped("channel_full", 3)
+	obs.OnEventsDropped("ringbuf", 2)
+	obs.OnEventsDropped("channel_full", 0)
+	obs.OnEventsDropped("channel_full", -1)
+
+	if got := scrapeMetric(t, m, `kernel_events_dropped_total{reason="channel_full"}`); got != 3 {
+		t.Errorf(`kernel_events_dropped_total{reason="channel_full"} = %d, want 3`, got)
+	}
+	if got := scrapeMetric(t, m, `kernel_events_dropped_total{reason="ringbuf"}`); got != 2 {
+		t.Errorf(`kernel_events_dropped_total{reason="ringbuf"} = %d, want 2`, got)
+	}
+	if got := m.KernelDroppedTotal(); got != 5 {
+		t.Errorf("KernelDroppedTotal = %d, want 5", got)
+	}
+}
+
+func TestStatusWriter_FoldsKernelDropsIntoNodeStatus(t *testing.T) {
+	router := NewRouter(nil)
+	exp := &recExp{name: "x"}
+	router.Publish([]CRRule{mkRule("ns", "pt", []uint64{1}, []events.EventType{events.EventDNS}, exp)})
+	router.Stats().incrDropped(CRKey{Namespace: "ns", Name: "pt"}, 2)
+
+	pt := &podtracev1alpha1.PodTrace{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pt"}}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(pt).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).
+		Build()
+
+	w := &StatusWriter{
+		Client:        c,
+		NodeName:      "node-x",
+		Router:        router,
+		Ready:         func() bool { return true },
+		KernelDropped: func() int64 { return 3 },
+	}
+	if err := w.emitOnce(context.Background()); err != nil {
+		t.Fatalf("emitOnce: %v", err)
+	}
+
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "pt"}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Status.NodeStatus) != 1 {
+		t.Fatalf("nodeStatus len = %d, want 1", len(got.Status.NodeStatus))
+	}
+	if got.Status.NodeStatus[0].DroppedEvents != 5 {
+		t.Errorf("DroppedEvents = %d, want 5 (2 exporter + 3 kernel)", got.Status.NodeStatus[0].DroppedEvents)
+	}
+}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -16,15 +17,16 @@ import (
 type Metrics struct {
 	registry *prometheus.Registry
 
-	AgentInfo       *prometheus.GaugeVec
-	EventsExported  *prometheus.CounterVec
-	EventsDropped   *prometheus.CounterVec
-	ActiveCgroups   *prometheus.GaugeVec
-	ActiveCRs       prometheus.Gauge
-	ReconcileTotal  prometheus.Counter
-	BackendDegraded *prometheus.GaugeVec
-	CgroupsAttached prometheus.Counter
-	CgroupsDetached prometheus.Counter
+	AgentInfo           *prometheus.GaugeVec
+	EventsExported      *prometheus.CounterVec
+	EventsDropped       *prometheus.CounterVec
+	KernelEventsDropped *prometheus.CounterVec
+	ActiveCgroups       *prometheus.GaugeVec
+	ActiveCRs           prometheus.Gauge
+	ReconcileTotal      prometheus.Counter
+	BackendDegraded     *prometheus.GaugeVec
+	CgroupsAttached     prometheus.Counter
+	CgroupsDetached     prometheus.Counter
 
 	ThresholdTripped    *prometheus.CounterVec
 	EffectiveSampleRate *prometheus.GaugeVec
@@ -48,6 +50,8 @@ type Metrics struct {
 	EnrichmentCacheSize     prometheus.Gauge
 	EnrichmentSnapshots     prometheus.Counter
 	EnrichmentOwnerResolved *prometheus.CounterVec
+
+	kernelDropped atomic.Int64
 
 	mu          sync.Mutex
 	lastEvents  map[CRKey]int64
@@ -83,6 +87,11 @@ func NewMetrics() *Metrics {
 			Name:      "events_dropped_total",
 			Help:      "Events a CR claimed but whose exporter returned an error (non-fatal, retried via stats only).",
 		}, []string{"cr_namespace", "cr_name"}),
+		KernelEventsDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "podtrace_agent",
+			Name:      "kernel_events_dropped_total",
+			Help:      "Events discarded before the dispatch loop (kernel ring buffer overrun or full event channel), labeled by reason. Node-level; predates CR routing so it is not attributable to a CR.",
+		}, []string{"reason"}),
 		ActiveCgroups: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "podtrace_agent",
 			Name:      "active_cgroups",
@@ -185,7 +194,7 @@ func NewMetrics() *Metrics {
 	}
 	reg.MustRegister(
 		m.AgentInfo,
-		m.EventsExported, m.EventsDropped, m.ActiveCgroups, m.ActiveCRs,
+		m.EventsExported, m.EventsDropped, m.KernelEventsDropped, m.ActiveCgroups, m.ActiveCRs,
 		m.ReconcileTotal, m.BackendDegraded, m.CgroupsAttached, m.CgroupsDetached,
 		m.EnrichmentLookups, m.EnrichmentCacheSize, m.EnrichmentSnapshots,
 		m.EnrichmentOwnerResolved,
@@ -427,6 +436,26 @@ func (o *metricsEngineObserver) OnTargetError(stage string, err error) {
 		zap.String("stage", stage),
 		zap.Error(err),
 	)
+}
+
+// OnEventsDropped records kernel-side event loss (ring buffer overrun, full
+// event channel) on the agent registry so it is visible in agent mode, where
+// the tracer's default-registry drop counter is not served.
+func (o *metricsEngineObserver) OnEventsDropped(reason string, n int) {
+	if n <= 0 {
+		return
+	}
+	o.m.KernelEventsDropped.WithLabelValues(reason).Add(float64(n))
+	o.m.kernelDropped.Add(int64(n))
+}
+
+// KernelDroppedTotal returns the cumulative count of events discarded before
+// the dispatch loop, for folding into per-node CR status.
+func (m *Metrics) KernelDroppedTotal() int64 {
+	if m == nil {
+		return 0
+	}
+	return m.kernelDropped.Load()
 }
 
 // RefreshFromRouter walks the router's rule set + stats table and

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -169,13 +169,14 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	writer := &StatusWriter{
-		Client:     mgr.GetClient(),
-		NodeName:   opts.NodeName,
-		Interval:   opts.StatusReportInterval,
-		Router:     router,
-		Ready:      probeSrv.IsReady,
-		Heartbeat:  probeSrv.Heartbeat,
-		BackendErr: backendErr,
+		Client:        mgr.GetClient(),
+		NodeName:      opts.NodeName,
+		Interval:      opts.StatusReportInterval,
+		Router:        router,
+		Ready:         probeSrv.IsReady,
+		Heartbeat:     probeSrv.Heartbeat,
+		KernelDropped: metrics.KernelDroppedTotal,
+		BackendErr:    backendErr,
 	}
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/internal/agent/status_writer.go
+++ b/internal/agent/status_writer.go
@@ -26,6 +26,8 @@ type StatusWriter struct {
 	Ready     func() bool
 	Heartbeat func()
 
+	KernelDropped func() int64
+
 	BackendErr error
 
 	reportedKeys map[CRKey]struct{}
@@ -69,6 +71,9 @@ func (w *StatusWriter) emitOnce(ctx context.Context) error {
 	current := make(map[CRKey]struct{}, len(rules))
 	for _, rule := range rules {
 		entry := buildNodeStatusEntry(w.NodeName, &rule, stats[rule.Key], agentReady, w.BackendErr, time.Now())
+		if w.KernelDropped != nil {
+			entry.DroppedEvents += w.KernelDropped()
+		}
 		if err := w.patchCRStatus(ctx, rule.Key, entry); err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -115,6 +115,7 @@ type Tracer struct {
 	pathCache                     *cache.PathCache
 	resourceMgr                   *resourceMonitorManager
 	lastDNSDrops                  uint64
+	dropReport                    func(reason string, n int)
 	cgroupPaths                   atomic.Pointer[[]string]
 	useUserspaceCgroupFilter      atomic.Bool
 	denyWhenNoTargets             atomic.Bool
@@ -1300,6 +1301,18 @@ func (t *Tracer) pidsForContainer(id string, seeds []uint32) []uint32 {
 	return out
 }
 
+// SetDropReporter installs a callback the tracer invokes on every discarded
+// event.
+func (t *Tracer) SetDropReporter(report func(reason string, n int)) {
+	t.dropReport = report
+}
+
+func (t *Tracer) reportDrop(reason string, n int) {
+	if t.dropReport != nil {
+		t.dropReport(reason, n)
+	}
+}
+
 func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) error {
 	errorLimiter := newErrorRateLimiter()
 	slidingWindow := newSlidingWindow(config.DefaultSlidingWindowSize, config.DefaultSlidingWindowBuckets)
@@ -1461,6 +1474,7 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 				slidingWindow.addError()
 				errorRate := slidingWindow.getErrorRate()
 				metricsexporter.RecordRingBufferDrop()
+				t.reportDrop("ringbuf", 1)
 
 				if config.ErrorBackoffEnabled && errorLimiter.shouldLog() {
 					if errorRate > config.HighErrorCountThreshold {
@@ -1647,6 +1661,7 @@ func (t *Tracer) processAndDispatch(ctx context.Context, event *events.Event,
 			metricsexporter.RecordEventProcessingLatency(time.Since(processingStart))
 		default:
 			metricsexporter.RecordRingBufferDrop()
+			t.reportDrop("channel_full", 1)
 			parser.PutEvent(event)
 		}
 	} else {

--- a/pkg/tracer/engine.go
+++ b/pkg/tracer/engine.go
@@ -17,17 +17,8 @@ type Config struct {
 
 	ExportBatchSize int
 
-	// ExportFlushInterval bounds how long a partial batch waits before it is
-	// flushed to exporters even when it has not reached ExportBatchSize.
-	// Without it, a low-traffic pod (e.g. one emitting only periodic
-	// resource-limit events) would never fill a batch, so its events — and
-	// anything that depends on their timely delivery, like alert-triggered
-	// sessions — would be delayed until the batch happened to fill or the
-	// engine shut down. Defaults to 1s.
 	ExportFlushInterval time.Duration
 
-	// ShutdownFlushTimeout bounds the final flush + drain on shutdown so
-	// a hung exporter cannot block engine teardown. Defaults to 10s.
 	ShutdownFlushTimeout time.Duration
 
 	Observer EngineObserver
@@ -122,6 +113,11 @@ func (e *engine) Run(ctx context.Context, targets <-chan TargetSet) error {
 	dispatchCtx, cancelDispatch := context.WithCancel(context.WithoutCancel(ctx))
 
 	eventCh := make(chan *events.Event, e.cfg.EventBufferSize)
+	if edo, ok := e.cfg.Observer.(EventDropObserver); ok {
+		if dr, ok := e.backend.(DropReporter); ok {
+			dr.SetDropReporter(edo.OnEventsDropped)
+		}
+	}
 	if err := e.backend.Start(ctx, eventCh); err != nil {
 		cancelDispatch()
 		return fmt.Errorf("tracer: backend start: %w", err)

--- a/pkg/tracer/engine_drop_reporter_test.go
+++ b/pkg/tracer/engine_drop_reporter_test.go
@@ -1,0 +1,78 @@
+package tracer_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/pkg/tracer"
+)
+
+type dropReportingBackend struct {
+	*mockBackend
+	reporter func(string, int)
+}
+
+func (b *dropReportingBackend) SetDropReporter(r func(reason string, n int)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reporter = r
+}
+
+func (b *dropReportingBackend) getReporter() func(string, int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.reporter
+}
+
+type recordingDropObserver struct {
+	mu     sync.Mutex
+	reason string
+	n      int
+	calls  int
+}
+
+func (o *recordingDropObserver) OnCgroupsAttached(int) {}
+func (o *recordingDropObserver) OnCgroupsDetached(int) {}
+func (o *recordingDropObserver) OnEventsDropped(reason string, n int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.reason = reason
+	o.n += n
+	o.calls++
+}
+
+func TestEngine_WiresDropReporterToObserver(t *testing.T) {
+	backend := &dropReportingBackend{mockBackend: &mockBackend{}}
+	obs := &recordingDropObserver{}
+	exp := &recordingExporter{name: "x"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{
+		EventBufferSize: 16,
+		ExportBatchSize: 4,
+		Observer:        obs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	targets := make(chan tracer.TargetSet, 1)
+	targets <- tracer.TargetSet{{CgroupPath: "/c"}}
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	waitUntil(t, 2*time.Second, func() bool { return backend.getReporter() != nil })
+	backend.getReporter()("channel_full", 4)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	if obs.calls != 1 || obs.reason != "channel_full" || obs.n != 4 {
+		t.Fatalf("observer got reason=%q n=%d calls=%d, want channel_full/4/1", obs.reason, obs.n, obs.calls)
+	}
+}

--- a/pkg/tracer/types.go
+++ b/pkg/tracer/types.go
@@ -77,6 +77,14 @@ type TargetErrorObserver interface {
 	OnTargetError(stage string, err error)
 }
 
+type EventDropObserver interface {
+	OnEventsDropped(reason string, n int)
+}
+
+type DropReporter interface {
+	SetDropReporter(report func(reason string, n int))
+}
+
 // CategoryGateable is an optional capability a TracerBackend can
 // implement to support kernel-side gating of probe groups by CRD
 // filter category.


### PR DESCRIPTION
## Summary

Kernel-side event loss was invisible when podtrace runs as the agent DaemonSet. The backend discards events at two points before they reach the dispatch loop, the kernel ring buffer overruns, or the 10k event channel to the engine fills and the non-blocking send drops, and both only increment RecordRingBufferDrop on the default Prometheus registry, which the agent never serves (its /metrics handler is bound to a private registry, so that counter is CLI-only).


## Changes

- Add two optional tracer capabilities: EventDropObserver (an EngineObserver that also wants drop notifications) and DropReporter (a backend the Engine can hand a drop callback).
- The Engine injects observer.OnEventsDropped into the backend before Start when both capabilities are present.
- The eBPF backend reports each discard through that callback with a reason label ("ringbuf" or "channel_full"), alongside the existing default-registry counter.
- The agent's observer records these on its own registry as podtrace_agent_kernel_events_dropped_total{reason} and accumulates a node total that the status writer folds into each CR's per-node droppedEvents.