### PR TITLE
fix: harden L7 decoders, redaction, alerting, and CLI lifecycle

### DIFF
--- a/cmd/podtrace/main.go
+++ b/cmd/podtrace/main.go
@@ -189,6 +189,9 @@ func main() {
 // applyTracingFlags copies the --tracing-* flag values into the process-
 // global config knobs.
 func applyTracingFlags(cmd *cobra.Command) error {
+	if config.TracingEnabled {
+		enableTracing = true
+	}
 	if !enableTracing {
 		return nil
 	}
@@ -217,6 +220,8 @@ func applyTracingFlags(cmd *cobra.Command) error {
 	}
 	return nil
 }
+
+const secondSignalGracePeriod = 3 * time.Second
 
 func runPodtrace(cmd *cobra.Command, args []string) error {
 	if showVersion {
@@ -379,7 +384,11 @@ func runPodtrace(cmd *cobra.Command, args []string) error {
 		}
 		select {
 		case <-sigChan:
-			_, _ = fmt.Fprintln(os.Stderr, "second interrupt — exiting immediately")
+			_, _ = fmt.Fprintln(os.Stderr, "second interrupt — finishing up (up to 3s) then exiting")
+			select {
+			case <-handlerDone:
+			case <-time.After(secondSignalGracePeriod):
+			}
 			logger.Sync()
 			exitFunc(130)
 		case <-handlerDone:

--- a/cmd/podtrace/tracing_flags_unit_test.go
+++ b/cmd/podtrace/tracing_flags_unit_test.go
@@ -107,6 +107,25 @@ func TestApplyTracingFlags_InvalidSampleRateErrors(t *testing.T) {
 	}
 }
 
+func TestApplyTracingFlags_EnvMasterSwitchEnablesGate(t *testing.T) {
+	restoreTracingFlagGlobals(t)
+	defer resetTracingConfig()
+
+	cmd := newTracingFlagsCommand()
+	enableTracing = false
+	config.TracingEnabled = true
+
+	if err := applyTracingFlags(cmd); err != nil {
+		t.Fatalf("applyTracingFlags: %v", err)
+	}
+	if !enableTracing {
+		t.Error("PODTRACE_TRACING_ENABLED must bridge into the flag gate so the CLI tracing manager is actually started/fed/shut down")
+	}
+	if !config.TracingEnabled {
+		t.Error("TracingEnabled must remain true")
+	}
+}
+
 func TestApplyTracingFlags_DisabledIsNoOp(t *testing.T) {
 	restoreTracingFlagGlobals(t)
 	defer resetTracingConfig()

--- a/internal/alerting/backoff_test.go
+++ b/internal/alerting/backoff_test.go
@@ -1,0 +1,32 @@
+package alerting
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCappedBackoff_NeverNegativeOrOverCap(t *testing.T) {
+	base := time.Second
+	for attempt := 1; attempt <= 1000; attempt++ {
+		b := cappedBackoff(base, attempt)
+		if b < 0 {
+			t.Fatalf("attempt %d produced a negative backoff %v (overflow)", attempt, b)
+		}
+		if b > maxAlertBackoff {
+			t.Fatalf("attempt %d produced %v, exceeding the %v cap", attempt, b, maxAlertBackoff)
+		}
+	}
+}
+
+func TestCappedBackoff_ExponentialThenCapped(t *testing.T) {
+	base := time.Second
+	if got := cappedBackoff(base, 1); got != time.Second {
+		t.Errorf("attempt 1 = %v, want 1s", got)
+	}
+	if got := cappedBackoff(base, 3); got != 4*time.Second {
+		t.Errorf("attempt 3 = %v, want 4s", got)
+	}
+	if got := cappedBackoff(base, 40); got != maxAlertBackoff {
+		t.Errorf("attempt 40 = %v, want the %v cap (not a wrapped negative)", got, maxAlertBackoff)
+	}
+}

--- a/internal/alerting/manager.go
+++ b/internal/alerting/manager.go
@@ -39,20 +39,11 @@ type Manager struct {
 	wg            sync.WaitGroup
 }
 
-// deliveryBudget is the per-alert deadline handed to each sender. It must
-// cover the sender's full retry schedule — maxRetries+1 attempts, each up
-// to the HTTP timeout, plus the exponential backoff sleeps between them —
-// or the deadline expires mid-schedule and the configured retries are
-// dead config. (The previous 2×HTTP-timeout budget allowed roughly one
-// retry of the default schedule.)
+// deliveryBudget is the per-alert deadline handed to each sender.
 func deliveryBudget() time.Duration {
 	budget := time.Duration(config.AlertMaxRetries+1) * config.AlertHTTPTimeout
 	for attempt := 1; attempt <= config.AlertMaxRetries; attempt++ {
-		backoff := config.DefaultAlertRetryBackoffBase * time.Duration(1<<uint(attempt-1))
-		if backoff > 30*time.Second {
-			backoff = 30 * time.Second
-		}
-		budget += backoff
+		budget += cappedBackoff(config.DefaultAlertRetryBackoffBase, attempt)
 	}
 	return budget + 5*time.Second
 }

--- a/internal/alerting/sender.go
+++ b/internal/alerting/sender.go
@@ -26,6 +26,24 @@ func NewRetrySender(sender Sender, maxRetries int, backoffBase time.Duration) *R
 	}
 }
 
+const maxAlertBackoff = 30 * time.Second
+
+// cappedBackoff returns base * 2^(attempt-1) capped at maxAlertBackoff.
+// attempt is 1-based.
+func cappedBackoff(base time.Duration, attempt int) time.Duration {
+	backoff := base
+	for i := 1; i < attempt; i++ {
+		if backoff >= maxAlertBackoff {
+			return maxAlertBackoff
+		}
+		backoff *= 2
+	}
+	if backoff <= 0 || backoff > maxAlertBackoff {
+		return maxAlertBackoff
+	}
+	return backoff
+}
+
 func (rs *RetrySender) Send(ctx context.Context, alert *Alert) error {
 	if alert == nil {
 		return fmt.Errorf("alert is nil")
@@ -37,10 +55,7 @@ func (rs *RetrySender) Send(ctx context.Context, alert *Alert) error {
 	var lastErr error
 	for attempt := 0; attempt <= rs.maxRetries; attempt++ {
 		if attempt > 0 {
-			backoff := rs.backoffBase * time.Duration(1<<uint(attempt-1))
-			if backoff > 30*time.Second {
-				backoff = 30 * time.Second
-			}
+			backoff := cappedBackoff(rs.backoffBase, attempt)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -62,5 +77,3 @@ func (rs *RetrySender) Send(ctx context.Context, alert *Alert) error {
 func (rs *RetrySender) Name() string {
 	return rs.sender.Name()
 }
-
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ const (
 	DefaultAlertDedupWindow      = 5 * time.Minute
 	DefaultAlertRateLimitPerMin  = 10
 	DefaultAlertMaxRetries       = 3
+	MaxAlertRetries              = 20
 	DefaultAlertRetryBackoffBase = 1 * time.Second
 	DefaultAlertMaxPayloadSize   = 1024 * 1024
 )
@@ -79,7 +80,7 @@ var (
 	AlertDeduplicationWindow  = getDurationEnvOrDefault("PODTRACE_ALERT_DEDUP_WINDOW", DefaultAlertDedupWindow)
 	AlertRateLimitPerMinute   = getIntEnvOrDefault("PODTRACE_ALERT_RATE_LIMIT", DefaultAlertRateLimitPerMin)
 	AlertHTTPTimeout          = getDurationEnvOrDefault("PODTRACE_ALERT_HTTP_TIMEOUT", DefaultAlertHTTPTimeout)
-	AlertMaxRetries           = getIntEnvOrDefault("PODTRACE_ALERT_MAX_RETRIES", DefaultAlertMaxRetries)
+	AlertMaxRetries           = min(getIntEnvOrDefault("PODTRACE_ALERT_MAX_RETRIES", DefaultAlertMaxRetries), MaxAlertRetries)
 	AlertMaxPayloadSize       = getInt64EnvOrDefault("PODTRACE_ALERT_MAX_PAYLOAD_SIZE", DefaultAlertMaxPayloadSize)
 	K8sAPITimeout             = getDurationEnvOrDefault("PODTRACE_K8S_API_TIMEOUT", DefaultK8sAPITimeout)
 	BatchProcessingInterval   = getDurationEnvOrDefault("PODTRACE_BATCH_INTERVAL", DefaultBatchProcessingInterval)

--- a/internal/ebpf/h2decode/decode.go
+++ b/internal/ebpf/h2decode/decode.go
@@ -126,13 +126,14 @@ type streamKey struct {
 
 // dirState is the ordered decode state for one (connection, direction).
 type dirState struct {
-	dec      *lateJoinDecoder
-	role     uint8
-	nextSeq  uint32
-	pending  map[uint32]*RawRecord
-	asm      []byte
-	lastSeen time.Time
-	stalled  time.Time
+	dec        *lateJoinDecoder
+	role       uint8
+	nextSeq    uint32
+	pending    map[uint32]*RawRecord
+	asm        []byte
+	lastSeen   time.Time
+	stalled    time.Time
+	discarding bool
 }
 
 // pendingReq is a request awaiting its response, for latency + endpoint stitching.
@@ -249,10 +250,21 @@ func (d *Decoder) drainLocked(st *dirState) []*events.Event {
 		st.nextSeq++
 		st.stalled = time.Time{}
 
+		if st.discarding {
+			if rec.endHeaders() {
+				st.discarding = false
+			}
+			continue
+		}
+
 		st.asm = append(st.asm, rec.Frag...)
 		if len(st.asm) > d.maxAssembly {
 			st.asm = nil
 			d.decodeErrors++
+			st.dec.resetEpoch()
+			if !rec.endHeaders() {
+				st.discarding = true
+			}
 			continue
 		}
 		if !rec.endHeaders() {
@@ -486,6 +498,9 @@ func (d *Decoder) skipGapLocked(st *dirState) {
 		return
 	}
 	st.nextSeq = lowest
+	if len(st.asm) > 0 {
+		st.discarding = true
+	}
 	st.asm = nil
 	st.stalled = time.Time{}
 	st.dec.resetEpoch()

--- a/internal/ebpf/h2decode/oversize_discard_test.go
+++ b/internal/ebpf/h2decode/oversize_discard_test.go
@@ -1,0 +1,53 @@
+package h2decode
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestDrain_OversizeDropDiscardsRestOfBlock(t *testing.T) {
+	d := New()
+	d.maxAssembly = 64
+
+	frag1 := rec(1, 0, 0, 1, bytes.Repeat([]byte{0x00}, 200))
+	frag1.Flags = 0
+	frag1.FragLen = uint16(len(frag1.Frag))
+	if evs := d.Ingest(frag1); len(evs) != 0 {
+		t.Fatalf("oversize partial fragment must emit nothing, got %d", len(evs))
+	}
+
+	tail := newBlockEncoder().encode(reqFields("GET", "/injected")...)
+	if evs := d.Ingest(rec(1, 0, 1, 1, tail)); len(evs) != 0 {
+		t.Fatalf("a CONTINUATION tail after an oversize drop must be discarded, not decoded as a fresh block; got %d fabricated events: %+v", len(evs), evs)
+	}
+
+	fresh := newBlockEncoder().encode(reqFields("GET", "/real")...)
+	if evs := d.Ingest(rec(1, 0, 2, 3, fresh)); len(evs) != 1 {
+		t.Fatalf("a genuine fresh block after recovery must still decode (discarding must clear), got %d", len(evs))
+	}
+}
+
+func TestSkipGap_MidBlockDiscardsRestOfBlock(t *testing.T) {
+	d := New()
+	base := time.Unix(1000, 0)
+	now := base
+	d.nowFn = func() time.Time { return now }
+
+	partial := rec(1, 0, 0, 1, newBlockEncoder().encode(reqFields("GET", "/partial")...))
+	partial.Flags = 0
+	partial.FragLen = uint16(len(partial.Frag))
+	if evs := d.Ingest(partial); len(evs) != 0 {
+		t.Fatalf("mid-block partial must emit nothing, got %d", len(evs))
+	}
+
+	// seq 1 is lost; seq 2 (a decodable block) stalls behind the gap.
+	if evs := d.Ingest(rec(1, 0, 2, 1, newBlockEncoder().encode(reqFields("GET", "/injected")...))); len(evs) != 0 {
+		t.Fatalf("seq2 must stall behind the seq1 gap, got %d", len(evs))
+	}
+
+	now = base.Add(d.gapTimeout + time.Second)
+	if evs := d.Sweep(); len(evs) != 0 {
+		t.Fatalf("after a mid-block gap skip, the tail must be discarded, not decoded as a fresh block; got %d fabricated events: %+v", len(evs), evs)
+	}
+}

--- a/internal/ebpf/qpackdecode/postbase_overflow_test.go
+++ b/internal/ebpf/qpackdecode/postbase_overflow_test.go
@@ -1,0 +1,25 @@
+package qpackdecode
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPostBaseOverflows(t *testing.T) {
+	cases := []struct {
+		base, index uint64
+		want        bool
+	}{
+		{1, 2, false},
+		{0, math.MaxUint64, false},
+		{math.MaxUint64, 0, false},
+		{math.MaxUint64, 1, true},
+		{1 << 63, 1 << 63, true},
+		{1 << 63, (1 << 63) - 1, false},
+	}
+	for _, c := range cases {
+		if got := postBaseOverflows(c.base, c.index); got != c.want {
+			t.Errorf("postBaseOverflows(%d,%d)=%v want %v", c.base, c.index, got, c.want)
+		}
+	}
+}

--- a/internal/ebpf/qpackdecode/qpackdecode.go
+++ b/internal/ebpf/qpackdecode/qpackdecode.go
@@ -5,11 +5,16 @@ package qpackdecode
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"golang.org/x/net/http2/hpack"
 
 	"github.com/gma1k/podtrace/internal/safeconv"
 )
+
+func postBaseOverflows(base, index uint64) bool {
+	return base > math.MaxUint64-index
+}
 
 // HeaderField is one decoded name/value pair.
 type HeaderField struct {
@@ -294,6 +299,12 @@ func (d *Decoder) decodeFieldSection(p []byte, bestEffort bool) ([]HeaderField, 
 		}
 		return d.absoluteEntry(absolute)
 	}
+	postBaseEntry := func(index uint64) (tableEntry, error) {
+		if postBaseOverflows(base, index) {
+			return tableEntry{}, fmt.Errorf("qpackdecode: post-base index overflow (base %d, index %d)", base, index)
+		}
+		return dynamicEntry(base+index, baseKnown)
+	}
 
 	for len(p) > 0 {
 		switch b := p[0]; {
@@ -373,7 +384,7 @@ func (d *Decoder) decodeFieldSection(p []byte, bestEffort bool) ([]HeaderField, 
 			if err != nil {
 				return nil, 0, sectionError(err)
 			}
-			entry, lookupErr := dynamicEntry(base+index, baseKnown)
+			entry, lookupErr := postBaseEntry(index)
 			if err := appendEntry(entry, lookupErr); err != nil {
 				return nil, 0, err
 			}
@@ -388,7 +399,7 @@ func (d *Decoder) decodeFieldSection(p []byte, bestEffort bool) ([]HeaderField, 
 			if err != nil {
 				return nil, 0, sectionError(err)
 			}
-			entry, lookupErr := dynamicEntry(base+index, baseKnown)
+			entry, lookupErr := postBaseEntry(index)
 			if lookupErr == nil {
 				fields = append(fields, HeaderField{Name: entry.name, Value: value})
 			} else if bestEffort {

--- a/internal/ebpf/quicinitial/hardening_test.go
+++ b/internal/ebpf/quicinitial/hardening_test.go
@@ -1,0 +1,24 @@
+package quicinitial
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecryptInitial_ScidOutOfRange(t *testing.T) {
+	b := []byte{0xc0, 0x00, 0x00, 0x00, 0x01, 0x02, 0xaa, 0xbb, 0x05}
+	_, _, err := decryptInitial(b)
+	if err == nil || !strings.Contains(err.Error(), "scid") {
+		t.Fatalf("a SCID length past the buffer must be rejected explicitly, got err=%v", err)
+	}
+}
+
+func TestBlock2_BadKeyReturnsError(t *testing.T) {
+	if _, err := block2(make([]byte, 15)); err == nil {
+		t.Fatal("block2 must return an error for an invalid key length instead of a nil cipher")
+	}
+	b, err := block2(make([]byte, 16))
+	if err != nil || b == nil {
+		t.Fatalf("block2 with a valid 16-byte key: block=%v err=%v", b, err)
+	}
+}

--- a/internal/ebpf/quicinitial/quicinitial.go
+++ b/internal/ebpf/quicinitial/quicinitial.go
@@ -241,6 +241,9 @@ func decryptInitial(b []byte) ([]byte, uint32, error) {
 	}
 	scidLen := int(b[p])
 	p++
+	if p+scidLen > len(b) {
+		return nil, 0, fmt.Errorf("scid out of range")
+	}
 	p += scidLen
 	tokenLen, n, ok := readVarint(b, p)
 	if !ok {
@@ -296,7 +299,11 @@ func decryptInitial(b []byte) ([]byte, uint32, error) {
 	for i := 0; i < 8; i++ {
 		nonce[4+i] ^= pnbuf[i]
 	}
-	gcm, err := cipher.NewGCM(block2(keys.Key))
+	block, err = block2(keys.Key)
+	if err != nil {
+		return nil, 0, fmt.Errorf("payload cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -313,9 +320,8 @@ func decryptInitial(b []byte) ([]byte, uint32, error) {
 }
 
 // block2 builds an AES cipher for the GCM key.
-func block2(key []byte) cipher.Block {
-	b, _ := aes.NewCipher(key)
-	return b
+func block2(key []byte) (cipher.Block, error) {
+	return aes.NewCipher(key)
 }
 
 // reassembleCrypto merges the CRYPTO frames (type 0x06) of one or more

--- a/internal/ebpf/quicinitial/quicinitial_test.go
+++ b/internal/ebpf/quicinitial/quicinitial_test.go
@@ -145,7 +145,8 @@ func buildClientInitial(t *testing.T, dcid, hs []byte) []byte {
 
 	nonce := make([]byte, 12)
 	copy(nonce, keys.IV)
-	gcm, err := cipher.NewGCM(block2(keys.Key))
+	blk, _ := block2(keys.Key)
+	gcm, err := cipher.NewGCM(blk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +240,8 @@ func buildClientInitialV(t *testing.T, dcid, hs []byte, version uint32) []byte {
 
 	nonce := make([]byte, 12)
 	copy(nonce, keys.IV)
-	gcm, err := cipher.NewGCM(block2(keys.Key))
+	blk, _ := block2(keys.Key)
+	gcm, err := cipher.NewGCM(blk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +384,8 @@ func buildClientInitialChunk(t *testing.T, dcid, hs []byte, off, n int) []byte {
 
 	nonce := make([]byte, 12)
 	copy(nonce, keys.IV)
-	gcm, err := cipher.NewGCM(block2(keys.Key))
+	blk, _ := block2(keys.Key)
+	gcm, err := cipher.NewGCM(blk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ebpf/tracer/dns_timeout.go
+++ b/internal/ebpf/tracer/dns_timeout.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gma1k/podtrace/internal/logger"
 	"github.com/gma1k/podtrace/internal/metricsexporter"
 	"github.com/gma1k/podtrace/internal/safeconv"
+	"github.com/gma1k/podtrace/internal/sanitize"
+	"github.com/gma1k/podtrace/internal/validation"
 	"go.uber.org/zap"
 )
 
@@ -116,19 +118,12 @@ func (t *Tracer) sweepDNSTimeouts(ctx context.Context, eventChan chan<- *events.
 		if age <= dnsTimeoutThresholdNS {
 			continue
 		}
-		ev := &events.Event{
-			Timestamp:   now,
-			PID:         val.PID,
-			Type:        events.EventDNS,
-			LatencyNS:   age,
-			CgroupID:    key.CgroupID,
-			TCPState:    val.QType,
-			Target:      string(bytes.TrimRight(val.Name[:], "\x00")),
-			Details:     "timeout",
-			ProcessName: string(bytes.TrimRight(val.Comm[:], "\x00")),
-		}
-		if t.piiRedactor != nil {
-			t.piiRedactor.Redact(ev)
+		staleKey = key
+		stale = append(stale, staleKey)
+
+		ev := t.buildDNSTimeoutEvent(key, val, now, age)
+		if ev == nil {
+			continue
 		}
 		select {
 		case <-ctx.Done():
@@ -136,8 +131,6 @@ func (t *Tracer) sweepDNSTimeouts(ctx context.Context, eventChan chan<- *events.
 		case eventChan <- ev:
 		default:
 		}
-		staleKey = key
-		stale = append(stale, staleKey)
 	}
 	if err := iter.Err(); err != nil {
 		logger.Debug("dns_inflight iterate error", zap.Error(err))
@@ -145,4 +138,29 @@ func (t *Tracer) sweepDNSTimeouts(ctx context.Context, eventChan chan<- *events.
 	for i := range stale {
 		_ = m.Delete(&stale[i])
 	}
+}
+
+// buildDNSTimeoutEvent turns one timed-out dns_inflight entry into an event,
+// applying the same protections as the main pipeline.
+func (t *Tracer) buildDNSTimeoutEvent(key dnsFlowKey, val dnsQueryState, now, age uint64) *events.Event {
+	ev := &events.Event{
+		Timestamp:   now,
+		PID:         val.PID,
+		Type:        events.EventDNS,
+		LatencyNS:   age,
+		CgroupID:    key.CgroupID,
+		TCPState:    val.QType,
+		Target:      sanitize.Terminal(string(bytes.TrimRight(val.Name[:], "\x00"))),
+		Details:     "timeout",
+		ProcessName: string(bytes.TrimRight(val.Comm[:], "\x00")),
+	}
+	t.attributeProcessName(ev)
+	ev.ProcessName = validation.SanitizeProcessName(ev.ProcessName)
+	if t.piiRedactor != nil {
+		t.piiRedactor.Redact(ev)
+	}
+	if !t.cgroupAllows(ev) {
+		return nil
+	}
+	return ev
 }

--- a/internal/ebpf/tracer/dns_timeout_cgroup_test.go
+++ b/internal/ebpf/tracer/dns_timeout_cgroup_test.go
@@ -1,0 +1,70 @@
+package tracer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gma1k/podtrace/internal/ebpf/filter"
+	"github.com/gma1k/podtrace/internal/events"
+	"github.com/gma1k/podtrace/internal/redactor"
+)
+
+func TestCgroupAllows_HonorsCgroupIDAllowlist(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	tr.storeCgroupIDs(map[uint64]struct{}{100: {}})
+
+	if !tr.cgroupAllows(&events.Event{CgroupID: 100, PID: 1}) {
+		t.Error("an event whose cgroup is in the allowlist must be allowed")
+	}
+	if tr.cgroupAllows(&events.Event{CgroupID: 200, PID: 1}) {
+		t.Error("an event whose cgroup is NOT in the allowlist must be denied (a --container-narrowed session must not emit sibling-container timeouts)")
+	}
+}
+
+func TestCgroupAllows_NoFilterConfiguredAllowsAll(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	if !tr.cgroupAllows(&events.Event{CgroupID: 7, PID: 1}) {
+		t.Error("with no cgroup filter configured, events must be allowed")
+	}
+}
+
+func TestCgroupAllows_IdleDenyDenies(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	tr.denyWhenNoTargets.Store(true)
+	if tr.cgroupAllows(&events.Event{CgroupID: 7, PID: 1}) {
+		t.Error("with deny-when-no-targets and no targets, events must be denied")
+	}
+}
+
+func TestCgroupAllows_UserspaceFilter(t *testing.T) {
+	tr := &Tracer{filter: filter.NewCgroupFilter()}
+	tr.useUserspaceCgroupFilter.Store(true)
+	tr.filter.SetCgroupPath("/kubepods/podX")
+	if tr.cgroupAllows(&events.Event{CgroupID: 0, PID: 999999}) {
+		t.Error("userspace filter must deny a pid outside the target cgroup")
+	}
+}
+
+func TestBuildDNSTimeoutEvent_SanitizesAndGates(t *testing.T) {
+	tr := newAttributionTestTracer()
+	tr.filter = filter.NewCgroupFilter()
+	tr.piiRedactor = redactor.Default()
+	tr.storeCgroupIDs(map[uint64]struct{}{100: {}})
+
+	var val dnsQueryState
+	copy(val.Name[:], "evil\x1b[31m.example\x00")
+	val.PID = 4242
+
+	allowed := tr.buildDNSTimeoutEvent(dnsFlowKey{CgroupID: 100}, val, 2000, 1000)
+	if allowed == nil {
+		t.Fatal("an event in the cgroup allowlist must be emitted")
+	}
+	if strings.ContainsAny(allowed.Target, "\x1b") {
+		t.Errorf("QNAME must be terminal-sanitized, got %q", allowed.Target)
+	}
+
+	denied := tr.buildDNSTimeoutEvent(dnsFlowKey{CgroupID: 999}, val, 2000, 1000)
+	if denied != nil {
+		t.Error("an event outside the cgroup allowlist must be dropped (nil)")
+	}
+}

--- a/internal/ebpf/tracer/tracer.go
+++ b/internal/ebpf/tracer/tracer.go
@@ -838,6 +838,22 @@ func (t *Tracer) idleDeny() bool {
 		len(t.loadCgroupIDs()) == 0 && !t.filter.HasTargets()
 }
 
+// cgroupAllows reports whether an event passes the active cgroup target gate.
+func (t *Tracer) cgroupAllows(event *events.Event) bool {
+	cgroupIDs := t.loadCgroupIDs()
+	switch {
+	case len(cgroupIDs) > 0 && event.CgroupID != 0:
+		_, ok := cgroupIDs[event.CgroupID]
+		return ok
+	case t.idleDeny():
+		return false
+	case t.useUserspaceCgroupFilter.Load():
+		return t.filter.IsPIDInCgroup(event.PID)
+	default:
+		return true
+	}
+}
+
 // SetCgroups replaces the tracer's entire cgroup filter set with the
 // given paths.
 // setCgroupPaths atomically publishes the current cgroup target set. Callers

--- a/internal/redactor/card_and_yaml_regression_test.go
+++ b/internal/redactor/card_and_yaml_regression_test.go
@@ -1,0 +1,54 @@
+package redactor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedact_YAMLColonWithoutSpace(t *testing.T) {
+	got := Default().RedactText("password:hunter2")
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("password:hunter2 (no space) must be redacted, got %q", got)
+	}
+}
+
+func TestRedact_CreditCardLengths(t *testing.T) {
+	redacted := []string{
+		"378282246310005",     // Amex, 15
+		"3782 822463 10005",   // Amex grouped
+		"30569309025904",      // Diners, 14
+		"4111111111111111",    // Visa, 16
+		"4111-1111-1111-1111", // Visa hyphenated
+	}
+	for _, in := range redacted {
+		if got := Default().RedactText("card " + in + " end"); strings.Contains(got, in) {
+			t.Errorf("card %q must be redacted, got %q", in, got)
+		}
+	}
+}
+
+func TestRedact_NonLuhnNumberKept(t *testing.T) {
+	in := "1234567890123" // 13 digits, not Luhn-valid
+	got := Default().RedactText("id " + in)
+	if !strings.Contains(got, in) {
+		t.Errorf("a non-Luhn numeric id must not be redacted as a card, got %q", got)
+	}
+}
+
+func TestLuhnValid(t *testing.T) {
+	if !luhnValid("4111111111111111") {
+		t.Error("valid Visa must pass Luhn")
+	}
+	if !luhnValid("378282246310005") {
+		t.Error("valid Amex (has a doubled digit > 9) must pass Luhn")
+	}
+	if luhnValid("4111111111111112") {
+		t.Error("bad checksum must fail Luhn")
+	}
+	if luhnValid("12345678") {
+		t.Error("too-short (< 13 digits) must fail")
+	}
+	if luhnValid("12345678901234567890") {
+		t.Error("too-long (> 19 digits) must fail")
+	}
+}

--- a/internal/redactor/redactor.go
+++ b/internal/redactor/redactor.go
@@ -11,9 +11,10 @@ import (
 
 // Rule describes one PII redaction pattern applied to event string fields.
 type Rule struct {
-	Name    string
-	Pattern *regexp.Regexp
-	Replace string
+	Name     string
+	Pattern  *regexp.Regexp
+	Replace  string
+	Validate func(match string) bool
 }
 
 // ruleSpec is the JSON shape of a custom rule as carried in the
@@ -98,18 +99,60 @@ func (r *Redactor) Redact(e *events.Event) {
 			}
 		}
 	}
-	for _, rule := range r.rules {
-		e.Target = rule.Pattern.ReplaceAllString(e.Target, rule.Replace)
-		e.Details = rule.Pattern.ReplaceAllString(e.Details, rule.Replace)
-		e.TraceState = rule.Pattern.ReplaceAllString(e.TraceState, rule.Replace)
-	}
+	e.Target = r.applyRules(e.Target)
+	e.Details = r.applyRules(e.Details)
+	e.TraceState = r.applyRules(e.TraceState)
 }
 
 func (r *Redactor) RedactText(s string) string {
+	return r.applyRules(s)
+}
+
+// applyRules runs every rule over s. A rule without Validate uses a straight
+// regex replace (with $-group expansion).
+func (r *Redactor) applyRules(s string) string {
 	for _, rule := range r.rules {
-		s = rule.Pattern.ReplaceAllString(s, rule.Replace)
+		if rule.Validate == nil {
+			s = rule.Pattern.ReplaceAllString(s, rule.Replace)
+			continue
+		}
+		rule := rule
+		s = rule.Pattern.ReplaceAllStringFunc(s, func(m string) string {
+			if !rule.Validate(m) {
+				return m
+			}
+			idx := rule.Pattern.FindStringSubmatchIndex(m)
+			return string(rule.Pattern.ExpandString(nil, rule.Replace, m, idx))
+		})
 	}
 	return s
+}
+
+// luhnValid reports whether the digits in s form a Luhn-valid sequence of a
+// plausible card length (13–19 digits).
+func luhnValid(s string) bool {
+	digits := make([]int, 0, len(s))
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits = append(digits, int(c-'0'))
+		}
+	}
+	if len(digits) < 13 || len(digits) > 19 {
+		return false
+	}
+	sum := 0
+	double := false
+	for i := len(digits) - 1; i >= 0; i-- {
+		d := digits[i]
+		if double {
+			if d *= 2; d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return sum%10 == 0
 }
 
 // credentialKeyNames is the single source of truth for the key names whose
@@ -160,7 +203,7 @@ func defaultRules() []Rule {
 		},
 		{
 			Name:    "credential_yaml",
-			Pattern: regexp.MustCompile(`(?i)\b(` + credentialKeyNames + `)\s*:\s+[^\s,}]+`),
+			Pattern: regexp.MustCompile(`(?i)\b(` + credentialKeyNames + `)\s*:\s*[^\s,}]+`),
 			Replace: "${1}: ***",
 		},
 		{
@@ -169,9 +212,10 @@ func defaultRules() []Rule {
 			Replace: "***@***",
 		},
 		{
-			Name:    "credit_card",
-			Pattern: regexp.MustCompile(`\b(\d{4}[\s\-]?){3}\d{4}\b`),
-			Replace: "****-****-****-****",
+			Name:     "credit_card",
+			Pattern:  regexp.MustCompile(`\b\d(?:[ -]?\d){12,18}\b`),
+			Replace:  "****-****-****-****",
+			Validate: luhnValid,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Correctness and hardening batch across the L7 decoders, redaction, alerting retries, and CLI lifecycle.

## Fixes
- Cap the alert retry backoff so a large max-retries value can't overflow into a negative sleep and spin the retry loop hot; bound max-retries.
- Redact `key:value` secrets written without a space after the colon, and match 13–19 digit card numbers validated by a Luhn check.
- Discard the rest of an HTTP/2 header block after an oversize drop or mid-block gap, so a stray CONTINUATION tail can no longer be decoded as a fresh block and emit a fabricated request/response event.
- Reject post-base QPACK indices whose base+index would overflow uint64 (which otherwise resolves to the wrong dynamic-table entry).
- Bounds-check the QUIC Initial source connection id and propagate the AES cipher construction error instead of using a nil cipher.
- Apply terminal sanitization, process-name resolution, and the cgroup allowlist to DNS-timeout events so a --container-narrowed session doesn't emit sibling-container timeouts.
- Give a second interrupt a short best-effort window to finish writing the session report before forcing exit.
- Honor PODTRACE_TRACING_ENABLED on the CLI so the documented env switch actually enables tracing instead of building an orphaned manager.