### PR TITLE
fix: harden agent runtime, resource use, and exporter/alert paths

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,10 +2,6 @@
 changelog:
   exclude:
     authors:
-      - renovate
-      - renovate[bot]
-      - dependabot
-      - dependabot[bot]
       - github-actions
       - github-actions[bot]
     labels:
@@ -31,6 +27,8 @@ changelog:
       labels: [test, tests]
     - title: CI / Build
       labels: [ci, build]
+    - title: Dependencies
+      labels: [dependencies]
     - title: Maintenance
       labels: [chore, refactor, style, revert]
     - title: Other Changes

--- a/internal/agent/datadog_event_exporter.go
+++ b/internal/agent/datadog_event_exporter.go
@@ -1,16 +1,18 @@
 package agent
 
 import (
+	"fmt"
+
 	"github.com/gma1k/podtrace/pkg/tracer"
 )
 
-// newDataDogEventExporter builds a tracer.Exporter that ships per-event
-// spans to DataDog via OTLP HTTP. DataDog supports OTLP through two
-// supported paths and the agent works with both:
 func newDataDogEventExporter(cr CRKey, b *BundlePayload, opts ...sdkOption) (tracer.Exporter, error) {
 	spanExporter, err := newOTLPSpanExporter(b)
 	if err != nil {
 		return nil, err
+	}
+	if len(b.Credential) == 0 {
+		return nil, fmt.Errorf("datadog exporter: missing api key")
 	}
 	return newSDKEventExporter("datadog", cr, b, spanExporter, opts...)
 }

--- a/internal/agent/exporter_credential_guard_test.go
+++ b/internal/agent/exporter_credential_guard_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gma1k/podtrace/pkg/exporter/bundle"
+)
+
+func TestBuildExporter_SplunkDataDogRequireCredential(t *testing.T) {
+	cases := []struct {
+		typ  bundle.Type
+		want string
+	}{
+		{bundle.TypeSplunk, "missing token"},
+		{bundle.TypeDataDog, "missing api key"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.typ), func(t *testing.T) {
+			p := &BundlePayload{
+				Type:       tc.typ,
+				Endpoint:   "collector.observability:4318",
+				Insecure:   true,
+				HeaderName: "X-Auth",
+			}
+			_, err := BuildExporter(p, CRKey{"ns", "cr"})
+			if err == nil {
+				t.Fatalf("%s with an empty credential must fail the build, not ship unauthenticated", tc.typ)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("%s empty-credential error = %v, want it to contain %q", tc.typ, err, tc.want)
+			}
+			if got := ClassifyExporterError(err); got != ExporterErrAuthMissing {
+				t.Fatalf("classifier = %q, want %q", got, ExporterErrAuthMissing)
+			}
+		})
+	}
+}

--- a/internal/agent/partials_cleanup_unit_test.go
+++ b/internal/agent/partials_cleanup_unit_test.go
@@ -13,11 +13,6 @@ import (
 	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
 )
 
-// TestObserveExportDelivery_RecordsAndShortCircuits drives every branch
-// of ObserveExportDelivery: the nil-receiver, nil-error, and
-// non-positive-span guards must all be no-ops, while a real delivery
-// failure must add spanCount to export_delivery_dropped_total under the
-// ClassifyExporterError reason label.
 func TestObserveExportDelivery_RecordsAndShortCircuits(t *testing.T) {
 	cr := CRKey{Namespace: "ns", Name: "cr"}
 
@@ -51,11 +46,6 @@ func TestObserveExportDelivery_RecordsAndShortCircuits(t *testing.T) {
 	}
 }
 
-// TestDropErrorRateDetector_RemovesAndNilSafe covers both branches of
-// dropErrorRateDetector: the nil-receiver short-circuit, and the
-// delete-from-map path verified indirectly by observing that a dropped
-// detector is reconstructed fresh (and thus does not breach until it
-// re-accumulates a full sample window).
 func TestDropErrorRateDetector_RemovesAndNilSafe(t *testing.T) {
 	var nilM *Metrics
 	nilM.dropErrorRateDetector(CRKey{Namespace: "ns", Name: "gone"})
@@ -93,11 +83,6 @@ func TestDropErrorRateDetector_RemovesAndNilSafe(t *testing.T) {
 	}
 }
 
-// TestNewProbeServer_DefaultStallWindow covers the stallWindow<=0
-// fallback branch of NewProbeServer that the existing probe tests skip
-// (they always pass a positive window). The constructor only builds the
-// struct and records an initial Heartbeat; it binds no port, so this is
-// safe to exercise directly without a listener.
 func TestNewProbeServer_DefaultStallWindow(t *testing.T) {
 	const addr = "127.0.0.1:0"
 
@@ -128,10 +113,6 @@ func TestNewProbeServer_DefaultStallWindow(t *testing.T) {
 	}
 }
 
-// TestClassifyRuleErr_Arms covers classifyRuleErr directly, hitting the
-// nil guard and the "policy" Contains arm that buildNodeStatusEntry
-// fixtures do not reach, plus a representative prefix arm and the
-// unknown fallback.
 func TestClassifyRuleErr_Arms(t *testing.T) {
 	cases := []struct {
 		name string
@@ -155,21 +136,15 @@ func TestClassifyRuleErr_Arms(t *testing.T) {
 	}
 }
 
-// TestResolveCgroupIDs_NoCgroupHost covers the reachable path of
-// resolveCgroupIDs on a host without a kubepods hierarchy: scanPodCgroups
-// finds no root and returns no entries, so the result is an empty,
-// non-nil map and a nil error. The live-cgroup-stat branch (inode read
-// from a real kubelet cgroup tree) needs a kubepods root and is not
-// unit-testable here.
-func TestResolveCgroupIDs_NoCgroupHost(t *testing.T) {
+func TestResolveCgroupIDs_MatchedPodsZeroCgroupsErrors(t *testing.T) {
 	pods := []*corev1.Pod{
 		{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns", UID: types.UID("11111111-2222-3333-4444-555555555555")}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "ns", UID: types.UID("66666666-7777-8888-9999-000000000000")}},
 	}
 
 	got, err := resolveCgroupIDs(pods)
-	if err != nil {
-		t.Fatalf("resolveCgroupIDs returned error: %v", err)
+	if err == nil {
+		t.Fatal("matched pods that resolve to zero cgroups must return an error, not a false-healthy success")
 	}
 	if got == nil {
 		t.Fatal("resolveCgroupIDs returned a nil map, want non-nil")
@@ -184,10 +159,6 @@ func TestResolveCgroupIDs_NoCgroupHost(t *testing.T) {
 	}
 }
 
-// TestResolveNodeName_EnvAndFallback drives both branches of
-// ResolveNodeName: the NODE_NAME env-set path (including whitespace
-// trimming) and the unset path that falls back to os.Hostname. The env
-// var is restored automatically by t.Setenv.
 func TestResolveNodeName_EnvAndFallback(t *testing.T) {
 	t.Setenv("NODE_NAME", "  worker-7  ")
 	if got := ResolveNodeName(); got != "worker-7" {

--- a/internal/agent/reconciler.go
+++ b/internal/agent/reconciler.go
@@ -55,8 +55,7 @@ type AgentReconciler struct {
 
 	exporterCacheMu sync.Mutex
 	exporterCache   map[CRKey]cachedExporter
-	// pendingClose accumulates exporters displaced during a reconcile.
-	pendingClose []tracer.Exporter
+	pendingClose    []tracer.Exporter
 }
 
 // exporterCloseTimeout bounds the asynchronous flush+shutdown of displaced
@@ -370,6 +369,9 @@ func resolveCgroupIDs(pods []*corev1.Pod) (map[uint64]struct{}, error) {
 	out := make(map[uint64]struct{}, len(entries))
 	for _, e := range entries {
 		out[e.CgroupID] = struct{}{}
+	}
+	if len(pods) > 0 && len(out) == 0 {
+		return out, fmt.Errorf("no cgroups resolved for %d matched pod(s)", len(pods))
 	}
 	return out, nil
 }

--- a/internal/agent/reconciler_test.go
+++ b/internal/agent/reconciler_test.go
@@ -42,9 +42,6 @@ func (e *fakeExporter) Close(_ context.Context) error {
 	return nil
 }
 
-// waitForCloses polls until the exporter's Close count reaches want.
-// Displaced exporters are closed asynchronously after Router.Publish (so a
-// hung collector cannot stall the reconcile loop), hence the wait.
 func waitForCloses(t *testing.T, e *fakeExporter, want int) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -137,8 +134,6 @@ func TestFilterToEventTypes_AllCategories(t *testing.T) {
 	}
 }
 
-// TestFilterToEventTypes_NetIncludesHTTP guards against the socket-level
-// HTTP/1.x events being dropped by the agent router.
 func TestFilterToEventTypes_NetIncludesHTTP(t *testing.T) {
 	got := filterToEventTypes(podtracev1alpha1.FilterNet)
 	want := map[events.EventType]bool{
@@ -957,8 +952,8 @@ func TestResolveCgroupIDs_SkipsUnresolvable(t *testing.T) {
 		},
 	}
 	out, err := resolveCgroupIDs(pods)
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	if err == nil {
+		t.Fatal("a matched pod that resolves to zero cgroups must error, not report false-healthy success")
 	}
 	if len(out) != 0 {
 		t.Errorf("expected empty result for synthetic pod, got %v", out)

--- a/internal/agent/sdk_event_exporter_test.go
+++ b/internal/agent/sdk_event_exporter_test.go
@@ -386,7 +386,7 @@ func TestSDKEventExporter_NameIncludesBackend(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := &BundlePayload{Type: "otlp", Endpoint: cs.endpointHostPort(), Insecure: true}
+			b := &BundlePayload{Type: "otlp", Endpoint: cs.endpointHostPort(), Insecure: true, HeaderName: "X-Auth", Credential: []byte("test-token")}
 			exp, err := tc.build(CRKey{"ns", "cr"}, b)
 			if err != nil {
 				t.Fatalf("build: %v", err)

--- a/internal/agent/splunk_event_exporter.go
+++ b/internal/agent/splunk_event_exporter.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+
 	"github.com/gma1k/podtrace/pkg/tracer"
 )
 
@@ -10,6 +12,9 @@ func newSplunkEventExporter(cr CRKey, b *BundlePayload, opts ...sdkOption) (trac
 	spanExporter, err := newOTLPSpanExporter(b)
 	if err != nil {
 		return nil, err
+	}
+	if len(b.Credential) == 0 {
+		return nil, fmt.Errorf("splunk exporter: missing token")
 	}
 	return newSDKEventExporter("splunk", cr, b, spanExporter, opts...)
 }

--- a/internal/alerting/alert.go
+++ b/internal/alerting/alert.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gma1k/podtrace/internal/config"
+	"github.com/gma1k/podtrace/internal/sanitize"
 )
 
 type AlertSeverity string
@@ -92,17 +93,25 @@ func (a *Alert) Sanitize() {
 	if a == nil {
 		return
 	}
-	a.Title = truncateUTF8(a.Title, 256)
-	a.Message = truncateUTF8(a.Message, 1024)
-	a.PodName = truncateUTF8(a.PodName, 256)
-	a.Namespace = truncateUTF8(a.Namespace, 256)
-	a.Source = truncateUTF8(a.Source, 128)
-	a.ErrorCode = truncateUTF8(a.ErrorCode, 64)
+	// Strip terminal-unsafe runes (ANSI, control, bidi) before length-capping:
+	// alert fields carry attacker-influenced strings (e.g. an AF_ALG salg_name
+	// bound by an untrusted process) that flow to Slack/webhook sinks and logs.
+	a.Title = truncateUTF8(sanitize.Terminal(a.Title), 256)
+	a.Message = truncateUTF8(sanitize.Terminal(a.Message), 1024)
+	a.PodName = truncateUTF8(sanitize.Terminal(a.PodName), 256)
+	a.Namespace = truncateUTF8(sanitize.Terminal(a.Namespace), 256)
+	a.Source = truncateUTF8(sanitize.Terminal(a.Source), 128)
+	a.ErrorCode = truncateUTF8(sanitize.Terminal(a.ErrorCode), 64)
 	if len(a.Recommendations) > 10 {
 		a.Recommendations = a.Recommendations[:10]
 	}
 	for i, rec := range a.Recommendations {
-		a.Recommendations[i] = truncateUTF8(rec, 512)
+		a.Recommendations[i] = truncateUTF8(sanitize.Terminal(rec), 512)
+	}
+	for k, v := range a.Context {
+		if s, ok := v.(string); ok {
+			a.Context[k] = truncateUTF8(sanitize.Terminal(s), 512)
+		}
 	}
 }
 

--- a/internal/alerting/alert_context_sanitize_test.go
+++ b/internal/alerting/alert_context_sanitize_test.go
@@ -1,0 +1,28 @@
+package alerting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitize_StripsControlCharsInMessageAndContext(t *testing.T) {
+	a := &Alert{
+		Message: "bound aead \x1b[31mEVIL\x07 transform \x00zero",
+		Context: map[string]interface{}{
+			"salg_name": "aead\x1b]0;pwn\x07",
+			"uid":       1000,
+		},
+	}
+	a.Sanitize()
+
+	if strings.ContainsAny(a.Message, "\x00\x07\x1b") {
+		t.Errorf("Message still carries control chars: %q", a.Message)
+	}
+	got, _ := a.Context["salg_name"].(string)
+	if strings.ContainsAny(got, "\x07\x1b") {
+		t.Errorf("Context salg_name still carries control chars: %q", got)
+	}
+	if a.Context["uid"] != 1000 {
+		t.Errorf("non-string Context value must be preserved, got %v", a.Context["uid"])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ const (
 	DefaultProcessCacheEvictionRatio = 0.9
 	MaxPIDCacheSize                  = 10000
 	DefaultPIDCacheEvictionRatio     = 0.9
+	DefaultPIDCacheTTLSeconds        = 30
 	MaxStackDepth                    = 64
 	MaxTargetStringLength            = 256
 	MaxCgroupFilePathLength          = 64
@@ -92,6 +93,7 @@ var (
 	MaxSpansPerTrace          = getIntEnvOrDefault("PODTRACE_MAX_SPANS_PER_TRACE", 1000)
 	ProcessCacheEvictionRatio = getFloatEnvInRange("PODTRACE_PROCESS_CACHE_EVICTION_RATIO", DefaultProcessCacheEvictionRatio, 0, 1)
 	PIDCacheEvictionRatio     = getFloatEnvInRange("PODTRACE_PID_CACHE_EVICTION_RATIO", DefaultPIDCacheEvictionRatio, 0, 1)
+	PIDCacheTTLSeconds        = getIntEnvOrDefault("PODTRACE_PID_CACHE_TTL_SECONDS", DefaultPIDCacheTTLSeconds)
 	CacheEvictionThreshold    = getFloatEnvInRange("PODTRACE_CACHE_EVICTION_THRESHOLD", DefaultCacheEvictionThreshold, 0, 1)
 	RateLimitPerSec           = getIntEnvOrDefault("PODTRACE_RATE_LIMIT_PER_SEC", DefaultRateLimitPerSec)
 	RateLimitBurst            = getIntEnvOrDefault("PODTRACE_RATE_LIMIT_BURST", DefaultRateLimitBurst)

--- a/internal/ebpf/filter/filter.go
+++ b/internal/ebpf/filter/filter.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/metricsexporter"
@@ -13,19 +14,40 @@ import (
 
 var readFile = os.ReadFile
 
+type pidCacheEntry struct {
+	result bool
+	at     time.Time
+}
+
 type CgroupFilter struct {
 	cgroupPath  string
 	cgroupPaths map[string]struct{}
-	pidCache    map[uint32]bool
+	pidCache    map[uint32]pidCacheEntry
 	pidCacheMu  sync.RWMutex
 	pathsMu     sync.RWMutex
+	now         func() time.Time
+	ttl         time.Duration
 }
 
 func NewCgroupFilter() *CgroupFilter {
 	return &CgroupFilter{
 		cgroupPaths: make(map[string]struct{}),
-		pidCache:    make(map[uint32]bool),
+		pidCache:    make(map[uint32]pidCacheEntry),
 	}
+}
+
+func (f *CgroupFilter) clock() time.Time {
+	if f.now != nil {
+		return f.now()
+	}
+	return time.Now()
+}
+
+func (f *CgroupFilter) cacheTTL() time.Duration {
+	if f.ttl > 0 {
+		return f.ttl
+	}
+	return time.Duration(config.PIDCacheTTLSeconds) * time.Second
 }
 
 func (f *CgroupFilter) SetCgroupPath(path string) {
@@ -37,7 +59,7 @@ func (f *CgroupFilter) SetCgroupPath(path string) {
 	}
 	f.pathsMu.Unlock()
 	f.pidCacheMu.Lock()
-	f.pidCache = make(map[uint32]bool)
+	f.pidCache = make(map[uint32]pidCacheEntry)
 	f.pidCacheMu.Unlock()
 }
 
@@ -53,7 +75,7 @@ func (f *CgroupFilter) SetCgroupPaths(paths []string) {
 	}
 	f.pathsMu.Unlock()
 	f.pidCacheMu.Lock()
-	f.pidCache = make(map[uint32]bool)
+	f.pidCache = make(map[uint32]pidCacheEntry)
 	f.pidCacheMu.Unlock()
 }
 
@@ -102,10 +124,10 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	}
 
 	f.pidCacheMu.RLock()
-	if cached, ok := f.pidCache[pid]; ok {
+	if cached, ok := f.pidCache[pid]; ok && f.clock().Sub(cached.at) < f.cacheTTL() {
 		f.pidCacheMu.RUnlock()
 		metricsexporter.RecordPIDCacheHit()
-		return cached
+		return cached.result
 	}
 	f.pidCacheMu.RUnlock()
 	metricsexporter.RecordPIDCacheMiss()
@@ -117,7 +139,7 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	data, err := readFile(cgroupFile)
 	if err != nil {
 		f.pidCacheMu.Lock()
-		f.pidCache[pid] = false
+		f.pidCache[pid] = pidCacheEntry{result: false, at: f.clock()}
 		if len(f.pidCache) > config.MaxPIDCacheSize {
 			evictCount := len(f.pidCache) / 10
 			if evictCount < 1 {
@@ -139,7 +161,7 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 	pidCgroupPath := ExtractCgroupPathFromProc(cgroupContent)
 	if pidCgroupPath == "" {
 		f.pidCacheMu.Lock()
-		f.pidCache[pid] = false
+		f.pidCache[pid] = pidCacheEntry{result: false, at: f.clock()}
 		if len(f.pidCache) > config.MaxPIDCacheSize {
 			evictCount := len(f.pidCache) / 10
 			if evictCount < 1 {
@@ -183,7 +205,7 @@ func (f *CgroupFilter) IsPIDInCgroup(pid uint32) bool {
 			}
 		}
 	}
-	f.pidCache[pid] = result
+	f.pidCache[pid] = pidCacheEntry{result: result, at: f.clock()}
 	f.pidCacheMu.Unlock()
 
 	return result

--- a/internal/ebpf/filter/pid_cache_ttl_test.go
+++ b/internal/ebpf/filter/pid_cache_ttl_test.go
@@ -1,0 +1,56 @@
+package filter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPIDCache_TTLInvalidatesReusedPID(t *testing.T) {
+	origReadFile := readFile
+	defer func() { readFile = origReadFile }()
+
+	f := NewCgroupFilter()
+	f.SetCgroupPath("/kubepods/podA")
+	base := time.Unix(1_000_000, 0)
+	now := base
+	f.now = func() time.Time { return now }
+	f.ttl = 30 * time.Second
+
+	readFile = func(string) ([]byte, error) { return []byte("0::/kubepods/podA"), nil }
+	if !f.IsPIDInCgroup(4242) {
+		t.Fatal("PID initially in the target cgroup must be admitted")
+	}
+
+	readFile = func(string) ([]byte, error) { return []byte("0::/kubepods/podB"), nil }
+	if !f.IsPIDInCgroup(4242) {
+		t.Fatal("within TTL the cached decision applies (a cache hit is expected)")
+	}
+
+	now = base.Add(31 * time.Second)
+	if f.IsPIDInCgroup(4242) {
+		t.Fatal("after TTL a reused PID must be re-evaluated and denied (no cross-tenant leak)")
+	}
+}
+
+func TestPIDCache_WithinTTLServesFromCache(t *testing.T) {
+	origReadFile := readFile
+	defer func() { readFile = origReadFile }()
+
+	f := NewCgroupFilter()
+	f.SetCgroupPath("/kubepods/podA")
+	now := time.Unix(2_000_000, 0)
+	f.now = func() time.Time { return now }
+	f.ttl = 30 * time.Second
+
+	reads := 0
+	readFile = func(string) ([]byte, error) {
+		reads++
+		return []byte("0::/kubepods/podA"), nil
+	}
+	f.IsPIDInCgroup(7777)
+	now = now.Add(5 * time.Second)
+	f.IsPIDInCgroup(7777)
+	if reads != 1 {
+		t.Fatalf("within TTL the /proc read must not repeat, got %d reads", reads)
+	}
+}

--- a/internal/ebpf/probes/quicherustresolve.go
+++ b/internal/ebpf/probes/quicherustresolve.go
@@ -14,17 +14,16 @@ import (
 	"github.com/gma1k/podtrace/internal/logger"
 )
 
-// quicheRustSendRequestPattern matches quiche::h3::Connection::send_request
-// in both Rust manglings via the length-prefixed identifiers.
 var quicheRustSendRequestPattern = []string{"6quiche", "2h3", "12send_request"}
 
-// maxQuicheRustAttachments bounds how many send_request monomorphizations
-// get a probe; typical binaries have exactly one (T = quiche::h3::Header).
 const maxQuicheRustAttachments = 4
 
 // findSymbolsContaining returns the virtual addresses of up to max defined
 // function symbols whose names contain every given substring.
 func findSymbolsContaining(f *elf.File, max int, subs ...string) []uint64 {
+	if !symbolSectionWithinCap(f, ".symtab") {
+		return nil
+	}
 	syms, err := f.Symbols()
 	if err != nil {
 		return nil
@@ -46,8 +45,8 @@ func findSymbolsContaining(f *elf.File, max int, subs ...string) []uint64 {
 
 // AttachQuicheRustProbes attaches a uprobe on
 // quiche::h3::Connection::send_request in a statically-linked Rust binary.
-func AttachQuicheRustProbes(coll *ebpf.Collection, pid uint32) []link.Link {
-	var links []link.Link
+func AttachQuicheRustProbes(coll *ebpf.Collection, pid uint32) (links []link.Link) {
+	defer recoverParse("AttachQuicheRustProbes")
 	if pid == 0 || runtime.GOARCH != "amd64" {
 		return links
 	}
@@ -57,7 +56,7 @@ func AttachQuicheRustProbes(coll *ebpf.Collection, pid uint32) []link.Link {
 	}
 
 	exePath := filepath.Join(config.ProcBasePath, fmt.Sprintf("%d", pid), "exe")
-	f, err := elf.Open(exePath)
+	f, err := openELFCapped(exePath)
 	if err != nil {
 		return links
 	}

--- a/internal/ebpf/probes/quicherustresolve_safeelf_test.go
+++ b/internal/ebpf/probes/quicherustresolve_safeelf_test.go
@@ -1,0 +1,48 @@
+package probes
+
+import (
+	"debug/elf"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/gma1k/podtrace/internal/config"
+	"github.com/gma1k/podtrace/internal/ebpf/safeelf"
+)
+
+func TestFindSymbolsContaining_OverCapSymtabReturnsNil(t *testing.T) {
+	f := &elf.File{Sections: []*elf.Section{
+		{SectionHeader: elf.SectionHeader{Name: ".symtab", Size: safeelf.MaxSectionSize + 1}},
+	}}
+	if got := findSymbolsContaining(f, 4, "anything"); got != nil {
+		t.Errorf("an over-cap .symtab must be refused before parsing, got %v", got)
+	}
+}
+
+func TestAttachQuicheRustProbes_MalformedExeNoPanic(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("quiche resolver only runs on amd64")
+	}
+	orig := config.ProcBasePath
+	defer config.SetProcBasePath(orig)
+
+	dir := t.TempDir()
+	config.SetProcBasePath(dir)
+	pidDir := filepath.Join(dir, "4242")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "exe"), []byte("this is not an ELF binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	coll := &ebpf.Collection{Programs: map[string]*ebpf.Program{
+		"uprobe_quiche_rs_send_request": {},
+	}}
+	if got := AttachQuicheRustProbes(coll, 4242); got != nil {
+		t.Errorf("a non-ELF exe must yield no links (and never panic), got %v", got)
+	}
+}

--- a/internal/kubernetes/enrich_prefilter_test.go
+++ b/internal/kubernetes/enrich_prefilter_test.go
@@ -1,0 +1,57 @@
+package kubernetes
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestEnrichNetworkTarget_ExternalIPSkipsResolversAndCache(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	var apiCalls int32
+	cs.PrependReactor("*", "*", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if v := a.GetVerb(); v == "list" || v == "get" {
+			atomic.AddInt32(&apiCalls, 1)
+		}
+		return false, nil, nil
+	})
+
+	ce := NewContextEnricher(cs, &PodInfo{Namespace: "src"})
+	ev := &events.Event{Type: events.EventConnect, Target: "8.8.8.8:53"}
+	enriched := ce.EnrichEvent(context.Background(), ev)
+
+	if enriched == nil || !enriched.KubernetesContext.IsExternal {
+		t.Fatalf("external IP must be flagged external, got %+v", enriched)
+	}
+	if n := atomic.LoadInt32(&apiCalls); n != 0 {
+		t.Fatalf("external IP must not trigger any API list/get, got %d", n)
+	}
+	populated := false
+	ce.podCache.Range(func(any, any) bool { populated = true; return false })
+	if populated {
+		t.Fatal("external IP must not leave an entry in the pod cache")
+	}
+}
+
+func TestResolveService_InformerEnabledSkipsClusterList(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	var lists int32
+	cs.PrependReactor("list", "endpoints", func(k8stesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt32(&lists, 1)
+		return false, nil, nil
+	})
+
+	ic := NewInformerCache(cs)
+	sr := NewServiceResolverWithCache(cs, ic)
+	sr.ResolveService(context.Background(), "10.1.2.3", 8080)
+
+	if n := atomic.LoadInt32(&lists); n != 0 {
+		t.Fatalf("with informers enabled, an endpoint miss must not fall back to a cluster-wide Endpoints LIST, got %d", n)
+	}
+}

--- a/internal/kubernetes/enricher.go
+++ b/internal/kubernetes/enricher.go
@@ -57,7 +57,6 @@ const negativeCacheTTL = 30 * time.Second
 type ContextEnricher struct {
 	clientset       kubernetes.Interface
 	podCache        *sync.Map
-	serviceCache    *sync.Map
 	podInfo         *PodInfo
 	serviceResolver *ServiceResolver
 	cacheTTL        time.Duration
@@ -70,7 +69,6 @@ func NewContextEnricher(clientset kubernetes.Interface, podInfo *PodInfo) *Conte
 	return &ContextEnricher{
 		clientset:       clientset,
 		podCache:        &sync.Map{},
-		serviceCache:    &sync.Map{},
 		podInfo:         podInfo,
 		serviceResolver: NewServiceResolverWithCache(clientset, ic),
 		cacheTTL:        ttl,
@@ -120,6 +118,11 @@ func (ce *ContextEnricher) EnrichEvent(ctx context.Context, event *events.Event)
 }
 
 func (ce *ContextEnricher) enrichNetworkTarget(ctx context.Context, enriched *EnrichedEvent, ip string, port int) {
+	if !isPrivateIP(ip) {
+		enriched.KubernetesContext.IsExternal = true
+		return
+	}
+
 	enrichCtx, cancel := context.WithTimeout(ctx, config.K8sAPITimeout)
 	defer cancel()
 
@@ -135,11 +138,6 @@ func (ce *ContextEnricher) enrichNetworkTarget(ctx context.Context, enriched *En
 		enriched.KubernetesContext.TargetPodName = podMeta.Name
 		enriched.KubernetesContext.TargetNamespace = podMeta.Namespace
 		enriched.KubernetesContext.TargetLabels = podMeta.Labels
-		return
-	}
-
-	if !isPrivateIP(ip) {
-		enriched.KubernetesContext.IsExternal = true
 	}
 }
 

--- a/internal/kubernetes/informer_transform_test.go
+++ b/internal/kubernetes/informer_transform_test.go
@@ -1,0 +1,70 @@
+package kubernetes
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTrimPodForCache_StripsHeavyFieldsKeepsIndexed(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "p",
+			Namespace:     "ns",
+			Labels:        map[string]string{"app": "x"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+			Annotations:   map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "huge"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "n1", Containers: []corev1.Container{{Name: "c"}}},
+		Status: corev1.PodStatus{PodIP: "10.0.0.5", ContainerStatuses: []corev1.ContainerStatus{{Name: "c"}}},
+	}
+
+	out, _ := trimPodForCache(pod)
+	got := out.(*corev1.Pod)
+	if got.ManagedFields != nil || got.Annotations != nil {
+		t.Error("managedFields/annotations must be cleared")
+	}
+	if len(got.Spec.Containers) != 0 {
+		t.Error("spec must be cleared")
+	}
+	if len(got.Status.ContainerStatuses) != 0 {
+		t.Error("status beyond the pod IP must be cleared")
+	}
+	if got.Status.PodIP != "10.0.0.5" {
+		t.Errorf("indexed PodIP must be preserved, got %q", got.Status.PodIP)
+	}
+	if got.Name != "p" || got.Namespace != "ns" || got.Labels["app"] != "x" {
+		t.Errorf("name/namespace/labels must be preserved, got %+v", got.ObjectMeta)
+	}
+
+	if passthrough, _ := trimPodForCache("tombstone"); passthrough != "tombstone" {
+		t.Error("a non-Pod object must pass through untouched")
+	}
+}
+
+func TestTrimEndpointSliceForCache_StripsHeavyFieldsKeepsIndexed(t *testing.T) {
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "e",
+			Namespace:     "ns",
+			Labels:        map[string]string{discoveryv1.LabelServiceName: "svc"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "eps-controller"}},
+			Annotations:   map[string]string{"big": "x"},
+		},
+		Endpoints: []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.6"}}},
+	}
+
+	out, _ := trimEndpointSliceForCache(es)
+	got := out.(*discoveryv1.EndpointSlice)
+	if got.ManagedFields != nil || got.Annotations != nil {
+		t.Error("managedFields/annotations must be cleared")
+	}
+	if len(got.Endpoints) != 1 || got.Endpoints[0].Addresses[0] != "10.0.0.6" {
+		t.Error("indexed endpoints must be preserved")
+	}
+	if got.Labels[discoveryv1.LabelServiceName] != "svc" {
+		t.Error("the service-name label must be preserved")
+	}
+}

--- a/internal/kubernetes/informers_cache.go
+++ b/internal/kubernetes/informers_cache.go
@@ -44,7 +44,6 @@ func NewInformerCache(clientset kubernetes.Interface) *InformerCache {
 }
 
 func (ic *InformerCache) Enabled() bool {
-	// Default enabled; can be disabled explicitly.
 	return config.K8sUseInformers()
 }
 
@@ -67,6 +66,7 @@ func (ic *InformerCache) Start(ctx context.Context) {
 	factory := informers.NewSharedInformerFactoryWithOptions(ic.clientset, resync, informers.WithNamespace(metav1.NamespaceAll))
 
 	podInf := factory.Core().V1().Pods().Informer()
+	_ = podInf.SetTransform(trimPodForCache)
 	_ = podInf.AddIndexers(cache.Indexers{
 		podIPIndex: func(obj interface{}) ([]string, error) {
 			pod, ok := obj.(*corev1.Pod)
@@ -81,6 +81,7 @@ func (ic *InformerCache) Start(ctx context.Context) {
 	})
 
 	esInf := factory.Discovery().V1().EndpointSlices().Informer()
+	_ = esInf.SetTransform(trimEndpointSliceForCache)
 	_ = esInf.AddIndexers(cache.Indexers{
 		ipOnlyIndex: func(obj interface{}) ([]string, error) {
 			es, ok := obj.(*discoveryv1.EndpointSlice)
@@ -237,4 +238,35 @@ func (ic *InformerCache) GetServiceByEndpoint(ip string, port int) *ServiceInfo 
 		return nil
 	}
 	return &ServiceInfo{Name: svcName, Namespace: es.Namespace, Port: port}
+}
+
+// trimPodForCache drops everything the enricher never reads before a Pod is
+// stored in the shared informer.
+func trimPodForCache(obj interface{}) (interface{}, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+	pod.ManagedFields = nil
+	pod.Annotations = nil
+	pod.OwnerReferences = nil
+	pod.Finalizers = nil
+	pod.Spec = corev1.PodSpec{}
+	pod.Status = corev1.PodStatus{PodIP: pod.Status.PodIP, PodIPs: pod.Status.PodIPs}
+	return pod, nil
+}
+
+// trimEndpointSliceForCache clears the heavy metadata the resolver never reads.
+// Endpoints, Ports and Labels (indexed by ipOnlyIndex/ipPortIndex and read by
+// GetServiceByEndpoint) are preserved.
+func trimEndpointSliceForCache(obj interface{}) (interface{}, error) {
+	es, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return obj, nil
+	}
+	es.ManagedFields = nil
+	es.Annotations = nil
+	es.OwnerReferences = nil
+	es.Finalizers = nil
+	return es, nil
 }

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -406,7 +406,7 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 	roots := cgroupRootCandidates()
 
 	if strings.HasPrefix(cg, "/") {
-		if _, err := os.Stat(cg); err == nil {
+		if statCgroupDirHasProcs(cg) {
 			if cg != config.CgroupBasePath {
 				return cg, nil
 			}
@@ -433,7 +433,7 @@ func resolveCgroupPathCRI(ctx context.Context, containerID string) (string, erro
 		if fullPath == root {
 			continue
 		}
-		if _, err := os.Stat(fullPath); err == nil {
+		if statCgroupDirHasProcs(fullPath) {
 			return fullPath, nil
 		}
 	}

--- a/internal/kubernetes/service_resolver.go
+++ b/internal/kubernetes/service_resolver.go
@@ -63,9 +63,7 @@ func (sr *ServiceResolver) ResolveService(ctx context.Context, ip string, port i
 	}
 
 	if sr.informerCache != nil {
-		if svc := sr.informerCache.GetServiceByEndpoint(ip, port); svc != nil {
-			return svc
-		}
+		return sr.informerCache.GetServiceByEndpoint(ip, port)
 	}
 
 	cacheKey := fmt.Sprintf("%s:%d", ip, port)

--- a/internal/usdt/scanner.go
+++ b/internal/usdt/scanner.go
@@ -19,6 +19,8 @@ type Probe struct {
 	Args     []Arg
 }
 
+const maxScannedProbes = 4096
+
 // Scan parses the .note.stapsdt section of exePath and returns all USDT probes.
 // Returns nil, nil when no USDT probes are present.
 func Scan(exePath string) (probes []Probe, err error) {
@@ -53,6 +55,9 @@ func parseStapsdtNotes(data []byte, order binary.ByteOrder) []Probe {
 	dlen := uint64(len(data))
 	var offset uint64
 	for offset+12 <= dlen {
+		if len(probes) >= maxScannedProbes {
+			break
+		}
 		nameSz := uint64(order.Uint32(data[offset:]))
 		descSz := uint64(order.Uint32(data[offset+4:]))
 		noteType := order.Uint32(data[offset+8:])

--- a/internal/usdt/scanner_probe_cap_internal_test.go
+++ b/internal/usdt/scanner_probe_cap_internal_test.go
@@ -1,0 +1,35 @@
+package usdt
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseStapsdtNotes_CapsProbeCount(t *testing.T) {
+	order := binary.ByteOrder(binary.LittleEndian)
+	one := note(order, "stapsdt", 3, stapsdtDesc(order, 0x1000, 0x2000, "p", "n"), -1, -1)
+
+	var data []byte
+	for i := 0; i < maxScannedProbes+500; i++ {
+		data = append(data, one...)
+	}
+
+	got := parseStapsdtNotes(data, order)
+	if len(got) != maxScannedProbes {
+		t.Fatalf("parseStapsdtNotes returned %d probes, want the %d cap", len(got), maxScannedProbes)
+	}
+}
+
+func TestParseStapsdtNotes_UnderCapReturnsAll(t *testing.T) {
+	order := binary.ByteOrder(binary.LittleEndian)
+	one := note(order, "stapsdt", 3, stapsdtDesc(order, 0x1000, 0x2000, "p", "n"), -1, -1)
+
+	const n = 10
+	var data []byte
+	for i := 0; i < n; i++ {
+		data = append(data, one...)
+	}
+	if got := parseStapsdtNotes(data, order); len(got) != n {
+		t.Fatalf("parseStapsdtNotes returned %d probes, want %d", len(got), n)
+	}
+}


### PR DESCRIPTION
## Summary

Agent/kubernetes runtime hardening fixes (resource-exhaustion, tenancy, and silent-failure classes).

## Fixes

- PID cache in the userspace cgroup filter now has a TTL, so a reused PID can no longer carry a dead process's allow decision across tenants.
- USDT note parsing caps the number of probes it materializes, so one hostile binary can't drive a ~1-2 GiB allocation.
- The quiche/Rust ELF resolver now goes through the shared safeelf path (panic recovery + size/symbol caps), so a malformed container binary can't crash the agent.
- Non-private (external) destination IPs are filtered out before the Kubernetes resolvers run, bounding both the per-IP resolver caches and the API-server load driven by untrusted egress.
- With informers enabled, service resolution is answered authoritatively from the EndpointSlice informer instead of falling back to an unpaginated cluster-wide Endpoints LIST per unseen destination.
- The Pod and EndpointSlice informers now use a transform that strips managedFields/annotations/spec, cutting the per-node memory footprint on large clusters.
- The CRI-reported cgroup path is accepted only when it is a real cgroup under the cgroup base, instead of any path that merely exists, so a wrong path no longer silently disables tracing for a container.
- resolveCgroupIDs now returns an error when pods matched but zero cgroups resolved, so the CR reports degraded instead of a false-healthy ready:true with nothing captured.
- The Splunk and DataDog exporters now fail the build when no credential is present, instead of shipping spans unauthenticated and 401ing silently.
- Alert content (including the attacker-influenced AF_ALG salg_name) is now control-character/ANSI/bidi sanitized before it reaches Slack/webhook/log sinks, centralized in Alert.Sanitize so every alert source is covered.