### PR TITLE
fix: harden pod specs, redact reports, and close filter/tee gaps

### DIFF
--- a/cmd/podtrace/cmd_branches_unit_test.go
+++ b/cmd/podtrace/cmd_branches_unit_test.go
@@ -46,7 +46,7 @@ func TestRunDiagnoseModeWithSource_InvalidDuration(t *testing.T) {
 
 	ch := make(chan *events.Event)
 	err := runDiagnoseModeWithSource(context.Background(), ch, "not-a-duration",
-		nil, nil, nil, nil, false, nil, nil)
+		nil, nil, nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid duration") {
 		t.Fatalf("expected invalid duration error, got %v", err)
 	}
@@ -58,7 +58,7 @@ func TestRunDiagnoseModeWithSource_NonPositiveDuration(t *testing.T) {
 
 	ch := make(chan *events.Event)
 	err := runDiagnoseModeWithSource(context.Background(), ch, "0s",
-		nil, nil, nil, nil, false, nil, nil)
+		nil, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected validation error for non-positive duration, got nil")
 	}
@@ -77,7 +77,7 @@ func TestRunDiagnoseModeWithSource_TimeoutFinishDrainsEvents(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := runDiagnoseModeWithSource(context.Background(), ch, "120ms",
-			nil, nil, nil, nil, false, nil, nil); err != nil {
+			nil, nil, nil, nil, nil); err != nil {
 			t.Fatalf("unexpected error from timeout finish: %v", err)
 		}
 	})
@@ -103,7 +103,7 @@ func TestRunDiagnoseModeWithSource_ContextCancelFinish(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := runDiagnoseModeWithSource(ctx, ch, "30s",
-			nil, nil, nil, nil, false, nil, nil); err != nil {
+			nil, nil, nil, nil, nil); err != nil {
 			t.Fatalf("ctx-cancel finish should return nil, got %v", err)
 		}
 	})
@@ -127,7 +127,7 @@ func TestRunDiagnoseModeWithSource_ExportJSONOnTimeout(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := runDiagnoseModeWithSource(context.Background(), ch, "100ms",
-			nil, nil, nil, nil, false, nil, nil); err != nil {
+			nil, nil, nil, nil, nil); err != nil {
 			t.Fatalf("unexpected error exporting JSON: %v", err)
 		}
 	})

--- a/cmd/podtrace/event_tee.go
+++ b/cmd/podtrace/event_tee.go
@@ -3,16 +3,14 @@ package main
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/events"
+	"github.com/gma1k/podtrace/internal/logger"
+	"github.com/gma1k/podtrace/internal/metricsexporter"
 )
 
-// teeEvents fans every event from source out to one primary channel plus
-// `auxiliary` additional channels. Go channels deliver each value to exactly
-// one receiver, so the report loop, metrics handler, tracing handler, and
-// profiling correlator — which all used to receive from the same channel —
-// each saw only a random disjoint subset of events, and with --filter events
-// randomly bypassed the filter pipeline entirely.
 func teeEvents(ctx context.Context, source <-chan *events.Event, auxiliary int) (chan *events.Event, []chan *events.Event) {
 	primary := make(chan *events.Event, config.EventChannelBufferSize)
 	aux := make([]chan *events.Event, auxiliary)
@@ -25,6 +23,7 @@ func teeEvents(ctx context.Context, source <-chan *events.Event, auxiliary int) 
 		for _, c := range aux {
 			defer close(c)
 		}
+		var auxDrops uint64
 		for {
 			select {
 			case <-ctx.Done():
@@ -38,11 +37,19 @@ func teeEvents(ctx context.Context, source <-chan *events.Event, auxiliary int) 
 				case <-ctx.Done():
 					return
 				}
-				for _, c := range aux {
+				for i, c := range aux {
 					evCopy := *ev
 					select {
 					case c <- &evCopy:
 					default:
+						auxDrops++
+						metricsexporter.RecordTeeAuxDrop()
+						if auxDrops == 1 || auxDrops%uint64(config.DroppedEventsLogRate) == 0 {
+							logger.Warn("Auxiliary event channel full; dropping event for a secondary consumer (metrics/tracing/profiling will undercount)",
+								zap.Int("aux_index", i),
+								zap.Uint64("total_aux_drops", auxDrops),
+								zap.String("event_type", ev.TypeString()))
+						}
 					}
 				}
 			}

--- a/cmd/podtrace/event_tee_test.go
+++ b/cmd/podtrace/event_tee_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gma1k/podtrace/internal/config"
 	"github.com/gma1k/podtrace/internal/events"
 )
 
@@ -151,6 +154,72 @@ func TestTeeEvents_SlowAuxiliaryDoesNotStallPrimary(t *testing.T) {
 			got++
 		case <-deadline:
 			t.Fatalf("primary stalled after %d events (auxiliary backpressure leaked)", got)
+		}
+	}
+}
+func promCounterTotal(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+func TestTeeEvents_CountsAuxDropsWhenConsumerStalls(t *testing.T) {
+	origBuf := config.EventChannelBufferSize
+	config.EventChannelBufferSize = 1
+	defer func() { config.EventChannelBufferSize = origBuf }()
+
+	before := promCounterTotal(t, "podtrace_event_tee_aux_drops_total")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan *events.Event, 16)
+	primary, aux := teeEvents(ctx, source, 1)
+
+	const total = 8
+	for i := 0; i < total; i++ {
+		source <- &events.Event{PID: uint32(i + 1)}
+	}
+	close(source)
+
+	for range primary {
+	}
+	_ = aux
+
+	if got := promCounterTotal(t, "podtrace_event_tee_aux_drops_total") - before; got < 1 {
+		t.Fatalf("aux drops counted = %v, want >= 1 (a stalled consumer must be visible)", got)
+	}
+}
+
+func TestTeeEvents_PrimarySendCanceledByContext(t *testing.T) {
+	origBuf := config.EventChannelBufferSize
+	config.EventChannelBufferSize = 0
+	defer func() { config.EventChannelBufferSize = origBuf }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	source := make(chan *events.Event)
+	primary, _ := teeEvents(ctx, source, 0)
+
+	source <- &events.Event{PID: 1}
+	cancel()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-primary:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("tee did not return after context cancel during a blocked primary send")
 		}
 	}
 }

--- a/cmd/podtrace/filter_test.go
+++ b/cmd/podtrace/filter_test.go
@@ -65,6 +65,25 @@ func TestFilterEvents(t *testing.T) {
 			expected: 2,
 		},
 		{
+			name:   "usdt filter",
+			filter: "usdt",
+			events: []*events.Event{
+				{Type: events.EventUSDT},
+				{Type: events.EventConnect},
+				{Type: events.EventUSDT},
+			},
+			expected: 2,
+		},
+		{
+			name:   "crypto filter",
+			filter: "crypto",
+			events: []*events.Event{
+				{Type: events.EventAFALG},
+				{Type: events.EventConnect},
+			},
+			expected: 1,
+		},
+		{
 			name:   "multiple filters",
 			filter: "dns,net",
 			events: []*events.Event{
@@ -107,6 +126,21 @@ func TestFilterEvents(t *testing.T) {
 				t.Errorf("Expected %d events, got %d", tt.expected, count)
 			}
 		})
+	}
+}
+
+func TestFilterEvents_DropsAndCountsWhenOutFull(t *testing.T) {
+	before := promCounterTotal(t, "podtrace_filtered_event_drops_total")
+
+	in := make(chan *events.Event, 1)
+	out := make(chan *events.Event)
+	in <- &events.Event{Type: events.EventDNS}
+	close(in)
+
+	filterEvents(context.Background(), in, out, "dns")
+
+	if got := promCounterTotal(t, "podtrace_filtered_event_drops_total") - before; got < 1 {
+		t.Fatalf("filtered-event drop delta = %v, want >= 1 (a full out channel must be counted)", got)
 	}
 }
 

--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -714,17 +714,17 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 	}
 
 	if diagnoseDuration != "" {
-		return runDiagnoseModeWithSource(ctx, filteredChan, diagnoseDuration, podInfo, enricher, nil, tracingManager, enableTracing, sourceIndex.Resolve, profilingReporter)
+		return runDiagnoseModeWithSource(ctx, filteredChan, diagnoseDuration, podInfo, enricher, nil, sourceIndex.Resolve, profilingReporter)
 	}
 
-	return runNormalModeWithSource(ctx, filteredChan, podInfo, enricher, nil, tracingManager, enableTracing, sourceIndex.Resolve, profilingReporter)
+	return runNormalModeWithSource(ctx, filteredChan, podInfo, enricher, nil, sourceIndex.Resolve, profilingReporter)
 }
 
-func runNormalMode(ctx context.Context, eventChan <-chan *events.Event, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, eventsCorrelator *kubernetes.EventsCorrelator, tracingManager *tracing.Manager, enableTracing bool) error {
-	return runNormalModeWithSource(ctx, eventChan, podInfo, enricher, eventsCorrelator, tracingManager, enableTracing, nil, nil)
+func runNormalMode(ctx context.Context, eventChan <-chan *events.Event, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, eventsCorrelator *kubernetes.EventsCorrelator) error {
+	return runNormalModeWithSource(ctx, eventChan, podInfo, enricher, eventsCorrelator, nil, nil)
 }
 
-func runNormalModeWithSource(ctx context.Context, eventChan <-chan *events.Event, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, _ *kubernetes.EventsCorrelator, tracingManager *tracing.Manager, enableTracing bool, resolveSource func(*events.Event) *kubernetes.PodInfo, profilingReporter profiling.Reporter) error {
+func runNormalModeWithSource(ctx context.Context, eventChan <-chan *events.Event, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, _ *kubernetes.EventsCorrelator, resolveSource func(*events.Event) *kubernetes.PodInfo, profilingReporter profiling.Reporter) error {
 	logger.Info("Tracing started",
 		zap.Duration("update_interval", config.DefaultRealtimeUpdateInterval))
 
@@ -788,11 +788,11 @@ func runNormalModeWithSource(ctx context.Context, eventChan <-chan *events.Event
 	}
 }
 
-func runDiagnoseMode(ctx context.Context, eventChan <-chan *events.Event, durationStr string, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, eventsCorrelator *kubernetes.EventsCorrelator, tracingManager *tracing.Manager, enableTracing bool) error {
-	return runDiagnoseModeWithSource(ctx, eventChan, durationStr, podInfo, enricher, eventsCorrelator, tracingManager, enableTracing, nil, nil)
+func runDiagnoseMode(ctx context.Context, eventChan <-chan *events.Event, durationStr string, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, eventsCorrelator *kubernetes.EventsCorrelator) error {
+	return runDiagnoseModeWithSource(ctx, eventChan, durationStr, podInfo, enricher, eventsCorrelator, nil, nil)
 }
 
-func runDiagnoseModeWithSource(ctx context.Context, eventChan <-chan *events.Event, durationStr string, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, _ *kubernetes.EventsCorrelator, tracingManager *tracing.Manager, enableTracing bool, resolveSource func(*events.Event) *kubernetes.PodInfo, profilingReporter profiling.Reporter) error {
+func runDiagnoseModeWithSource(ctx context.Context, eventChan <-chan *events.Event, durationStr string, podInfo *kubernetes.PodInfo, enricher *kubernetes.ContextEnricher, _ *kubernetes.EventsCorrelator, resolveSource func(*events.Event) *kubernetes.PodInfo, profilingReporter profiling.Reporter) error {
 	duration, err := time.ParseDuration(durationStr)
 	if err != nil {
 		return fmt.Errorf("invalid duration: %w", err)
@@ -919,6 +919,8 @@ func filterEvents(ctx context.Context, in <-chan *events.Event, out chan<- *even
 			case filterMap["proc"] && (event.Type == events.EventExec || event.Type == events.EventFork || event.Type == events.EventOpen || event.Type == events.EventClose):
 				shouldInclude = true
 			case filterMap["crypto"] && event.Type == events.EventAFALG:
+				shouldInclude = true
+			case filterMap["usdt"] && event.Type == events.EventUSDT:
 				shouldInclude = true
 			}
 			if shouldInclude {

--- a/cmd/podtrace/mode_test.go
+++ b/cmd/podtrace/mode_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gma1k/podtrace/internal/events"
 	"github.com/gma1k/podtrace/internal/kubernetes"
-	"github.com/gma1k/podtrace/internal/tracing"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -49,7 +48,7 @@ func TestRunNormalMode_WithEvents(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -101,7 +100,7 @@ func TestRunNormalMode_Interrupt(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -153,7 +152,7 @@ func TestRunNormalMode_TickerBeforeInterrupt(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -205,7 +204,7 @@ func TestRunNormalMode_HasPrintedReport(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -257,7 +256,7 @@ func TestRunNormalMode_NoEvents(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -310,7 +309,7 @@ func TestRunNormalMode_WithTicker(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -356,7 +355,7 @@ func TestRunDiagnoseMode_Timeout(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -393,7 +392,7 @@ func TestRunDiagnoseMode_WithExport(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -412,7 +411,7 @@ func TestRunDiagnoseMode_InvalidDuration(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "invalid", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "invalid", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -449,7 +448,7 @@ func TestRunDiagnoseMode_WithExportFormat(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -486,7 +485,7 @@ func TestRunDiagnoseMode_WithExportFormatCSV(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -532,7 +531,7 @@ func TestRunDiagnoseMode_Interrupt(t *testing.T) {
 			cancel()
 		}()
 
-		err := runDiagnoseMode(ctx, eventChan, "10s", nil, nil, nil, nil, false)
+		err := runDiagnoseMode(ctx, eventChan, "10s", nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -587,7 +586,7 @@ func TestRunDiagnoseMode_InterruptWithExport(t *testing.T) {
 			cancel()
 		}()
 
-		err := runDiagnoseMode(ctx, eventChan, "10s", nil, nil, nil, nil, false)
+		err := runDiagnoseMode(ctx, eventChan, "10s", nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -648,7 +647,7 @@ func TestRunNormalMode_WithEnricher(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, podInfo, enricher, nil, nil, false)
+		err := runNormalMode(ctx, eventChan, podInfo, enricher, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -688,7 +687,6 @@ func TestRunNormalMode_WithTracing(t *testing.T) {
 		fsSlowThreshold = origFSThreshold
 	}()
 
-	tracingManager, _ := tracing.NewManager()
 
 	go func() {
 		stdoutMutex.Lock()
@@ -703,7 +701,7 @@ func TestRunNormalMode_WithTracing(t *testing.T) {
 			cancel()
 		}()
 
-		err := runNormalMode(ctx, eventChan, nil, nil, nil, tracingManager, true)
+		err := runNormalMode(ctx, eventChan, nil, nil, nil)
 
 		_ = w.Close()
 		os.Stdout = originalStdout
@@ -758,7 +756,7 @@ func TestRunDiagnoseMode_WithEnricher(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", podInfo, enricher, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", podInfo, enricher, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -787,7 +785,6 @@ func TestRunDiagnoseMode_WithTracing(t *testing.T) {
 		exportFormat = origExportFormat
 	}()
 
-	tracingManager, _ := tracing.NewManager()
 
 	go func() {
 		eventChan <- &events.Event{Type: events.EventDNS, LatencyNS: 5000000, Target: "example.com"}
@@ -798,7 +795,7 @@ func TestRunDiagnoseMode_WithTracing(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil, tracingManager, true)
+	err := runDiagnoseMode(context.Background(), eventChan, "100ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()
@@ -838,7 +835,7 @@ func TestRunDiagnoseMode_BatchProcessing(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	err := runDiagnoseMode(context.Background(), eventChan, "200ms", nil, nil, nil, nil, false)
+	err := runDiagnoseMode(context.Background(), eventChan, "200ms", nil, nil, nil)
 	_ = w.Close()
 	os.Stdout = originalStdout
 	stdoutMutex.Unlock()

--- a/cmd/podtrace/normal_mode_unit_test.go
+++ b/cmd/podtrace/normal_mode_unit_test.go
@@ -29,7 +29,7 @@ func TestRunNormalModeWithSource_ConsumesEventsThenReturnsOnCancel(t *testing.T)
 	reporter := &fakeProfilingReporter{}
 	done := make(chan error, 1)
 	go func() {
-		done <- runNormalModeWithSource(ctx, ch, nil, nil, nil, nil, false, nil, reporter)
+		done <- runNormalModeWithSource(ctx, ch, nil, nil, nil, nil, reporter)
 	}()
 
 	time.Sleep(50 * time.Millisecond)
@@ -58,7 +58,7 @@ func TestRunNormalMode_WrapperReturnsOnCancel(t *testing.T) {
 	podInfo := &kubernetes.PodInfo{PodName: "p", Namespace: "default"}
 	done := make(chan error, 1)
 	go func() {
-		done <- runNormalMode(ctx, ch, podInfo, nil, nil, nil, false)
+		done <- runNormalMode(ctx, ch, podInfo, nil, nil)
 	}()
 
 	cancel()

--- a/cmd/podtrace/session_sink.go
+++ b/cmd/podtrace/session_sink.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gma1k/podtrace/internal/diagnose"
 	"github.com/gma1k/podtrace/internal/hostfs"
 	"github.com/gma1k/podtrace/internal/logger"
+	"github.com/gma1k/podtrace/internal/redactor"
 	"go.uber.org/zap"
 )
 
@@ -179,16 +180,22 @@ func writeTerminationMessage(path string, summary SessionSummary) error {
 	return writeArtifactFile(path, data, 0o600)
 }
 
-// objectStoreReportFile is the on-disk handoff path between the main
-// session container and the report-uploader sidecar. A var, not a const,
-// so tests can redirect it. Lives in a pod-private emptyDir.
 var objectStoreReportFile = "/var/run/podtrace/report.txt"
 
+// redactReportText scrubs the rendered report before it is persisted to any
+// sink.
+func redactReportText(reportText string) string {
+	red, err := redactor.DefaultWithCustomRules(config.RedactCustomRules)
+	if err != nil {
+		logger.Warn("custom redaction rules invalid; redacting report with defaults only", zap.Error(err))
+	}
+	return red.RedactText(reportText)
+}
+
 func uploadReport(ctx context.Context, spec, reportText string) error {
+	reportText = redactReportText(reportText)
 	if strings.Contains(spec, "://") {
-		// 0644 (other-readable) is required, not lax: the main container runs
-		// as root but the report-uploader sidecar is the distroless nonroot
-		// user, and it must read this file over the shared emptyDir.
+
 		if err := hostfs.WriteFileAtomic(objectStoreReportFile, []byte(reportText), 0o644); err != nil {
 			return fmt.Errorf("write report file for sidecar: %w", err)
 		}

--- a/cmd/podtrace/session_sink_redaction_test.go
+++ b/cmd/podtrace/session_sink_redaction_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/config"
+)
+
+func TestRedactReportText_ScrubsSecretsBeforeSink(t *testing.T) {
+	report := strings.Join([]string{
+		"=== Diagnostic Report ===",
+		"Top URLs:",
+		"  - /login?token=SUPERSECRET",
+		"Captured headers:",
+		"  Cookie: sid=deadbeef",
+		"  Authorization: Bearer AAA.BBB.CCC",
+	}, "\n")
+
+	got := redactReportText(report)
+
+	for _, leak := range []string{"SUPERSECRET", "deadbeef", "AAA.BBB.CCC"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("report reached the sink with %q unredacted:\n%s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "Diagnostic Report") {
+		t.Errorf("redaction destroyed report structure:\n%s", got)
+	}
+}
+
+func TestRedactReportText_InvalidCustomRulesStillRedactsWithDefaults(t *testing.T) {
+	orig := config.RedactCustomRules
+	config.RedactCustomRules = `[{"name":"bad","pattern":"([","replace":"x"}]`
+	defer func() { config.RedactCustomRules = orig }()
+
+	got := redactReportText("Cookie: sid=deadbeef")
+	if strings.Contains(got, "deadbeef") {
+		t.Errorf("invalid custom rules must fall back to default redaction, got %q", got)
+	}
+}

--- a/deploy/charts/podtrace/templates/_helpers.tpl
+++ b/deploy/charts/podtrace/templates/_helpers.tpl
@@ -58,10 +58,17 @@ all live here regardless of the Helm release namespace.
 {{- end }}
 
 {{/*
-Resolved container image reference (repository:tag).
+Resolved container image reference. Prefers an immutable digest when
+image.digest is set (repository@sha256:...); otherwise falls back to
+repository:tag. Pinning by digest closes the mutable-tag supply-chain gap for
+the root+CAP_SYS_ADMIN workload.
 */}}
 {{- define "podtrace.image" -}}
 {{- $repo := .Values.image.repository -}}
-{{- $tag  := default .Chart.AppVersion .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repo .Values.image.digest -}}
+{{- else -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
 {{- end }}

--- a/deploy/charts/podtrace/templates/networkpolicy.yaml
+++ b/deploy/charts/podtrace/templates/networkpolicy.yaml
@@ -25,4 +25,33 @@ spec:
       from:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "podtrace.fullname" . }}-operator
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "podtrace.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: health
+          protocol: TCP
+        - port: webhook
+          protocol: TCP
+    - ports:
+        - port: metrics
+          protocol: TCP
+      {{- with .Values.networkPolicy.metricsFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/deploy/charts/podtrace/templates/operator-deployment.yaml
+++ b/deploy/charts/podtrace/templates/operator-deployment.yaml
@@ -38,6 +38,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
         fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: operator
           image: {{ include "podtrace.image" . }}

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -30,6 +30,11 @@ crds:
 image:
   repository: ghcr.io/gma1k/podtrace
   tag: ""
+  # digest pins the image immutably (e.g. "sha256:abc..."). When set it takes
+  # precedence over tag for every podtrace workload, including the agent
+  # DaemonSet bootstrapped from PODTRACE_BOOTSTRAP_IMAGE. Released digests are
+  # published with each chart version.
+  digest: ""
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -127,6 +132,10 @@ metrics:
     interval: 30s
     path: /metrics
 
+# Opt-in ingress NetworkPolicies for the agent and operator pods (metrics/health,
+# plus webhook for the operator). metricsFrom gates only the metrics port; empty
+# allows any source. Health/webhook stay open so probes and admission are never
+# blocked. Requires a CNI that enforces NetworkPolicy.
 networkPolicy:
   enabled: false
   metricsFrom: []

--- a/internal/hostfs/hostfs.go
+++ b/internal/hostfs/hostfs.go
@@ -27,14 +27,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
-// ErrInvalidPath is returned when the supplied path is not absolute or
-// contains a ".." element.
 var ErrInvalidPath = errors.New("hostfs: path must be absolute and contain no '..' elements")
 
-// ErrUnsafeMode is returned by the write helpers when the requested mode
-// grants write permission to group or other.
 var ErrUnsafeMode = errors.New("hostfs: refusing to write with a group/other-writable mode")
 
 func validate(path string) error {
@@ -105,7 +102,15 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 	if perm&0o022 != 0 {
 		return fmt.Errorf("%w: %#o (%s)", ErrUnsafeMode, perm, path)
 	}
-	return os.WriteFile(path, data, perm) // #nosec G304,G306 -- path validated absolute/no-"..", mode asserted non-group/other-writable above; some handoffs pass 0644 so a nonroot sidecar can read a root-written file over a pod-private emptyDir.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- path validated absolute/no-".."; mode asserted non-group/other-writable above; O_NOFOLLOW blocks symlink redirection; some handoffs pass 0644 so a nonroot sidecar can read a root-written file over a pod-private emptyDir.
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write(data)
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	return werr
 }
 
 // ErrOutsideBase is returned by WriteFileWithin when the target path

--- a/internal/hostfs/hostfs_open_write_test.go
+++ b/internal/hostfs/hostfs_open_write_test.go
@@ -70,3 +70,46 @@ func TestWriteFileAtomic_RenameFailureCleansTemp(t *testing.T) {
 		t.Errorf("temp file must be removed after a rename failure, stat err = %v", statErr)
 	}
 }
+
+func TestWriteFile_RefusesSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret")
+	if err := os.WriteFile(secret, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "artifact")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := WriteFile(link, []byte("redirected"), 0o600)
+	if err == nil {
+		t.Fatal("WriteFile through a symlink must be refused")
+	}
+
+	got, rerr := os.ReadFile(secret)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(got) != "original" {
+		t.Errorf("symlink target was overwritten: %q", got)
+	}
+}
+
+func TestWriteFile_PlainFileRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.txt")
+	if err := WriteFile(path, []byte("first"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := WriteFile(path, []byte("second"), 0o600); err != nil {
+		t.Fatalf("WriteFile overwrite: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "second" {
+		t.Errorf("content = %q, want %q", got, "second")
+	}
+}

--- a/internal/kubernetes/nodespawn/pod_spec.go
+++ b/internal/kubernetes/nodespawn/pod_spec.go
@@ -69,7 +69,7 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("nodespawn: Image is required")
 	}
 
-	priv := true
+	priv := false
 	runAsRoot := int64(0)
 
 	suffix, err := randomSuffix()
@@ -154,10 +154,12 @@ func BuildPodSpec(opts PodSpecOptions) (*corev1.Pod, error) {
 		TTY:                      false,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: &priv,
-			RunAsUser:  &runAsRoot,
+			Privileged:               &priv,
+			RunAsUser:                &runAsRoot,
+			AllowPrivilegeEscalation: ptrBool(false),
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN"},
+				Add: []corev1.Capability{"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN", "SYS_PTRACE"},
 			},
 		},
 		VolumeMounts: mounts,
@@ -255,7 +257,9 @@ func sanitizeLabelValue(s string) string {
 	return out
 }
 
-func randomSuffix() (string, error) {
+// randomSuffix is a var so tests can force its (otherwise unreachable)
+// crypto/rand error path.
+var randomSuffix = func() (string, error) {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		return "", fmt.Errorf("nodespawn: random suffix: %w", err)

--- a/internal/kubernetes/nodespawn/pod_spec_test.go
+++ b/internal/kubernetes/nodespawn/pod_spec_test.go
@@ -1,6 +1,7 @@
 package nodespawn
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -68,6 +69,24 @@ func TestBuildPodSpec_NodeNameSanitized(t *testing.T) {
 	}
 }
 
+func TestBuildPodSpec_RequiresImage(t *testing.T) {
+	o := baseOpts()
+	o.Image = ""
+	if _, err := BuildPodSpec(o); err == nil {
+		t.Fatal("BuildPodSpec must require a non-empty Image")
+	}
+}
+
+func TestBuildPodSpec_PropagatesSuffixError(t *testing.T) {
+	orig := randomSuffix
+	defer func() { randomSuffix = orig }()
+	randomSuffix = func() (string, error) { return "", errors.New("boom") }
+
+	if _, err := BuildPodSpec(baseOpts()); err == nil {
+		t.Fatal("BuildPodSpec must propagate a randomSuffix error")
+	}
+}
+
 func TestBuildPodSpec_SecurityContext(t *testing.T) {
 	got, err := BuildPodSpec(baseOpts())
 	if err != nil {
@@ -76,12 +95,18 @@ func TestBuildPodSpec_SecurityContext(t *testing.T) {
 	if !got.Spec.HostPID {
 		t.Errorf("expected HostPID=true")
 	}
-	if got.Spec.Containers[0].SecurityContext.Privileged == nil || !*got.Spec.Containers[0].SecurityContext.Privileged {
-		t.Errorf("expected privileged container")
+	sc := got.Spec.Containers[0].SecurityContext
+	if sc.Privileged == nil || *sc.Privileged {
+		t.Errorf("expected non-privileged container (capabilities suffice, matching the DaemonSet/session Job)")
 	}
-	caps := got.Spec.Containers[0].SecurityContext.Capabilities.Add
-	wantCaps := map[string]bool{"BPF": true, "SYS_ADMIN": true, "PERFMON": true, "SYS_RESOURCE": true, "NET_ADMIN": true}
-	for _, c := range caps {
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Errorf("expected AllowPrivilegeEscalation=false")
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("expected seccompProfile RuntimeDefault, got %+v", sc.SeccompProfile)
+	}
+	wantCaps := map[string]bool{"BPF": true, "SYS_ADMIN": true, "PERFMON": true, "SYS_RESOURCE": true, "NET_ADMIN": true, "SYS_PTRACE": true}
+	for _, c := range sc.Capabilities.Add {
 		delete(wantCaps, string(c))
 	}
 	if len(wantCaps) > 0 {

--- a/internal/kubernetes/nodespawn/run.go
+++ b/internal/kubernetes/nodespawn/run.go
@@ -321,6 +321,8 @@ var dumpPodLogs = func(ctx context.Context, clientset kubernetes.Interface, name
 
 func ptrInt64(v int64) *int64 { return &v }
 
+func ptrBool(b bool) *bool { return &b }
+
 // ExitError carries a non-zero exit code from a spawned pod so the CLI can
 // propagate the same code to its caller.
 type ExitError struct {

--- a/internal/metricsexporter/filtered_event_drop_test.go
+++ b/internal/metricsexporter/filtered_event_drop_test.go
@@ -24,3 +24,14 @@ func TestRecordFilteredEventDrop_DoesNotTouchRingBufferCounter(t *testing.T) {
 		t.Errorf("ring-buffer drop counter changed by %v, want 0 (distinct failure mode)", after-before)
 	}
 }
+
+func TestRecordTeeAuxDrop_IncrementsCounter(t *testing.T) {
+	before := testutil.ToFloat64(teeAuxDropsCounter)
+	RecordTeeAuxDrop()
+	RecordTeeAuxDrop()
+	RecordTeeAuxDrop()
+	after := testutil.ToFloat64(teeAuxDropsCounter)
+	if after-before != 3 {
+		t.Errorf("teeAuxDropsCounter delta = %v, want 3", after-before)
+	}
+}

--- a/internal/metricsexporter/promexporter.go
+++ b/internal/metricsexporter/promexporter.go
@@ -142,6 +142,13 @@ var (
 		},
 	)
 
+	teeAuxDropsCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "podtrace_event_tee_aux_drops_total",
+			Help: "Total events dropped for a secondary consumer (metrics/tracing/profiling) because its fan-out channel was full. A non-zero rate means those consumers undercount relative to the primary diagnose report.",
+		},
+	)
+
 	processCacheHitsCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "podtrace_process_cache_hits_total",
@@ -410,6 +417,7 @@ func init() {
 	prometheus.MustRegister(ringBufferDropsCounter)
 	prometheus.MustRegister(dnsDropsCounter)
 	prometheus.MustRegister(filteredEventDropsCounter)
+	prometheus.MustRegister(teeAuxDropsCounter)
 	prometheus.MustRegister(processCacheHitsCounter)
 	prometheus.MustRegister(processCacheMissesCounter)
 	prometheus.MustRegister(pidCacheHitsCounter)
@@ -744,6 +752,10 @@ func RecordRingBufferDrop() {
 // a kernel ring-buffer drop and must not inflate that metric.
 func RecordFilteredEventDrop() {
 	filteredEventDropsCounter.Inc()
+}
+
+func RecordTeeAuxDrop() {
+	teeAuxDropsCounter.Inc()
 }
 
 func AddDNSDrops(delta uint64) {

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -154,8 +154,10 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: &priv,
-			RunAsUser:  &runAsRoot,
+			Privileged:               &priv,
+			RunAsUser:                &runAsRoot,
+			AllowPrivilegeEscalation: boolPtr(false),
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN", "SYS_PTRACE"},
 			},
@@ -244,6 +246,14 @@ func buildSessionSidecar(enabled bool, reportTo, image string, pullPolicy corev1
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		VolumeMounts:             mounts,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot:             boolPtr(true),
+			RunAsUser:                ptrInt64(65532),
+			AllowPrivilegeEscalation: boolPtr(false),
+			ReadOnlyRootFilesystem:   boolPtr(true),
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
 	}}
 }
 

--- a/internal/operator/session_securitycontext_test.go
+++ b/internal/operator/session_securitycontext_test.go
@@ -1,0 +1,73 @@
+package operator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func TestBuildSessionJobSpec_MainContainerHardened(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	spec := buildSessionJobSpec(minimalSession(), tc, "node-a", sessionTargets{})
+	sc := spec.Template.Spec.Containers[0].SecurityContext
+
+	if sc == nil {
+		t.Fatal("main container SecurityContext is nil")
+	}
+	if sc.Privileged != nil && *sc.Privileged {
+		t.Error("session main container must not be privileged (caps-only)")
+	}
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Error("session main container must set allowPrivilegeEscalation=false")
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("session main container must set seccompProfile RuntimeDefault, got %+v", sc.SeccompProfile)
+	}
+}
+
+func TestBuildSessionJobSpec_ReportUploaderSidecarLockedDown(t *testing.T) {
+	tc := &podtracev1alpha1.TracerConfig{
+		Spec: podtracev1alpha1.TracerConfigSpec{
+			Image:   "ghcr.io/gma1k/podtrace:test",
+			Session: podtracev1alpha1.SessionRuntimeSpec{SidecarUploader: true},
+		},
+	}
+	s := minimalSession()
+	s.Spec.ReportRef = &podtracev1alpha1.ReportReference{
+		ConfigMap: &corev1.LocalObjectReference{Name: "rep"},
+	}
+	spec := buildSessionJobSpec(s, tc, "node-a", sessionTargets{})
+
+	var sidecar *corev1.Container
+	for i := range spec.Template.Spec.InitContainers {
+		if spec.Template.Spec.InitContainers[i].Name == "report-uploader" {
+			sidecar = &spec.Template.Spec.InitContainers[i]
+		}
+	}
+	if sidecar == nil {
+		t.Fatal("report-uploader sidecar not found")
+	}
+	sc := sidecar.SecurityContext
+	if sc == nil {
+		t.Fatal("report-uploader sidecar has no SecurityContext")
+	}
+	if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		t.Error("sidecar must set runAsNonRoot=true")
+	}
+	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		t.Error("sidecar must set allowPrivilegeEscalation=false")
+	}
+	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Error("sidecar must set readOnlyRootFilesystem=true")
+	}
+	if sc.SeccompProfile == nil || sc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("sidecar must set seccompProfile RuntimeDefault, got %+v", sc.SeccompProfile)
+	}
+	if sc.Capabilities == nil || len(sc.Capabilities.Drop) == 0 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("sidecar must drop ALL capabilities, got %+v", sc.Capabilities)
+	}
+}

--- a/internal/operator/tracerconfig_daemonset.go
+++ b/internal/operator/tracerconfig_daemonset.go
@@ -127,8 +127,10 @@ func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string)
 					Env:             env,
 					Resources:       tc.Spec.Agent.Resources,
 					SecurityContext: &corev1.SecurityContext{
-						Privileged: &priv,
-						RunAsUser:  &runAsRoot,
+						Privileged:               &priv,
+						RunAsUser:                &runAsRoot,
+						AllowPrivilegeEscalation: boolPtr(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{
 								"BPF", "SYS_ADMIN", "PERFMON", "SYS_RESOURCE", "NET_ADMIN", "SYS_PTRACE",
@@ -185,6 +187,8 @@ func mountPropagationHostToContainer() *corev1.MountPropagationMode {
 }
 
 func ptrInt64(v int64) *int64 { return &v }
+
+func boolPtr(b bool) *bool { return &b }
 func itoa(n int) string       { return strconv.Itoa(n) }
 
 // intstrFromString returns an IntOrString whose StrVal names a port by

--- a/internal/operator/tracerconfig_daemonset_test.go
+++ b/internal/operator/tracerconfig_daemonset_test.go
@@ -23,9 +23,6 @@ func tc(mod func(*podtracev1alpha1.TracerConfig)) *podtracev1alpha1.TracerConfig
 }
 
 func TestBuildAgentDaemonSetSpec_SelectorStability(t *testing.T) {
-	// The DaemonSet selector is IMMUTABLE after creation — agent pods
-	// would orphan themselves if it changed. Lock in the key labels the
-	// selector depends on.
 	spec := buildAgentDaemonSetSpec(tc(nil), "podtrace-system")
 	want := map[string]string{
 		LabelManagedBy:    ManagedByValue,
@@ -55,6 +52,12 @@ func TestBuildAgentDaemonSetSpec_CapabilitiesNotPrivileged(t *testing.T) {
 	}
 	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
 		t.Error("agent must run as root (user 0)")
+	}
+	if c.SecurityContext.AllowPrivilegeEscalation == nil || *c.SecurityContext.AllowPrivilegeEscalation {
+		t.Error("agent must set allowPrivilegeEscalation=false")
+	}
+	if c.SecurityContext.SeccompProfile == nil || c.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Errorf("agent must set seccompProfile RuntimeDefault, got %+v", c.SecurityContext.SeccompProfile)
 	}
 	wantCaps := map[corev1.Capability]bool{
 		"BPF": false, "SYS_ADMIN": false, "PERFMON": false, "SYS_RESOURCE": false, "NET_ADMIN": false,
@@ -153,7 +156,6 @@ func TestBuildAgentDaemonSetSpec_PriorityClassDefault(t *testing.T) {
 	if spec.Template.Spec.PriorityClassName != "system-node-critical" {
 		t.Errorf("priorityClassName=%q want system-node-critical", spec.Template.Spec.PriorityClassName)
 	}
-	// Explicit override wins.
 	spec = buildAgentDaemonSetSpec(tc(func(x *podtracev1alpha1.TracerConfig) {
 		x.Spec.Agent.PriorityClassName = "podtrace-high"
 	}), "podtrace-system")

--- a/internal/redactor/redact_text_test.go
+++ b/internal/redactor/redact_text_test.go
@@ -1,0 +1,27 @@
+package redactor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactText_ScrubsSensitivePatterns(t *testing.T) {
+	in := "GET /api?token=SECRET123 HTTP/1.1\nCookie: session=abcdef\nAuthorization: Bearer XYZ.abc\ncontact foo@bar.com"
+	got := Default().RedactText(in)
+
+	for _, leak := range []string{"SECRET123", "abcdef", "XYZ.abc", "foo@bar.com"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("RedactText leaked %q: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "GET /api") {
+		t.Errorf("RedactText destroyed surrounding non-sensitive text: %s", got)
+	}
+}
+
+func TestRedactText_NoSensitiveDataIsUnchanged(t *testing.T) {
+	in := "Total events: 1494\nEvents per second: 49.8\n"
+	if got := Default().RedactText(in); got != in {
+		t.Errorf("RedactText(%q) = %q, want unchanged", in, got)
+	}
+}

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -105,6 +105,13 @@ func (r *Redactor) Redact(e *events.Event) {
 	}
 }
 
+func (r *Redactor) RedactText(s string) string {
+	for _, rule := range r.rules {
+		s = rule.Pattern.ReplaceAllString(s, rule.Replace)
+	}
+	return s
+}
+
 // credentialKeyNames is the single source of truth for the key names whose
 // values are treated as secrets, shared by the key=value, JSON, and YAML
 // rules so coverage cannot drift between formats.


### PR DESCRIPTION
## Summary
Security and correctness batch across the CLI, session sink, operator, and chart.

## Fixes
- Add the missing --filter usdt switch case so USDT captures are no longer silently discarded.
- Count and log auxiliary event-tee drops so metrics/tracing undercount is visible.
- Open artifact writes with O_NOFOLLOW so a pre-planted symlink cannot redirect them.
- Always redact the diagnostic report before it is persisted to a ConfigMap, Secret, or object store, independent of the live-event redaction toggle, honoring custom rules.
- Ship an opt-in NetworkPolicy for the operator (metrics gated; health and webhook always reachable).
- Add seccompProfile and allowPrivilegeEscalation:false to the privileged eBPF pod specs, fully lock down the report-uploader sidecar, and set seccompProfile on the operator.
- Run the CLI node-spawn pod as non-privileged with capabilities (adding SYS_PTRACE), matching the DaemonSet and session Job.
- Support pinning the chart image by digest via image.digest.