### PR TITLE
fix: rescope Trivy to vuln/secret and fix code-scanning findings

### DIFF
--- a/.github/actions/preload-kind-node/action.yml
+++ b/.github/actions/preload-kind-node/action.yml
@@ -27,9 +27,11 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
       run: |
         set -euo pipefail
-        image="${{ inputs.image }}"
+        image="${IMAGE}"
         tag="${image%@*}"
 
         pulled=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,9 @@ jobs:
         uses: ./.github/actions/verify-bpf-objects
 
       - name: Build CLI tarballs (linux+darwin x amd64+arm64)
-        run: make release VERSION=${{ github.ref_name }}
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: make release VERSION="${VERSION}"
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -160,13 +160,24 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/v0.74.0/contrib/install.sh" \
-            | sudo sh -s -- -b /usr/local/bin v0.74.0
+          ver="0.74.0"
+          arch="$(dpkg --print-architecture)"
+          case "${arch}" in
+            amd64) asset="trivy_${ver}_Linux-64bit.tar.gz"; want="2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a" ;;
+            arm64) asset="trivy_${ver}_Linux-ARM64.tar.gz"; want="b94ce1976bbf3c15b514b605ee88be7c6d94a29be2302847ff01cb794d47aad5" ;;
+            *) echo "::error::no pinned Trivy for arch ${arch}"; exit 1 ;;
+          esac
+          tmp="$(mktemp -d)"
+          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${ver}/${asset}" -o "${tmp}/trivy.tgz"
+          echo "${want}  ${tmp}/trivy.tgz" | sha256sum -c -
+          tar -C "${tmp}" -xzf "${tmp}/trivy.tgz" trivy
+          sudo install -m0755 "${tmp}/trivy" /usr/local/bin/trivy
+          rm -rf "${tmp}"
           trivy --version
 
-      - name: Trivy filesystem scan (SARIF, advisory)
+      - name: Trivy vulnerability and secret scan (SARIF, advisory)
         run: |
-          trivy fs --scanners vuln,misconfig,secret \
+          trivy fs --scanners vuln,secret \
             --format sarif --output trivy.sarif \
             --severity HIGH,CRITICAL --exit-code 0 --no-progress .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,6 @@ LABEL org.opencontainers.image.title="podtrace" \
 
 COPY --from=builder /out/podtrace /usr/local/bin/podtrace
 
+USER 65532:65532
+
 ENTRYPOINT ["/usr/local/bin/podtrace"]


### PR DESCRIPTION
## Summary

The advisory scanners added in #425 raised 124 code-scanning alerts, almost all noise.

## Changes

- security.yml: install Trivy from a pinned, SHA256-verified release binary (arch-aware) instead of `curl | sh` (fixes the Scorecard PinnedDependencies alert), and run `--scanners vuln,secret` instead of also running the misconfig IaC linter. Trivy's misconfig engine flags an eBPF tool's mandatory privileged mode / CAP_SYS_ADMIN / hostPath as "misconfigurations", which is a tool-target mismatch, not a set of defects; vuln + secret scanning is Trivy's high-signal  purpose here and reports 0 findings today.
- release.yml and preload-kind-node/action.yml: move `${{ github.ref_name }}` and `${{ inputs.image }}` out of `run:` and into `env:`, referenced as shell variables — the recommended mitigation for template-injection in run steps.
- Dockerfile: add an explicit `USER 65532:65532`. The distroless :nonroot base already runs as that UID; the explicit directive documents the non-root user. The agent DaemonSet still overrides runAsUser: 0 where eBPF requires it.