### PR TITLE
fix: correct BPF L7 parser desyncs and wire the gRPC port knob

### DIFF
--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -18,6 +18,7 @@
 #define MAX_ANSWERS 4
 #define MAX_NAME_LABELS 32
 #define DNS_OFF_MASK 0x7ff
+#define DNS_PTR_MASK 0x3fff
 #define DNS_NAME_SCAN_LEN 96
 #define IP6_HOPOPTS 0
 #define IP6_ROUTING 43
@@ -146,7 +147,7 @@ static __noinline void parse_name_compressed(struct __sk_buff *skb, int dns_off,
 		__u8 lo = 0;
 		if (bpf_skb_load_bytes(skb, off + 1, &lo, 1) < 0)
 			return;
-		off = (dns_off + (((first & 0x3f) << 8) | lo)) & DNS_OFF_MASK;
+		off = (dns_off + (((first & 0x3f) << 8) | lo)) & DNS_PTR_MASK;
 	}
 
 	int j = 0, label_remaining = 0, need_len = 1;

--- a/bpf/grpc.c
+++ b/bpf/grpc.c
@@ -19,7 +19,10 @@ int kprobe_grpc_tcp_sendmsg(struct pt_regs *ctx)
 		return 0;
 
 	u16 dport = __builtin_bswap16(BPF_CORE_READ(sk, __sk_common.skc_dport));
-	if (dport != GRPC_DEFAULT_PORT)
+	u32 zero = 0;
+	u32 *cfg = bpf_map_lookup_elem(&grpc_port_cfg, &zero);
+	u16 want = (cfg && *cfg != 0 && *cfg <= 0xffff) ? (u16)*cfg : GRPC_DEFAULT_PORT;
+	if (dport != want)
 		return 0;
 
 	struct msghdr *msg = (struct msghdr *)PT_REGS_PARM2(ctx);

--- a/bpf/h2.c
+++ b/bpf/h2.c
@@ -135,17 +135,51 @@ static long h2_frames_cb(u32 idx, void *vctx)
 		return 0;
 	}
 
-	if (off + HTTP2_FRAME_HDR > c->avail)
-		return 1;
 	u8 fh[HTTP2_FRAME_HDR];
-	if (bpf_probe_read_user(fh, sizeof(fh), (u8 *)c->base + off) != 0)
-		return 1;
+	if (fs->hdr_have > 0) {
+		u32 have = fs->hdr_have;
+		u32 avail_here = c->avail - off;
+		u32 need = HTTP2_FRAME_HDR - have;
+		if (avail_here < need) {
+			fs->hdr_have = 0;
+			return 1;
+		}
+#pragma clang loop unroll(full)
+		for (u32 i = 0; i < HTTP2_FRAME_HDR; i++) {
+			if (i < have) {
+				fh[i] = fs->hdr_partial[i];
+			} else {
+				u8 b = 0;
+				bpf_probe_read_user(&b, 1, (u8 *)c->base + off + (i - have));
+				fh[i] = b;
+			}
+		}
+		off += need;
+		fs->hdr_have = 0;
+	} else {
+		if (off + HTTP2_FRAME_HDR > c->avail) {
+			u32 tail = c->avail - off;
+#pragma clang loop unroll(full)
+			for (u32 i = 0; i < HTTP2_FRAME_HDR; i++) {
+				if (i < tail) {
+					u8 b = 0;
+					bpf_probe_read_user(&b, 1, (u8 *)c->base + off + i);
+					fs->hdr_partial[i] = b;
+				}
+			}
+			fs->hdr_have = (u8)tail;
+			s->off = c->avail;
+			return 1;
+		}
+		if (bpf_probe_read_user(fh, sizeof(fh), (u8 *)c->base + off) != 0)
+			return 1;
+		off += HTTP2_FRAME_HDR;
+	}
 	u32 flen = ((u32)fh[0] << 16) | ((u32)fh[1] << 8) | (u32)fh[2];
 	u8 type = fh[3];
 	u8 flags = fh[4];
 	u32 sid = (((u32)fh[5] << 24) | ((u32)fh[6] << 16) |
 		   ((u32)fh[7] << 8) | (u32)fh[8]) & 0x7fffffff;
-	off += HTTP2_FRAME_HDR;
 
 	u8 pad_bytes = 0;
 	if (type == HTTP2_HEADERS) {
@@ -154,8 +188,9 @@ static long h2_frames_cb(u32 idx, void *vctx)
 			if (bpf_probe_read_user(&pb, 1, (u8 *)c->base + off) == 0) {
 				off += 1;
 				flen = flen >= 1 ? flen - 1 : 0;
-				flen = flen >= pb ? flen - pb : 0;
-				pad_bytes = pb;
+				u32 pad = pb <= flen ? pb : flen;
+				flen -= pad;
+				pad_bytes = (u8)pad;
 			}
 		}
 		if (flags & HTTP2_FLAG_PRIORITY) {
@@ -254,11 +289,43 @@ int kprobe_h2_tcp_sendmsg(struct pt_regs *ctx)
 	if (!http_should_trace())
 		return 0;
 
-	u64 conn = (u64)PT_REGS_PARM1(ctx);
 	struct msghdr *msg = (struct msghdr *)PT_REGS_PARM2(ctx);
 	u64 avail = 0;
 	void *base = msghdr_user_base(msg, &avail);
-	h2_emit_frames(base, avail, conn, H2_DIR_EGRESS, HTTP_TRANSPORT_H2C);
+	if (!base)
+		return 0;
+
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+
+	struct h2_recv_info info = {
+		.base = (u64)base,
+		.conn_id = (u64)PT_REGS_PARM1(ctx),
+	};
+	bpf_map_update_elem(&h2_send_base, &key, &info, BPF_ANY);
+	return 0;
+}
+
+SEC("kretprobe/tcp_sendmsg")
+int kretprobe_h2_tcp_sendmsg(struct pt_regs *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	u64 key = get_key(pid, tid);
+
+	struct h2_recv_info *info = bpf_map_lookup_elem(&h2_send_base, &key);
+	if (!info)
+		return 0;
+	void *base = (void *)info->base;
+	u64 conn = info->conn_id;
+	bpf_map_delete_elem(&h2_send_base, &key);
+
+	s64 ret = PT_REGS_RC(ctx);
+	if (ret <= 0)
+		return 0;
+
+	h2_emit_frames(base, (u64)ret, conn, H2_DIR_EGRESS, HTTP_TRANSPORT_H2C);
 	return 0;
 }
 
@@ -339,6 +406,9 @@ int kprobe_h2_tcp_close(struct pt_regs *ctx)
 
 SEC("kprobe/tcp_sendmsg")
 int kprobe_h2_tcp_sendmsg(struct pt_regs *ctx) { return 0; }
+
+SEC("kretprobe/tcp_sendmsg")
+int kretprobe_h2_tcp_sendmsg(struct pt_regs *ctx) { return 0; }
 
 SEC("kprobe/tcp_recvmsg")
 int kprobe_h2_tcp_recvmsg(struct pt_regs *ctx) { return 0; }

--- a/bpf/maps.h
+++ b/bpf/maps.h
@@ -192,6 +192,13 @@ struct {
 } dns_payload_enabled SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u32);
+} grpc_port_cfg SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__type(key, u32);
@@ -577,6 +584,13 @@ struct {
 } h2_recv_base SEC(".maps");
 
 struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1024);
+	__type(key, u64);
+	__type(value, struct h2_recv_info);
+} h2_send_base SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 2 * 1024 * 1024);
 } h2_hdr_events SEC(".maps");
@@ -834,6 +848,8 @@ struct h2_frame_state {
 	u8  flags;
 	u8  preface_seen;
 	u8  pad;
+	u8  hdr_have;
+	u8  hdr_partial[9];
 };
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -585,7 +585,9 @@ SEC("tp/net/net_dev_xmit")
 int tracepoint_net_dev_xmit(void *ctx) {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	struct net_dev_xmit_args args_local;
-	bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx);
+	if (bpf_probe_read_kernel(&args_local, sizeof(args_local), ctx) != 0) {
+		return 0;
+	}
 	if (args_local.rc == 0) {
 		return 0;
 	}

--- a/bpf/rustls.c
+++ b/bpf/rustls.c
@@ -28,9 +28,10 @@
 
 #define RUSTLS_PEEK 16
 
-static __always_inline u64 rustls_conn_key(void)
+static __always_inline u64 rustls_conn_key(u32 dir)
 {
-	struct tcp_peer *p = lookup_tcp_peer(PAIR_TCP_SENDMSG);
+	u32 prefer = (dir == H2_DIR_EGRESS) ? PAIR_TCP_SENDMSG : PAIR_TCP_RECVMSG;
+	struct tcp_peer *p = lookup_tcp_peer(prefer);
 	if (!p)
 		return 0;
 	return ((u64)p->saddr << 32) ^ (u64)p->daddr ^
@@ -40,7 +41,7 @@ static __always_inline u64 rustls_conn_key(void)
 static __always_inline void rustls_dispatch(void *ctx, void *base, u64 len,
 					    u64 conn, u32 dir)
 {
-	if (!base || len == 0)
+	if (!base || len == 0 || conn == 0)
 		return;
 	u8 peek[RUSTLS_PEEK] = {};
 	u32 plen = len < sizeof(peek) ? (u32)len : sizeof(peek);
@@ -61,8 +62,8 @@ int uprobe_rustls_write(struct pt_regs *ctx)
 {
 	if (!http_should_trace())
 		return 0;
-	rustls_dispatch(ctx, RUSTLS_BUF(ctx), RUSTLS_LEN(ctx), rustls_conn_key(),
-			H2_DIR_EGRESS);
+	rustls_dispatch(ctx, RUSTLS_BUF(ctx), RUSTLS_LEN(ctx),
+			rustls_conn_key(H2_DIR_EGRESS), H2_DIR_EGRESS);
 	return 0;
 }
 
@@ -76,7 +77,7 @@ int uprobe_rustls_read(struct pt_regs *ctx)
 	u64 key = get_key(pid, tid);
 	struct ssl_read_state st = {
 		.buf = (u64)RUSTLS_BUF(ctx),
-		.conn = rustls_conn_key(),
+		.conn = rustls_conn_key(H2_DIR_INGRESS),
 	};
 	bpf_map_update_elem(&rustls_read_args, &key, &st, BPF_ANY);
 	return 0;

--- a/bpf/usdt.c
+++ b/bpf/usdt.c
@@ -7,8 +7,9 @@
 
 static __always_inline u32 usdt_put_char(char *buf, u32 pos, char c)
 {
-	pos &= (MAX_STRING_LEN - 1);
-	buf[pos] = c;
+	buf[pos & (MAX_STRING_LEN - 1)] = c;
+	if (pos >= MAX_STRING_LEN - 1)
+		return MAX_STRING_LEN - 1;
 	return pos + 1;
 }
 

--- a/internal/ebpf/probes/groups.go
+++ b/internal/ebpf/probes/groups.go
@@ -132,6 +132,7 @@ var probeGroupMap = map[string]ProbeGroup{
 
 	// HTTP/2 h2c (HPACK endpoint capture)
 	"kprobe_h2_tcp_sendmsg":    GroupNetwork,
+	"kretprobe_h2_tcp_sendmsg": GroupNetwork,
 	"kprobe_h2_tcp_recvmsg":    GroupNetwork,
 	"kretprobe_h2_tcp_recvmsg": GroupNetwork,
 	"kprobe_h2_tcp_close":      GroupNetwork,

--- a/internal/ebpf/probes/groups_test.go
+++ b/internal/ebpf/probes/groups_test.go
@@ -32,6 +32,7 @@ func TestGroupForProbe_TLSPlaintextProbes(t *testing.T) {
 func TestGroupForProbe_H2Probes(t *testing.T) {
 	for _, prog := range []string{
 		"kprobe_h2_tcp_sendmsg",
+		"kretprobe_h2_tcp_sendmsg",
 		"kprobe_h2_tcp_recvmsg",
 		"kretprobe_h2_tcp_recvmsg",
 	} {

--- a/internal/ebpf/probes/protocols.go
+++ b/internal/ebpf/probes/protocols.go
@@ -267,6 +267,7 @@ func AttachH2Probes(coll *ebpf.Collection) []link.Link {
 		}
 	}
 	attach("kprobe_h2_tcp_sendmsg", "tcp_sendmsg", false)
+	attach("kretprobe_h2_tcp_sendmsg", "tcp_sendmsg", true)
 	attach("kprobe_h2_tcp_recvmsg", "tcp_recvmsg", false)
 	attach("kretprobe_h2_tcp_recvmsg", "tcp_recvmsg", true)
 	attach("kprobe_h2_tcp_close", "tcp_close", false)

--- a/internal/ebpf/tracer/map_helper_guards_test.go
+++ b/internal/ebpf/tracer/map_helper_guards_test.go
@@ -21,6 +21,11 @@ func TestMapHelpers_NilAndMissingMapGuards(t *testing.T) {
 	setDNSPayloadFlag(nil, true)
 	setDNSPayloadFlag(emptyColl(), true)
 
+	setGRPCPort(nil, 50051)
+	setGRPCPort(emptyColl(), 50051)
+	setGRPCPort(emptyColl(), 0)
+	setGRPCPort(emptyColl(), 70000)
+
 	populatePidNamespace(&ebpf.Collection{})
 
 	populateCaptureHeaderNames(nil, nil)

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -746,6 +746,7 @@ func NewTracer() (*Tracer, error) {
 	}
 	populateCaptureHeaderNames(coll, captureHeaders)
 	populatePidNamespace(coll)
+	setGRPCPort(coll, config.GRPCPort)
 
 	var quicrd *ringbuf.Reader
 	if m := coll.Maps["quic_initial_events"]; m != nil {
@@ -1790,6 +1791,26 @@ func (t *Tracer) runH2DecodeReader(ctx context.Context, eventChan chan<- *events
 }
 
 const dnsResolvedNameLen = 128
+
+// setGRPCPort publishes the runtime gRPC destination port (PODTRACE_GRPC_PORT)
+// into the array map the gRPC method probe filters on.
+func setGRPCPort(coll *ebpf.Collection, port int) {
+	if coll == nil || coll.Maps == nil {
+		return
+	}
+	m, ok := coll.Maps["grpc_port_cfg"]
+	if !ok || m == nil {
+		return
+	}
+	if port <= 0 || port > 65535 {
+		return
+	}
+	var zero uint32
+	val := uint32(port)
+	if err := m.Update(&zero, &val, ebpf.UpdateAny); err != nil {
+		logger.Warn("failed to set gRPC port config", zap.Error(err))
+	}
+}
 
 // setDNSPayloadFlag flips the dedicated array flag the DNS ingress program
 // consults before shipping raw DNS payloads.


### PR DESCRIPTION
## Summary

Six verified correctness fixes in the eBPF protocol parsers, plus wiring a config knob. None are memory-safety issues, every BPF read here was already bounds-checked; these are parser-desync and telemetry-integrity bugs. The full object passes the kernel verifier load-test.

## Fixes

- **DNS compression-pointer wrap (dns.c).** `DNS_OFF_MASK` was `0x7ff` (2047), but a DNS compression pointer is 14 bits (max 16383) and EDNS0 UDP messages reach ~4096 B, so a pointer past 2047 wrapped mod 2048 and parsed a name from an unrelated offset. Split the mask: the sequential name-walk loops keep `0x7ff` (a wider clamp defeats the verifier's state pruning on their data-dependent stride), and a new `DNS_PTR_MASK` (`0x3fff`) is used only at the one-shot pointer follow, whose constant-stride read loop the verifier handles at full width.

- **HTTP/2 padded HEADERS over-consume (h2.c).** A padded HEADERS frame stored the raw wire Pad Length without clamping it to the frame body, so a bogus large value consumed into the following frames and permanently desynced that connection's frame parser. Pad Length is now clamped so header fragment + padding consumes exactly the frame body.

- **HTTP/2 frame header straddling a buffer boundary (h2.c).** A 9-byte frame header split across two `tcp_sendmsg` buffers was dropped and the next buffer parsed as a fresh header, a desync. The frame state now stashes the partial header and completes it on the next buffer (the common two-buffer split; a header dribbled across 3+ sub-9-byte writes, which real senders never produce, resyncs instead).

- **HTTP/2 short-send double-count (h2.c).** The egress path drove the frame parser from the `tcp_sendmsg` entry probe using the requested byte count, so a short send followed by an application retry reprocessed the unsent tail and double-counted frames. It now stashes the buffer at entry and parses on a `kretprobe/tcp_sendmsg` using the bytes actually sent, mirroring the existing recvmsg path.

- **Unchecked kernel read in net_dev_xmit (network.c).** The `net_dev_xmit` tracepoint read its args struct without checking the return value, unlike its two sibling tracepoints, so a failed read emitted an error event with a garbage error code, byte count, and device name. Now checked like its siblings.

- **USDT string truncation wraps instead of clamping (usdt.c).** The per-character writer masked the write index but returned an unmasked position, so at the buffer end it wrapped to index 0 and overwrote the start of the string. It now saturates: the store is masked (which is what bounds it for the verifier) and the returned position clamps at the last byte.

- **gRPC port knob was inert (grpc.c + tracer).** `PODTRACE_GRPC_PORT` was read into config and documented as an override, but the probe filtered on a compile-time constant and the config value was used nowhere, so gRPC on a non-default port was silently untraced. The agent now publishes the configured port into a small array map that the probe reads (falling back to the built-in default when unset), so the documented override works.

- **rustls connection key collapse (rustls.c).** On a TCP-peer-stash miss, routine for rustls, whose userspace write/read probes fire apart from the kernel send/recv that populates the stash, the key fell back to a constant 0, collapsing every such connection onto one shared frame-reassembly state machine and interleaving their L7. The lookup is now direction-aware (a write follows a sendmsg, a read a recvmsg; both yield the same connection tuple, so correlation is preserved), and on a residual miss the event is dropped rather than mis-attributed onto a shared machine.