### PR TITLE
fix: guard exporter egress against SSRF, cleartext, and redirects

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -117,13 +118,27 @@ func validateEndpointScheme(field, endpoint string) error {
 		return fmt.Errorf("%s: parse %q: %w", field, raw, err)
 	}
 	if u.Scheme == "" || u.Host == "" {
-		if _, err := url.Parse("http://" + raw); err != nil {
+		u, err = url.Parse("http://" + raw)
+		if err != nil {
 			return fmt.Errorf("%s: parse %q: %w", field, raw, err)
 		}
-		return nil
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
+	} else if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("%s: endpoint scheme must be http or https, got %q", field, u.Scheme)
 	}
+	if blockedEndpointHost(u.Hostname()) {
+		return fmt.Errorf("%s: endpoint host %q is a blocked address (link-local/metadata)", field, u.Hostname())
+	}
 	return nil
+}
+
+// blockedEndpointHost reports whether host is a literal IP an exporter must
+// never reach: link-local / cloud-metadata (169.254.0.0/16, fe80::/10), the
+// unspecified address, and multicast.
+func blockedEndpointHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsUnspecified() || ip.IsMulticast() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }

--- a/api/v1alpha1/validation_endpoint_test.go
+++ b/api/v1alpha1/validation_endpoint_test.go
@@ -1,0 +1,28 @@
+package v1alpha1
+
+import "testing"
+
+func TestValidateEndpointScheme_BlocksMetadataAndLinkLocal(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		wantErr  bool
+	}{
+		{"http://169.254.169.254:4318", true},
+		{"169.254.169.254:4318", true},
+		{"https://169.254.169.254", true},
+		{"http://[fe80::1]:4318", true},
+		{"http://0.0.0.0:4318", true},
+		{"ftp://collector", true},
+		{"https://collector.example.com", false},
+		{"http://localhost:4318", false},
+		{"http://10.1.2.3:4318", false},
+		{"collector:4318", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		err := validateEndpointScheme("spec.datadog.endpoint", c.endpoint)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateEndpointScheme(%q) err=%v, wantErr=%v", c.endpoint, err, c.wantErr)
+		}
+	}
+}

--- a/internal/agent/otlp_event_exporter.go
+++ b/internal/agent/otlp_event_exporter.go
@@ -10,7 +10,9 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 
+	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/events"
+	"github.com/gma1k/podtrace/internal/netguard"
 	"github.com/gma1k/podtrace/pkg/tracer"
 )
 
@@ -38,6 +40,7 @@ func newOTLPSpanExporter(b *BundlePayload) (*otlptrace.Exporter, error) {
 
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(endpoint.host),
+		otlptracehttp.WithHTTPClient(netguard.HardenedClient(config.TracingExporterTimeout)),
 	}
 	if endpoint.path != "" && endpoint.path != "/" {
 		opts = append(opts, otlptracehttp.WithURLPath(endpoint.path))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -539,6 +539,10 @@ func ExporterAllowInsecureNonLoopback() bool {
 	return getBoolEnvOrDefault("PODTRACE_EXPORTER_INSECURE", false)
 }
 
+func ExporterBlockPrivateRanges() bool {
+	return getBoolEnvOrDefault("PODTRACE_EXPORTER_BLOCK_PRIVATE", false)
+}
+
 func MetricsEnablePprof() bool {
 	return getBoolEnvOrDefault("PODTRACE_METRICS_ENABLE_PPROF", false) || ProfilingEnabled
 }

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -1,0 +1,80 @@
+// Package netguard hardens outbound HTTP made on behalf of tenant-supplied
+// exporter endpoints.
+package netguard
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+// IsBlockedIP reports whether ip is an address an exporter must never connect
+// to: cloud-metadata / link-local (169.254.0.0/16, fe80::/10), the unspecified
+// address, and multicast.
+func IsBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsUnspecified() || ip.IsMulticast() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	if config.ExporterBlockPrivateRanges() && ip.IsPrivate() {
+		return true
+	}
+	return false
+}
+
+// IsLoopbackHost reports whether host is localhost or a loopback IP literal.
+func IsLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// ValidateEndpointHost rejects an endpoint whose host is a literal IP an
+// exporter must never reach.
+func ValidateEndpointHost(host string) error {
+	if ip := net.ParseIP(host); ip != nil && IsBlockedIP(ip) {
+		return fmt.Errorf("endpoint host %q is a blocked address (link-local/metadata)", host)
+	}
+	return nil
+}
+
+// controlBlockSSRF is a net.Dialer.Control hook.
+func controlBlockSSRF(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	if ip := net.ParseIP(host); ip == nil || IsBlockedIP(ip) {
+		return fmt.Errorf("netguard: refusing exporter connection to blocked address %q", address)
+	}
+	return nil
+}
+
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("netguard: refusing redirect to %s: exporter endpoints must not redirect (credential-exfiltration guard)", req.URL.Redacted())
+}
+
+// HardenedClient returns an *http.Client for exporter egress that refuses
+// connections to blocked addresses (SSRF guard) and refuses redirects.
+func HardenedClient(timeout time.Duration) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   controlBlockSSRF,
+	}).DialContext
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     tr,
+		CheckRedirect: refuseRedirect,
+	}
+}

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,0 +1,110 @@
+package netguard
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+	}{
+		{"169.254.169.254", true},
+		{"169.254.0.1", true},
+		{"fe80::1", true},
+		{"0.0.0.0", true},
+		{"224.0.0.1", true},
+		{"8.8.8.8", false},
+		{"127.0.0.1", false},
+		{"::1", false},
+		{"10.0.0.5", false},
+		{"192.168.1.1", false},
+	}
+	for _, c := range cases {
+		if got := IsBlockedIP(net.ParseIP(c.ip)); got != c.blocked {
+			t.Errorf("IsBlockedIP(%s) = %v, want %v", c.ip, got, c.blocked)
+		}
+	}
+	if !IsBlockedIP(nil) {
+		t.Error("IsBlockedIP(nil) = false, want true")
+	}
+}
+
+func TestIsBlockedIP_PrivateOptIn(t *testing.T) {
+	t.Setenv("PODTRACE_EXPORTER_BLOCK_PRIVATE", "1")
+	if !IsBlockedIP(net.ParseIP("10.0.0.5")) {
+		t.Error("10.0.0.5 not blocked when private-range block is enabled")
+	}
+	if IsBlockedIP(net.ParseIP("8.8.8.8")) {
+		t.Error("8.8.8.8 blocked when only private-range block is enabled")
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		if !IsLoopbackHost(h) {
+			t.Errorf("IsLoopbackHost(%q) = false, want true", h)
+		}
+	}
+	for _, h := range []string{"example.com", "8.8.8.8", "169.254.169.254"} {
+		if IsLoopbackHost(h) {
+			t.Errorf("IsLoopbackHost(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestValidateEndpointHost(t *testing.T) {
+	if err := ValidateEndpointHost("169.254.169.254"); err == nil {
+		t.Error("metadata IP literal accepted")
+	}
+	if err := ValidateEndpointHost("8.8.8.8"); err != nil {
+		t.Errorf("public IP rejected: %v", err)
+	}
+	if err := ValidateEndpointHost("collector.example.com"); err != nil {
+		t.Errorf("DNS name rejected at admission: %v", err)
+	}
+}
+
+func TestHardenedClient_RefusesRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example.com/elsewhere", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := HardenedClient(5 * time.Second).Get(srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "refusing redirect") {
+		t.Fatalf("expected refusing-redirect error, got %v", err)
+	}
+}
+
+func TestHardenedClient_BlocksSSRFDial(t *testing.T) {
+	_, err := HardenedClient(5 * time.Second).Get("http://169.254.169.254:9/latest/meta-data/")
+	if err == nil || !strings.Contains(err.Error(), "blocked address") {
+		t.Fatalf("expected blocked-address error, got %v", err)
+	}
+}
+
+func TestControlBlockSSRF(t *testing.T) {
+	cases := []struct {
+		address string
+		wantErr bool
+	}{
+		{"8.8.8.8:443", false},
+		{"127.0.0.1:4318", false},
+		{"169.254.169.254:80", true},
+		{"[fe80::1]:80", true},
+		{"not-an-ip:80", true},
+		{"missing-port", true},
+	}
+	for _, c := range cases {
+		err := controlBlockSSRF("tcp", c.address, nil)
+		if (err != nil) != c.wantErr {
+			t.Errorf("controlBlockSSRF(%q) err=%v, wantErr=%v", c.address, err, c.wantErr)
+		}
+	}
+}

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -3,7 +3,6 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/diagnose/tracker"
+	"github.com/gma1k/podtrace/internal/netguard"
 )
 
 type DataDogExporter struct {
@@ -46,7 +46,7 @@ func NewDataDogExporter(endpoint, apiKey string, sampleRate float64) (*DataDogEx
 	return &DataDogExporter{
 		endpoint:   endpoint,
 		apiKey:     apiKey,
-		client:     &http.Client{Timeout: config.TracingExporterTimeout},
+		client:     netguard.HardenedClient(config.TracingExporterTimeout),
 		enabled:    true,
 		sampleRate: sampleRate,
 	}, nil
@@ -121,7 +121,7 @@ func (e *DataDogExporter) exportTrace(t *tracker.Trace) error {
 	}
 
 	// v0.4 payload: array of traces, each trace is an array of spans.
-	payload, err := json.Marshal([][]datadogSpan{ddSpans})
+	payload, err := marshalJSON([][]datadogSpan{ddSpans})
 	if err != nil {
 		return fmt.Errorf("failed to marshal datadog payload: %w", err)
 	}

--- a/internal/tracing/exporter/otlp.go
+++ b/internal/tracing/exporter/otlp.go
@@ -86,12 +86,12 @@ func NewOTLPExporter(endpoint string, sampleRate float64) (*OTLPExporter, error)
 	if useInsecure {
 		opts = append(opts, otlptracehttp.WithInsecure())
 	}
-	otlpExporter, err := otlptracehttp.New(ctx, opts...)
+	otlpExporter, err := newOTLPClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
 	}
 
-	res, err := resource.New(ctx,
+	res, err := newResource(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("Podtrace"),
 		),

--- a/internal/tracing/exporter/seam_error_test.go
+++ b/internal/tracing/exporter/seam_error_test.go
@@ -1,0 +1,66 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestExportTrace_MarshalError(t *testing.T) {
+	orig := marshalJSON
+	marshalJSON = func(any) ([]byte, error) { return nil, errors.New("boom") }
+	defer func() { marshalJSON = orig }()
+
+	dd, err := NewDataDogExporter("https://collector.example.com", "k", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dd.exportTrace(newTestTrace()); err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("datadog exportTrace: err=%v, want marshal error", err)
+	}
+
+	sp, err := NewSplunkExporter("https://collector.example.com", "tok", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.exportTrace(newTestTrace()); err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("splunk exportTrace: err=%v, want marshal error", err)
+	}
+
+	zp, err := NewZipkinExporter("https://collector.example.com", 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := zp.exportTrace(newTestTrace()); err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("zipkin exportTrace: err=%v, want marshal error", err)
+	}
+}
+
+func TestNewOTLPExporter_ConstructorErrors(t *testing.T) {
+	origClient := newOTLPClient
+	origResource := newResource
+	defer func() {
+		newOTLPClient = origClient
+		newResource = origResource
+	}()
+
+	newOTLPClient = func(context.Context, ...otlptracehttp.Option) (*otlptrace.Exporter, error) {
+		return nil, errors.New("boom client")
+	}
+	if _, err := NewOTLPExporter("https://collector.example.com", 1.0); err == nil || !strings.Contains(err.Error(), "OTLP exporter") {
+		t.Errorf("client constructor: err=%v, want OTLP exporter error", err)
+	}
+
+	newOTLPClient = origClient
+	newResource = func(context.Context, ...resource.Option) (*resource.Resource, error) {
+		return nil, errors.New("boom resource")
+	}
+	if _, err := NewOTLPExporter("https://collector.example.com", 1.0); err == nil || !strings.Contains(err.Error(), "resource") {
+		t.Errorf("resource constructor: err=%v, want resource error", err)
+	}
+}

--- a/internal/tracing/exporter/seams.go
+++ b/internal/tracing/exporter/seams.go
@@ -1,0 +1,14 @@
+package exporter
+
+import (
+	"encoding/json"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+var (
+	marshalJSON   = json.Marshal
+	newOTLPClient = otlptracehttp.New
+	newResource   = resource.New
+)

--- a/internal/tracing/exporter/splunk.go
+++ b/internal/tracing/exporter/splunk.go
@@ -3,13 +3,13 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/diagnose/tracker"
+	"github.com/gma1k/podtrace/internal/netguard"
 )
 
 type SplunkExporter struct {
@@ -37,7 +37,7 @@ func NewSplunkExporter(endpoint, token string, sampleRate float64) (*SplunkExpor
 	return &SplunkExporter{
 		endpoint:   endpoint,
 		token:      token,
-		client:     &http.Client{Timeout: config.TracingExporterTimeout},
+		client:     netguard.HardenedClient(config.TracingExporterTimeout),
 		enabled:    true,
 		sampleRate: sampleRate,
 	}, nil
@@ -106,7 +106,7 @@ func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {
 
 	var errs []error
 	for _, event := range events {
-		payload, err := json.Marshal(event)
+		payload, err := marshalJSON(event)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("marshal event: %w", err))
 			continue

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -3,13 +3,13 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/diagnose/tracker"
+	"github.com/gma1k/podtrace/internal/netguard"
 )
 
 type ZipkinExporter struct {
@@ -50,7 +50,7 @@ func NewZipkinExporter(endpoint string, sampleRate float64) (*ZipkinExporter, er
 
 	return &ZipkinExporter{
 		endpoint:   endpoint,
-		client:     &http.Client{Timeout: config.TracingExporterTimeout},
+		client:     netguard.HardenedClient(config.TracingExporterTimeout),
 		enabled:    true,
 		sampleRate: sampleRate,
 	}, nil
@@ -127,7 +127,7 @@ func (e *ZipkinExporter) exportTrace(t *tracker.Trace) error {
 		zipkinSpans = append(zipkinSpans, zs)
 	}
 
-	payload, err := json.Marshal(zipkinSpans)
+	payload, err := marshalJSON(zipkinSpans)
 	if err != nil {
 		return fmt.Errorf("failed to marshal zipkin payload: %w", err)
 	}


### PR DESCRIPTION
## Summary

A namespaced ExporterConfig CRD steers where the privileged agent DaemonSet connects and which Secret-materialized credentials it attaches, and that egress was unguarded on three axes.

## Changes

- New internal/netguard package: IsBlockedIP (link-local/metadata/unspecified/multicast always blocked; private ranges blocked only under PODTRACE_EXPORTER_BLOCK_PRIVATE), and HardenedClient, an http.Client whose net.Dialer.Control rejects blocked IPs at the resolved address before connect (TOCTOU-safe, preserves hostname TLS) and whose CheckRedirect refuses all redirects.
- Agent OTLP: normalizeOTLPEndpoint refuses cleartext http to a non-loopback host unless PODTRACE_EXPORTER_INSECURE, matching the other exporter paths.
- Transport: datadog/splunk/zipkin build their client via netguard.HardenedClient; the OTLP exporter passes it through otlptracehttp.WithHTTPClient. All four credentialed exporters now get the SSRF dial-guard and redirect refusal.
- Admission: validateEndpointScheme rejects an endpoint whose host is a literal metadata/link-local IP, and the bare host:port path now inspects the host too. api/v1alpha1 stays free of internal imports.
- New config knob ExporterBlockPrivateRanges (PODTRACE_EXPORTER_BLOCK_PRIVATE), default off.