### PR TITLE
fix: close PII redaction gaps and CSV formula injection

### DIFF
--- a/internal/redactor/custom_rules_test.go
+++ b/internal/redactor/custom_rules_test.go
@@ -56,3 +56,13 @@ func TestParseRules_MalformedJSON(t *testing.T) {
 		t.Fatal("expected error for malformed JSON")
 	}
 }
+
+func TestParseRules_InvalidPatternWithoutNameUsesIndex(t *testing.T) {
+	_, err := redactor.ParseRules(`[{"pattern":"[","replace":"x"}]`)
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+	if !strings.Contains(err.Error(), `"#0"`) {
+		t.Errorf("nameless invalid rule should be reported by index, got: %v", err)
+	}
+}

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -110,11 +110,13 @@ func (r *Redactor) Redact(e *events.Event) {
 // rules so coverage cannot drift between formats.
 const credentialKeyNames = `password|passwd|pwd|token|api[_-]?key|apikey|secret|access[_-]?key|` +
 	`authorization|auth|bearer|session[_-]?id|jsessionid|phpsessid|asp\.net_sessionid|session|sid|` +
-	`csrf[_-]?token|xsrf[_-]?token|refresh[_-]?token|id[_-]?token`
+	`csrf[_-]?token|xsrf[_-]?token|refresh[_-]?token|id[_-]?token|` +
+	`private[_-]?key|client[_-]?key|passphrase|signature|credentials?`
 
 // sensitiveHeaderNames are HTTP header names whose entire value is a
 // credential (or a cookie jar of them).
 const sensitiveHeaderNames = `cookie|set-cookie|authorization|proxy-authorization|` +
+	`www-authenticate|proxy-authenticate|` +
 	`x-auth-token|x-api-key|x-csrf-token|x-xsrf-token`
 
 func defaultRules() []Rule {
@@ -138,6 +140,11 @@ func defaultRules() []Rule {
 			Name:    "basic_auth",
 			Pattern: regexp.MustCompile(`(?i)Basic\s+[A-Za-z0-9+/]+=*`),
 			Replace: "Basic ***",
+		},
+		{
+			Name:    "url_userinfo",
+			Pattern: regexp.MustCompile(`(?i)([a-z][a-z0-9+.\-]*://)[^/@\s]+@`),
+			Replace: "${1}***@",
 		},
 		{
 			Name:    "credential_json",

--- a/internal/redactor/url_and_names_regression_test.go
+++ b/internal/redactor/url_and_names_regression_test.go
@@ -1,0 +1,64 @@
+package redactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func redactBoth(t *testing.T, r *Redactor, in, leaked, keep string) {
+	t.Helper()
+	e := &events.Event{Type: events.EventHTTPReq, Target: in, Details: in}
+	r.Redact(e)
+	for _, v := range []string{e.Target, e.Details} {
+		if leaked != "" && strings.Contains(v, leaked) {
+			t.Errorf("leaked %q in %q (input %q)", leaked, v, in)
+		}
+		if keep != "" && !strings.Contains(v, keep) {
+			t.Errorf("lost context %q in %q (input %q)", keep, v, in)
+		}
+	}
+}
+
+func TestDefaultRules_URLUserinfoRedacted(t *testing.T) {
+	r := Default()
+	cases := []struct{ in, leaked, keep string }{
+		{"GET http://admin:s3cr3t@host/path", "s3cr3t", "host"},
+		{"conn redis://user:redispw@redis.svc/0", "redispw", "redis.svc"},
+		{"postgres://u:pgpw@db:5432/app", "pgpw", "db:5432"},
+		{"login https://root:toor@10.0.0.5/", "toor", "10.0.0.5"},
+		{"user only http://tokenuser@api/", "tokenuser", "api"},
+	}
+	for _, c := range cases {
+		redactBoth(t, r, c.in, c.leaked, c.keep)
+	}
+}
+
+func TestDefaultRules_AdditionalCredentialKeys(t *testing.T) {
+	r := Default()
+	cases := []struct{ in, leaked, keep string }{
+		{"GET /k?private_key=MIIEpriv", "MIIEpriv", "/k"},
+		{"GET /k?private-key=MIIEpriv2", "MIIEpriv2", "/k"},
+		{"POST /c?client_key=ck_live_9", "ck_live_9", "/c"},
+		{"GET /p?passphrase=letmein", "letmein", "/p"},
+		{"GET /s?signature=SIGZ9", "SIGZ9", "/s"},
+		{"GET /x?credential=cred77", "cred77", "/x"},
+		{`{"private_key":"PEMDATA"}`, "PEMDATA", ""},
+		{"passphrase: letmein2", "letmein2", "passphrase"},
+	}
+	for _, c := range cases {
+		redactBoth(t, r, c.in, c.leaked, c.keep)
+	}
+}
+
+func TestDefaultRules_AuthenticateHeaders(t *testing.T) {
+	r := Default()
+	cases := []struct{ in, leaked, keep string }{
+		{`WWW-Authenticate: Bearer realm="x", error="invalid_token"`, "invalid_token", "WWW-Authenticate"},
+		{`Proxy-Authenticate: Basic realm="proxy-realm-secret"`, "proxy-realm-secret", "Proxy-Authenticate"},
+	}
+	for _, c := range cases {
+		redactBoth(t, r, c.in, c.leaked, c.keep)
+	}
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -129,6 +129,9 @@ func ValidateContainerID(containerID string) bool {
 }
 
 func SanitizeCSVField(field string) string {
+	if field != "" && strings.IndexByte("=+-@\t\r", field[0]) >= 0 {
+		field = "'" + field
+	}
 	if strings.ContainsAny(field, ",\"\n\r") {
 		field = strings.ReplaceAll(field, "\"", "\"\"")
 		return "\"" + field + "\""

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -237,6 +237,12 @@ worker"`},
 		{"with carriage return", "nginx\rworker", `"nginx` + "\r" + `worker"`}, // \r is quoted
 		{"empty", "", ""},
 		{"all special chars", `a,b"c\nd`, `"a,b""c\nd"`}, // Backslash is preserved
+		{"formula equals", "=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"},
+		{"formula plus", "+1+1", "'+1+1"},
+		{"formula minus", "-2+3", "'-2+3"},
+		{"formula at", "@SUM(A1)", "'@SUM(A1)"},
+		{"formula leading tab", "\t=1+1", "'\t=1+1"},
+		{"formula with comma", "=1,2", `"'=1,2"`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The redactor's only @-matching rule is `email`, which requires a dotted TLD and rejects a colon in the local part, so http://admin:s3cr3t@host/ (the dominant credential-in-URL shape for in-cluster traffic, where hostnames have no TLD)
passed through verbatim. credentialKeyNames omitted private_key, client_key, passphrase, signature, and credential; sensitiveHeaderNames omitted www-authenticate and proxy-authenticate.

SanitizeCSVField CSV-quoted commas/quotes/newlines but did not neutralize formula injection. event.Target is an attacker-controllable HTTP path, so a value like =cmd|'/c calc'!A1 in traced traffic executes when the operator opens
the report in Excel or Sheets.

## Changes

- redactor: add a url_userinfo rule that redacts scheme://user:pass@host to scheme://***@host (any scheme), placed before the email rule so it wins.
- redactor: extend credentialKeyNames with private[_-]?key, client[_-]?key, passphrase, signature, credentials?; extend sensitiveHeaderNames with www-authenticate and proxy-authenticate. The shared constants keep the
  key=value, JSON, YAML, and header rules in sync.
- validation: SanitizeCSVField prefixes a single quote when a field begins with =, +, -, @, tab, or carriage return, then applies the existing CSV quoting.