### PR TITLE
fix: harden trace export, metrics, and diagnose resource bounds

### DIFF
--- a/deploy/charts/podtrace/templates/networkpolicy.yaml
+++ b/deploy/charts/podtrace/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "podtrace.fullname" . }}-agent
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+spec:
+  podSelector:
+    matchLabels:
+      podtrace.io/managed-by: podtrace-operator
+      podtrace.io/component: agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: health
+          protocol: TCP
+    - ports:
+        - port: metrics
+          protocol: TCP
+      {{- with .Values.networkPolicy.metricsFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -127,6 +127,10 @@ metrics:
     interval: 30s
     path: /metrics
 
+networkPolicy:
+  enabled: false
+  metricsFrom: []
+
 tracerConfig:
   create: true
   name: default

--- a/internal/agent/metrics_server_timeouts_test.go
+++ b/internal/agent/metrics_server_timeouts_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewMetricsServer_SetsAllTimeouts(t *testing.T) {
+	srv := newMetricsServer(http.NewServeMux())
+
+	if srv.ReadHeaderTimeout == 0 {
+		t.Error("ReadHeaderTimeout must be set")
+	}
+	if srv.ReadTimeout == 0 {
+		t.Error("ReadTimeout must be set so a slow-body client cannot hold a connection open")
+	}
+	if srv.WriteTimeout == 0 {
+		t.Error("WriteTimeout must be set")
+	}
+	if srv.IdleTimeout == 0 {
+		t.Error("IdleTimeout must be set so idle keep-alive connections are reaped")
+	}
+}

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -237,6 +237,16 @@ func buildBackend(opts Options, logger logr.Logger) (tracer.TracerBackend, error
 	return backend, nil
 }
 
+func newMetricsServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+}
+
 // serveMetrics exposes the agent's Prometheus registry on the
 // metrics-addr port. Short-circuit when the address is empty — useful
 // in tests.
@@ -251,10 +261,7 @@ func serveMetrics(ctx context.Context, addr string, metrics *Metrics, logger log
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", addr, err)
 	}
-	srv := &http.Server{
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+	srv := newMetricsServer(mux)
 	go func() {
 		<-ctx.Done()
 		sctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)

--- a/internal/alerting/manager.go
+++ b/internal/alerting/manager.go
@@ -3,6 +3,8 @@ package alerting
 import (
 	"context"
 	"net/url"
+	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -55,7 +57,8 @@ func deliveryBudget() time.Duration {
 	return budget + 5*time.Second
 }
 
-// redactURLForLog returns a URL safe to log (query and fragment stripped).
+// redactURLForLog returns a URL safe to log (userinfo, query and fragment
+// stripped, only scheme://host retained).
 func redactURLForLog(raw string) string {
 	if raw == "" {
 		return ""
@@ -65,6 +68,19 @@ func redactURLForLog(raw string) string {
 		return "[invalid-url]"
 	}
 	return u.Scheme + "://" + u.Host
+}
+
+func RedactURLForLog(raw string) string {
+	return redactURLForLog(raw)
+}
+
+var embeddedURLPattern = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.-]*://[^\s"'<>` + "`" + `]+`)
+
+func RedactURLsInText(s string) string {
+	return embeddedURLPattern.ReplaceAllStringFunc(s, func(match string) string {
+		trimmed := strings.TrimRight(match, `.,:;!?)]}"'`)
+		return redactURLForLog(trimmed) + match[len(trimmed):]
+	})
 }
 
 func NewManager() (*Manager, error) {

--- a/internal/alerting/redact_url_test.go
+++ b/internal/alerting/redact_url_test.go
@@ -1,0 +1,53 @@
+package alerting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRedactURLForLog_StripsUserinfoAndQuery(t *testing.T) {
+	got := RedactURLForLog("https://user:s3cret@collector.example.com:8088/services/collector?token=abc123")
+	if got != "https://collector.example.com:8088" {
+		t.Fatalf("RedactURLForLog = %q, want https://collector.example.com:8088", got)
+	}
+	for _, leak := range []string{"s3cret", "token", "abc123", "user"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("RedactURLForLog leaked %q: %s", leak, got)
+		}
+	}
+}
+
+func TestRedactURLsInText_ScrubsEmbeddedURLKeepsContext(t *testing.T) {
+	wrapped := fmt.Errorf("send request: %w", &urlErr{
+		url: "https://user:s3cret@collector.example.com/v1/traces?api_key=abc123",
+	})
+	got := RedactURLsInText(wrapped.Error())
+
+	for _, leak := range []string{"s3cret", "api_key", "abc123", "user:"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("RedactURLsInText leaked %q: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "https://collector.example.com") {
+		t.Errorf("RedactURLsInText dropped the safe host: %s", got)
+	}
+	if !strings.Contains(got, "send request") || !strings.Contains(got, "dial refused") {
+		t.Errorf("RedactURLsInText dropped surrounding error context: %s", got)
+	}
+}
+
+func TestRedactURLsInText_NoURLIsUnchanged(t *testing.T) {
+	in := "context deadline exceeded"
+	if got := RedactURLsInText(in); got != in {
+		t.Errorf("RedactURLsInText(%q) = %q, want unchanged", in, got)
+	}
+}
+
+type urlErr struct {
+	url string
+}
+
+func (e *urlErr) Error() string {
+	return fmt.Sprintf("Post %q: dial refused", e.url)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,9 @@ var (
 	ProfilingAutoTriggerMS   = getPositiveFloatEnvOrDefault("PODTRACE_PROFILING_AUTO_TRIGGER_MS", DefaultProfilingAutoTriggerMS)
 	ProfilingDefaultDuration = getDurationEnvOrDefault("PODTRACE_PROFILING_DEFAULT_DURATION", DefaultProfilingDuration)
 	ProfilingMaxConcurrent   = getIntEnvOrDefault("PODTRACE_PROFILING_MAX_CONCURRENT", DefaultProfilingMaxConcurrent)
+	ProfilingMaxDuration     = getDurationEnvOrDefault("PODTRACE_PROFILING_MAX_DURATION", DefaultProfilingMaxDuration)
+
+	ReportGenerationTimeout = getDurationEnvOrDefault("PODTRACE_REPORT_GENERATION_TIMEOUT", DefaultReportGenerationTimeout)
 )
 
 const (
@@ -149,6 +152,7 @@ const (
 	DefaultRealtimeUpdateInterval  = 5 * time.Second
 	DefaultErrorLogInterval        = 5 * time.Second
 	DefaultAddr2lineTimeout        = 500 * time.Millisecond
+	DefaultReportGenerationTimeout = 25 * time.Second
 	MinBurstWindowDuration         = 100 * time.Millisecond
 	MaxDiagnoseDuration            = 24 * time.Hour
 	DefaultK8sAPITimeout           = 500 * time.Millisecond
@@ -199,6 +203,7 @@ const (
 	DefaultProfilingAutoTriggerMS = 500.0
 	DefaultProfilingDuration      = 30 * time.Second
 	DefaultProfilingMaxConcurrent = 1
+	DefaultProfilingMaxDuration   = 5 * time.Minute
 )
 
 const (

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -183,13 +183,28 @@ func (d *Diagnostician) CalculateRate(count int, duration time.Duration) float64
 	return 0
 }
 
+// FilterEvents returns the events of a given type.
 func (d *Diagnostician) FilterEvents(eventType events.EventType) []*events.Event {
-	allEvents := d.GetEvents()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	var filtered []*events.Event
-	for _, e := range allEvents {
-		if e.Type == eventType {
+	match := func(e *events.Event) {
+		if e != nil && e.Type == eventType {
 			filtered = append(filtered, e)
 		}
+	}
+	if !d.wrapped {
+		for _, e := range d.events {
+			match(e)
+		}
+		return filtered
+	}
+	for _, e := range d.events[d.evHead:] {
+		match(e)
+	}
+	for _, e := range d.events[:d.evHead] {
+		match(e)
 	}
 	return filtered
 }
@@ -215,7 +230,9 @@ func (d *Diagnostician) FSSlowThreshold() float64 {
 }
 
 func (d *Diagnostician) GenerateReport() string {
-	return d.GenerateReportWithContext(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), config.ReportGenerationTimeout)
+	defer cancel()
+	return d.GenerateReportWithContext(ctx)
 }
 
 func (d *Diagnostician) GenerateReportWithContext(ctx context.Context) string {

--- a/internal/diagnose/filter_events_test.go
+++ b/internal/diagnose/filter_events_test.go
@@ -1,0 +1,37 @@
+package diagnose
+
+import (
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestFilterEvents_NotWrappedReturnsMatchesInOrder(t *testing.T) {
+	d := NewDiagnostician()
+	d.AddEvent(&events.Event{Type: events.EventHTTPReq, Target: "a"})
+	d.AddEvent(&events.Event{Type: events.EventConnect, Target: "b"})
+	d.AddEvent(&events.Event{Type: events.EventHTTPReq, Target: "c"})
+
+	got := d.FilterEvents(events.EventHTTPReq)
+	if len(got) != 2 || got[0].Target != "a" || got[1].Target != "c" {
+		t.Fatalf("FilterEvents(HTTPReq) = %+v, want targets [a c]", got)
+	}
+}
+
+func TestFilterEvents_WalksRingInOrderAcrossWrap(t *testing.T) {
+	a := &events.Event{Type: events.EventDNS, Target: "a"}
+	b := &events.Event{Type: events.EventConnect, Target: "b"}
+	c := &events.Event{Type: events.EventDNS, Target: "c"}
+	dd := &events.Event{Type: events.EventConnect, Target: "d"}
+
+	d := NewDiagnostician()
+	d.maxEvents = 4
+	d.events = []*events.Event{c, dd, a, b}
+	d.evHead = 2
+	d.wrapped = true
+
+	got := d.FilterEvents(events.EventDNS)
+	if len(got) != 2 || got[0].Target != "a" || got[1].Target != "c" {
+		t.Fatalf("FilterEvents(DNS) across wrap = %+v, want targets [a c] in ring order", got)
+	}
+}

--- a/internal/diagnose/report_timeout_test.go
+++ b/internal/diagnose/report_timeout_test.go
@@ -1,0 +1,24 @@
+package diagnose
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/config"
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestGenerateReport_HonorsConfiguredTimeout(t *testing.T) {
+	orig := config.ReportGenerationTimeout
+	config.ReportGenerationTimeout = time.Nanosecond
+	defer func() { config.ReportGenerationTimeout = orig }()
+
+	d := NewDiagnostician()
+	d.AddEvent(&events.Event{Type: events.EventHTTPReq})
+
+	report := d.GenerateReport()
+	if !strings.Contains(report, "cancelled") {
+		t.Fatalf("GenerateReport ignored the configured deadline; got %q", report)
+	}
+}

--- a/internal/diagnose/tracker/trace_tracker.go
+++ b/internal/diagnose/tracker/trace_tracker.go
@@ -22,7 +22,7 @@ type Trace struct {
 	Services  map[string]*ServiceInfo
 	mu        sync.RWMutex
 
-	exportedSpans int
+	exportedSpans map[string]int
 	lastUpdate    time.Time
 }
 
@@ -69,11 +69,12 @@ func (tt *TraceTracker) ProcessEvent(event *events.Event, k8sContext interface{}
 			return
 		}
 		trace = &Trace{
-			TraceID:   event.TraceID,
-			Spans:     make([]*Span, 0),
-			StartTime: event.TimestampTime(),
-			EndTime:   event.TimestampTime(),
-			Services:  make(map[string]*ServiceInfo),
+			TraceID:       event.TraceID,
+			Spans:         make([]*Span, 0),
+			StartTime:     event.TimestampTime(),
+			EndTime:       event.TimestampTime(),
+			Services:      make(map[string]*ServiceInfo),
+			exportedSpans: make(map[string]int),
 		}
 		tt.traces[event.TraceID] = trace
 	}
@@ -222,7 +223,7 @@ func (tt *TraceTracker) GetAllTraces() []*Trace {
 
 // SnapshotForExport returns deep copies of traces carrying only the spans that
 // have not been handed to an exporter yet.
-func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool) []*Trace {
+func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool, exporter string) []*Trace {
 	tt.mu.RLock()
 	live := make([]*Trace, 0, len(tt.traces))
 	for _, trace := range tt.traces {
@@ -238,20 +239,21 @@ func (tt *TraceTracker) SnapshotForExport(settle time.Duration, force bool) []*T
 			trace.mu.Unlock()
 			continue
 		}
-		if trace.exportedSpans >= len(trace.Spans) {
+		sent := trace.exportedSpans[exporter]
+		if sent >= len(trace.Spans) {
 			trace.mu.Unlock()
 			continue
 		}
-		snapshot := cloneTraceLocked(trace, trace.exportedSpans)
+		snapshot := cloneTraceLocked(trace, sent)
 		trace.mu.Unlock()
 		out = append(out, snapshot)
 	}
 	return out
 }
 
-// CommitExport advances each trace's export watermark by the number of spans
-// that were successfully exported in the matching snapshot.
-func (tt *TraceTracker) CommitExport(exported []*Trace) {
+// CommitExport advances the named exporter's watermark on each trace by the
+// number of spans it accepted in the matching snapshot.
+func (tt *TraceTracker) CommitExport(exported []*Trace, exporter string) {
 	tt.mu.RLock()
 	defer tt.mu.RUnlock()
 	for _, snap := range exported {
@@ -260,9 +262,12 @@ func (tt *TraceTracker) CommitExport(exported []*Trace) {
 			continue
 		}
 		live.mu.Lock()
-		live.exportedSpans += len(snap.Spans)
-		if live.exportedSpans > len(live.Spans) {
-			live.exportedSpans = len(live.Spans)
+		if live.exportedSpans == nil {
+			live.exportedSpans = make(map[string]int)
+		}
+		live.exportedSpans[exporter] += len(snap.Spans)
+		if live.exportedSpans[exporter] > len(live.Spans) {
+			live.exportedSpans[exporter] = len(live.Spans)
 		}
 		live.mu.Unlock()
 	}

--- a/internal/diagnose/tracker/trace_tracker_snapshot_test.go
+++ b/internal/diagnose/tracker/trace_tracker_snapshot_test.go
@@ -24,27 +24,27 @@ func TestSnapshotForExport_ExactlyOnce(t *testing.T) {
 	tt := NewTraceTracker()
 	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
 
-	first := tt.SnapshotForExport(time.Hour, true)
+	first := tt.SnapshotForExport(time.Hour, true, "otlp")
 	if len(first) != 1 || len(first[0].Spans) != 1 {
 		t.Fatalf("first snapshot = %d traces, want 1 trace with 1 span", len(first))
 	}
 
-	if again := tt.SnapshotForExport(time.Hour, true); len(again) != 1 {
+	if again := tt.SnapshotForExport(time.Hour, true, "otlp"); len(again) != 1 {
 		t.Fatalf("uncommitted snapshot must re-appear, got %d traces", len(again))
 	}
 
-	tt.CommitExport(first)
-	if second := tt.SnapshotForExport(time.Hour, true); len(second) != 0 {
+	tt.CommitExport(first, "otlp")
+	if second := tt.SnapshotForExport(time.Hour, true, "otlp"); len(second) != 0 {
 		t.Fatalf("second snapshot = %d traces, want 0 (spans export exactly once after commit)", len(second))
 	}
 
 	tt.ProcessEvent(snapshotEvent("t1", "s2"), nil)
-	third := tt.SnapshotForExport(time.Hour, true)
+	third := tt.SnapshotForExport(time.Hour, true, "otlp")
 	if len(third) != 1 || len(third[0].Spans) != 1 || third[0].Spans[0].SpanID != "s2" {
 		t.Fatalf("third snapshot must carry only the new span s2, got %+v", third)
 	}
-	tt.CommitExport(third)
-	if fourth := tt.SnapshotForExport(time.Hour, true); len(fourth) != 0 {
+	tt.CommitExport(third, "otlp")
+	if fourth := tt.SnapshotForExport(time.Hour, true, "otlp"); len(fourth) != 0 {
 		t.Fatalf("fourth snapshot = %d traces, want 0", len(fourth))
 	}
 }
@@ -55,10 +55,10 @@ func TestSnapshotForExport_SettleWindow(t *testing.T) {
 	tt := NewTraceTracker()
 	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
 
-	if got := tt.SnapshotForExport(time.Hour, false); len(got) != 0 {
+	if got := tt.SnapshotForExport(time.Hour, false, "otlp"); len(got) != 0 {
 		t.Fatalf("just-updated trace must settle before export, got %d traces", len(got))
 	}
-	if got := tt.SnapshotForExport(time.Hour, true); len(got) != 1 {
+	if got := tt.SnapshotForExport(time.Hour, true, "otlp"); len(got) != 1 {
 		t.Fatalf("force must flush settling traces, got %d traces", len(got))
 	}
 }
@@ -90,7 +90,7 @@ func TestSnapshotAll_DeepCopyAndNoWatermark(t *testing.T) {
 	}
 	live.mu.RUnlock()
 
-	if got := tt.SnapshotForExport(time.Hour, true); len(got) != 1 {
+	if got := tt.SnapshotForExport(time.Hour, true, "otlp"); len(got) != 1 {
 		t.Errorf("SnapshotAll must not consume the export watermark, export snapshot = %d traces", len(got))
 	}
 }

--- a/internal/diagnose/tracker/trace_tracker_watermark_test.go
+++ b/internal/diagnose/tracker/trace_tracker_watermark_test.go
@@ -1,0 +1,55 @@
+package tracker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotForExport_WatermarkIsPerExporter(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
+
+	if got := tt.SnapshotForExport(time.Hour, true, "a"); len(got) != 1 {
+		t.Fatalf("exporter a first snapshot = %d traces, want 1", len(got))
+	}
+	if got := tt.SnapshotForExport(time.Hour, true, "b"); len(got) != 1 {
+		t.Fatalf("exporter b first snapshot = %d traces, want 1", len(got))
+	}
+
+	tt.CommitExport([]*Trace{{TraceID: "t1", Spans: []*Span{{SpanID: "s1"}}}}, "a")
+
+	if got := tt.SnapshotForExport(time.Hour, true, "a"); len(got) != 0 {
+		t.Fatalf("exporter a re-export after commit = %d traces, want 0", len(got))
+	}
+	if got := tt.SnapshotForExport(time.Hour, true, "b"); len(got) != 1 {
+		t.Fatalf("exporter b snapshot = %d traces, want 1; a's commit must not advance b's watermark", len(got))
+	}
+}
+
+func TestCommitExport_InitializesNilWatermarkMap(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.traces["t1"] = &Trace{TraceID: "t1", Spans: []*Span{{SpanID: "s1"}}}
+
+	tt.CommitExport([]*Trace{{TraceID: "t1", Spans: []*Span{{SpanID: "s1"}}}}, "a")
+
+	if got := tt.SnapshotForExport(time.Hour, true, "a"); len(got) != 0 {
+		t.Fatalf("committing against a trace with no watermark map must still record it; re-export = %d", len(got))
+	}
+}
+
+func TestCommitExport_AdvancesOnlyNamedExporter(t *testing.T) {
+	tt := NewTraceTracker()
+	tt.ProcessEvent(snapshotEvent("t1", "s1"), nil)
+	tt.ProcessEvent(snapshotEvent("t1", "s2"), nil)
+
+	tt.CommitExport([]*Trace{{TraceID: "t1", Spans: []*Span{{SpanID: "s1"}}}}, "a")
+
+	gotA := tt.SnapshotForExport(time.Hour, true, "a")
+	if len(gotA) != 1 || len(gotA[0].Spans) != 1 || gotA[0].Spans[0].SpanID != "s2" {
+		t.Fatalf("exporter a must only see the uncommitted span s2, got %+v", gotA)
+	}
+	gotB := tt.SnapshotForExport(time.Hour, true, "b")
+	if len(gotB) != 1 || len(gotB[0].Spans) != 2 {
+		t.Fatalf("exporter b must still see both spans, got %+v", gotB)
+	}
+}

--- a/internal/diagnose/tracker/tracker_summary_test.go
+++ b/internal/diagnose/tracker/tracker_summary_test.go
@@ -129,7 +129,7 @@ func TestProcessEvent_NonMapContextIgnored(t *testing.T) {
 
 func TestCommitExport_UnknownTraceSkipped(t *testing.T) {
 	tt := NewTraceTracker()
-	tt.CommitExport([]*Trace{{TraceID: "does-not-exist", Spans: []*Span{{SpanID: "x"}}}})
+	tt.CommitExport([]*Trace{{TraceID: "does-not-exist", Spans: []*Span{{SpanID: "x"}}}}, "otlp")
 	if tt.GetTraceCount() != 0 {
 		t.Error("committing an unknown trace must not create state")
 	}
@@ -140,9 +140,9 @@ func TestCommitExport_ClampsExportedSpans(t *testing.T) {
 	tt.ProcessEvent(&events.Event{Type: events.EventHTTPReq, TraceID: "t1", SpanID: "s1"}, nil)
 
 	overClaim := &Trace{TraceID: "t1", Spans: []*Span{{SpanID: "a"}, {SpanID: "b"}, {SpanID: "c"}}}
-	tt.CommitExport([]*Trace{overClaim})
+	tt.CommitExport([]*Trace{overClaim}, "otlp")
 
-	if got := tt.SnapshotForExport(time.Hour, true); len(got) != 0 {
+	if got := tt.SnapshotForExport(time.Hour, true, "otlp"); len(got) != 0 {
 		t.Errorf("watermark must clamp to the live span count; re-export = %d traces", len(got))
 	}
 }

--- a/internal/metricsexporter/gauge_reset_test.go
+++ b/internal/metricsexporter/gauge_reset_test.go
@@ -1,0 +1,32 @@
+package metricsexporter
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestResetLatestGauges_ClearsStaleSeries(t *testing.T) {
+	ResetLatestGauges()
+
+	ExportDNSMetricWithContext(&events.Event{Type: events.EventDNS, LatencyNS: 1_000_000}, "ns-reset")
+	ExportTLSMetricWithContext(&events.Event{Type: events.EventTLSHandshake, LatencyNS: 2_000_000}, "ns-reset")
+
+	if n := testutil.CollectAndCount(dnsGauge); n == 0 {
+		t.Fatal("expected a dns gauge series after export")
+	}
+	if n := testutil.CollectAndCount(tlsGauge); n == 0 {
+		t.Fatal("expected a tls gauge series after export")
+	}
+
+	ResetLatestGauges()
+
+	if n := testutil.CollectAndCount(dnsGauge); n != 0 {
+		t.Fatalf("ResetLatestGauges left %d dns gauge series, want 0", n)
+	}
+	if n := testutil.CollectAndCount(tlsGauge); n != 0 {
+		t.Fatalf("ResetLatestGauges left %d tls gauge series, want 0", n)
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -298,22 +298,6 @@ var (
 		[]string{"pool_id", "process_name", "namespace"},
 	)
 
-	poolConnectionsGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "podtrace_pool_connections_current",
-			Help: "Current number of connections in pool.",
-		},
-		[]string{"pool_id", "process_name", "namespace"},
-	)
-
-	poolUtilizationGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "podtrace_pool_utilization_percent",
-			Help: "Pool utilization percentage (current/max * 100).",
-		},
-		[]string{"pool_id", "process_name", "namespace"},
-	)
-
 	eventChannelDepthGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "podtrace_event_channel_depth",
@@ -445,8 +429,6 @@ func init() {
 	prometheus.MustRegister(poolReleasesCounter)
 	prometheus.MustRegister(poolExhaustedCounter)
 	prometheus.MustRegister(poolWaitTimeHistogram)
-	prometheus.MustRegister(poolConnectionsGauge)
-	prometheus.MustRegister(poolUtilizationGauge)
 	prometheus.MustRegister(eventChannelDepthGauge)
 	prometheus.MustRegister(bpfMapUtilizationGauge)
 	prometheus.MustRegister(redisLatencyHistogram)
@@ -864,7 +846,22 @@ func addrIsLoopback(addr string) bool {
 }
 
 type Server struct {
-	server *http.Server
+	server   *http.Server
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+const resetLatestGaugeInterval = 5 * time.Minute
+
+// ResetLatestGauges clears the "latest value" gauges so a dead process's last
+// sample stops being reported as the current value.
+func ResetLatestGauges() {
+	dnsGauge.Reset()
+	fsGauge.Reset()
+	cpuGauge.Reset()
+	rttGauge.Reset()
+	latencyGauge.Reset()
+	tlsGauge.Reset()
 }
 
 func StartServer() *Server {
@@ -900,7 +897,20 @@ func StartServer() *Server {
 		WriteTimeout: config.DefaultMetricsWriteTimeout,
 	}
 
-	srv := &Server{server: server}
+	srv := &Server{server: server, stop: make(chan struct{})}
+
+	go func() {
+		t := time.NewTicker(resetLatestGaugeInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-srv.stop:
+				return
+			case <-t.C:
+				ResetLatestGauges()
+			}
+		}
+	}()
 
 	go func() {
 		defer func() {
@@ -923,6 +933,11 @@ func StartServer() *Server {
 }
 
 func (s *Server) Shutdown() {
+	s.stopOnce.Do(func() {
+		if s.stop != nil {
+			close(s.stop)
+		}
+	})
 	if s.server != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), config.DefaultMetricsShutdownTimeout)
 		defer cancel()

--- a/internal/profiling/correlator.go
+++ b/internal/profiling/correlator.go
@@ -13,6 +13,13 @@ import (
 	"github.com/gma1k/podtrace/internal/sanitize"
 )
 
+// maxCorrelatedSlowEvents caps the slow events retained for reporting and, more
+// importantly, the number of time windows the SchedSwitch scan tests each event
+// against, keeping that scan O(N_sched * maxCorrelatedSlowEvents) rather than
+// O(N_sched * N_slow), which blows up on a busy pod where both counts reach
+// config.MaxEvents.
+const maxCorrelatedSlowEvents = 20
+
 func safeInt64(v uint64) int64 {
 	if v > math.MaxInt64 {
 		return math.MaxInt64
@@ -39,29 +46,21 @@ type ProcessCPU struct {
 // slow events, CPU hot-path frames from SchedSwitch stacks, memory page-fault
 // data, and optional pprof endpoint results fetched from the pod.
 type CorrelatedResult struct {
-	// Slow events that exceeded the latency trigger threshold.
 	SlowEvents []*events.Event
 
-	// CPU hot frames aggregated from EventSchedSwitch events whose time windows
-	// overlap with slow events (matched using BPF-to-wall-clock alignment).
 	HotFrames []FrameCount
 
-	// All SchedSwitch events aggregated by process.
 	CPUHotProcesses []ProcessCPU
 
-	// Memory — BPF-observed page faults and OOM kills.
 	PageFaultCounts map[uint32]int // PID → fault count
 	OOMEvents       []*events.Event
 
-	// Optional pprof endpoint data (nil if pod has no pprof server).
 	HeapProfile      *ProfileResult
 	GoroutineProfile *ProfileResult
 
-	// Whether a pprof endpoint was found on the pod.
 	PprofAvailable bool
 	PodIP          string
 
-	// Time range covered by the correlation.
 	StartTime time.Time
 	EndTime   time.Time
 }
@@ -94,10 +93,7 @@ func Correlate(
 
 	triggerNS := uint64(cpuTriggerMS * float64(config.NSPerMS))
 
-	// Collect slow events and build time windows around them.
-	type window struct{ start, end time.Time }
-	var slowWindows []window
-
+	// Collect slow events (windows are built after capping, below).
 	for _, e := range allEvents {
 		if e == nil {
 			continue
@@ -114,23 +110,26 @@ func Correlate(
 
 		if e.LatencyNS >= triggerNS && isSlowEventType(e.Type) {
 			result.SlowEvents = append(result.SlowEvents, e)
-			eventWall := clock.BPFTimestampToWall(e.Timestamp)
-			slowWindows = append(slowWindows, window{
-				start: eventWall.Add(-50 * time.Millisecond),
-				end:   eventWall.Add(time.Duration(safeInt64(e.LatencyNS)) + 50*time.Millisecond),
-			})
 		}
 	}
 
-	// Sort slow events by latency (highest first).
 	sort.Slice(result.SlowEvents, func(i, j int) bool {
 		return result.SlowEvents[i].LatencyNS > result.SlowEvents[j].LatencyNS
 	})
-	if len(result.SlowEvents) > 20 {
-		result.SlowEvents = result.SlowEvents[:20]
+	if len(result.SlowEvents) > maxCorrelatedSlowEvents {
+		result.SlowEvents = result.SlowEvents[:maxCorrelatedSlowEvents]
 	}
 
-	// Aggregate SchedSwitch events: per-process stats + hot frames during slow windows.
+	type window struct{ start, end time.Time }
+	slowWindows := make([]window, 0, len(result.SlowEvents))
+	for _, e := range result.SlowEvents {
+		eventWall := clock.BPFTimestampToWall(e.Timestamp)
+		slowWindows = append(slowWindows, window{
+			start: eventWall.Add(-50 * time.Millisecond),
+			end:   eventWall.Add(time.Duration(safeInt64(e.LatencyNS)) + 50*time.Millisecond),
+		})
+	}
+
 	pidStats := map[uint32]*ProcessCPU{}
 	frameAgg := map[string]int{}
 
@@ -171,7 +170,6 @@ func Correlate(
 		}
 	}
 
-	// Finalise per-process averages.
 	for _, ps := range pidStats {
 		if ps.SchedCount > 0 {
 			ps.AvgBlockNS /= float64(ps.SchedCount)
@@ -185,7 +183,6 @@ func Correlate(
 		result.CPUHotProcesses = result.CPUHotProcesses[:10]
 	}
 
-	// Convert frame map to sorted slice.
 	for frame, count := range frameAgg {
 		result.HotFrames = append(result.HotFrames, FrameCount{Frame: frame, Count: count})
 	}
@@ -236,7 +233,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 	var sb strings.Builder
 	sb.WriteString("Performance Profiling Correlation:\n")
 
-	// pprof availability notice.
 	if cr.PprofAvailable {
 		fmt.Fprintf(&sb, "  pprof endpoint: available (pod %s)\n", cr.PodIP)
 	} else {
@@ -246,7 +242,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 	}
 	sb.WriteString("\n")
 
-	// Slow events summary.
 	if len(cr.SlowEvents) > 0 {
 		fmt.Fprintf(&sb, "  Slow events (> threshold) count: %d\n", len(cr.SlowEvents))
 		sb.WriteString("  Top slow events:\n")
@@ -264,7 +259,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("\n")
 	}
 
-	// CPU hot processes from SchedSwitch.
 	if len(cr.CPUHotProcesses) > 0 {
 		sb.WriteString("  CPU Scheduling Activity (from BPF sched_switch):\n")
 		fmt.Fprintf(&sb, "    %-8s  %-16s  %-10s  %s\n",
@@ -277,7 +271,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("\n")
 	}
 
-	// Hot frames correlated with slow events.
 	if len(cr.HotFrames) > 0 {
 		sb.WriteString("  CPU hot frames during slow-event windows (BPF stacks):\n")
 		for i, f := range cr.HotFrames {
@@ -289,7 +282,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("  (Use addr2line or go tool pprof to resolve addresses to function names)\n\n")
 	}
 
-	// Goroutine data.
 	if cr.GoroutineProfile != nil && cr.GoroutineProfile.Available {
 		fmt.Fprintf(&sb, "  Goroutines: %d total, %d blocked\n",
 			cr.GoroutineProfile.GoroutineCount,
@@ -300,7 +292,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("\n")
 	}
 
-	// Heap data.
 	if cr.HeapProfile != nil && cr.HeapProfile.Available && len(cr.HeapProfile.TopFunctions) > 0 {
 		sb.WriteString("  Top heap allocating functions (from pprof heap profile):\n")
 		for i, f := range cr.HeapProfile.TopFunctions {
@@ -313,7 +304,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("\n")
 	}
 
-	// Page faults.
 	if len(cr.PageFaultCounts) > 0 {
 		type kv struct {
 			pid   uint32
@@ -334,7 +324,6 @@ func GenerateSection(cr *CorrelatedResult, duration time.Duration) string {
 		sb.WriteString("\n")
 	}
 
-	// OOM events.
 	if len(cr.OOMEvents) > 0 {
 		fmt.Fprintf(&sb, "  OOM Kill events: %d\n", len(cr.OOMEvents))
 		for _, e := range cr.OOMEvents {

--- a/internal/profiling/correlator_window_bound_test.go
+++ b/internal/profiling/correlator_window_bound_test.go
@@ -1,0 +1,45 @@
+package profiling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/clock"
+	"github.com/gma1k/podtrace/internal/events"
+)
+
+func TestCorrelate_FrameWindowsBoundedToRetainedSlowEvents(t *testing.T) {
+	base := time.Now()
+	var all []*events.Event
+
+	for i := 0; i < maxCorrelatedSlowEvents; i++ {
+		all = append(all, &events.Event{
+			Type:      events.EventDNS,
+			LatencyNS: 5_000_000,
+			Timestamp: clock.WallToBPFTimestamp(base.Add(time.Duration(i) * time.Second)),
+		})
+	}
+
+	droppedAt := base.Add(1000 * time.Second)
+	all = append(all, &events.Event{
+		Type:      events.EventDNS,
+		LatencyNS: 1_000_000,
+		Timestamp: clock.WallToBPFTimestamp(droppedAt),
+	})
+	all = append(all, &events.Event{
+		Type:      events.EventSchedSwitch,
+		LatencyNS: 1000,
+		Stack:     []uint64{0xdeadbeef},
+		Timestamp: clock.WallToBPFTimestamp(droppedAt),
+	})
+
+	result := Correlate(all, nil, nil, 0.5)
+
+	if len(result.SlowEvents) != maxCorrelatedSlowEvents {
+		t.Fatalf("SlowEvents = %d, want capped at %d", len(result.SlowEvents), maxCorrelatedSlowEvents)
+	}
+	if len(result.HotFrames) != 0 {
+		t.Fatalf("a SchedSwitch inside only a dropped (rank>%d) slow window must not aggregate; HotFrames = %+v",
+			maxCorrelatedSlowEvents, result.HotFrames)
+	}
+}

--- a/internal/profiling/duration_clamp_test.go
+++ b/internal/profiling/duration_clamp_test.go
@@ -1,0 +1,49 @@
+package profiling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestClampProfileDuration(t *testing.T) {
+	if got := clampProfileDuration(0); got != config.ProfilingDefaultDuration {
+		t.Errorf("clampProfileDuration(0) = %v, want default %v", got, config.ProfilingDefaultDuration)
+	}
+	if got := clampProfileDuration(-5 * time.Second); got != config.ProfilingDefaultDuration {
+		t.Errorf("clampProfileDuration(negative) = %v, want default %v", got, config.ProfilingDefaultDuration)
+	}
+	over := config.ProfilingMaxDuration + time.Hour
+	if got := clampProfileDuration(over); got != config.ProfilingMaxDuration {
+		t.Errorf("clampProfileDuration(%v) = %v, want max %v", over, got, config.ProfilingMaxDuration)
+	}
+	if got := clampProfileDuration(2 * time.Second); got != 2*time.Second {
+		t.Errorf("clampProfileDuration(2s) = %v, want 2s unchanged", got)
+	}
+}
+
+func TestHTTPStart_ClampsRequestedDuration(t *testing.T) {
+	h := NewHandler("", nil)
+	req := httptest.NewRequest(http.MethodPost, "/profile/start?type=cpu&duration=99h", nil)
+	w := httptest.NewRecorder()
+	h.HTTPStart(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("HTTPStart status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	got, err := time.ParseDuration(body["duration"])
+	if err != nil {
+		t.Fatalf("parse echoed duration %q: %v", body["duration"], err)
+	}
+	if got > config.ProfilingMaxDuration {
+		t.Errorf("HTTPStart accepted %v exceeding the %v cap", got, config.ProfilingMaxDuration)
+	}
+}

--- a/internal/profiling/handler.go
+++ b/internal/profiling/handler.go
@@ -29,8 +29,9 @@ type Handler struct {
 	profiler    *PodProfiler
 	mu          sync.RWMutex
 	result      *CorrelatedResult
-	triggered   atomic.Bool // rate-limit: only one auto-trigger per session
+	triggered   atomic.Bool
 	triggerChan chan triggerReq
+	sem         chan struct{}
 	podIP       string
 }
 
@@ -42,11 +43,29 @@ type triggerReq struct {
 // NewHandler creates a Handler for the pod at podIP. ports is the list of
 // candidate pprof HTTP ports to probe.
 func NewHandler(podIP string, ports []int) *Handler {
+	concurrency := config.ProfilingMaxConcurrent
+	if concurrency < 1 {
+		concurrency = 1
+	}
 	return &Handler{
 		profiler:    NewPodProfiler(podIP, ports),
-		triggerChan: make(chan triggerReq, config.ProfilingMaxConcurrent),
+		triggerChan: make(chan triggerReq, concurrency),
+		sem:         make(chan struct{}, concurrency),
 		podIP:       podIP,
 	}
+}
+
+// clampProfileDuration bounds a requested profile duration to a sane maximum so
+// an on-demand request cannot pin a profile fetch (and its worker slot) open
+// for an arbitrarily long time.
+func clampProfileDuration(d time.Duration) time.Duration {
+	if d <= 0 {
+		return config.ProfilingDefaultDuration
+	}
+	if max := config.ProfilingMaxDuration; max > 0 && d > max {
+		return max
+	}
+	return d
 }
 
 // Run consumes eventChan, watching for latency spikes that auto-trigger a
@@ -61,7 +80,11 @@ func (h *Handler) Run(ctx context.Context, eventChan <-chan *events.Event) {
 		case <-ctx.Done():
 			return
 		case req := <-h.triggerChan:
-			h.doProfile(ctx, req.ptype, req.duration)
+			go func(req triggerReq) {
+				h.sem <- struct{}{}
+				defer func() { <-h.sem }()
+				h.doProfile(ctx, req.ptype, req.duration)
+			}(req)
 		case e, ok := <-eventChan:
 			if !ok {
 				return
@@ -103,9 +126,7 @@ func (h *Handler) checkSpike(ctx context.Context, e *events.Event) {
 
 // doProfile fetches the requested profile type and stores/updates the result.
 func (h *Handler) doProfile(ctx context.Context, ptype ProfileType, duration time.Duration) {
-	if duration == 0 {
-		duration = config.ProfilingDefaultDuration
-	}
+	duration = clampProfileDuration(duration)
 
 	var heap, goroutine *ProfileResult
 
@@ -229,7 +250,7 @@ func (h *Handler) HTTPStart(w http.ResponseWriter, r *http.Request) {
 	dur := config.ProfilingDefaultDuration
 	if durationStr != "" {
 		if d, err := time.ParseDuration(durationStr); err == nil && d > 0 {
-			dur = d
+			dur = clampProfileDuration(d)
 		}
 	}
 

--- a/internal/tracing/correlation_cache_test.go
+++ b/internal/tracing/correlation_cache_test.go
@@ -126,7 +126,7 @@ func TestManager_ExportTraces_SuccessAdvancesWatermark(t *testing.T) {
 	}, nil)
 
 	m.exportTraces(true)
-	if got := m.traceTracker.SnapshotForExport(m.exportInterval, true); len(got) != 0 {
+	if got := m.traceTracker.SnapshotForExport(m.exportInterval, true, "otlp"); len(got) != 0 {
 		t.Errorf("a successful export must advance the watermark; re-export snapshot = %d traces", len(got))
 	}
 }
@@ -180,7 +180,7 @@ func TestManager_ExportTraces_SplunkFailureAlertSuppressed(t *testing.T) {
 	}, nil)
 
 	m.exportTraces(true)
-	if got := m.traceTracker.SnapshotForExport(m.exportInterval, true); len(got) == 0 {
+	if got := m.traceTracker.SnapshotForExport(m.exportInterval, true, "splunk"); len(got) == 0 {
 		t.Error("a failed export must not advance the watermark; the trace should remain exportable")
 	}
 }

--- a/internal/tracing/exporter/datadog.go
+++ b/internal/tracing/exporter/datadog.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -142,6 +143,7 @@ func (e *DataDogExporter) exportTrace(t *tracker.Trace) error {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 

--- a/internal/tracing/exporter/seam_error_test.go
+++ b/internal/tracing/exporter/seam_error_test.go
@@ -28,8 +28,8 @@ func TestExportTrace_MarshalError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := sp.exportTrace(newTestTrace()); err == nil || !strings.Contains(err.Error(), "marshal") {
-		t.Errorf("splunk exportTrace: err=%v, want marshal error", err)
+	if err := sp.sendBatch(sp.buildEvents(newTestTrace())); err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("splunk sendBatch: err=%v, want marshal error", err)
 	}
 
 	zp, err := NewZipkinExporter("https://collector.example.com", 1.0)

--- a/internal/tracing/exporter/splunk.go
+++ b/internal/tracing/exporter/splunk.go
@@ -5,12 +5,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/diagnose/tracker"
 	"github.com/gma1k/podtrace/internal/netguard"
 )
+
+// splunkMaxBatchBytes bounds a single HEC request body so a large export is
+// split into a few sized requests rather than one unbounded POST (or, as
+// before, one POST per span).
+const splunkMaxBatchBytes = 512 * 1024
 
 type SplunkExporter struct {
 	endpoint   string
@@ -48,31 +54,26 @@ func (e *SplunkExporter) ExportTraces(traces []*tracker.Trace) error {
 		return nil
 	}
 
-	var errs []error
+	events := make([]SplunkEvent, 0)
 	for _, t := range traces {
 		if !e.shouldSample(t) {
 			continue
 		}
-
-		if err := e.exportTrace(t); err != nil {
-			errs = append(errs, fmt.Errorf("trace %s: %w", t.TraceID, err))
-		}
+		events = append(events, e.buildEvents(t)...)
+	}
+	if len(events) == 0 {
+		return nil
 	}
 
-	return errors.Join(errs...)
+	return e.sendBatch(events)
 }
 
 func (e *SplunkExporter) shouldSample(t *tracker.Trace) bool {
 	return sampleTrace(t.TraceID, e.sampleRate)
 }
 
-func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {
-	if len(t.Spans) == 0 {
-		return nil
-	}
-
-	events := make([]SplunkEvent, 0)
-
+func (e *SplunkExporter) buildEvents(t *tracker.Trace) []SplunkEvent {
+	events := make([]SplunkEvent, 0, len(t.Spans))
 	for _, span := range t.Spans {
 		span.UpdateDuration()
 
@@ -95,48 +96,74 @@ func (e *SplunkExporter) exportTrace(t *tracker.Trace) error {
 			eventData["error"] = true
 		}
 
-		event := SplunkEvent{
+		events = append(events, SplunkEvent{
 			Time:       span.StartTime.Unix(),
 			Sourcetype: "Podtrace:trace",
 			Event:      eventData,
-		}
+		})
+	}
+	return events
+}
 
-		events = append(events, event)
+// sendBatch delivers events as HEC batches: JSON objects are concatenated into
+// one request body (the format Splunk HEC accepts) and flushed once the body
+// would exceed splunkMaxBatchBytes, so a whole export is a few sized POSTs
+// instead of one request per span.
+func (e *SplunkExporter) sendBatch(events []SplunkEvent) error {
+	var errs []error
+	var body bytes.Buffer
+
+	flush := func() {
+		if body.Len() == 0 {
+			return
+		}
+		if err := e.postBatch(body.Bytes()); err != nil {
+			errs = append(errs, err)
+		}
+		body.Reset()
 	}
 
-	var errs []error
 	for _, event := range events {
 		payload, err := marshalJSON(event)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("marshal event: %w", err))
 			continue
 		}
-
-		req, err := http.NewRequestWithContext(context.Background(), "POST", e.endpoint, bytes.NewReader(payload))
-		if err != nil {
-			errs = append(errs, fmt.Errorf("create request: %w", err))
-			continue
+		if body.Len() > 0 && body.Len()+len(payload)+1 > splunkMaxBatchBytes {
+			flush()
 		}
-
-		req.Header.Set("Content-Type", "application/json")
-		if e.token != "" {
-			req.Header.Set("Authorization", "Splunk "+e.token)
-		}
-
-		resp, err := e.client.Do(req)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("send request: %w", err))
-			continue
-		}
-		_ = resp.Body.Close()
-		// HEC failures (401 bad token, 400 malformed event) used to be
-		// indistinguishable from success.
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-			errs = append(errs, fmt.Errorf("unexpected status code: %d", resp.StatusCode))
-		}
+		body.Write(payload)
+		body.WriteByte('\n')
 	}
+	flush()
 
 	return errors.Join(errs...)
+}
+
+func (e *SplunkExporter) postBatch(payload []byte) error {
+	req, err := http.NewRequestWithContext(context.Background(), "POST", e.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if e.token != "" {
+		req.Header.Set("Authorization", "Splunk "+e.token)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
 }
 
 func (e *SplunkExporter) Shutdown(ctx context.Context) error {

--- a/internal/tracing/exporter/splunk_batch_test.go
+++ b/internal/tracing/exporter/splunk_batch_test.go
@@ -1,0 +1,90 @@
+package exporter
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gma1k/podtrace/internal/diagnose/tracker"
+)
+
+func TestSplunkExporter_BatchesSpansIntoOneRequest(t *testing.T) {
+	var requests int32
+	var events int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		body, _ := io.ReadAll(r.Body)
+		atomic.AddInt32(&events, int32(bytes.Count(bytes.TrimSpace(body), []byte("\n"))+1))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exporter, err := NewSplunkExporter(srv.URL, "tok", 1.0)
+	if err != nil {
+		t.Fatalf("NewSplunkExporter() error = %v", err)
+	}
+	exporter.client = srv.Client()
+
+	spans := make([]*tracker.Span, 10)
+	for i := range spans {
+		spans[i] = &tracker.Span{TraceID: "t1", SpanID: string(rune('a' + i)), StartTime: time.Now()}
+	}
+	if err := exporter.ExportTraces([]*tracker.Trace{{TraceID: "t1", Spans: spans}}); err != nil {
+		t.Fatalf("ExportTraces() error = %v", err)
+	}
+
+	if n := atomic.LoadInt32(&requests); n != 1 {
+		t.Errorf("10 spans produced %d HTTP requests, want 1 batched request", n)
+	}
+	if n := atomic.LoadInt32(&events); n != 10 {
+		t.Errorf("batch carried %d HEC events, want 10", n)
+	}
+}
+
+func TestSplunkExporter_SplitsOversizeBatch(t *testing.T) {
+	var requests int32
+	var events int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		body, _ := io.ReadAll(r.Body)
+		if len(body) > splunkMaxBatchBytes*2 {
+			t.Errorf("batch body %d bytes exceeds the flush threshold by too much", len(body))
+		}
+		atomic.AddInt32(&events, int32(bytes.Count(bytes.TrimSpace(body), []byte("\n"))+1))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exporter, err := NewSplunkExporter(srv.URL, "tok", 1.0)
+	if err != nil {
+		t.Fatalf("NewSplunkExporter() error = %v", err)
+	}
+	exporter.client = srv.Client()
+
+	const spanCount = 150
+	blob := strings.Repeat("x", 8192)
+	spans := make([]*tracker.Span, spanCount)
+	for i := range spans {
+		spans[i] = &tracker.Span{
+			TraceID:    "t1",
+			SpanID:     "s",
+			StartTime:  time.Now(),
+			Attributes: map[string]string{"blob": blob},
+		}
+	}
+	if err := exporter.ExportTraces([]*tracker.Trace{{TraceID: "t1", Spans: spans}}); err != nil {
+		t.Fatalf("ExportTraces() error = %v", err)
+	}
+
+	if n := atomic.LoadInt32(&requests); n < 2 {
+		t.Errorf("an oversize export produced %d requests, want it split into >= 2 batches", n)
+	}
+	if n := atomic.LoadInt32(&events); n != spanCount {
+		t.Errorf("batches carried %d events total, want %d", n, spanCount)
+	}
+}

--- a/internal/tracing/exporter/splunk_test.go
+++ b/internal/tracing/exporter/splunk_test.go
@@ -71,7 +71,7 @@ func TestSplunkExporter_exportTrace_NoSpans(t *testing.T) {
 		TraceID: "test",
 		Spans:   []*tracker.Span{},
 	}
-	err := exporter.exportTrace(trace)
+	err := exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Errorf("exportTrace() error = %v", err)
 	}
@@ -102,7 +102,7 @@ func TestSplunkExporter_exportTrace_WithSpans(t *testing.T) {
 			},
 		},
 	}
-	err = exporter.exportTrace(trace)
+	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err == nil {
 		t.Log("exportTrace() succeeded (may fail in CI without server)")
 	} else {
@@ -193,7 +193,7 @@ func TestSplunkExporter_exportTrace_WithErrorSpan(t *testing.T) {
 		},
 	}
 
-	err = exporter.exportTrace(trace)
+	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
 	}
@@ -219,7 +219,7 @@ func TestSplunkExporter_exportTrace_WithToken(t *testing.T) {
 		},
 	}
 
-	err = exporter.exportTrace(trace)
+	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
 	}
@@ -246,7 +246,7 @@ func TestSplunkExporter_exportTrace_WithParentSpanID(t *testing.T) {
 		},
 	}
 
-	err = exporter.exportTrace(trace)
+	err = exporter.ExportTraces([]*tracker.Trace{trace})
 	if err != nil {
 		t.Logf("exportTrace() error (expected for test without server): %v", err)
 	}

--- a/internal/tracing/exporter/zipkin.go
+++ b/internal/tracing/exporter/zipkin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/gma1k/podtrace/internal/config"
@@ -144,6 +145,7 @@ func (e *ZipkinExporter) exportTrace(t *tracker.Trace) error {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 

--- a/internal/tracing/manager.go
+++ b/internal/tracing/manager.go
@@ -272,46 +272,45 @@ func (m *Manager) exporterTargets() []exporterTarget {
 // interval). force (shutdown) flushes spans of traces that are still
 // settling.
 func (m *Manager) exportTraces(force bool) {
-	traces := m.traceTracker.SnapshotForExport(m.exportInterval, force)
-	if len(traces) == 0 {
+	for _, target := range m.exporterTargets() {
+		traces := m.traceTracker.SnapshotForExport(m.exportInterval, force, target.name)
+		if len(traces) == 0 {
+			continue
+		}
+		if err := target.export(traces); err != nil {
+			m.reportExporterFailure(target, err)
+			continue
+		}
+		// Advance only this exporter's watermark, on its own success.
+		m.traceTracker.CommitExport(traces, target.name)
+	}
+}
+
+// reportExporterFailure logs and (unless suppressed) raises an alert for a
+// failed export.
+func (m *Manager) reportExporterFailure(target exporterTarget, err error) {
+	safeErr := alerting.RedactURLsInText(err.Error())
+	logger.Warn("Failed to export traces", zap.String("exporter", target.name), zap.String("error", safeErr))
+	if target.suppressAlert {
 		return
 	}
-
-	allSucceeded := true
-	for _, target := range m.exporterTargets() {
-		err := target.export(traces)
-		if err == nil {
-			continue
-		}
-		allSucceeded = false
-		logger.Warn("Failed to export traces", zap.String("exporter", target.name), zap.Error(err))
-		if target.suppressAlert {
-			continue
-		}
-		manager := alerting.GetGlobalManager()
-		if manager == nil {
-			continue
-		}
-		manager.SendAlert(&alerting.Alert{
-			Severity:  alerting.SeverityWarning,
-			Title:     fmt.Sprintf("%s Exporter Failure", strings.ToUpper(target.name[:1])+target.name[1:]),
-			Message:   fmt.Sprintf("Failed to export traces to %s: %v", target.name, err),
-			Timestamp: time.Now(),
-			Source:    "exporter",
-			Context: map[string]interface{}{
-				"exporter": target.name,
-				"endpoint": target.endpoint,
-				"error":    err.Error(),
-			},
-			Recommendations: target.recommendations,
-		})
+	manager := alerting.GetGlobalManager()
+	if manager == nil {
+		return
 	}
-
-	// Advance the per-trace watermark only when every exporter accepted the
-	// spans.
-	if allSucceeded {
-		m.traceTracker.CommitExport(traces)
-	}
+	manager.SendAlert(&alerting.Alert{
+		Severity:  alerting.SeverityWarning,
+		Title:     fmt.Sprintf("%s Exporter Failure", strings.ToUpper(target.name[:1])+target.name[1:]),
+		Message:   fmt.Sprintf("Failed to export traces to %s: %s", target.name, safeErr),
+		Timestamp: time.Now(),
+		Source:    "exporter",
+		Context: map[string]interface{}{
+			"exporter": target.name,
+			"endpoint": alerting.RedactURLForLog(target.endpoint),
+			"error":    safeErr,
+		},
+		Recommendations: target.recommendations,
+	})
 }
 
 func (m *Manager) GetRequestFlowGraph() *graph.RequestFlowGraph {

--- a/internal/tracing/manager_synthesis_test.go
+++ b/internal/tracing/manager_synthesis_test.go
@@ -55,7 +55,7 @@ func httpResp(corr uint64, tsNS, latencyNS uint64) *events.Event {
 
 func onlySpan(t *testing.T, m *Manager) *tracker.Span {
 	t.Helper()
-	traces := m.traceTracker.SnapshotForExport(0, true)
+	traces := m.traceTracker.SnapshotForExport(0, true, "otlp")
 	if len(traces) != 1 {
 		t.Fatalf("expected 1 trace, got %d", len(traces))
 	}

--- a/internal/tracing/manager_test.go
+++ b/internal/tracing/manager_test.go
@@ -215,8 +215,7 @@ func TestManager_Start_Enabled(t *testing.T) {
 	}
 
 	time.Sleep(10 * time.Millisecond)
-	cancel()
-	time.Sleep(10 * time.Millisecond)
+	_ = manager.Shutdown(context.Background())
 }
 
 func TestManager_Start_StopCh(t *testing.T) {
@@ -237,7 +236,7 @@ func TestManager_Start_StopCh(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 	close(manager.stopCh)
-	time.Sleep(10 * time.Millisecond)
+	manager.wg.Wait()
 }
 
 func TestManager_ExportLoop_Ticker(t *testing.T) {
@@ -261,8 +260,7 @@ func TestManager_ExportLoop_Ticker(t *testing.T) {
 	}
 
 	time.Sleep(30 * time.Millisecond)
-	cancel()
-	time.Sleep(10 * time.Millisecond)
+	_ = manager.Shutdown(context.Background())
 }
 
 func TestManager_CleanupLoop_Ticker(t *testing.T) {
@@ -286,8 +284,7 @@ func TestManager_CleanupLoop_Ticker(t *testing.T) {
 	}
 
 	time.Sleep(30 * time.Millisecond)
-	cancel()
-	time.Sleep(10 * time.Millisecond)
+	_ = manager.Shutdown(context.Background())
 }
 
 func TestManager_ExportTraces_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary
Hardening batch across tracing export, metrics, and the diagnose report path.

## Fixes
- Per-exporter export watermark: a failing backend no longer re-sends spans another backend already stored (at-least-once per exporter, was all-or-nothing).
- Redact exporter endpoints and errors before they reach alert payloads, logs, and downstream sinks (userinfo and query strings stripped, error text kept).
- Periodically reset the point-in-time "latest value" gauges so a dead process's last sample stops reading as current; remove two gauges that had no writers.
- Splunk exporter batches spans into sized HEC requests (was one request per span) and drains response bodies so keep-alive connections are reused.
- Agent /metrics server sets ReadTimeout, WriteTimeout, and IdleTimeout (previously only ReadHeaderTimeout).
- Ship an opt-in NetworkPolicy for the agent pods (networkPolicy.enabled), limiting ingress to the metrics and health ports.
- Clamp requested profiling durations to a maximum and run triggered profiles off the Run loop so a long CPU profile can't stall spike detection.
- Bound shutdown report generation with a deadline so stack symbolization cannot run past the pod's termination grace and lose the report.
- FilterEvents walks the event ring in place instead of copying the whole buffer once per event type.
- Correlator builds its slow-event correlation windows from the retained top-N, keeping the SchedSwitch scan linear instead of quadratic.