### PR TITLE
fix: harden setup scripts/CI and tracer lifecycle races

### DIFF
--- a/.github/actions/setup-bpf-toolchain/action.yml
+++ b/.github/actions/setup-bpf-toolchain/action.yml
@@ -53,17 +53,30 @@ runs:
             bpftool_works && return 0
           fi
 
-          local arch url
+          local ver="v7.7.0"
+          local arch want url tmp
           arch="$(dpkg --print-architecture)"
-          url="$(curl -fsSL https://api.github.com/repos/libbpf/bpftool/releases/latest 2>/dev/null \
-            | grep -oE '"browser_download_url": *"[^"]+"' | cut -d'"' -f4 \
-            | grep -E "bpftool-.*-${arch}\.tar\.gz$" | head -1 || true)"
-          if [[ -n "${url}" ]] && curl -fsSL "${url}" -o /tmp/bpftool.tar.gz; then
-            sudo tar -C /usr/local/bin -xzf /tmp/bpftool.tar.gz bpftool || true
-            sudo chmod 0755 /usr/local/bin/bpftool 2>/dev/null || true
-            hash -r
-            bpftool_works && return 0
+          case "${arch}" in
+            amd64) want="09150596f09356b0ff632dd7f9856e0ea86bf96b269e9bc94278d9a9432a268c" ;;
+            arm64) want="d68443d945c146080151eb215bebaa400294ab7ada22af4f5d0a940f5992b9d9" ;;
+            *) echo "::warning::no pinned bpftool for arch ${arch}"; return 1 ;;
+          esac
+          url="https://github.com/libbpf/bpftool/releases/download/${ver}/bpftool-${ver}-${arch}.tar.gz"
+          tmp="$(mktemp)"
+          if ! curl -fsSL "${url}" -o "${tmp}"; then
+            rm -f "${tmp}"; return 1
           fi
+          if ! echo "${want}  ${tmp}" | sha256sum -c - >/dev/null 2>&1; then
+            echo "::error::bpftool ${ver} ${arch} checksum mismatch; refusing to install"
+            rm -f "${tmp}"; return 1
+          fi
+          if ! sudo tar -C /usr/local/bin -xzf "${tmp}" bpftool; then
+            rm -f "${tmp}"; return 1
+          fi
+          sudo chmod 0755 /usr/local/bin/bpftool || true
+          rm -f "${tmp}"
+          hash -r
+          bpftool_works && return 0
 
           return 1
         }

--- a/.github/scripts/cppcheck_to_sarif.py
+++ b/.github/scripts/cppcheck_to_sarif.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Convert cppcheck --xml-version=2 output to SARIF 2.1.0.
+
+cppcheck (<= 2.13, the version shipped by Ubuntu runners) has no native SARIF
+writer, so this maps its stable XML v2 schema onto the minimal SARIF the
+GitHub code-scanning upload accepts. Advisory only: unknown/empty input still
+produces a valid empty SARIF run so the upload step never fails the job.
+"""
+import sys
+import xml.etree.ElementTree as ET
+
+SEVERITY_TO_LEVEL = {
+    "error": "error",
+    "warning": "warning",
+    "portability": "note",
+    "performance": "note",
+    "style": "note",
+    "information": "note",
+}
+
+
+def main() -> int:
+    in_path = sys.argv[1] if len(sys.argv) > 1 else "cppcheck.xml"
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "cppcheck.sarif"
+
+    results = []
+    rules = {}
+    try:
+        tree = ET.parse(in_path)
+        for err in tree.getroot().iter("error"):
+            rule_id = err.get("id", "cppcheck")
+            severity = err.get("severity", "warning")
+            level = SEVERITY_TO_LEVEL.get(severity, "warning")
+            message = err.get("verbose") or err.get("msg") or rule_id
+
+            loc = err.find("location")
+            file_uri = loc.get("file") if loc is not None else "bpf/"
+            line = int(loc.get("line", "1")) if loc is not None else 1
+            if line < 1:
+                line = 1
+
+            rules.setdefault(rule_id, {"id": rule_id, "name": rule_id})
+            results.append({
+                "ruleId": rule_id,
+                "level": level,
+                "message": {"text": message},
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": file_uri},
+                        "region": {"startLine": line},
+                    }
+                }],
+            })
+    except (ET.ParseError, FileNotFoundError) as exc:
+        print(f"cppcheck_to_sarif: no parseable input ({exc}); emitting empty run", file=sys.stderr)
+
+    sarif = {
+        "version": "2.1.0",
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "runs": [{
+            "tool": {"driver": {"name": "cppcheck", "rules": list(rules.values())}},
+            "results": results,
+        }],
+    }
+
+    import json
+    with open(out_path, "w") as f:
+        json.dump(sarif, f)
+    print(f"cppcheck_to_sarif: wrote {len(results)} result(s) to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ebpf-build.yml
+++ b/.github/workflows/ebpf-build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Run embed smoke test
         run: GOTOOLCHAIN=auto GOARCH=${{ matrix.goarch }} go test -tags embed_bpf ./internal/ebpf/embedded/...
 
+      - name: BPF loader + kernel verifier load-test
+        run: sudo -E env "PATH=$PATH" make test-bpf-load GO=go BPF_GOARCH=${{ matrix.goarch }}
+
       - name: List outputs
         run: |
           echo "=== eBPF object (arch=${{ matrix.bpf_arch }}) ==="

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,3 +113,101 @@ jobs:
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
+  semgrep:
+    name: semgrep
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install semgrep
+        run: pipx install semgrep==1.173.0
+
+      - name: Run semgrep (SARIF, advisory)
+        run: |
+          semgrep scan \
+            --config p/golang --config p/dockerfile \
+            --config p/github-actions --config p/secrets \
+            --config .semgrep/ \
+            --sarif --output semgrep.sarif --metrics=off . || true
+          test -s semgrep.sarif || echo '{"version":"2.1.0","runs":[]}' > semgrep.sarif
+
+      - name: Upload semgrep SARIF
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  trivy:
+    name: trivy
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Trivy
+        run: |
+          curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/v0.74.0/contrib/install.sh" \
+            | sudo sh -s -- -b /usr/local/bin v0.74.0
+          trivy --version
+
+      - name: Trivy filesystem scan (SARIF, advisory)
+        run: |
+          trivy fs --scanners vuln,misconfig,secret \
+            --format sarif --output trivy.sarif \
+            --severity HIGH,CRITICAL --exit-code 0 --no-progress .
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          sarif_file: trivy.sarif
+          category: trivy
+
+  cppcheck:
+    name: cppcheck
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cppcheck
+          cppcheck --version
+
+      - name: Run cppcheck over bpf/ (advisory)
+        run: |
+          cppcheck --enable=warning,portability,performance --inline-suppr \
+            --std=c11 -D__TARGET_ARCH_x86 -I bpf \
+            --suppress=missingInclude --suppress=missingIncludeSystem \
+            --suppress=unusedStructMember --suppress=unknownMacro \
+            --xml --xml-version=2 bpf/ 2> cppcheck.xml || true
+
+      - name: Convert cppcheck report to SARIF
+        run: python3 .github/scripts/cppcheck_to_sarif.py cppcheck.xml cppcheck.sarif
+
+      - name: Upload cppcheck SARIF
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          sarif_file: cppcheck.sarif
+          category: cppcheck

--- a/.semgrep/podtrace.yml
+++ b/.semgrep/podtrace.yml
@@ -1,0 +1,35 @@
+rules:
+  - id: podtrace-unpinned-github-action
+    languages: [generic]
+    severity: WARNING
+    message: >
+      GitHub Actions must be pinned to a full-length 40-character commit SHA,
+      not a tag or branch, so a re-tagged upstream release cannot inject code
+      into podtrace's CI (which builds and attests release artifacts).
+    paths:
+      include:
+        - "**/.github/workflows/*.yml"
+        - "**/.github/workflows/*.yaml"
+        - "**/.github/actions/**/*.yml"
+        - "**/.github/actions/**/*.yaml"
+    patterns:
+      - pattern-regex: 'uses:\s+(?!\./)[A-Za-z0-9._/-]+@(?![0-9a-f]{40}(?:\s|#|$))\S+'
+
+  - id: podtrace-default-http-client
+    languages: [go]
+    severity: WARNING
+    message: >
+      Avoid the timeout-less default HTTP client and package-level
+      http.Get/Post/Head; use an explicit *http.Client with a timeout, and for
+      any outbound exporter traffic the netguard-hardened dialer.
+    paths:
+      exclude:
+        - "**/*_test.go"
+        - "**/test/**"
+    patterns:
+      - pattern-either:
+          - pattern: http.Get(...)
+          - pattern: http.Post(...)
+          - pattern: http.PostForm(...)
+          - pattern: http.Head(...)
+          - pattern: http.DefaultClient

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all build clean test check-go test-unit test-integration test-bench coverage \
         generate manifests clientset envtest docker-build helm-lint helm-template operator-tools \
         lint lint-version fmt fmt-check \
+        test-bpf-load \
         chainsaw chainsaw-tools \
         e2e-kind e2e-kind-cleanup \
         bundle bundle-validate bundle-build bundle-push bundle-clean
@@ -213,6 +214,17 @@ test-unit-verbose:
 test-integration:
 	@echo "Running integration tests..."
 	$(GO) test -v -tags=integration ./test
+
+test-bpf-load: $(BPF_OBJ)
+	@echo "Running BPF loader tests against the freshly built object..."
+	$(GO) test -count=1 ./internal/ebpf/loader/...
+	@if [ "$$(id -u)" = "0" ]; then \
+		echo ">>> root detected: running kernel verifier load-test"; \
+		$(GO) test -count=1 -tags bpf_loadtest -run TestLoadPodtrace_KernelVerifierAccepts ./internal/ebpf/loader/...; \
+	else \
+		echo ">>> not root: skipping kernel verifier load-test"; \
+		echo ">>> to include it: sudo -E env \"PATH=\$$PATH\" make test-bpf-load"; \
+	fi
 
 test-bench:
 	@echo "Running benchmarks..."

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -69,6 +69,8 @@ static __attribute__((noinline)) u32 append_dec(char *buf, u32 idx, u32 max_idx,
 	u32 divisor = 10000;
 	int started = 0;
 	for (int i = 0; i < 5; i++) {
+		/* divisor cycles 10000,1000,100,10,1 over these 5 iterations, never 0 */
+		// cppcheck-suppress zerodivcond
 		u32 digit = (val / divisor) % 10;
 		if (digit != 0 || started || divisor == 1) {
 			if (idx < max_idx) buf[idx++] = '0' + digit;

--- a/internal/ebpf/loader/loader_kernel_test.go
+++ b/internal/ebpf/loader/loader_kernel_test.go
@@ -1,0 +1,46 @@
+//go:build bpf_loadtest
+
+package loader
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestLoadPodtrace_KernelVerifierAccepts(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("kernel BPF load requires root (run: sudo -E go test -tags bpf_loadtest ./internal/ebpf/loader/...)")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatalf("RemoveMemlock: %v", err)
+	}
+
+	originalPath := config.BPFObjectPath
+	t.Cleanup(func() { config.BPFObjectPath = originalPath })
+	config.BPFObjectPath = findBPFObjectPath()
+
+	spec, err := LoadPodtrace()
+	if err != nil {
+		t.Skipf("BPF object not built (run: make internal/ebpf/embedded/podtrace.$GOARCH.bpf.o): %v", err)
+	}
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("kernel verifier rejected the freshly built object:\n%+v", ve)
+		}
+		t.Fatalf("NewCollectionWithOptions: %v", err)
+	}
+	defer coll.Close()
+
+	if len(coll.Programs) == 0 {
+		t.Fatal("collection loaded zero programs into the kernel")
+	}
+}

--- a/internal/ebpf/loader/loader_spec_test.go
+++ b/internal/ebpf/loader/loader_spec_test.go
@@ -1,0 +1,82 @@
+package loader
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func loadSpecOrSkip(t *testing.T) (programs, maps map[string]struct{}) {
+	t.Helper()
+	originalPath := config.BPFObjectPath
+	t.Cleanup(func() { config.BPFObjectPath = originalPath })
+
+	config.BPFObjectPath = findBPFObjectPath()
+
+	spec, err := LoadPodtrace()
+	if err != nil {
+		t.Skipf("BPF object not built in this environment (run: make internal/ebpf/embedded/podtrace.$GOARCH.bpf.o): %v", err)
+	}
+	if spec == nil {
+		t.Fatal("LoadPodtrace returned nil spec without error")
+	}
+
+	programs = make(map[string]struct{}, len(spec.Programs))
+	for name := range spec.Programs {
+		programs[name] = struct{}{}
+	}
+	maps = make(map[string]struct{}, len(spec.Maps))
+	for name := range spec.Maps {
+		maps[name] = struct{}{}
+	}
+	return programs, maps
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func findBPFObjectPath() string {
+	rel := config.DefaultBPFObjectPath()
+	prefix := ""
+	for i := 0; i < 6; i++ {
+		if fileExists(prefix + rel) {
+			return prefix + rel
+		}
+		prefix += "../"
+	}
+	return rel
+}
+
+func TestLoadedSpec_HasCoreProgramsAndMaps(t *testing.T) {
+	programs, maps := loadSpecOrSkip(t)
+
+	corePrograms := []string{"dns_egress", "dns_ingress", "kprobe_tcp_connect"}
+	for _, name := range corePrograms {
+		if _, ok := programs[name]; !ok {
+			t.Errorf("compiled BPF object is missing core program %q (a stub/truncated build?)", name)
+		}
+	}
+
+	coreMaps := []string{"events", "stack_traces", "target_cgroup_ids"}
+	for _, name := range coreMaps {
+		if _, ok := maps[name]; !ok {
+			t.Errorf("compiled BPF object is missing core map %q (a stub/truncated build?)", name)
+		}
+	}
+}
+
+func TestLoadedSpec_HasHealthyProgramAndMapCounts(t *testing.T) {
+	programs, maps := loadSpecOrSkip(t)
+
+	const minPrograms = 10
+	const minMaps = 10
+	if len(programs) < minPrograms {
+		t.Errorf("compiled BPF object has %d programs, want >= %d (truncated build?)", len(programs), minPrograms)
+	}
+	if len(maps) < minMaps {
+		t.Errorf("compiled BPF object has %d maps, want >= %d (truncated build?)", len(maps), minMaps)
+	}
+}

--- a/internal/ebpf/tracer/lifecycle_field_race_test.go
+++ b/internal/ebpf/tracer/lifecycle_field_race_test.go
@@ -1,0 +1,52 @@
+package tracer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf/link"
+
+	"github.com/gma1k/podtrace/internal/ebpf/probes"
+)
+
+func TestSetDropReporter_ConcurrentWithReportDrop(t *testing.T) {
+	tr := &Tracer{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100000; i++ {
+			tr.SetDropReporter(func(string, int) {})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100000; i++ {
+			tr.reportDrop("ringbuf_full", 1)
+		}
+	}()
+	wg.Wait()
+}
+
+func TestSetContainerIDs_ConcurrentWrites(t *testing.T) {
+	tr := &Tracer{probeGroups: map[probes.ProbeGroup][]link.Link{}}
+	tr.attachContainerGroupFn = func(probes.ProbeGroup, string, []uint32) []link.Link { return nil }
+
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			id := fmt.Sprintf("container%04d", g)
+			for i := 0; i < 200; i++ {
+				_ = tr.SetContainerIDs([]string{id})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := tr.lastContainerID(); got == "" {
+		t.Fatal("expected a container ID to be recorded")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -108,6 +108,7 @@ type Tracer struct {
 	dnsResolved6Map               *ebpf.Map
 	filter                        *filter.CgroupFilter
 	containerID                   string
+	containerIDMu                 sync.Mutex
 	containerPID                  uint32
 	processNameCache              *cache.LRUCache
 	attributionTable              *attribution.Table
@@ -115,7 +116,7 @@ type Tracer struct {
 	pathCache                     *cache.PathCache
 	resourceMgr                   *resourceMonitorManager
 	lastDNSDrops                  uint64
-	dropReport                    func(reason string, n int)
+	dropReport                    atomic.Pointer[dropReportFn]
 	cgroupPaths                   atomic.Pointer[[]string]
 	useUserspaceCgroupFilter      atomic.Bool
 	denyWhenNoTargets             atomic.Bool
@@ -1216,8 +1217,19 @@ func (t *Tracer) SetContainerIDs(containerIDs []string) error {
 	if len(targets) == 0 {
 		return fmt.Errorf("all container IDs are empty")
 	}
+	t.containerIDMu.Lock()
 	t.containerID = targets[0].ID
+	t.containerIDMu.Unlock()
 	return t.SetContainerTargets(targets)
+}
+
+// lastContainerID returns the most recently recorded primary container ID
+// under the guarding mutex, so readers never race a concurrent
+// SetContainerIDs writer.
+func (t *Tracer) lastContainerID() string {
+	t.containerIDMu.Lock()
+	defer t.containerIDMu.Unlock()
+	return t.containerID
 }
 
 // pidForContainer resolves the PID used to discover a container's binaries
@@ -1301,15 +1313,22 @@ func (t *Tracer) pidsForContainer(id string, seeds []uint32) []uint32 {
 	return out
 }
 
+type dropReportFn func(reason string, n int)
+
 // SetDropReporter installs a callback the tracer invokes on every discarded
 // event.
 func (t *Tracer) SetDropReporter(report func(reason string, n int)) {
-	t.dropReport = report
+	if report == nil {
+		t.dropReport.Store(nil)
+		return
+	}
+	fn := dropReportFn(report)
+	t.dropReport.Store(&fn)
 }
 
 func (t *Tracer) reportDrop(reason string, n int) {
-	if t.dropReport != nil {
-		t.dropReport(reason, n)
+	if fn := t.dropReport.Load(); fn != nil && *fn != nil {
+		(*fn)(reason, n)
 	}
 }
 

--- a/internal/ebpf/tracer/tracer_supplemental_test.go
+++ b/internal/ebpf/tracer/tracer_supplemental_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/gma1k/podtrace/internal/ebpf/probes"
 )
 
-// fakeProfilingController records HTTP method calls so we can verify the
-// management API wires the profiling endpoints correctly.
 type fakeProfilingController struct {
 	mu       sync.Mutex
 	starts   int
@@ -54,10 +52,6 @@ func TestSetProfilingController(t *testing.T) {
 	}
 }
 
-// TestServeManagementAPI_WithProfilingController verifies that when a
-// profiling controller is registered the /profile/* paths are wired
-// onto the mux. We exercise the mux directly via httptest rather than
-// running the goroutine-based ListenAndServe loop.
 func TestServeManagementAPI_WithProfilingController(t *testing.T) {
 	ctrl := &fakeProfilingController{}
 	tr := &Tracer{
@@ -65,17 +59,9 @@ func TestServeManagementAPI_WithProfilingController(t *testing.T) {
 		profilingCtrl: ctrl,
 	}
 
-	// Reuse the real mux setup by calling serveManagementAPI on a
-	// short-lived context. ListenAndServe can fail (port in use); we
-	// don't care about the listener's success — only that the mux is
-	// configured. To do that without binding a port, we replicate the
-	// mux setup by running serveManagementAPI in a goroutine and
-	// cancelling immediately.
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		// Use a port that is almost certainly bindable; rapid cancel
-		// closes the server before any external traffic.
 		tr.serveManagementAPI(ctx, 0)
 		close(done)
 	}()
@@ -83,7 +69,6 @@ func TestServeManagementAPI_WithProfilingController(t *testing.T) {
 	<-done
 }
 
-// TestSetContainerIDs_AllEmpty exercises the all-blank validation guard.
 func TestSetContainerIDs_AllEmpty(t *testing.T) {
 	tr := &Tracer{collection: &ebpf.Collection{Programs: map[string]*ebpf.Program{}}}
 	err := tr.SetContainerIDs([]string{"", "", ""})
@@ -104,22 +89,17 @@ func TestSetContainerIDs_NoIDs(t *testing.T) {
 	}
 }
 
-// TestSetContainerIDs_PicksFirstNonEmpty: even with leading blanks the
-// first non-empty ID wins as the primary; collection has no programs
-// so no probes attach but the function returns nil.
 func TestSetContainerIDs_PicksFirstNonEmpty(t *testing.T) {
 	tr := &Tracer{collection: &ebpf.Collection{Programs: map[string]*ebpf.Program{}}}
 	if err := tr.SetContainerIDs([]string{"", "abc123def456", ""}); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if tr.containerID != "abc123def456" {
-		t.Errorf("containerID = %q, want abc123def456", tr.containerID)
+	if tr.lastContainerID() != "abc123def456" {
+		t.Errorf("containerID = %q, want abc123def456", tr.lastContainerID())
 	}
 }
 
 func TestActiveProbeGroups_StableOrder(t *testing.T) {
-	// Just verify ActiveProbeGroups returns membership equality with
-	// the source map. Order is undefined.
 	tr := &Tracer{
 		probeGroups: map[probes.ProbeGroup][]link.Link{
 			probes.ProbeGroup("a"): {},
@@ -139,10 +119,6 @@ func TestActiveProbeGroups_StableOrder(t *testing.T) {
 	}
 }
 
-// TestServeManagementAPI_ProfilingPaths exercises the registered handlers
-// using httptest by reaching into the mux indirectly: we invoke the tracer's
-// inner HandlerFunc behaviour by issuing requests against an httptest server
-// configured with a mirrored ServeMux.
 func TestServeManagementAPI_ProfilingPaths(t *testing.T) {
 	ctrl := &fakeProfilingController{}
 	mux := http.NewServeMux()

--- a/internal/ebpf/tracer/tracer_test.go
+++ b/internal/ebpf/tracer/tracer_test.go
@@ -122,8 +122,8 @@ func TestTracer_SetContainerID(t *testing.T) {
 
 	err := tracer.SetContainerID(containerID)
 	if err == nil {
-		if tracer.containerID != containerID {
-			t.Errorf("Expected containerID %q, got %q", containerID, tracer.containerID)
+		if tracer.lastContainerID() != containerID {
+			t.Errorf("Expected containerID %q, got %q", containerID, tracer.lastContainerID())
 		}
 	}
 }
@@ -243,8 +243,8 @@ func TestTracer_SetContainerID_EmptyContainerID(t *testing.T) {
 
 	err := tracer.SetContainerID("")
 	if err == nil {
-		if tracer.containerID != "" {
-			t.Errorf("Expected empty containerID, got %q", tracer.containerID)
+		if tracer.lastContainerID() != "" {
+			t.Errorf("Expected empty containerID, got %q", tracer.lastContainerID())
 		}
 	}
 }
@@ -265,8 +265,8 @@ func TestTracer_SetContainerID_WithLinks(t *testing.T) {
 
 	err := tracer.SetContainerID("test-container-id")
 	if err == nil {
-		if tracer.containerID != "test-container-id" {
-			t.Errorf("Expected containerID 'test-container-id', got %q", tracer.containerID)
+		if tracer.lastContainerID() != "test-container-id" {
+			t.Errorf("Expected containerID 'test-container-id', got %q", tracer.lastContainerID())
 		}
 	}
 }
@@ -620,8 +620,8 @@ func TestTracer_SetContainerID_WithCollection(t *testing.T) {
 
 	err := tracer.SetContainerID(containerID)
 	if err == nil {
-		if tracer.containerID != containerID {
-			t.Errorf("Expected containerID %q, got %q", containerID, tracer.containerID)
+		if tracer.lastContainerID() != containerID {
+			t.Errorf("Expected containerID %q, got %q", containerID, tracer.lastContainerID())
 		}
 	}
 }
@@ -644,8 +644,8 @@ func TestTracer_SetContainerID_MultipleCalls(t *testing.T) {
 	err2 := tracer.SetContainerID("container-2")
 
 	if err1 == nil && err2 == nil {
-		if tracer.containerID != "container-2" {
-			t.Errorf("Expected containerID 'container-2', got %q", tracer.containerID)
+		if tracer.lastContainerID() != "container-2" {
+			t.Errorf("Expected containerID 'container-2', got %q", tracer.lastContainerID())
 		}
 	}
 }
@@ -1635,8 +1635,8 @@ func TestTracer_SetContainerID_AllProbeTypes(t *testing.T) {
 
 	err := tracer.SetContainerID("test-container")
 	if err == nil {
-		if tracer.containerID != "test-container" {
-			t.Errorf("Expected containerID 'test-container', got %q", tracer.containerID)
+		if tracer.lastContainerID() != "test-container" {
+			t.Errorf("Expected containerID 'test-container', got %q", tracer.lastContainerID())
 		}
 	}
 }
@@ -1659,8 +1659,8 @@ func TestTracer_SetContainerID_MultipleProbes(t *testing.T) {
 	if err == nil {
 		err = tracer.SetContainerID("container-2")
 		if err == nil {
-			if tracer.containerID != "container-2" {
-				t.Errorf("Expected containerID 'container-2', got %q", tracer.containerID)
+			if tracer.lastContainerID() != "container-2" {
+				t.Errorf("Expected containerID 'container-2', got %q", tracer.lastContainerID())
 			}
 		}
 	}

--- a/pkg/tracer/engine_lifecycle_race_test.go
+++ b/pkg/tracer/engine_lifecycle_race_test.go
@@ -1,0 +1,118 @@
+package tracer_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/events"
+	"github.com/gma1k/podtrace/pkg/tracer"
+)
+
+func (m *mockBackend) trySend(ev *events.Event, stop <-chan struct{}) bool {
+	m.mu.Lock()
+	ch := m.eventCh
+	m.mu.Unlock()
+	if ch == nil {
+		return false
+	}
+	select {
+	case ch <- ev:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
+func TestEngine_LifecycleConcurrentWithEventPath(t *testing.T) {
+	backend := &mockBackend{}
+	exp := &recordingExporter{name: "rec"}
+	eng, err := tracer.NewEngine(backend, []tracer.Exporter{exp}, tracer.Config{
+		EventBufferSize:     256,
+		ExportBatchSize:     8,
+		ExportFlushInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	targets := make(chan tracer.TargetSet, 64)
+	targets <- tracer.TargetSet{{CgroupPath: "/c/seed"}}
+
+	done := make(chan error, 1)
+	go func() { done <- eng.Run(ctx, targets) }()
+
+	waitUntil(t, 2*time.Second, func() bool { return len(backend.attachedPaths()) == 1 })
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for e := 0; e < 4; e++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if !backend.trySend(&events.Event{Type: events.EventDNS}, stop) {
+					return
+				}
+			}
+		}()
+	}
+
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = eng.Stats()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			select {
+			case targets <- tracer.TargetSet{{CgroupPath: fmtPath(i%3, i)}, {CgroupPath: fmtPath(i%3, i-1)}}:
+				i++
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	waitUntil(t, 3*time.Second, func() bool { return eng.Stats().EventsReceived > 100 })
+
+	close(stop)
+	wg.Wait()
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if s := eng.Stats(); s.EventsReceived == 0 {
+		t.Fatalf("expected events received, stats=%+v", s)
+	}
+}

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -14,6 +14,8 @@
 set -euo pipefail
 
 KERNEL_RELEASE=$(uname -r)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 detect_distro() {
 	if [[ -f /etc/os-release ]]; then
@@ -116,9 +118,14 @@ install_alpine() {
 }
 
 install_go_if_needed() {
-	local required="1.24"
-	local go_bin=""
+	local required
+	required="$(awk '/^go [0-9]+\.[0-9]+/{print $2; exit}' "${PROJECT_ROOT}/go.mod" 2>/dev/null || true)"
+	if [[ -z "${required}" ]]; then
+		echo "Error: could not read the Go version from ${PROJECT_ROOT}/go.mod" >&2
+		return 1
+	fi
 
+	local go_bin=""
 	for candidate in /usr/local/go/bin/go go; do
 		if command -v "${candidate}" &>/dev/null; then
 			go_bin="${candidate}"
@@ -127,22 +134,20 @@ install_go_if_needed() {
 	done
 
 	if [[ -n "${go_bin}" ]]; then
-		local current
+		local current highest
 		current=$("${go_bin}" version 2>/dev/null | awk '{print $3}' | tr -d 'go')
-		local major minor
-		major=$(echo "${current}" | cut -d. -f1)
-		minor=$(echo "${current}" | cut -d. -f2)
-		if [[ "${major}" -ge 1 && "${minor}" -ge 24 ]]; then
+		highest="$(printf '%s\n%s\n' "${required}" "${current}" | sort -V | tail -1)"
+		if [[ -n "${current}" && "${highest}" == "${current}" ]]; then
 			echo "Go ${current} already installed and satisfies requirement (>=${required})."
 			return
 		fi
-		echo "Installed Go ${current} is below ${required}."
+		echo "Installed Go ${current:-unknown} is below ${required}."
 	else
 		echo "Go not found."
 	fi
 
 	echo "Installing Go ${required}..."
-	local arch
+	local arch arch_tag
 	arch=$(uname -m)
 	case "${arch}" in
 	x86_64) arch_tag="amd64" ;;
@@ -158,21 +163,39 @@ install_go_if_needed() {
 	local tarball="go${required}.linux-${arch_tag}.tar.gz"
 	local url="https://go.dev/dl/${tarball}"
 
+	local want_sha
+	want_sha="$(curl -fsSL 'https://go.dev/dl/?mode=json&include=all' 2>/dev/null |
+		grep -F "\"${tarball}\"" -A 6 |
+		grep -oE '[a-f0-9]{64}' |
+		head -1 || true)"
+	if [[ -z "${want_sha}" ]]; then
+		echo "Error: could not resolve the published SHA256 for ${tarball}; refusing to install unverified" >&2
+		return 1
+	fi
+
+	local tmp
+	tmp="$(mktemp)"
+	trap 'rm -f "${tmp}"' RETURN
+
 	echo "Downloading ${url}..."
 	if command -v curl &>/dev/null; then
-		curl -fsSL "${url}" -o "/tmp/${tarball}"
+		curl -fsSL "${url}" -o "${tmp}"
 	elif command -v wget &>/dev/null; then
-		wget -q "${url}" -O "/tmp/${tarball}"
+		wget -q "${url}" -O "${tmp}"
 	else
 		echo "Error: neither curl nor wget found. Install Go manually from https://go.dev/dl/"
 		return
 	fi
 
-	rm -rf /usr/local/go
-	tar -C /usr/local -xzf "/tmp/${tarball}"
-	rm "/tmp/${tarball}"
+	if ! printf '%s  %s\n' "${want_sha}" "${tmp}" | sha256sum -c - >/dev/null 2>&1; then
+		echo "Error: checksum mismatch for ${tarball}; refusing to install" >&2
+		return 1
+	fi
 
-	echo "Go ${required} installed to /usr/local/go."
+	rm -rf /usr/local/go
+	tar -C /usr/local -xzf "${tmp}"
+
+	echo "Go ${required} installed and verified to /usr/local/go."
 	echo "Add to PATH: export PATH=\$PATH:/usr/local/go/bin"
 }
 

--- a/scripts/setup-capabilities.sh
+++ b/scripts/setup-capabilities.sh
@@ -5,9 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BINARY="${PROJECT_ROOT}/bin/podtrace"
 
-REQUIRED_CAPS="cap_bpf,cap_sys_admin,cap_sys_resource,cap_net_admin"
+REQUIRED_CAPS="cap_bpf,cap_perfmon,cap_sys_admin,cap_net_admin,cap_sys_resource"
 
 check_binary_exists() {
+	if [[ -L "${BINARY}" ]]; then
+		echo "Error: ${BINARY} is a symlink; refusing to grant capabilities to a symlink target" >&2
+		exit 1
+	fi
+
 	if [[ ! -f "${BINARY}" ]]; then
 		echo "Error: ${BINARY} not found" >&2
 		echo "Build it first with: make build" >&2
@@ -34,6 +39,11 @@ set_capabilities() {
 
 	if ! command -v setcap &>/dev/null; then
 		echo "Error: setcap command not found. Install libcap2-bin package." >&2
+		exit 1
+	fi
+
+	if [[ -L "${BINARY}" ]]; then
+		echo "Error: ${BINARY} became a symlink before capabilities were set; aborting" >&2
 		exit 1
 	fi
 


### PR DESCRIPTION
## Summary

Hardens the root-run setup scripts and CI BPF toolchain, two confirmed tracer data races, missing static-analysis/supply-chain CI, and no local/CI coverage of the compiled BPF object.

## Setup scripts and CI toolchain

- setup-capabilities.sh: reject a symlinked bin/podtrace before the existence check and again immediately before setcap (setcap follows symlinks, so a planted symlink could grant caps to an attacker binary); add cap_perfmon.
- install-deps.sh: source the Go version from go.mod's go directive, download to a mktemp file instead of a predictable /tmp path, and verify the go.dev SHA256 before untar.
- setup-bpf-toolchain/action.yml: pin bpftool to v7.7.0 with hardcoded per-arch SHA256 and drop the || true that swallowed fetch/checksum failures.

## Tracer lifecycle data races

- dropReport: written by SetDropReporter and read by reportDrop on the event-path goroutines with no synchronization. Now an atomic.Pointer.
- containerID: written unlocked by concurrent SetContainerIDs. Now guarded by a mutex with a lastContainerID() getter; white-box test reads use the getter.

The Engine (pkg/tracer) was already race-clean; a new stress test drives Stats() and target churn concurrently with the event path to keep it that way.

## Static-analysis CI (advisory)

- semgrep 1.173.0 with community rulesets plus .semgrep/podtrace.yml custom rules (require SHA-pinned Actions; discourage the timeout-less default HTTP client).
- Trivy v0.74.0 filesystem scan (vuln + misconfig + secret).
- cppcheck over bpf/, converted to SARIF by .github/scripts/cppcheck_to_sarif.py (the runner's cppcheck predates native SARIF output).

## BPF load coverage

- internal/ebpf/loader/loader_spec_test.go: loads the compiled object and asserts the core programs and maps the tracer depends on are present.
- internal/ebpf/loader/loader_kernel_test.go (build tag bpf_loadtest): loads the object into the running kernel and asserts the verifier accepts it; skips when not root.
- make test-bpf-load builds the host object and runs both (kernel test only as root); ebpf-build.yml runs it under sudo on the native amd64 and arm64 runners.