### PR TITLE
fix: bound CR names stamped into label values to 63 chars

### DIFF
--- a/api/v1alpha1/names.go
+++ b/api/v1alpha1/names.go
@@ -1,0 +1,3 @@
+package v1alpha1
+
+const MaxManagedCRNameLength = 63

--- a/internal/operator/applicationtrace_controller.go
+++ b/internal/operator/applicationtrace_controller.go
@@ -51,6 +51,15 @@ func (r *ApplicationTraceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.setCondition(&app, ConditionPaused, metav1.ConditionFalse, "NotPaused", "")
 	}
 
+	if err := validateManagedCRName("ApplicationTrace", app.Name); err != nil {
+		r.setCondition(&app, ConditionDegraded, metav1.ConditionTrue, "NameTooLong", err.Error())
+		r.setCondition(&app, ConditionReady, metav1.ConditionFalse, "NameTooLong", err.Error())
+		if perr := r.patchStatus(ctx, &app); perr != nil {
+			return ctrl.Result{}, perr
+		}
+		return ctrl.Result{}, nil
+	}
+
 	pt, err := r.ensureChildPodTrace(ctx, &app)
 	if err != nil {
 		r.setCondition(&app, ConditionDegraded, metav1.ConditionTrue, "ChildPodTrace", err.Error())

--- a/internal/operator/cr_name_length_test.go
+++ b/internal/operator/cr_name_length_test.go
@@ -1,0 +1,174 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestValidateManagedCRName(t *testing.T) {
+	if err := validateManagedCRName("PodTrace", strings.Repeat("a", 63)); err != nil {
+		t.Errorf("63-char name rejected: %v", err)
+	}
+	if err := validateManagedCRName("PodTrace", strings.Repeat("a", 64)); err == nil {
+		t.Error("64-char name accepted, want rejected")
+	}
+	if err := validateManagedCRName("PodTrace", ""); err != nil {
+		t.Errorf("empty name rejected: %v", err)
+	}
+}
+
+func TestPodTraceReconciler_RejectsTooLongName(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("a", 64)
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo", Finalizers: []string{FinalizerCleanup}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pt).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected terminal (no requeue), got %+v", res)
+	}
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: name}, &got); err != nil {
+		t.Fatal(err)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "NameTooLong" {
+		t.Fatalf("Ready condition = %+v, want False/NameTooLong", cond)
+	}
+}
+
+func TestPodTraceReconciler_RejectsTooLongExporterConfigName(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	ecName := strings.Repeat("e", 64)
+	pt := &podtracev1alpha1.PodTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: "pt", Namespace: "demo", Finalizers: []string{FinalizerCleanup}},
+		Spec:       podtracev1alpha1.PodTraceSpec{ExporterRef: podtracev1alpha1.LocalObjectReference{Name: ecName}},
+	}
+	ec := &podtracev1alpha1.ExporterConfig{ObjectMeta: metav1.ObjectMeta{Name: ecName, Namespace: "demo"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pt, ec).
+		WithStatusSubresource(&podtracev1alpha1.PodTrace{}, &podtracev1alpha1.ExporterConfig{}).Build()
+	r := &PodTraceReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: "pt"}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected terminal (no requeue), got %+v", res)
+	}
+	var got podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: "pt"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "ExporterConfigNameTooLong" {
+		t.Fatalf("Ready condition = %+v, want False/ExporterConfigNameTooLong", cond)
+	}
+}
+
+func TestPodTraceSessionReconciler_RejectsTooLongName(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("s", 64)
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo", Finalizers: []string{FinalizerCleanup}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(s).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected terminal (no requeue loop), got %+v", res)
+	}
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: name}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Fatalf("state = %q, want Failed (terminal, so TTL-GC runs)", got.Status.State)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionDegraded)
+	if cond == nil || cond.Reason != "NameTooLong" {
+		t.Fatalf("Degraded condition = %+v, want reason NameTooLong", cond)
+	}
+}
+
+func TestApplicationTraceReconciler_RejectsTooLongName(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("a", 64)
+	app := &podtracev1alpha1.ApplicationTrace{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}, &podtracev1alpha1.PodTrace{}).Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no requeue, got %+v", res)
+	}
+	var child podtracev1alpha1.PodTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: name}, &child); !apierrors.IsNotFound(err) {
+		t.Fatalf("child PodTrace must not be created for an over-long name, got err=%v", err)
+	}
+	var got podtracev1alpha1.ApplicationTrace
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: name}, &got); err != nil {
+		t.Fatal(err)
+	}
+	cond := findCondition(got.Status.Conditions, ConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "NameTooLong" {
+		t.Fatalf("Ready condition = %+v, want False/NameTooLong", cond)
+	}
+}
+
+func TestExporterConfigReconciler_RejectsTooLongName(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("e", 64)
+	ec := &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo", Generation: 1},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "http://collector:4318"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var got podtracev1alpha1.ExporterConfig
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "demo", Name: name}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.Ready {
+		t.Error("ExporterConfig marked Ready despite over-long name")
+	}
+	cond := findCondition(got.Status.Conditions, ConditionReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "NameTooLong" {
+		t.Fatalf("Ready condition = %+v, want False/NameTooLong", cond)
+	}
+}

--- a/internal/operator/exporterconfig_controller.go
+++ b/internal/operator/exporterconfig_controller.go
@@ -77,6 +77,27 @@ func (r *ExporterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	orig := ec.DeepCopy()
 
+	if err := validateManagedCRName("ExporterConfig", ec.Name); err != nil {
+		ec.Status.ObservedGeneration = ec.Generation
+		ec.Status.Ready = false
+		setCondition(&ec.Status.Conditions, ec.Generation, metav1.Condition{
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  "NameTooLong",
+			Message: clampMessage(err.Error()),
+		})
+		if statusEqual(orig.Status, ec.Status) {
+			return ctrl.Result{}, nil
+		}
+		if perr := r.Status().Patch(ctx, &ec, client.MergeFrom(orig)); perr != nil {
+			if apierrors.IsConflict(perr) {
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("patch status: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	ready, readyStatus, readyReason, readyMessage := r.evaluateReadiness(ctx, &ec)
 
 	refs, err := r.countReferences(ctx, &ec)

--- a/internal/operator/name_guard_error_paths_test.go
+++ b/internal/operator/name_guard_error_paths_test.go
@@ -1,0 +1,125 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestSessionJobName_EmptyNodeFallsBackToPrefixAndSuffix(t *testing.T) {
+	got := SessionJobName(types.UID("abcdef012345"), "!!!")
+	if !strings.HasPrefix(got, "pts-") || len(got) == 0 {
+		t.Fatalf("SessionJobName with unsanitisable node = %q, want pts-<uid><suffix>", got)
+	}
+}
+
+func longNameExporterConfig(name string) *podtracev1alpha1.ExporterConfig {
+	return &podtracev1alpha1.ExporterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo", Generation: 1},
+		Spec: podtracev1alpha1.ExporterConfigSpec{
+			Type: podtracev1alpha1.ExporterTypeOTLP,
+			OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "http://collector:4318"},
+		},
+	}
+}
+
+func TestExporterConfigReconciler_TooLongNameIsIdempotent(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("e", 64)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(longNameExporterConfig(name)).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	res, err := r.Reconcile(context.Background(), req)
+	if err != nil || res.RequeueAfter != 0 {
+		t.Fatalf("second reconcile (status unchanged) res=%+v err=%v, want no-op", res, err)
+	}
+}
+
+func TestExporterConfigReconciler_TooLongNamePatchConflictRequeues(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("e", 64)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(longNameExporterConfig(name)).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(context.Context, client.Client, string, client.Object, client.Patch, ...client.SubResourcePatchOption) error {
+				return apierrors.NewConflict(schema.GroupResource{Group: "podtrace.io", Resource: "exporterconfigs"}, name, errors.New("conflict"))
+			},
+		}).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}})
+	if err != nil || res.RequeueAfter != time.Second {
+		t.Fatalf("conflict path res=%+v err=%v, want RequeueAfter=1s nil", res, err)
+	}
+}
+
+func TestExporterConfigReconciler_TooLongNamePatchErrorPropagates(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("e", 64)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(longNameExporterConfig(name)).
+		WithStatusSubresource(&podtracev1alpha1.ExporterConfig{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(context.Context, client.Client, string, client.Object, client.Patch, ...client.SubResourcePatchOption) error {
+				return errors.New("boom")
+			},
+		}).Build()
+	r := &ExporterConfigReconciler{Client: c, Scheme: scheme}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}}); err == nil {
+		t.Fatal("expected patch error to propagate")
+	}
+}
+
+func TestApplicationTraceReconciler_TooLongNameStatusWriteErrorPropagates(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("a", 64)
+	app := &podtracev1alpha1.ApplicationTrace{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "demo"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(app).
+		WithStatusSubresource(&podtracev1alpha1.ApplicationTrace{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+				return errors.New("boom")
+			},
+		}).Build()
+	r := &ApplicationTraceReconciler{Client: c, Scheme: scheme}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "demo", Name: name}}); err == nil {
+		t.Fatal("expected patchStatus error to propagate")
+	}
+}
+
+func TestTracerConfigReconciler_InvalidNameStatusWriteErrorPropagates(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	name := strings.Repeat("t", 64)
+	tc := &podtracev1alpha1.TracerConfig{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc).
+		WithStatusSubresource(&podtracev1alpha1.TracerConfig{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+				return errors.New("boom")
+			},
+		}).Build()
+	r := &TracerConfigReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err == nil {
+		t.Fatal("expected InvalidName status-update error to propagate")
+	}
+}

--- a/internal/operator/names.go
+++ b/internal/operator/names.go
@@ -1,0 +1,16 @@
+package operator
+
+import (
+	"fmt"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func validateManagedCRName(kind, name string) error {
+	if len(name) > podtracev1alpha1.MaxManagedCRNameLength {
+		return fmt.Errorf(
+			"metadata.name is %d characters; %s names are limited to %d because the name is stamped into a Kubernetes label value, which is capped at %d characters",
+			len(name), kind, podtracev1alpha1.MaxManagedCRNameLength, podtracev1alpha1.MaxManagedCRNameLength)
+	}
+	return nil
+}

--- a/internal/operator/podtrace_controller.go
+++ b/internal/operator/podtrace_controller.go
@@ -97,6 +97,12 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	r.setCondition(&pt, ConditionPaused, metav1.ConditionFalse, "NotPaused", "")
 
+	if err := validateManagedCRName("PodTrace", pt.Name); err != nil {
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "NameTooLong", err.Error())
+		r.setCondition(&pt, ConditionReady, metav1.ConditionFalse, "NameTooLong", err.Error())
+		return ctrl.Result{}, r.Status().Update(ctx, &pt)
+	}
+
 	var ec podtracev1alpha1.ExporterConfig
 	ecKey := types.NamespacedName{Namespace: pt.Namespace, Name: pt.Spec.ExporterRef.Name}
 	if err := r.Get(ctx, ecKey, &ec); err != nil {
@@ -108,6 +114,12 @@ func (r *PodTraceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
+	}
+
+	if err := validateManagedCRName("ExporterConfig", ec.Name); err != nil {
+		r.setCondition(&pt, ConditionDegraded, metav1.ConditionTrue, "ExporterConfigNameTooLong", err.Error())
+		r.setCondition(&pt, ConditionReady, metav1.ConditionFalse, "ExporterConfigNameTooLong", err.Error())
+		return ctrl.Result{}, r.Status().Update(ctx, &pt)
 	}
 
 	// Resolve spec.namespaceSelector against the cluster's Namespace

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -104,6 +104,10 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.reconcileTerminalSession(ctx, &session)
 	}
 
+	if err := validateManagedCRName("PodTraceSession", session.Name); err != nil {
+		return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "NameTooLong", err.Error())
+	}
+
 	if session.Spec.ReportRef != nil && session.Spec.ReportRef.ObjectStore != nil {
 		if err := podtracev1alpha1.ValidateObjectStoreReference(session.Spec.ReportRef.ObjectStore); err != nil {
 			return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "ObjectStoreURIInvalid", err.Error())
@@ -155,6 +159,9 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get ExporterConfig: %w", err)
+	}
+	if err := validateManagedCRName("ExporterConfig", ec.Name); err != nil {
+		return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "ExporterConfigNameTooLong", err.Error())
 	}
 	// A session whose nodes span fleets with different spec.systemNamespace
 	// puts Jobs in more than one namespace, and a Job cannot mount a bundle,

--- a/internal/operator/session_reconcile_failure_branches_test.go
+++ b/internal/operator/session_reconcile_failure_branches_test.go
@@ -1,0 +1,112 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestEnsureJobs_UnresolvedNodeErrors(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: "podtrace-system"}
+	s := &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "u-ghost"},
+	}
+	targets := sessionTargets{Nodes: []string{"ghost-node"}}
+	resolved := resolvedFleet(r.SystemNamespace, nil, testTracerConfig("default", "img:test", "", nil))
+
+	if _, err := r.ensureJobs(context.Background(), s, resolved, targets, nil); err == nil {
+		t.Fatal("expected error when a target node has no resolved TracerConfig")
+	}
+}
+
+func TestSessionReconcile_BundleSyncErrorRequeues(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	objs := append(sessMoreFanOutObjects(), sessMoreSession(nil))
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Namespace == sessMoreSysNS {
+					return errInternal()
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	res, err := sessMoreReconcile(t, r)
+	if err != nil || res.RequeueAfter != 60*time.Second {
+		t.Fatalf("bundle-sync failure: res=%+v err=%v, want RequeueAfter=60s nil", res, err)
+	}
+}
+
+func TestSessionReconcile_FinalStatusUpdateErrorPropagates(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	objs := append(sessMoreFanOutObjects(), sessMoreSession(nil))
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+				return errInternal()
+			},
+		}).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	if _, err := sessMoreReconcile(t, r); err == nil {
+		t.Fatal("expected the final status update error to propagate")
+	}
+}
+
+func TestSessionReconcile_ExporterConfigNameTooLongFailsTerminally(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	longEC := strings.Repeat("e", 64)
+	objs := []client.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default", Labels: map[string]string{"a": "b"}},
+			Spec:       corev1.PodSpec{NodeName: "n1"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&podtracev1alpha1.ExporterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: longEC, Namespace: "default"},
+			Spec: podtracev1alpha1.ExporterConfigSpec{
+				Type: podtracev1alpha1.ExporterTypeOTLP,
+				OTLP: &podtracev1alpha1.OTLPExporter{Endpoint: "otel:4318", Protocol: podtracev1alpha1.OTLPProtocolHTTP},
+			},
+		},
+		&podtracev1alpha1.TracerConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: DefaultTracerConfigName},
+			Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+		},
+		sessMoreSession(func(s *podtracev1alpha1.PodTraceSession) { s.Spec.ExporterRef.Name = longEC }),
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(objs...).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	res, err := sessMoreReconcile(t, r)
+	if err != nil || res.RequeueAfter != 0 {
+		t.Fatalf("ExporterConfig-name-too-long: res=%+v err=%v, want terminal (no requeue)", res, err)
+	}
+	var got podtracev1alpha1.PodTraceSession
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "s"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Fatalf("state = %q, want Failed", got.Status.State)
+	}
+}


### PR DESCRIPTION
## Summary

A namespaced CR name is a DNS subdomain (up to 253 chars), but the operator stamps it verbatim into a Kubernetes label value, which is capped at 63. So a 64–253-character name is admitted as a CR yet rejected as a label value: PodTrace stamps LabelPodTraceName=pt.Name, PodTraceSession stamps LabelSessionName=s.Name, ApplicationTrace stamps LabelApplication=app.Name, and both PodTrace and PodTraceSession stamp LabelExporterConfig=ec.Name.

For PodTraceSession this is worst: the bundle-sync failure sets Degraded/BundleSync and returns RequeueAfter 60s with a nil error, so the session never reaches a terminal state, reconcileTerminalSession never TTL-deletes it, and the reconciler runs a permanent 60-second loop of cluster-wide List calls (Namespaces, Pods, TracerConfigs, Nodes) plus a status write, per object, forever. A single CR with a long name, creatable by any namespace owner, wedges the shared operator. TracerConfig already guards this (validateTracerConfigName, MaxTracerConfigNameLength=63, terminal with no requeue); the other four kinds did not.

## Changes

- Add MaxManagedCRNameLength (63) and validateManagedCRName, mirroring validateTracerConfigName.
- Guard the four kinds early in Reconcile, terminal and without requeue: PodTraceSession fails terminally (so it TTL-collects), PodTrace/ApplicationTrace/ExporterConfig set InvalidName/NameTooLong conditions and return without requeue.
- PodTrace and PodTraceSession also validate the resolved ExporterConfig name before stamping it, so a long-named referenced ExporterConfig cannot wedge the referrer either.
- Guards run after finalizer/deletion handling, so an over-long CR still cleans up on delete.