### PR TITLE
fix: honor human bool env values and range-check float config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ var (
 	ErrorBackoffEnabled       = getBoolEnvOrDefault("PODTRACE_ERROR_BACKOFF_ENABLED", true)
 	CircuitBreakerEnabled     = getBoolEnvOrDefault("PODTRACE_CIRCUIT_BREAKER_ENABLED", true)
 	TracingEnabled            = getBoolEnvOrDefault("PODTRACE_TRACING_ENABLED", false)
-	TracingSampleRate         = getFloatEnvOrDefault("PODTRACE_TRACING_SAMPLE_RATE", DefaultTracingSampleRate)
+	TracingSampleRate         = getFloatEnvInRange("PODTRACE_TRACING_SAMPLE_RATE", DefaultTracingSampleRate, 0, 1)
 	SynthesizeSpans           = getBoolEnvOrDefault("PODTRACE_TRACING_SYNTHESIZE_SPANS", DefaultSynthesizeSpans)
 	OTLPEndpoint              = getEnvOrDefault("PODTRACE_OTLP_ENDPOINT", DefaultOTLPEndpoint)
 	JaegerEndpoint            = os.Getenv("PODTRACE_JAEGER_ENDPOINT")
@@ -90,9 +90,9 @@ var (
 	MetricsPodLabelLimit      = getIntEnvOrDefault("PODTRACE_METRICS_POD_LABEL_LIMIT", 500)
 	MaxTrackedTraces          = getIntEnvOrDefault("PODTRACE_MAX_TRACKED_TRACES", 10000)
 	MaxSpansPerTrace          = getIntEnvOrDefault("PODTRACE_MAX_SPANS_PER_TRACE", 1000)
-	ProcessCacheEvictionRatio = getFloatEnvOrDefault("PODTRACE_PROCESS_CACHE_EVICTION_RATIO", DefaultProcessCacheEvictionRatio)
-	PIDCacheEvictionRatio     = getFloatEnvOrDefault("PODTRACE_PID_CACHE_EVICTION_RATIO", DefaultPIDCacheEvictionRatio)
-	CacheEvictionThreshold    = getFloatEnvOrDefault("PODTRACE_CACHE_EVICTION_THRESHOLD", DefaultCacheEvictionThreshold)
+	ProcessCacheEvictionRatio = getFloatEnvInRange("PODTRACE_PROCESS_CACHE_EVICTION_RATIO", DefaultProcessCacheEvictionRatio, 0, 1)
+	PIDCacheEvictionRatio     = getFloatEnvInRange("PODTRACE_PID_CACHE_EVICTION_RATIO", DefaultPIDCacheEvictionRatio, 0, 1)
+	CacheEvictionThreshold    = getFloatEnvInRange("PODTRACE_CACHE_EVICTION_THRESHOLD", DefaultCacheEvictionThreshold, 0, 1)
 	RateLimitPerSec           = getIntEnvOrDefault("PODTRACE_RATE_LIMIT_PER_SEC", DefaultRateLimitPerSec)
 	RateLimitBurst            = getIntEnvOrDefault("PODTRACE_RATE_LIMIT_BURST", DefaultRateLimitBurst)
 	TopTargetsLimit           = getIntEnvOrDefault("PODTRACE_TOP_TARGETS_LIMIT", DefaultTopTargetsLimit)
@@ -107,7 +107,7 @@ var (
 	TimelineBuckets           = getIntEnvOrDefault("PODTRACE_TIMELINE_BUCKETS", DefaultTimelineBuckets)
 	MaxConnectionTargets      = getIntEnvOrDefault("PODTRACE_MAX_CONNECTION_TARGETS", DefaultMaxConnectionTargets)
 	HighErrorCountThreshold   = getIntEnvOrDefault("PODTRACE_HIGH_ERROR_COUNT_THRESHOLD", DefaultHighErrorCountThreshold)
-	SpikeRateThreshold        = getFloatEnvOrDefault("PODTRACE_SPIKE_RATE_THRESHOLD", DefaultSpikeRateThreshold)
+	SpikeRateThreshold        = getPositiveFloatEnvOrDefault("PODTRACE_SPIKE_RATE_THRESHOLD", DefaultSpikeRateThreshold)
 	MaxEventsForStacks        = getIntEnvOrDefault("PODTRACE_MAX_EVENTS_FOR_STACKS", DefaultMaxEventsForStacks)
 	MinLatencyForStackNS      = getInt64EnvOrDefault("PODTRACE_MIN_LATENCY_FOR_STACK_NS", DefaultMinLatencyForStackNS)
 	MaxBytesForBandwidth      = getInt64EnvOrDefault("PODTRACE_MAX_BYTES_FOR_BANDWIDTH", DefaultMaxBytesForBandwidth)
@@ -134,7 +134,7 @@ var (
 
 	ProfilingEnabled         = getBoolEnvOrDefault("PODTRACE_PROFILING_ENABLED", false)
 	ProfilingPprofPorts      = getEnvOrDefault("PODTRACE_PROFILING_PPROF_PORTS", "6060,8080,8081,9090,2345")
-	ProfilingAutoTriggerMS   = getFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
+	ProfilingAutoTriggerMS   = getPositiveFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
 	ProfilingDefaultDuration = getDurationEnvOrDefault("PODTRACE_PROFILING_DEFAULT_DURATION", DefaultProfilingDuration)
 	ProfilingMaxConcurrent   = getIntEnvOrDefault("PODTRACE_PROFILING_MAX_CONCURRENT", DefaultProfilingMaxConcurrent)
 )
@@ -334,27 +334,35 @@ func GetDefaultProcRootPath() string {
 }
 
 var (
-	TCPLatencySpikeThresholdMS = getFloatEnvOrDefault("PODTRACE_TCP_LATENCY_SPIKE_MS", 100.0)
-	TCPRealtimeThresholdMS     = getFloatEnvOrDefault("PODTRACE_TCP_REALTIME_MS", 10.0)
-	UDPLatencySpikeThresholdMS = getFloatEnvOrDefault("PODTRACE_UDP_LATENCY_SPIKE_MS", 100.0)
-	ConnectLatencyThresholdMS  = getFloatEnvOrDefault("PODTRACE_CONNECT_LATENCY_MS", 1.0)
+	TCPLatencySpikeThresholdMS = getPositiveFloatEnvOrDefault("PODTRACE_TCP_LATENCY_SPIKE_MS", 100.0)
+	TCPRealtimeThresholdMS     = getPositiveFloatEnvOrDefault("PODTRACE_TCP_REALTIME_MS", 10.0)
+	UDPLatencySpikeThresholdMS = getPositiveFloatEnvOrDefault("PODTRACE_UDP_LATENCY_SPIKE_MS", 100.0)
+	ConnectLatencyThresholdMS  = getPositiveFloatEnvOrDefault("PODTRACE_CONNECT_LATENCY_MS", 1.0)
 )
 
-// getBoolEnvOrDefault parses the env var with strconv.ParseBool, so
-// "true", "TRUE", "True", "1", "t" (and their negatives) all work — the
-// previous string comparison silently treated "TRUE" or "1" as false. A
-// set-but-unparsable value is reported instead of silently ignored.
+func parseBoolLenient(value string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "y", "yes", "on", "enable", "enabled":
+		return true, true
+	case "0", "f", "false", "n", "no", "off", "disable", "disabled":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// getBoolEnvOrDefault parses the env var with parseBoolLenient. A set-but-
+// unrecognized value is reported instead of silently ignored.
 func getBoolEnvOrDefault(key string, defaultValue bool) bool {
 	value := os.Getenv(key)
 	if value == "" {
 		return defaultValue
 	}
-	b, err := strconv.ParseBool(strings.TrimSpace(value))
-	if err != nil {
-		warnIgnoredEnv(key, value, "not a boolean")
-		return defaultValue
+	if b, ok := parseBoolLenient(value); ok {
+		return b
 	}
-	return b
+	warnIgnoredEnv(key, value, "not a boolean")
+	return defaultValue
 }
 
 // warnIgnoredEnv surfaces configuration that LOOKS set but is being
@@ -373,12 +381,37 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-func getFloatEnvOrDefault(key string, defaultValue float64) float64 {
+// getFloatEnvInRange parses a float and accepts it only within the inclusive
+// [lo, hi] range its consumer requires (e.g. a sample rate or eviction ratio
+// in [0,1]).
+func getFloatEnvInRange(key string, defaultValue, lo, hi float64) float64 {
 	if value := os.Getenv(key); value != "" {
-		if f, err := strconv.ParseFloat(value, 64); err == nil {
+		f, err := strconv.ParseFloat(value, 64)
+		switch {
+		case err != nil:
+			warnIgnoredEnv(key, value, "not a number")
+		case f < lo || f > hi:
+			warnIgnoredEnv(key, value, fmt.Sprintf("must be within [%g, %g]", lo, hi))
+		default:
 			return f
 		}
-		warnIgnoredEnv(key, value, "not a number")
+	}
+	return defaultValue
+}
+
+// getPositiveFloatEnvOrDefault mirrors getIntEnvOrDefault for float knobs that
+// must be strictly positive (durations, latency thresholds).
+func getPositiveFloatEnvOrDefault(key string, defaultValue float64) float64 {
+	if value := os.Getenv(key); value != "" {
+		f, err := strconv.ParseFloat(value, 64)
+		switch {
+		case err != nil:
+			warnIgnoredEnv(key, value, "not a number")
+		case f <= 0:
+			warnIgnoredEnv(key, value, "must be a positive number")
+		default:
+			return f
+		}
 	}
 	return defaultValue
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,42 +55,49 @@ func TestGetEnvOrDefault(t *testing.T) {
 	}
 }
 
-func TestGetFloatEnvOrDefault(t *testing.T) {
-	key := "TEST_FLOAT_ENV_VAR"
-	originalValue := os.Getenv(key)
-	defer func() {
-		if originalValue != "" {
-			_ = os.Setenv(key, originalValue)
-		} else {
-			_ = os.Unsetenv(key)
-		}
-	}()
-
-	tests := []struct {
-		name         string
-		setValue     string
-		defaultValue float64
-		expected     float64
+func TestGetFloatEnvInRange(t *testing.T) {
+	const key = "PODTRACE_TEST_FLOAT_RANGE"
+	cases := []struct {
+		value    string
+		def      float64
+		lo, hi   float64
+		expected float64
 	}{
-		{"valid float", "123.45", 0.0, 123.45},
-		{"valid int", "100", 0.0, 100.0},
-		{"invalid float", "invalid", 50.0, 50.0},
-		{"env not set", "", 50.0, 50.0},
-		{"empty string", "", 50.0, 50.0},
+		{"0.5", 0.9, 0, 1, 0.5},
+		{"0", 0.9, 0, 1, 0},
+		{"1", 0.9, 0, 1, 1},
+		{"1.5", 0.9, 0, 1, 0.9},
+		{"-0.1", 0.9, 0, 1, 0.9},
+		{"notanumber", 0.9, 0, 1, 0.9},
+		{"", 0.9, 0, 1, 0.9},
 	}
+	for _, c := range cases {
+		t.Setenv(key, c.value)
+		if got := getFloatEnvInRange(key, c.def, c.lo, c.hi); got != c.expected {
+			t.Errorf("getFloatEnvInRange(%q, [%g,%g]) = %g, want %g", c.value, c.lo, c.hi, got, c.expected)
+		}
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.setValue != "" {
-				_ = os.Setenv(key, tt.setValue)
-			} else {
-				_ = os.Unsetenv(key)
-			}
-			result := getFloatEnvOrDefault(key, tt.defaultValue)
-			if result != tt.expected {
-				t.Errorf("Expected %f, got %f", tt.expected, result)
-			}
-		})
+func TestGetPositiveFloatEnvOrDefault(t *testing.T) {
+	const key = "PODTRACE_TEST_FLOAT_POS"
+	cases := []struct {
+		value    string
+		def      float64
+		expected float64
+	}{
+		{"5", 500, 5},
+		{"0.001", 500, 0.001},
+		{"0", 500, 500},
+		{"-1", 500, 500},
+		{"notanumber", 500, 500},
+		{"", 500, 500},
+	}
+	for _, c := range cases {
+		t.Setenv(key, c.value)
+		if got := getPositiveFloatEnvOrDefault(key, c.def); got != c.expected {
+			t.Errorf("getPositiveFloatEnvOrDefault(%q) = %g, want %g", c.value, got, c.expected)
+		}
 	}
 }
 

--- a/internal/config/env_parsing_regression_test.go
+++ b/internal/config/env_parsing_regression_test.go
@@ -2,8 +2,6 @@ package config
 
 import "testing"
 
-// TestGetBoolEnvOrDefault_AcceptedForms: only lowercase "true" used to
-// count; "TRUE", "True", and "1" silently read as false.
 func TestGetBoolEnvOrDefault_AcceptedForms(t *testing.T) {
 	cases := []struct {
 		value string
@@ -11,8 +9,12 @@ func TestGetBoolEnvOrDefault_AcceptedForms(t *testing.T) {
 	}{
 		{"true", true}, {"TRUE", true}, {"True", true}, {"1", true}, {"t", true},
 		{"false", false}, {"FALSE", false}, {"0", false},
-		{"garbage", true}, // unparsable keeps the default (true here)
-		{" true ", true},  // surrounding whitespace tolerated
+		{"yes", true}, {"YES", true}, {"on", true}, {"On", true},
+		{"enable", true}, {"enabled", true}, {"ENABLED", true}, {"y", true},
+		{"no", false}, {"NO", false}, {"off", false}, {"Off", false},
+		{"disable", false}, {"disabled", false}, {"n", false},
+		{"garbage", true},
+		{" true ", true},
 	}
 	for _, c := range cases {
 		t.Setenv("PODTRACE_TEST_BOOL", c.value)
@@ -23,6 +25,22 @@ func TestGetBoolEnvOrDefault_AcceptedForms(t *testing.T) {
 	t.Setenv("PODTRACE_TEST_BOOL", "garbage")
 	if got := getBoolEnvOrDefault("PODTRACE_TEST_BOOL", false); got != false {
 		t.Error("unparsable value must keep the default (false)")
+	}
+}
+
+func TestRedactPII_HumanTruthyEnablesRedaction(t *testing.T) {
+	const key = "PODTRACE_REDACT_PII"
+	for _, v := range []string{"yes", "YES", "on", "enabled", "enable", "y", "true", "1"} {
+		t.Setenv(key, v)
+		if !getBoolEnvOrDefault(key, false) {
+			t.Errorf("%s=%q must enable redaction (fail-open regression)", key, v)
+		}
+	}
+	for _, v := range []string{"no", "off", "disabled", "false", "0", "n"} {
+		t.Setenv(key, v)
+		if getBoolEnvOrDefault(key, false) {
+			t.Errorf("%s=%q must keep redaction off", key, v)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

PODTRACE_REDACT_PII was parsed with strconv.ParseBool, which rejects the common human spellings yes/on/enabled. A rejected value fell back to the default (false), so an operator who set PODTRACE_REDACT_PII=yes believed redaction was on while it was silently off, and the redactor (Cookie/Set-Cookie, Authorization, session/JSESSIONID, custom rules) is only built when the toggle is true, so PII flowed unredacted into events and exporters.

getFloatEnvOrDefault did no range validation, unlike getIntEnvOrDefault's positive-only constraint. PODTRACE_CACHE_EVICTION_THRESHOLD=1.5 made the LRU's "evict at >100% full" never trigger (unbounded cache growth), and a negative PODTRACE_PROFILING_AUTO_TRIGGER_MS silently disabled the auto-trigger.

## Changes

- Add parseBoolLenient, accepting strconv.ParseBool's forms plus yes/no, on/off, enable(d)/disable(d), y/n (case-insensitive). getBoolEnvOrDefault uses it, so every boolean env var honors those spellings; a still-unrecognized value is   reported and the default kept (unchanged convention).
- Replace getFloatEnvOrDefault with getFloatEnvInRange(key, default, lo, hi) and getPositiveFloatEnvOrDefault(key, default). Wire each float config to its real range: [0,1] for the tracing sample rate and the cache eviction ratios/ threshold; strictly positive for the profiling auto-trigger, spike-rate, and TCP/UDP/connect latency thresholds.