### PR TITLE
fix: close operator tenancy gaps and bound session/map lifecycles

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -84,6 +84,14 @@ jobs:
             -coverprofile=coverage.out -covermode=atomic \
             ./cmd/... ./internal/... | tee test-report.txt
 
+      - name: Exclude e2e-covered BPF integration code from unit coverage
+        if: always()
+        run: |
+          if [ -f coverage.out ]; then
+            grep -v 'github.com/gma1k/podtrace/internal/ebpf/probes/' coverage.out > coverage.filtered.out
+            mv coverage.filtered.out coverage.out
+          fi
+
       - name: Run integration suite
         timeout-minutes: 5
         run: |

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ clean:
 	rm -f $(BINARY)
 	rm -rf bin
 	rm -rf $(RELEASE_DIR)
-	rm -f coverage.out coverage.html
+	rm -f coverage.out coverage.unit.out coverage.html
 	rm -rf "$(BPF_GEN_DIR)"
 
 deps:
@@ -250,12 +250,15 @@ test-changed:
 		$(GO) test -short -count=1 -parallel=4 $(shell $(GO) list ./... | grep -v '/test$$'); \
 	fi
 
+COVERAGE_EXCLUDE ?= github.com/gma1k/podtrace/internal/ebpf/probes/
+
 coverage: test-unit
 	@echo "Generating coverage report..."
-	$(GO) tool cover -html=coverage.out -o coverage.html
+	@grep -v '$(COVERAGE_EXCLUDE)' coverage.out > coverage.unit.out
+	$(GO) tool cover -html=coverage.unit.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
-	@echo "Coverage summary:"
-	$(GO) tool cover -func=coverage.out | tail -1
+	@echo "Coverage summary (excluding e2e-covered BPF integration code):"
+	$(GO) tool cover -func=coverage.unit.out | tail -1
 
 CONTROLLER_GEN_VERSION ?= v0.18.0
 CONTROLLER_GEN ?= $(shell go env GOPATH 2>/dev/null)/bin/controller-gen

--- a/api/v1alpha1/template_metadata_validation.go
+++ b/api/v1alpha1/template_metadata_validation.go
@@ -10,12 +10,6 @@ import (
 // SessionTemplate would stamp onto every child PodTraceSession that the
 // apiserver would itself reject (an over-long key, an invalid value, an
 // oversized annotation set).
-//
-// Left unchecked, a bad entry surfaces only when a child create fails, and
-// because that create is retried every reconcile the schedule requeues on the
-// same error forever. Validated up front in the webhook (and terminally in the
-// controller for schedules that predate it) the fault is reported once and the
-// schedule stops churning.
 func ValidateSessionTemplateMetadata(meta PodTraceSessionTemplateMetadata) error {
 	base := field.NewPath("spec", "sessionTemplate", "metadata")
 	var errs field.ErrorList

--- a/api/v1alpha1/template_metadata_validation.go
+++ b/api/v1alpha1/template_metadata_validation.go
@@ -1,0 +1,25 @@
+package v1alpha1
+
+import (
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateSessionTemplateMetadata rejects labels or annotations a schedule's
+// SessionTemplate would stamp onto every child PodTraceSession that the
+// apiserver would itself reject (an over-long key, an invalid value, an
+// oversized annotation set).
+//
+// Left unchecked, a bad entry surfaces only when a child create fails, and
+// because that create is retried every reconcile the schedule requeues on the
+// same error forever. Validated up front in the webhook (and terminally in the
+// controller for schedules that predate it) the fault is reported once and the
+// schedule stops churning.
+func ValidateSessionTemplateMetadata(meta PodTraceSessionTemplateMetadata) error {
+	base := field.NewPath("spec", "sessionTemplate", "metadata")
+	var errs field.ErrorList
+	errs = append(errs, metav1validation.ValidateLabels(meta.Labels, base.Child("labels"))...)
+	errs = append(errs, apivalidation.ValidateAnnotations(meta.Annotations, base.Child("annotations"))...)
+	return errs.ToAggregate()
+}

--- a/api/v1alpha1/template_metadata_validation_test.go
+++ b/api/v1alpha1/template_metadata_validation_test.go
@@ -1,0 +1,60 @@
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSessionTemplateMetadata(t *testing.T) {
+	longKey := strings.Repeat("a", 64)
+	cases := []struct {
+		name    string
+		meta    PodTraceSessionTemplateMetadata
+		wantErr string
+	}{
+		{
+			name: "valid labels and annotations",
+			meta: PodTraceSessionTemplateMetadata{
+				Labels:      map[string]string{"team": "obs", "app.kubernetes.io/name": "podtrace"},
+				Annotations: map[string]string{"note": "scheduled"},
+			},
+		},
+		{
+			name: "empty is valid",
+			meta: PodTraceSessionTemplateMetadata{},
+		},
+		{
+			name:    "label key too long",
+			meta:    PodTraceSessionTemplateMetadata{Labels: map[string]string{longKey: "v"}},
+			wantErr: "labels",
+		},
+		{
+			name:    "label value invalid",
+			meta:    PodTraceSessionTemplateMetadata{Labels: map[string]string{"team": "not a valid value"}},
+			wantErr: "labels",
+		},
+		{
+			name:    "annotation key invalid",
+			meta:    PodTraceSessionTemplateMetadata{Annotations: map[string]string{"bad key": "v"}},
+			wantErr: "annotations",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSessionTemplateMetadata(tc.meta)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateSessionTemplateMetadata() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateSessionTemplateMetadata() = nil, want error mentioning %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to mention %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/tracerconfig_grant.go
+++ b/api/v1alpha1/tracerconfig_grant.go
@@ -1,0 +1,44 @@
+package v1alpha1
+
+import "strings"
+
+// AllowSessionsFromAnnotation is the opt-in grant a TracerConfig must carry
+// before PodTraceSessions in OTHER namespaces may pin it via tracerConfigRef.
+// A pinned config decides where the session's (privileged, hostPID, SYS_ADMIN)
+// Jobs and credential Secrets are created — its systemNamespace — so without
+// this consent a tenant could place a privileged workload in a fleet namespace
+// it has no access to.
+const AllowSessionsFromAnnotation = "podtrace.io/allow-sessions-from"
+
+// TracerConfigAllowsSessionFrom reports whether tc permits a session in
+// sourceNamespace to pin it. Pinning is always allowed when the config lands
+// its Jobs in the session's own namespace or in the operator's default
+// namespace (the normal path — the "default" config lives there and every
+// unpinned session uses it); any other systemNamespace is a cross-tenant
+// placement and requires the config to grant sourceNamespace (or "*").
+func TracerConfigAllowsSessionFrom(tc *TracerConfig, sourceNamespace, operatorDefaultNamespace string) bool {
+	if tc == nil || sourceNamespace == "" {
+		return false
+	}
+	target := tc.Spec.SystemNamespace
+	if target == "" {
+		target = operatorDefaultNamespace
+	}
+	if target == sourceNamespace || target == operatorDefaultNamespace {
+		return true
+	}
+	grant, ok := tc.Annotations[AllowSessionsFromAnnotation]
+	if !ok {
+		return false
+	}
+	for _, entry := range strings.Split(grant, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if entry == AllowTracingFromWildcard || entry == sourceNamespace {
+			return true
+		}
+	}
+	return false
+}

--- a/api/v1alpha1/tracerconfig_grant.go
+++ b/api/v1alpha1/tracerconfig_grant.go
@@ -2,20 +2,10 @@ package v1alpha1
 
 import "strings"
 
-// AllowSessionsFromAnnotation is the opt-in grant a TracerConfig must carry
-// before PodTraceSessions in OTHER namespaces may pin it via tracerConfigRef.
-// A pinned config decides where the session's (privileged, hostPID, SYS_ADMIN)
-// Jobs and credential Secrets are created — its systemNamespace — so without
-// this consent a tenant could place a privileged workload in a fleet namespace
-// it has no access to.
 const AllowSessionsFromAnnotation = "podtrace.io/allow-sessions-from"
 
 // TracerConfigAllowsSessionFrom reports whether tc permits a session in
-// sourceNamespace to pin it. Pinning is always allowed when the config lands
-// its Jobs in the session's own namespace or in the operator's default
-// namespace (the normal path — the "default" config lives there and every
-// unpinned session uses it); any other systemNamespace is a cross-tenant
-// placement and requires the config to grant sourceNamespace (or "*").
+// sourceNamespace to pin it.
 func TracerConfigAllowsSessionFrom(tc *TracerConfig, sourceNamespace, operatorDefaultNamespace string) bool {
 	if tc == nil || sourceNamespace == "" {
 		return false

--- a/api/v1alpha1/tracerconfig_grant_test.go
+++ b/api/v1alpha1/tracerconfig_grant_test.go
@@ -1,0 +1,56 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTracerConfigAllowsSessionFrom(t *testing.T) {
+	const operatorDefault = "podtrace-system"
+	tc := func(systemNamespace, grant string) *TracerConfig {
+		obj := &TracerConfig{Spec: TracerConfigSpec{SystemNamespace: systemNamespace}}
+		if grant != "-" {
+			obj.Annotations = map[string]string{AllowSessionsFromAnnotation: grant}
+		}
+		return obj
+	}
+
+	cases := []struct {
+		name   string
+		config *TracerConfig
+		source string
+		want   bool
+	}{
+		{"NilConfigDenies", nil, "team-a", false},
+		{"EmptySourceDenies", tc("fleet-b", "*"), "", false},
+		{"OwnNamespaceAllowed", tc("team-a", "-"), "team-a", true},
+		{"OperatorDefaultAllowed", tc(operatorDefault, "-"), "team-a", true},
+		{"EmptySystemNamespaceUsesDefault", tc("", "-"), "team-a", true},
+		{"CrossTenantNoGrantDenies", tc("fleet-b", "-"), "team-a", false},
+		{"CrossTenantEmptyGrantDenies", tc("fleet-b", ""), "team-a", false},
+		{"CrossTenantWildcardAllows", tc("fleet-b", "*"), "team-a", true},
+		{"CrossTenantExactAllows", tc("fleet-b", "team-a"), "team-a", true},
+		{"CrossTenantListAllows", tc("fleet-b", "ops,team-a,audit"), "team-a", true},
+		{"CrossTenantNonMemberDenies", tc("fleet-b", "ops,audit"), "team-a", false},
+		{"CrossTenantPrefixIsNotAMatch", tc("fleet-b", "team-a-2"), "team-a", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TracerConfigAllowsSessionFrom(tc.config, tc.source, operatorDefault); got != tc.want {
+				t.Errorf("TracerConfigAllowsSessionFrom(%v, %q) = %v, want %v", tc.config, tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTracerConfigAllowsSessionFrom_IgnoresUnrelatedAnnotation(t *testing.T) {
+	config := &TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"unrelated": "team-a"}},
+		Spec:       TracerConfigSpec{SystemNamespace: "fleet-b"},
+	}
+	if TracerConfigAllowsSessionFrom(config, "team-a", "podtrace-system") {
+		t.Fatal("an unrelated annotation must not grant a cross-tenant pin")
+	}
+}

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -94,7 +94,7 @@ struct usdt_probe {
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, u64);
 	__type(value, struct usdt_probe);
@@ -692,15 +692,15 @@ struct {
 } h3_req_stash SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
 	__type(key, u32);
 	__type(value, struct h3_field_offsets);
 } h3_offsets SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1024);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 4096);
 	__type(key, u32);
 	__type(value, struct h3_peer_paths);
 } h3_peer_paths_map SEC(".maps");

--- a/internal/ebpf/tracer/reader_recover_test.go
+++ b/internal/ebpf/tracer/reader_recover_test.go
@@ -1,0 +1,21 @@
+package tracer
+
+import "testing"
+
+func TestRecoverReaderPanic_SwallowsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("recoverReaderPanic let a panic escape: %v", r)
+		}
+	}()
+	func() {
+		defer recoverReaderPanic("http/2 decode")
+		panic("malformed record")
+	}()
+}
+
+func TestRecoverReaderPanic_NoPanicIsNoop(t *testing.T) {
+	func() {
+		defer recoverReaderPanic("dns payload")
+	}()
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -126,6 +126,9 @@ type Tracer struct {
 	cpAnalyzer                    *criticalpath.Analyzer
 	piiRedactor                   *redactor.Redactor
 	profilingCtrl                 ProfilingController
+
+	stopCancel context.CancelFunc
+	readerWG   sync.WaitGroup
 }
 
 // registerGroupLinks records freshly attached links under their probe group
@@ -1332,11 +1335,27 @@ func (t *Tracer) reportDrop(reason string, n int) {
 	}
 }
 
+// recoverReaderPanic recovers a panic from processing a single record so a
+// malformed/edge-case event skips that iteration instead of unwinding the
+// reader goroutine and permanently ending event collection.
+func recoverReaderPanic(where string) {
+	if r := recover(); r != nil {
+		logger.Error("panic processing record (recovered, reader continues)",
+			zap.String("reader", where),
+			zap.Any("panic", r),
+			zap.ByteString("stack", debug.Stack()))
+	}
+}
+
 func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) error {
 	errorLimiter := newErrorRateLimiter()
 	slidingWindow := newSlidingWindow(config.DefaultSlidingWindowSize, config.DefaultSlidingWindowBuckets)
 	circuitBreaker := newCircuitBreaker(config.DefaultCircuitBreakerThreshold, config.DefaultCircuitBreakerTimeout)
 	stackMap := t.collection.Maps["stack_traces"]
+
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	t.stopCancel = stopCancel
+	ctx = stopCtx
 
 	t.cgroupWriteMu.Lock()
 	dnsCgroups := t.currentCgroupPaths()
@@ -1352,7 +1371,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		t.collection.Maps["cgroup_alerts"],
 		t.collection.Maps["cgroup_cpu_quota"])
 
+	t.readerWG.Add(1)
 	go func() {
+		defer t.readerWG.Done()
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for {
@@ -1371,7 +1392,11 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		}
 	}()
 
-	go t.runDNSTimeoutSweeper(ctx, eventChan)
+	t.readerWG.Add(1)
+	go func() {
+		defer t.readerWG.Done()
+		t.runDNSTimeoutSweeper(ctx, eventChan)
+	}()
 
 	if config.ManagementPort > 0 {
 		go t.serveManagementAPI(ctx, config.ManagementPort)
@@ -1395,7 +1420,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		zap.Int("target_cgroup_id_count", len(t.loadCgroupIDs())),
 		zap.Bool("use_userspace_filter", t.useUserspaceCgroupFilter.Load()))
 
+	t.readerWG.Add(1)
 	go func() {
+		defer t.readerWG.Done()
 		eventCollectionTicker := time.NewTicker(5 * time.Second)
 		defer eventCollectionTicker.Stop()
 		filterAutoDisableHintLogged := false
@@ -1458,7 +1485,9 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 		}
 	}()
 
+	t.readerWG.Add(1)
 	go func() {
+		defer t.readerWG.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				logger.Error("Panic in event reader",
@@ -1521,35 +1550,44 @@ func (t *Tracer) Start(ctx context.Context, eventChan chan<- *events.Event) erro
 			}
 
 			processingStart := time.Now()
-			event := parser.ParseEvent(record.RawSample)
-			if event != nil {
-				t.processAndDispatch(ctx, event, eventChan, stackMap, ec, processingStart)
-			}
+			func() {
+				defer recoverReaderPanic("event reader")
+				event := parser.ParseEvent(record.RawSample)
+				if event != nil {
+					t.processAndDispatch(ctx, event, eventChan, stackMap, ec, processingStart)
+				}
+			}()
 		}
 	}()
 
 	if t.h2Reader != nil && t.h2Decoder != nil {
-		go t.runH2DecodeReader(ctx, eventChan, stackMap, ec)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runH2DecodeReader(ctx, eventChan, stackMap, ec) }()
 	}
 
 	if t.h3Reader != nil {
-		go t.runH3DecodeReader(ctx, eventChan, stackMap, ec)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runH3DecodeReader(ctx, eventChan, stackMap, ec) }()
 	}
 
 	if t.h3ChunkReader != nil && t.h3Assembler != nil {
-		go t.runH3ChunkReader(ctx)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runH3ChunkReader(ctx) }()
 	}
 
 	if t.h3Reader != nil && t.h3SectionStash != nil {
-		go t.runH3ParkedFlusher(ctx, eventChan, stackMap, ec)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runH3ParkedFlusher(ctx, eventChan, stackMap, ec) }()
 	}
 
 	if t.quicReader != nil {
-		go t.runQUICInitialReader(ctx, eventChan, stackMap, ec)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runQUICInitialReader(ctx, eventChan, stackMap, ec) }()
 	}
 
 	if t.dnsPayloadReader != nil {
-		go t.runDNSPayloadReader(ctx, eventChan, stackMap, ec)
+		t.readerWG.Add(1)
+		go func() { defer t.readerWG.Done(); t.runDNSPayloadReader(ctx, eventChan, stackMap, ec) }()
 	}
 
 	return nil
@@ -1701,7 +1739,9 @@ func (t *Tracer) runH2DecodeReader(ctx context.Context, eventChan chan<- *events
 		}
 	}()
 
+	t.readerWG.Add(1)
 	go func() {
+		defer t.readerWG.Done()
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 		for {
@@ -1732,17 +1772,20 @@ func (t *Tracer) runH2DecodeReader(ctx context.Context, eventChan chan<- *events
 			continue
 		}
 
-		rec, ok := h2decode.ParseRecord(record.RawSample)
-		if !ok {
-			continue
-		}
-		if rec.IsClose() {
-			t.h2Decoder.Evict(rec.ConnID)
-			continue
-		}
-		for _, ev := range t.h2Decoder.Ingest(rec) {
-			t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
-		}
+		func() {
+			defer recoverReaderPanic("http/2 decode")
+			rec, ok := h2decode.ParseRecord(record.RawSample)
+			if !ok {
+				return
+			}
+			if rec.IsClose() {
+				t.h2Decoder.Evict(rec.ConnID)
+				return
+			}
+			for _, ev := range t.h2Decoder.Ingest(rec) {
+				t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+			}
+		}()
 	}
 }
 
@@ -1797,12 +1840,15 @@ func (t *Tracer) runDNSPayloadReader(ctx context.Context, eventChan chan<- *even
 			continue
 		}
 
-		rec, ok := dns.ParseRecord(record.RawSample)
-		if !ok {
-			continue
-		}
-		t.populateDNSResolved(rec)
-		t.processAndDispatch(ctx, buildDNSEventFromRecord(rec), eventChan, stackMap, ec, time.Now())
+		func() {
+			defer recoverReaderPanic("dns payload")
+			rec, ok := dns.ParseRecord(record.RawSample)
+			if !ok {
+				return
+			}
+			t.populateDNSResolved(rec)
+			t.processAndDispatch(ctx, buildDNSEventFromRecord(rec), eventChan, stackMap, ec, time.Now())
+		}()
 	}
 }
 
@@ -1913,23 +1959,26 @@ func (t *Tracer) runH3DecodeReader(ctx context.Context, eventChan chan<- *events
 			continue
 		}
 
-		txn, ok := t.h3Decoder.ParseRecord(record.RawSample)
-		if !ok {
-			continue
-		}
-		if h3Logged := h3TxnLogCount.Add(1); h3Logged <= 20 {
-			logger.Debug("h3 txn decoded",
-				zap.String("method", txn.Method), zap.String("path", txn.Path),
-				zap.Uint16("status", txn.Status), zap.Bool("client", txn.IsClient),
-				zap.Uint8("flags", txn.Flags), zap.String("peer_ip", txn.PeerIP),
-				zap.Uint16("peer_port", txn.PeerPort), zap.Int("headers", len(txn.Headers)))
-		}
-		if t.h3EnrichOrPark(txn) {
-			continue
-		}
-		for _, ev := range txn.Events() {
-			t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
-		}
+		func() {
+			defer recoverReaderPanic("http/3 decode")
+			txn, ok := t.h3Decoder.ParseRecord(record.RawSample)
+			if !ok {
+				return
+			}
+			if h3Logged := h3TxnLogCount.Add(1); h3Logged <= 20 {
+				logger.Debug("h3 txn decoded",
+					zap.String("method", txn.Method), zap.String("path", txn.Path),
+					zap.Uint16("status", txn.Status), zap.Bool("client", txn.IsClient),
+					zap.Uint8("flags", txn.Flags), zap.String("peer_ip", txn.PeerIP),
+					zap.Uint16("peer_port", txn.PeerPort), zap.Int("headers", len(txn.Headers)))
+			}
+			if t.h3EnrichOrPark(txn) {
+				return
+			}
+			for _, ev := range txn.Events() {
+				t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+			}
+		}()
 	}
 }
 
@@ -2012,15 +2061,18 @@ func (t *Tracer) runH3ChunkReader(ctx context.Context) {
 			}
 			continue
 		}
-		if c, ok := h3stream.ParseChunk(record.RawSample); ok {
-			if n := h3ChunkLogCount.Add(1); n <= 20 {
-				logger.Debug("h3 stream chunk",
-					zap.Uint32("tgid", c.TGID), zap.Uint64("conn", c.Conn),
-					zap.Uint64("stream", c.StreamID), zap.Uint32("len", c.CopiedLen),
-					zap.Uint32("offset", c.Offset))
+		func() {
+			defer recoverReaderPanic("http/3 chunk")
+			if c, ok := h3stream.ParseChunk(record.RawSample); ok {
+				if n := h3ChunkLogCount.Add(1); n <= 20 {
+					logger.Debug("h3 stream chunk",
+						zap.Uint32("tgid", c.TGID), zap.Uint64("conn", c.Conn),
+						zap.Uint64("stream", c.StreamID), zap.Uint32("len", c.CopiedLen),
+						zap.Uint32("offset", c.Offset))
+				}
+				t.h3Assembler.Feed(c)
 			}
-			t.h3Assembler.Feed(c)
-		}
+		}()
 	}
 }
 
@@ -2200,72 +2252,78 @@ func (t *Tracer) runQUICInitialReader(ctx context.Context, eventChan chan<- *eve
 			}
 			continue
 		}
-		data := record.RawSample
-		if len(data) <= hdr {
-			continue
-		}
-		family := data[20]
-		dport := binary.LittleEndian.Uint16(data[22:24])
-		var v6 [16]byte
-		copy(v6[:], data[24:40])
-		var ip string
-		if family == 10 {
-			ip = events.PeerIP(10, 0, v6)
-		} else {
-			ip = events.PeerIP(2, binary.BigEndian.Uint32(data[24:28]), v6)
-		}
-
-		now := time.Now()
-		key := quicFlowKey{cgroup: binary.LittleEndian.Uint64(data[8:16]), addr: v6, port: dport}
-		st := flows[key]
-		if st == nil {
-			if len(flows) >= quicMaxTrackedFlows {
-				evictQUICFlows(flows, now)
+		func() {
+			defer recoverReaderPanic("http/3 quic")
+			data := record.RawSample
+			if len(data) <= hdr {
+				return
 			}
-			st = &quicFlowState{lastSeen: now}
-			flows[key] = st
-		}
-		if st.done {
-			continue
-		}
-		st.lastSeen = now
-		pktEnd := hdr + int(binary.LittleEndian.Uint16(data[40:42]))
-		if pktEnd > len(data) {
-			pktEnd = len(data)
-		}
-		pkt := make([]byte, pktEnd-hdr)
-		copy(pkt, data[hdr:pktEnd])
-		st.pkts = append(st.pkts, pkt)
-
-		info, xerr := quicinitial.ExtractPackets(st.pkts)
-		if xerr != nil && len(st.pkts) < quicInitialMaxPackets {
-			continue
-		}
-		st.done = true
-		st.pkts = nil
-
-		ev := &events.Event{}
-		ev.Timestamp = binary.LittleEndian.Uint64(data[0:8])
-		ev.CgroupID = binary.LittleEndian.Uint64(data[8:16])
-		ev.PID = binary.LittleEndian.Uint32(data[16:20])
-		ev.ProcessName = string(bytes.TrimRight(data[44:60], "\x00"))
-		ev.Type = events.EventHTTP3
-		ev.Target = fmt.Sprintf("%s:%d", ip, dport)
-		ev.PeerDstIP = ip
-		ev.PeerDstPort = dport
-		if xerr == nil && info.SNI != "" {
-			ev.Details = "sni: " + info.SNI
-			if len(info.ALPN) > 0 {
-				ev.Details += " alpn: " + strings.Join(info.ALPN, ",")
+			family := data[20]
+			dport := binary.LittleEndian.Uint16(data[22:24])
+			var v6 [16]byte
+			copy(v6[:], data[24:40])
+			var ip string
+			if family == 10 {
+				ip = events.PeerIP(10, 0, v6)
+			} else {
+				ip = events.PeerIP(2, binary.BigEndian.Uint32(data[24:28]), v6)
 			}
-		} else {
-			ev.Details = "HTTP/3 (QUIC)"
-		}
-		t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+
+			now := time.Now()
+			key := quicFlowKey{cgroup: binary.LittleEndian.Uint64(data[8:16]), addr: v6, port: dport}
+			st := flows[key]
+			if st == nil {
+				if len(flows) >= quicMaxTrackedFlows {
+					evictQUICFlows(flows, now)
+				}
+				st = &quicFlowState{lastSeen: now}
+				flows[key] = st
+			}
+			if st.done {
+				return
+			}
+			st.lastSeen = now
+			pktEnd := hdr + int(binary.LittleEndian.Uint16(data[40:42]))
+			if pktEnd > len(data) {
+				pktEnd = len(data)
+			}
+			pkt := make([]byte, pktEnd-hdr)
+			copy(pkt, data[hdr:pktEnd])
+			st.pkts = append(st.pkts, pkt)
+
+			info, xerr := quicinitial.ExtractPackets(st.pkts)
+			if xerr != nil && len(st.pkts) < quicInitialMaxPackets {
+				return
+			}
+			st.done = true
+			st.pkts = nil
+
+			ev := &events.Event{}
+			ev.Timestamp = binary.LittleEndian.Uint64(data[0:8])
+			ev.CgroupID = binary.LittleEndian.Uint64(data[8:16])
+			ev.PID = binary.LittleEndian.Uint32(data[16:20])
+			ev.ProcessName = string(bytes.TrimRight(data[44:60], "\x00"))
+			ev.Type = events.EventHTTP3
+			ev.Target = fmt.Sprintf("%s:%d", ip, dport)
+			ev.PeerDstIP = ip
+			ev.PeerDstPort = dport
+			if xerr == nil && info.SNI != "" {
+				ev.Details = "sni: " + info.SNI
+				if len(info.ALPN) > 0 {
+					ev.Details += " alpn: " + strings.Join(info.ALPN, ",")
+				}
+			} else {
+				ev.Details = "HTTP/3 (QUIC)"
+			}
+			t.processAndDispatch(ctx, ev, eventChan, stackMap, ec, time.Now())
+		}()
 	}
 }
 
 func (t *Tracer) Stop() error {
+	if t.stopCancel != nil {
+		t.stopCancel()
+	}
 	if t.reader != nil {
 		_ = t.reader.Close()
 	}
@@ -2306,6 +2364,8 @@ func (t *Tracer) Stop() error {
 	for _, l := range closing {
 		_ = l.Close()
 	}
+
+	t.readerWG.Wait()
 
 	if t.collection != nil {
 		t.collection.Close()

--- a/internal/operator/finalizer.go
+++ b/internal/operator/finalizer.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -30,15 +31,10 @@ import (
 // This is the standard pattern in Prometheus Operator, cert-manager, etc.
 const FinalizerCleanup = "podtrace.io/cleanup"
 
-// ensureFinalizer adds FinalizerCleanup to the object if it is not
-// already present. Returns true when the finalizer was added and the
-// caller should update the object.
 func ensureFinalizer(obj client.Object) bool {
 	return controllerutil.AddFinalizer(obj, FinalizerCleanup)
 }
 
-// removeFinalizer removes FinalizerCleanup from the object. Returns
-// true when removal changed the object.
 func removeFinalizer(obj client.Object) bool {
 	return controllerutil.RemoveFinalizer(obj, FinalizerCleanup)
 }
@@ -175,4 +171,54 @@ func cleanupPodTraceSessionChildren(ctx context.Context, c client.Client, s *pod
 		return err
 	}
 	return nil
+}
+
+// sessionChildNamespaces returns every namespace that currently holds a
+// resource labelled as owned by this session, unioned with the caller's
+// best-effort seed (the currently-resolved system namespace plus the operator
+// default).
+func sessionChildNamespaces(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, seed []string) ([]string, error) {
+	set := map[string]struct{}{}
+	for _, ns := range seed {
+		if ns != "" {
+			set[ns] = struct{}{}
+		}
+	}
+	sel := client.MatchingLabels(sessionRBACLabels(s))
+
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, sel); err != nil {
+		return nil, fmt.Errorf("list session Jobs for cleanup: %w", err)
+	}
+	for i := range jobs.Items {
+		set[jobs.Items[i].Namespace] = struct{}{}
+	}
+	var configMaps corev1.ConfigMapList
+	if err := c.List(ctx, &configMaps, sel); err != nil {
+		return nil, fmt.Errorf("list session ConfigMaps for cleanup: %w", err)
+	}
+	for i := range configMaps.Items {
+		set[configMaps.Items[i].Namespace] = struct{}{}
+	}
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets, sel); err != nil {
+		return nil, fmt.Errorf("list session Secrets for cleanup: %w", err)
+	}
+	for i := range secrets.Items {
+		set[secrets.Items[i].Namespace] = struct{}{}
+	}
+	var serviceAccounts corev1.ServiceAccountList
+	if err := c.List(ctx, &serviceAccounts, sel); err != nil {
+		return nil, fmt.Errorf("list session ServiceAccounts for cleanup: %w", err)
+	}
+	for i := range serviceAccounts.Items {
+		set[serviceAccounts.Items[i].Namespace] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for ns := range set {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out, nil
 }

--- a/internal/operator/operator_regression_test.go
+++ b/internal/operator/operator_regression_test.go
@@ -92,7 +92,7 @@ func TestEnsureSessionPodReadRBAC(t *testing.T) {
 	s := newSession(nil)
 	const systemNS = "podtrace-system"
 
-	if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-a", "team-b"}, systemNS); err != nil {
+	if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-a", "team-b"}, []string{systemNS}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/operator/podtraceschedule_controller.go
+++ b/internal/operator/podtraceschedule_controller.go
@@ -80,6 +80,15 @@ func (r *PodTraceScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	r.setCondition(&sch, ConditionPaused, metav1.ConditionFalse, "NotSuspended", "")
 
+	if err := podtracev1alpha1.ValidateSessionTemplateMetadata(sch.Spec.SessionTemplate.Metadata); err != nil {
+		r.setCondition(&sch, ConditionDegraded, metav1.ConditionTrue, "SessionTemplateInvalid", err.Error())
+		r.refreshStatus(&sch, active, nil)
+		if perr := r.patchStatus(ctx, &sch); perr != nil {
+			return ctrl.Result{}, perr
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if sch.Spec.Trigger != nil {
 		return r.reconcileTrigger(ctx, &sch, active, succeeded, failed, now)
 	}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -31,6 +31,27 @@ type PodTraceSessionReconciler struct {
 	APIReader       client.Reader
 	Scheme          *runtime.Scheme
 	SystemNamespace string
+
+	nowFn func() time.Time
+}
+
+func (r *PodTraceSessionReconciler) now() time.Time {
+	if r.nowFn != nil {
+		return r.nowFn()
+	}
+	return time.Now()
+}
+
+const pendingMatchDeadline = 30 * time.Minute
+
+// sessionPendingDeadline is the instant after which a zero-match session is
+// failed terminally, or the zero time when the creation timestamp is unset.
+func sessionPendingDeadline(s *podtracev1alpha1.PodTraceSession) time.Time {
+	created := s.CreationTimestamp.Time
+	if created.IsZero() {
+		return time.Time{}
+	}
+	return created.Add(pendingMatchDeadline)
 }
 
 // +kubebuilder:rbac:groups=podtrace.io,resources=podtracesessions,verbs=get;list;watch;update;patch
@@ -73,7 +94,11 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			tc = nil
 		}
 		sessionNS := systemNamespaceForSession(tc, r.SystemNamespace)
-		for _, ns := range candidateSystemNamespaces(sessionNS, r.SystemNamespace) {
+		namespaces, err := sessionChildNamespaces(ctx, r.Client, &session, candidateSystemNamespaces(sessionNS, r.SystemNamespace))
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		for _, ns := range namespaces {
 			if err := cleanupPodTraceSessionChildren(ctx, r.Client, &session, ns); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -129,6 +154,10 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if len(targets.DeniedNamespaces) > 0 {
 			reason = "CrossNamespaceNotGranted"
 			message = crossNamespaceDeniedMessage(session.Namespace, targets.DeniedNamespaces)
+		}
+		if deadline := sessionPendingDeadline(&session); !deadline.IsZero() && r.now().After(deadline) {
+			return ctrl.Result{}, r.failSessionTerminally(ctx, &session, reason+"DeadlineExceeded",
+				fmt.Sprintf("%s; no pods matched within %s of creation", message, pendingMatchDeadline))
 		}
 		logger.Info("no matched pods; session stays Pending until pods appear", "reason", reason)
 		session.Status.State = podtracev1alpha1.SessionStatePending
@@ -195,17 +224,15 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		_ = r.Status().Update(ctx, &session)
 		return ctrl.Result{}, err
 	}
-	for _, ns := range resolved.namespaces {
-		if err := ensureSessionReportRBAC(ctx, r.Client, &session, r.Scheme, ns); err != nil {
-			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
-			_ = r.Status().Update(ctx, &session)
-			return ctrl.Result{}, err
-		}
-		if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, r.Scheme, sessionPodNamespaces(&session, targets), ns); err != nil {
-			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
-			_ = r.Status().Update(ctx, &session)
-			return ctrl.Result{}, err
-		}
+	if err := ensureSessionReportRBAC(ctx, r.Client, &session, r.Scheme, resolved.namespaces); err != nil {
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
+		_ = r.Status().Update(ctx, &session)
+		return ctrl.Result{}, err
+	}
+	if err := ensureSessionPodReadRBAC(ctx, r.Client, &session, r.Scheme, sessionPodNamespaces(&session, targets), resolved.namespaces); err != nil {
+		r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "SessionRBAC", err.Error())
+		_ = r.Status().Update(ctx, &session)
+		return ctrl.Result{}, err
 	}
 
 	cap := effectiveMaxConcurrentSessionsPerNode(tc)

--- a/internal/operator/runtime.go
+++ b/internal/operator/runtime.go
@@ -119,7 +119,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	if opts.WebhookCertDir != "" {
-		if err := registerWebhooks(mgr); err != nil {
+		if err := registerWebhooks(mgr, opts.SystemNamespace); err != nil {
 			return fmt.Errorf("register webhooks: %w", err)
 		}
 	}
@@ -177,11 +177,11 @@ func leaderElectionID(opts Options) string {
 }
 
 // registerWebhooks wires the validating webhooks onto the manager.
-func registerWebhooks(mgr ctrl.Manager) error {
+func registerWebhooks(mgr ctrl.Manager, systemNamespace string) error {
 	if err := webhookv1alpha1.SetupPodTraceWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("podtrace webhook: %w", err)
 	}
-	if err := webhookv1alpha1.SetupPodTraceSessionWebhookWithManager(mgr); err != nil {
+	if err := webhookv1alpha1.SetupPodTraceSessionWebhookWithManager(mgr, systemNamespace); err != nil {
 		return fmt.Errorf("podtracesession webhook: %w", err)
 	}
 	if err := webhookv1alpha1.SetupExporterConfigWebhookWithManager(mgr); err != nil {

--- a/internal/operator/runtime_wiring_test.go
+++ b/internal/operator/runtime_wiring_test.go
@@ -45,7 +45,7 @@ func TestNewSchemeRegistersBothGroups(t *testing.T) {
 }
 
 func TestRegisterWebhooksWiresEveryValidator(t *testing.T) {
-	if err := registerWebhooks(nonConnectingManager(t)); err != nil {
+	if err := registerWebhooks(nonConnectingManager(t), "podtrace-system"); err != nil {
 		t.Fatalf("registerWebhooks: %v", err)
 	}
 }

--- a/internal/operator/schedule_template_metadata_test.go
+++ b/internal/operator/schedule_template_metadata_test.go
@@ -1,0 +1,66 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestScheduleReconcile_InvalidTemplateMetadataFailsTerminally(t *testing.T) {
+	sch := &podtracev1alpha1.PodTraceSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "bad-template",
+			Namespace:         "default",
+			UID:               "sch-bad",
+			Generation:        1,
+			CreationTimestamp: metav1.NewTime(fixedScheduleNow.Add(-6 * time.Minute)),
+		},
+		Spec: podtracev1alpha1.PodTraceScheduleSpec{
+			Schedule: "*/5 * * * *",
+			SessionTemplate: podtracev1alpha1.PodTraceSessionTemplateSpec{
+				Metadata: podtracev1alpha1.PodTraceSessionTemplateMetadata{
+					Labels: map[string]string{"team": "not a valid value"},
+				},
+				Spec: podtracev1alpha1.PodTraceSessionSpec{},
+			},
+		},
+	}
+
+	r, _ := newScheduleReconciler(t, sch)
+	ctx := context.Background()
+
+	res, err := r.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("terminal validation failure must not return an error, got %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("an invalid template must not requeue, got %v", res.RequeueAfter)
+	}
+
+	var sessions podtracev1alpha1.PodTraceSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(sch.Namespace)); err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions.Items) != 0 {
+		t.Fatalf("no child session should be created from an invalid template, got %d", len(sessions.Items))
+	}
+
+	var got podtracev1alpha1.PodTraceSchedule
+	if err := r.Get(ctx, types.NamespacedName{Name: sch.Name, Namespace: sch.Namespace}, &got); err != nil {
+		t.Fatalf("get schedule: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, ConditionDegraded)
+	if cond == nil || cond.Reason != "SessionTemplateInvalid" {
+		t.Fatalf("degraded condition = %+v, want reason SessionTemplateInvalid", cond)
+	}
+}

--- a/internal/operator/session_child_namespaces_test.go
+++ b/internal/operator/session_child_namespaces_test.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -9,7 +11,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
 )
@@ -70,5 +74,37 @@ func TestSessionReconcile_DeletionSweepsStaleNamespaceChildren(t *testing.T) {
 	err := c.Get(context.Background(), types.NamespacedName{Name: "job-stale", Namespace: "fleet-gone"}, &batchv1.Job{})
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("stale-namespace Job should have been swept before the finalizer cleared, err = %v", err)
+	}
+}
+
+func TestSessionChildNamespaces_ListErrorsSurface(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finTestSession()
+	cases := []struct {
+		name   string
+		failOn func(client.ObjectList) bool
+		want   string
+	}{
+		{"jobs", func(l client.ObjectList) bool { _, ok := l.(*batchv1.JobList); return ok }, "list session Jobs for cleanup"},
+		{"configmaps", func(l client.ObjectList) bool { _, ok := l.(*corev1.ConfigMapList); return ok }, "list session ConfigMaps for cleanup"},
+		{"secrets", func(l client.ObjectList) bool { _, ok := l.(*corev1.SecretList); return ok }, "list session Secrets for cleanup"},
+		{"serviceaccounts", func(l client.ObjectList) bool { _, ok := l.(*corev1.ServiceAccountList); return ok }, "list session ServiceAccounts for cleanup"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if tc.failOn(list) {
+							return errors.New("boom")
+						}
+						return cl.List(ctx, list, opts...)
+					},
+				}).Build()
+			_, err := sessionChildNamespaces(context.Background(), c, s, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want it to mention %q", err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/operator/session_child_namespaces_test.go
+++ b/internal/operator/session_child_namespaces_test.go
@@ -1,0 +1,74 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func hasNamespace(list []string, ns string) bool {
+	for _, n := range list {
+		if n == ns {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSessionChildNamespaces_UnionsSeedAndDiscovered(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finTestSession()
+	staleJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "job-x", Namespace: "fleet-gone", UID: "job-x-uid", Labels: sessionRBACLabels(s),
+	}}
+	staleSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: SessionBundleName(s.UID), Namespace: "fleet-also-gone", Labels: sessionRBACLabels(s),
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(staleJob, staleSecret).Build()
+
+	got, err := sessionChildNamespaces(context.Background(), c, s, []string{"podtrace-system"})
+	if err != nil {
+		t.Fatalf("sessionChildNamespaces: %v", err)
+	}
+	for _, want := range []string{"podtrace-system", "fleet-gone", "fleet-also-gone"} {
+		if !hasNamespace(got, want) {
+			t.Errorf("namespace %q missing from %v", want, got)
+		}
+	}
+}
+
+func TestSessionReconcile_DeletionSweepsStaleNamespaceChildren(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	now := metav1.Now()
+	s := sessMoreSession(func(s *podtracev1alpha1.PodTraceSession) { s.DeletionTimestamp = &now })
+	staleJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "job-stale", Namespace: "fleet-gone", UID: "job-stale-uid",
+		Labels: map[string]string{
+			LabelManagedBy:   ManagedByValue,
+			LabelComponent:   ComponentSession,
+			LabelSessionName: s.Name,
+			LabelSessionNS:   s.Namespace,
+		},
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s, staleJob).Build()
+	r := &PodTraceSessionReconciler{Client: c, Scheme: scheme, SystemNamespace: sessMoreSysNS}
+
+	if _, err := sessMoreReconcile(t, r); err != nil {
+		t.Fatalf("deletion reconcile: %v", err)
+	}
+
+	err := c.Get(context.Background(), types.NamespacedName{Name: "job-stale", Namespace: "fleet-gone"}, &batchv1.Job{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("stale-namespace Job should have been swept before the finalizer cleared, err = %v", err)
+	}
+}

--- a/internal/operator/session_pending_deadline_test.go
+++ b/internal/operator/session_pending_deadline_test.go
@@ -1,0 +1,81 @@
+package operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+var pendingDeadlineCreated = metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+func newPendingDeadlineReconciler(t *testing.T, at time.Time) (*PodTraceSessionReconciler, *fakeGetter) {
+	t.Helper()
+	scheme := newOperatorScheme(t)
+	s := sessMoreSession(func(s *podtracev1alpha1.PodTraceSession) { s.CreationTimestamp = pendingDeadlineCreated })
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&podtracev1alpha1.PodTraceSession{}).
+		WithObjects(s).Build()
+	r := &PodTraceSessionReconciler{
+		Client:          c,
+		Scheme:          scheme,
+		SystemNamespace: sessMoreSysNS,
+		nowFn:           func() time.Time { return at },
+	}
+	return r, &fakeGetter{r: r}
+}
+
+type fakeGetter struct{ r *PodTraceSessionReconciler }
+
+func (g *fakeGetter) session(t *testing.T) podtracev1alpha1.PodTraceSession {
+	t.Helper()
+	var got podtracev1alpha1.PodTraceSession
+	if err := g.r.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	return got
+}
+
+func TestSessionReconcile_ZeroMatchPastDeadlineFailsTerminally(t *testing.T) {
+	r, g := newPendingDeadlineReconciler(t, pendingDeadlineCreated.Add(pendingMatchDeadline+time.Minute))
+
+	res, err := sessMoreReconcile(t, r)
+	if err != nil {
+		t.Fatalf("terminal failure must not return an error, got %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("a terminally failed session must not requeue, got %v", res.RequeueAfter)
+	}
+
+	got := g.session(t)
+	if got.Status.State != podtracev1alpha1.SessionStateFailed {
+		t.Fatalf("state = %q, want Failed", got.Status.State)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, ConditionDegraded)
+	if cond == nil || cond.Reason != "NoMatchedPodsDeadlineExceeded" {
+		t.Fatalf("degraded condition = %+v, want reason NoMatchedPodsDeadlineExceeded", cond)
+	}
+}
+
+func TestSessionReconcile_ZeroMatchBeforeDeadlineStaysPending(t *testing.T) {
+	r, g := newPendingDeadlineReconciler(t, pendingDeadlineCreated.Add(pendingMatchDeadline-time.Minute))
+
+	res, err := sessMoreReconcile(t, r)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatal("a still-pending session must requeue to re-check for matched pods")
+	}
+
+	got := g.session(t)
+	if got.Status.State != podtracev1alpha1.SessionStatePending {
+		t.Fatalf("state = %q, want Pending", got.Status.State)
+	}
+}

--- a/internal/operator/session_pending_deadline_test.go
+++ b/internal/operator/session_pending_deadline_test.go
@@ -63,6 +63,16 @@ func TestSessionReconcile_ZeroMatchPastDeadlineFailsTerminally(t *testing.T) {
 	}
 }
 
+func TestSessionReconcilerNow_DefaultsToWallClock(t *testing.T) {
+	r := &PodTraceSessionReconciler{}
+	before := time.Now()
+	got := r.now()
+	after := time.Now()
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("now() = %v, want within [%v, %v]", got, before, after)
+	}
+}
+
 func TestSessionReconcile_ZeroMatchBeforeDeadlineStaysPending(t *testing.T) {
 	r, g := newPendingDeadlineReconciler(t, pendingDeadlineCreated.Add(pendingMatchDeadline-time.Minute))
 

--- a/internal/operator/session_rbac.go
+++ b/internal/operator/session_rbac.go
@@ -44,9 +44,27 @@ func cleanupSessionServiceAccount(ctx context.Context, c client.Client, s *podtr
 	return nil
 }
 
-// ensureSessionReportRBAC provisions per-session RBAC in the user
-// namespace.
-func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, systemNS string) error {
+func sessionSubjects(s *podtracev1alpha1.PodTraceSession, systemNamespaces []string) []rbacv1.Subject {
+	seen := make(map[string]struct{}, len(systemNamespaces))
+	subs := make([]rbacv1.Subject, 0, len(systemNamespaces))
+	for _, ns := range systemNamespaces {
+		if ns == "" {
+			continue
+		}
+		if _, dup := seen[ns]; dup {
+			continue
+		}
+		seen[ns] = struct{}{}
+		subs = append(subs, rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      SessionServiceAccountName(s.UID),
+			Namespace: ns,
+		})
+	}
+	return subs
+}
+
+func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, systemNamespaces []string) error {
 	roleName := SessionReportRoleName(s.UID)
 	bindingName := SessionReportRoleBindingName(s.UID)
 
@@ -81,11 +99,7 @@ func ensureSessionReportRBAC(ctx context.Context, c client.Client, s *podtracev1
 			Kind:     "Role",
 			Name:     roleName,
 		}
-		binding.Subjects = []rbacv1.Subject{{
-			Kind:      rbacv1.ServiceAccountKind,
-			Name:      SessionServiceAccountName(s.UID),
-			Namespace: systemNS,
-		}}
+		binding.Subjects = sessionSubjects(s, systemNamespaces)
 		return controllerutil.SetControllerReference(s, binding, scheme)
 	}); err != nil {
 		return fmt.Errorf("ensure session report RoleBinding: %w", err)
@@ -150,7 +164,7 @@ func sessionPodNamespaces(s *podtracev1alpha1.PodTraceSession, targets sessionTa
 
 // ensureSessionPodReadRBAC grants the session SA pods+events read in each
 // extra namespace a cross-namespace session targets.
-func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, namespaces []string, systemNS string) error {
+func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev1alpha1.PodTraceSession, scheme *runtime.Scheme, namespaces []string, systemNamespaces []string) error {
 	for _, ns := range namespaces {
 		sameNS := ns == s.Namespace
 		role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: SessionPodReadRoleName(s.UID), Namespace: ns}}
@@ -176,11 +190,7 @@ func ensureSessionPodReadRBAC(ctx context.Context, c client.Client, s *podtracev
 				Kind:     "Role",
 				Name:     SessionPodReadRoleName(s.UID),
 			}
-			binding.Subjects = []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      SessionServiceAccountName(s.UID),
-				Namespace: systemNS,
-			}}
+			binding.Subjects = sessionSubjects(s, systemNamespaces)
 			if sameNS {
 				return controllerutil.SetControllerReference(s, binding, scheme)
 			}

--- a/internal/operator/session_rbac_errors_test.go
+++ b/internal/operator/session_rbac_errors_test.go
@@ -135,7 +135,7 @@ func TestEnsureSessionPodReadRBAC_CreateErrors(t *testing.T) {
 					return cl.Create(ctx, obj, opts...)
 				},
 			}).Build()
-		if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-b"}, "podtrace-system"); err == nil {
+		if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-b"}, []string{"podtrace-system"}); err == nil {
 			t.Fatal("expected Role create error")
 		}
 	})
@@ -150,7 +150,7 @@ func TestEnsureSessionPodReadRBAC_CreateErrors(t *testing.T) {
 					return cl.Create(ctx, obj, opts...)
 				},
 			}).Build()
-		if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-b"}, "podtrace-system"); err == nil {
+		if err := ensureSessionPodReadRBAC(context.Background(), c, s, scheme, []string{"team-b"}, []string{"podtrace-system"}); err == nil {
 			t.Fatal("expected RoleBinding create error")
 		}
 	})
@@ -168,7 +168,7 @@ func TestEnsureSessionReportRBAC_BindingCreateError(t *testing.T) {
 				return cl.Create(ctx, obj, opts...)
 			},
 		}).Build()
-	if err := ensureSessionReportRBAC(context.Background(), c, s, scheme, "podtrace-system"); err == nil {
+	if err := ensureSessionReportRBAC(context.Background(), c, s, scheme, []string{"podtrace-system"}); err == nil {
 		t.Fatal("expected RoleBinding create error from ensureSessionReportRBAC")
 	}
 }

--- a/internal/operator/session_rbac_subject_accumulation_test.go
+++ b/internal/operator/session_rbac_subject_accumulation_test.go
@@ -1,0 +1,73 @@
+package operator
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func subjectNamespaces(subs []rbacv1.Subject) []string {
+	out := make([]string, 0, len(subs))
+	for _, sub := range subs {
+		out = append(out, sub.Namespace)
+	}
+	return out
+}
+
+func TestEnsureSessionReportRBAC_SubjectPerSystemNamespace(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finTestSession()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, []string{"fleet-a", "fleet-b"}); err != nil {
+		t.Fatalf("ensureSessionReportRBAC: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionReportRoleBindingName(s.UID), Namespace: s.Namespace}, &rb); err != nil {
+		t.Fatalf("get report RoleBinding: %v", err)
+	}
+	if got, want := subjectNamespaces(rb.Subjects), []string{"fleet-a", "fleet-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("report binding subject namespaces = %v, want %v", got, want)
+	}
+	for _, sub := range rb.Subjects {
+		if sub.Name != SessionServiceAccountName(s.UID) {
+			t.Errorf("subject name = %q, want %q", sub.Name, SessionServiceAccountName(s.UID))
+		}
+		if sub.Kind != rbacv1.ServiceAccountKind {
+			t.Errorf("subject kind = %q, want %q", sub.Kind, rbacv1.ServiceAccountKind)
+		}
+	}
+}
+
+func TestEnsureSessionPodReadRBAC_SubjectPerSystemNamespace(t *testing.T) {
+	scheme := newOperatorScheme(t)
+	s := finTestSession()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	if err := ensureSessionPodReadRBAC(ctx, c, s, scheme, []string{"team-x"}, []string{"fleet-a", "fleet-b"}); err != nil {
+		t.Fatalf("ensureSessionPodReadRBAC: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := c.Get(ctx, types.NamespacedName{Name: SessionPodReadRoleBindingName(s.UID), Namespace: "team-x"}, &rb); err != nil {
+		t.Fatalf("get pod-read RoleBinding: %v", err)
+	}
+	if got, want := subjectNamespaces(rb.Subjects), []string{"fleet-a", "fleet-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pod-read binding subject namespaces = %v, want %v", got, want)
+	}
+}
+
+func TestSessionSubjects_DeduplicatesAndSkipsEmpty(t *testing.T) {
+	s := finTestSession()
+	subs := sessionSubjects(s, []string{"fleet-a", "", "fleet-a", "fleet-b"})
+	if got, want := subjectNamespaces(subs), []string{"fleet-a", "fleet-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("subject namespaces = %v, want %v", got, want)
+	}
+}

--- a/internal/operator/session_rbac_test.go
+++ b/internal/operator/session_rbac_test.go
@@ -57,7 +57,7 @@ func TestEnsureSessionReportRBAC_CreatesNarrowRole(t *testing.T) {
 		},
 	}
 
-	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, []string{"podtrace-system"}); err != nil {
 		t.Fatalf("ensureSessionReportRBAC: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestEnsureSessionReportRBAC_NoSinkStillGrantsPodRead(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "sess-abc"},
 	}
-	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, []string{"podtrace-system"}); err != nil {
 		t.Fatalf("ensureSessionReportRBAC: %v", err)
 	}
 
@@ -271,7 +271,7 @@ func TestEnsureSessionReportRBAC_OwnsSameNamespaceRBAC(t *testing.T) {
 			ReportRef: &podtracev1alpha1.ReportReference{ConfigMap: &corev1.LocalObjectReference{Name: "r"}},
 		},
 	}
-	if err := ensureSessionReportRBAC(ctx, c, s, scheme, "podtrace-system"); err != nil {
+	if err := ensureSessionReportRBAC(ctx, c, s, scheme, []string{"podtrace-system"}); err != nil {
 		t.Fatalf("ensureSessionReportRBAC: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestEnsureSessionPodReadRBAC_OwnsOnlySameNamespace(t *testing.T) {
 	s := &podtracev1alpha1.PodTraceSession{
 		ObjectMeta: metav1.ObjectMeta{Name: "diag", Namespace: "team-a", UID: "own-2"},
 	}
-	if err := ensureSessionPodReadRBAC(ctx, c, s, scheme, []string{"team-a", "team-b"}, "podtrace-system"); err != nil {
+	if err := ensureSessionPodReadRBAC(ctx, c, s, scheme, []string{"team-a", "team-b"}, []string{"podtrace-system"}); err != nil {
 		t.Fatalf("ensureSessionPodReadRBAC: %v", err)
 	}
 

--- a/internal/operator/session_tracerconfig.go
+++ b/internal/operator/session_tracerconfig.go
@@ -40,12 +40,7 @@ func (e *errNoTracerConfig) Error() string {
 
 // sessionTracerConfigs holds the per-node resolution for one session.
 type sessionTracerConfigs struct {
-	// byNode maps a node name to the config its Job must run under.
-	byNode map[string]*podtracev1alpha1.TracerConfig
-	// namespaces lists the distinct system namespaces those configs
-	// resolve to, sorted. A session whose nodes span fleets with different
-	// spec.systemNamespace needs its bundle, credentials, ServiceAccount
-	// and RBAC provisioned in each of them.
+	byNode     map[string]*podtracev1alpha1.TracerConfig
 	namespaces []string
 }
 
@@ -93,6 +88,13 @@ func (r *PodTraceSessionReconciler) resolveSessionTracerConfigs(
 				return out, &errNoTracerConfig{pinned: ref.Name, reason: "TracerConfig not found"}
 			}
 			return out, fmt.Errorf("get TracerConfig %q: %w", ref.Name, err)
+		}
+		if !podtracev1alpha1.TracerConfigAllowsSessionFrom(&pinned, s.Namespace, r.SystemNamespace) {
+			return out, &errNoTracerConfig{
+				pinned: ref.Name,
+				reason: fmt.Sprintf("not entitled: TracerConfig %q does not grant sessions from namespace %q (set annotation %s on the config)",
+					ref.Name, s.Namespace, podtracev1alpha1.AllowSessionsFromAnnotation),
+			}
 		}
 		for _, node := range nodes {
 			out.byNode[node] = &pinned

--- a/internal/operator/session_tracerconfig_entitlement_test.go
+++ b/internal/operator/session_tracerconfig_entitlement_test.go
@@ -1,0 +1,49 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestSessionRefCrossTenantWithoutConsentIsTerminal(t *testing.T) {
+	r := sessionResolver(t, testTracerConfig("regulated", "img:regulated", "fleet-b", nil))
+
+	_, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("regulated"), []string{"n1"})
+	var missing *errNoTracerConfig
+	if !errors.As(err, &missing) {
+		t.Fatalf("want errNoTracerConfig, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "not entitled") {
+		t.Errorf("error should explain the missing consent, got %q", err)
+	}
+}
+
+func TestSessionRefCrossTenantWithConsentResolves(t *testing.T) {
+	granted := testTracerConfig("regulated", "img:regulated", "fleet-b", nil)
+	granted.Annotations = map[string]string{podtracev1alpha1.AllowSessionsFromAnnotation: "team-a"}
+	r := sessionResolver(t, granted)
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("regulated"), []string{"n1"})
+	if err != nil {
+		t.Fatalf("a consented cross-tenant pin must resolve, got %v", err)
+	}
+	if name := got.forNode("n1").Name; name != "regulated" {
+		t.Errorf("n1 resolved to %q, want regulated", name)
+	}
+}
+
+func TestSessionRefOwnNamespacePinResolvesWithoutConsent(t *testing.T) {
+	r := sessionResolver(t, testTracerConfig("local", "img:local", "team-a", nil))
+
+	got, err := r.resolveSessionTracerConfigs(context.Background(), sessionWithRef("local"), []string{"n1"})
+	if err != nil {
+		t.Fatalf("a pin landing in the session's own namespace needs no grant, got %v", err)
+	}
+	if name := got.forNode("n1").Name; name != "local" {
+		t.Errorf("n1 resolved to %q, want local", name)
+	}
+}

--- a/internal/webhook/v1alpha1/podtraceschedule_webhook.go
+++ b/internal/webhook/v1alpha1/podtraceschedule_webhook.go
@@ -96,6 +96,9 @@ func (v *PodTraceScheduleCustomValidator) validate(ctx context.Context, s *podtr
 	if err := validateReportRef(tmpl.ReportRef); err != nil {
 		return nil, fmt.Errorf("spec.sessionTemplate.%w", err)
 	}
+	if err := podtracev1alpha1.ValidateSessionTemplateMetadata(s.Spec.SessionTemplate.Metadata); err != nil {
+		return nil, err
+	}
 	tmplWarnings, err := validateCrossNamespaceGrants(ctx, v.Client, s.Namespace, tmpl.PodRefs, tmpl.NamespaceSelector)
 	if err != nil {
 		return nil, fmt.Errorf("spec.sessionTemplate.%w", err)

--- a/internal/webhook/v1alpha1/podtraceschedule_webhook_test.go
+++ b/internal/webhook/v1alpha1/podtraceschedule_webhook_test.go
@@ -215,6 +215,22 @@ func TestPodTraceScheduleValidator(t *testing.T) {
 			},
 			exporter: "prod-otlp",
 		},
+		{
+			name: "template-invalid-label-value",
+			mutate: func(s *podtracev1alpha1.PodTraceSchedule) {
+				s.Spec.SessionTemplate.Metadata.Labels = map[string]string{"team": "not a valid value"}
+			},
+			exporter:  "prod-otlp",
+			wantError: "labels",
+		},
+		{
+			name: "template-invalid-annotation-key",
+			mutate: func(s *podtracev1alpha1.PodTraceSchedule) {
+				s.Spec.SessionTemplate.Metadata.Annotations = map[string]string{"bad key": "v"}
+			},
+			exporter:  "prod-otlp",
+			wantError: "annotations",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/webhook/v1alpha1/podtracesession_webhook.go
+++ b/internal/webhook/v1alpha1/podtracesession_webhook.go
@@ -25,12 +25,13 @@ import (
 //     CRD schema accepts as a valid metav1.Duration but produces an
 //     instantly-expired session that spawns Jobs with activeDeadline 0).
 type PodTraceSessionCustomValidator struct {
-	Client client.Client
+	Client          client.Client
+	SystemNamespace string
 }
 
-func SetupPodTraceSessionWebhookWithManager(mgr ctrl.Manager) error {
+func SetupPodTraceSessionWebhookWithManager(mgr ctrl.Manager, systemNamespace string) error {
 	return ctrl.NewWebhookManagedBy(mgr, &podtracev1alpha1.PodTraceSession{}).
-		WithValidator(&PodTraceSessionCustomValidator{Client: mgr.GetClient()}).
+		WithValidator(&PodTraceSessionCustomValidator{Client: mgr.GetClient(), SystemNamespace: systemNamespace}).
 		Complete()
 }
 
@@ -64,7 +65,7 @@ func (v *PodTraceSessionCustomValidator) validate(ctx context.Context, s *podtra
 	if err := resolveExporterRef(ctx, v.Client, s.Namespace, s.Spec.ExporterRef.Name); err != nil {
 		return nil, err
 	}
-	if err := resolveTracerConfigRef(ctx, v.Client, s.Spec.TracerConfigRef); err != nil {
+	if err := resolveTracerConfigRef(ctx, v.Client, s.Spec.TracerConfigRef, s.Namespace, v.SystemNamespace); err != nil {
 		return nil, err
 	}
 	if err := validateReportRef(s.Spec.ReportRef); err != nil {

--- a/internal/webhook/v1alpha1/setup_webhook_unit_test.go
+++ b/internal/webhook/v1alpha1/setup_webhook_unit_test.go
@@ -63,7 +63,7 @@ func TestSetupPodTraceScheduleWebhookWithManager(t *testing.T) {
 
 func TestSetupPodTraceSessionWebhookWithManager(t *testing.T) {
 	mgr := newNonConnectingManager(t)
-	if err := webhookv1alpha1.SetupPodTraceSessionWebhookWithManager(mgr); err != nil {
+	if err := webhookv1alpha1.SetupPodTraceSessionWebhookWithManager(mgr, "podtrace-system"); err != nil {
 		t.Fatalf("SetupPodTraceSessionWebhookWithManager: %v", err)
 	}
 }

--- a/internal/webhook/v1alpha1/tracerconfig_ref_entitlement_test.go
+++ b/internal/webhook/v1alpha1/tracerconfig_ref_entitlement_test.go
@@ -1,0 +1,58 @@
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func entitlementClient(t *testing.T, config *podtracev1alpha1.TracerConfig) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := podtracev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+}
+
+func TestResolveTracerConfigRef_CrossTenantWithoutConsentRejected(t *testing.T) {
+	config := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "regulated"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "img", SystemNamespace: "fleet-b"},
+	}
+	c := entitlementClient(t, config)
+
+	err := resolveTracerConfigRef(context.Background(), c, &podtracev1alpha1.LocalObjectReference{Name: "regulated"}, "team-a", "podtrace-system")
+	if err == nil {
+		t.Fatal("a cross-tenant pin without consent must be rejected at admission")
+	}
+	if !strings.Contains(err.Error(), podtracev1alpha1.AllowSessionsFromAnnotation) {
+		t.Errorf("error should name the consent annotation, got %q", err)
+	}
+}
+
+func TestResolveTracerConfigRef_CrossTenantWithConsentAccepted(t *testing.T) {
+	config := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "regulated",
+			Annotations: map[string]string{podtracev1alpha1.AllowSessionsFromAnnotation: "team-a"},
+		},
+		Spec: podtracev1alpha1.TracerConfigSpec{Image: "img", SystemNamespace: "fleet-b"},
+	}
+	c := entitlementClient(t, config)
+
+	if err := resolveTracerConfigRef(context.Background(), c, &podtracev1alpha1.LocalObjectReference{Name: "regulated"}, "team-a", "podtrace-system"); err != nil {
+		t.Fatalf("a consented cross-tenant pin must pass admission, got %v", err)
+	}
+}

--- a/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
+++ b/internal/webhook/v1alpha1/tracerconfig_webhook_test.go
@@ -196,7 +196,7 @@ func TestTracerConfigValidateWithoutClientSkipsClusterChecks(t *testing.T) {
 }
 
 func TestResolveTracerConfigRefWithoutClient(t *testing.T) {
-	err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{Name: "regulated"})
+	err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{Name: "regulated"}, "team-a", "podtrace-system")
 	if err == nil {
 		t.Fatal("an unconfigured client cannot verify the pin, so it must not silently accept it")
 	}
@@ -206,10 +206,10 @@ func TestResolveTracerConfigRefWithoutClient(t *testing.T) {
 }
 
 func TestResolveTracerConfigRefNilAndEmptyAreUnset(t *testing.T) {
-	if err := resolveTracerConfigRef(context.Background(), nil, nil); err != nil {
+	if err := resolveTracerConfigRef(context.Background(), nil, nil, "team-a", "podtrace-system"); err != nil {
 		t.Errorf("a nil ref means resolve per node, got %v", err)
 	}
-	if err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{}); err != nil {
+	if err := resolveTracerConfigRef(context.Background(), nil, &podtracev1alpha1.LocalObjectReference{}, "team-a", "podtrace-system"); err != nil {
 		t.Errorf("an empty ref name means resolve per node, got %v", err)
 	}
 }

--- a/internal/webhook/v1alpha1/webhook_error_paths_test.go
+++ b/internal/webhook/v1alpha1/webhook_error_paths_test.go
@@ -40,7 +40,7 @@ func TestResolveTracerConfigRefSurfacesNonNotFoundErrors(t *testing.T) {
 		},
 	})
 
-	err := resolveTracerConfigRef(context.Background(), c, &podtracev1alpha1.LocalObjectReference{Name: "regulated"})
+	err := resolveTracerConfigRef(context.Background(), c, &podtracev1alpha1.LocalObjectReference{Name: "regulated"}, "team-a", "podtrace-system")
 	if err == nil {
 		t.Fatal("an apiserver failure must not be mistaken for a missing TracerConfig")
 	}

--- a/internal/webhook/v1alpha1/webhook_helpers.go
+++ b/internal/webhook/v1alpha1/webhook_helpers.go
@@ -27,15 +27,7 @@ import (
 )
 
 // specUnchanged reports whether old and new spec values are deep-equal. When
-// they are, validating webhooks should skip re-validation of the spec: the
-// admission request is touching only metadata (finalizers, labels, annotations)
-// or status, and re-running spec validation can wedge legacy CRs whose spec
-// pre-dates a stricter validation rule (e.g. a session created before the
-// "at most one reportRef sink" rule landed can't have its finalizer cleared
-// because the webhook rejects every UPDATE on spec grounds).
-//
-// Standard Kubernetes pattern — built-in validators use the same shortcut to
-// allow finalizer-only updates on otherwise-invalid resources.
+// they are, validating webhooks should skip re-validation of the spec.
 func specUnchanged(oldSpec, newSpec any) bool {
 	return reflect.DeepEqual(oldSpec, newSpec)
 }
@@ -169,7 +161,7 @@ func validateCrossNamespaceGrants(
 // fail the session terminally at run time, long after apply.
 //
 // TracerConfig is cluster-scoped, so the lookup carries no namespace.
-func resolveTracerConfigRef(ctx context.Context, c client.Client, ref *podtracev1alpha1.LocalObjectReference) error {
+func resolveTracerConfigRef(ctx context.Context, c client.Client, ref *podtracev1alpha1.LocalObjectReference, sourceNamespace, operatorNamespace string) error {
 	if ref == nil || ref.Name == "" {
 		return nil
 	}
@@ -179,6 +171,11 @@ func resolveTracerConfigRef(ctx context.Context, c client.Client, ref *podtracev
 	var tc podtracev1alpha1.TracerConfig
 	err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, &tc)
 	if err == nil {
+		if !podtracev1alpha1.TracerConfigAllowsSessionFrom(&tc, sourceNamespace, operatorNamespace) {
+			return fmt.Errorf(
+				"spec.tracerConfigRef.name %q: TracerConfig does not grant sessions from namespace %q (set annotation %s on the config, or leave tracerConfigRef unset)",
+				ref.Name, sourceNamespace, podtracev1alpha1.AllowSessionsFromAnnotation)
+		}
 		return nil
 	}
 	if apierrors.IsNotFound(err) {

--- a/pkg/tracer/engine.go
+++ b/pkg/tracer/engine.go
@@ -171,7 +171,6 @@ func (e *engine) applyTargets(set TargetSet) error {
 	}
 
 	e.mu.Lock()
-
 	added, removed, changed := 0, 0, 0
 	for path, t := range desired {
 		prev, ok := e.activeCgroups[path]
@@ -188,15 +187,16 @@ func (e *engine) applyTargets(set TargetSet) error {
 			removed++
 		}
 	}
+	e.mu.Unlock()
 
 	if added == 0 && removed == 0 && changed == 0 {
-		e.mu.Unlock()
 		return nil
 	}
 
 	var attachErrs []attachError
 
 	if err := e.backend.SetCgroups(snapshot); err != nil {
+		e.mu.Lock()
 		e.attachFailure++
 		e.mu.Unlock()
 		e.reportAttachErrors([]attachError{{stage: "set_cgroups", err: err}})
@@ -217,7 +217,6 @@ func (e *engine) applyTargets(set TargetSet) error {
 			cts = append(cts, ContainerUprobeTarget{ContainerID: t.ContainerID, PID: t.ContainerPID})
 		}
 		if err := rec.SetContainerTargets(cts); err != nil {
-			e.attachFailure++
 			attachErrs = append(attachErrs, attachError{stage: "set_container_targets", err: err})
 		}
 	} else {
@@ -238,13 +237,11 @@ func (e *engine) applyTargets(set TargetSet) error {
 				SetContainerIDs(containerIDs []string) error
 			}); ok {
 				if err := multi.SetContainerIDs(ids); err != nil {
-					e.attachFailure++
 					attachErrs = append(attachErrs, attachError{stage: "set_container_ids", err: err})
 				}
 			} else {
 				for _, id := range ids {
 					if err := e.backend.SetContainerID(id); err != nil {
-						e.attachFailure++
 						attachErrs = append(attachErrs, attachError{stage: "set_container_id", err: err})
 					}
 				}
@@ -256,9 +253,11 @@ func (e *engine) applyTargets(set TargetSet) error {
 	for path, t := range desired {
 		next[path] = cgroupState{containerID: t.ContainerID, containerPID: t.ContainerPID}
 	}
+	e.mu.Lock()
 	e.activeCgroups = next
 	e.cgroupsAttached += int64(added)
 	e.cgroupsDetached += int64(removed)
+	e.attachFailure += int64(len(attachErrs))
 	e.mu.Unlock()
 
 	e.reportAttachErrors(attachErrs)


### PR DESCRIPTION
## Summary

Ten verified operator-tenancy, lifecycle, and eBPF map-lifetime fixes. Each ships with a regression test that fails without the fix.

## Operator tenancy

- **Cross-tenant `tracerConfigRef` entitlement.** A session could pin a `TracerConfig` whose `systemNamespace` is a fleet namespace and place its privileged (hostPID, `SYS_ADMIN`) Jobs and credential Secrets there. Pinning a config that lands outside the session's own namespace (or the operator default) now requires the config to grant consent via `podtrace.io/allow-sessions-from` (comma list or `*`), mirroring the existing namespace `allow-tracing-from` model. Enforced authoritatively in the session resolver (terminal) and echoed by the admission webhook for fast feedback.

- **RBAC subjects per system namespace.** For a session spanning fleets with distinct `systemNamespace`, the report and pod-read RoleBindings were assigned a single subject that the per-namespace loop overwrote, leaving every fleet but the last-sorted one unauthorized. Bindings now carry one ServiceAccount subject per distinct system namespace.

## Lifecycle

- **Cross-namespace deletion sweep.** On session deletion the finalizer only cleaned the currently-resolved system namespace(s). When resolution shifted (or became unreadable) between create and delete, Jobs, exporter bundles, credential Secrets, and ServiceAccounts were orphaned in other fleet namespaces until the grace-delayed reaper caught them. Deletion now discovers every namespace holding a labelled child and sweeps all of them before clearing the finalizer.

- **Terminal deadline for zero-match sessions.** A session whose selector never matched (typo, ungranted namespace, pods that never shipped) requeued every 10s forever, held its finalizer, and was never TTL-GC'd. After a generous 30-minute window it now fails terminally with a descriptive reason.

- **Schedule SessionTemplate metadata validation.** An invalid label or annotation in a schedule's `sessionTemplate.metadata` made every child-session create fail, requeuing the schedule on the same error indefinitely. The metadata is now validated up front in the schedule webhook and terminally in the controller (`SessionTemplateInvalid`, no requeue) for schedules that predate it.

## eBPF map lifetimes

- `usdt_probes`, `h3_offsets`, and `h3_peer_paths_map` converted from `HASH` to `LRU_HASH` (the two h3 maps also sized up to 4096) so stale entries evict under churn instead of wedging the map at capacity.

## Engine / tracer lifecycle

- The engine no longer holds its lock across blocking backend attach calls, so the dispatch loop keeps draining the event channel during retargeting.
- Ringbuf reader loops recover per-iteration rather than tearing down the whole reader on one bad record, and `Stop()` cancels reader contexts and waits on a WaitGroup for a clean shutdown.