### PR TITLE
build: remove dead BPF pid/tid stores, gate warnings, fix sudo hygiene

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LLC ?= llc
 GO ?= $(shell if [ -f /usr/local/go/bin/go ]; then echo /usr/local/go/bin/go; else echo go; fi)
 BPF_SRC = bpf/podtrace.bpf.c bpf/network.c bpf/filesystem.c bpf/cpu.c bpf/memory.c
 BPF_OBJ = internal/ebpf/embedded/podtrace.$(BPF_GOARCH).bpf.o
+BPF_LOADTEST_BIN = bin/bpf-loadtest.test
 BPF_GEN_DIR = bpf/.generated
 VMLINUX_GEN = $(BPF_GEN_DIR)/vmlinux.h
 BINARY = bin/podtrace
@@ -36,6 +37,7 @@ endif
 
 LIBBPF_INCLUDE ?= /usr/include
 BPF_CFLAGS = -O2 -g -target bpf $(BPF_ARCH_DEFINE) -mcpu=$(BPF_MCPU) \
+	-Wall -Werror=unused-variable \
 	-Wno-missing-declarations \
 	-I$(LIBBPF_INCLUDE) -I$(BPF_GEN_DIR)
 
@@ -191,7 +193,17 @@ clean:
 	rm -rf bin
 	rm -rf $(RELEASE_DIR)
 	rm -f coverage.out coverage.unit.out coverage.html
-	rm -rf "$(BPF_GEN_DIR)"
+	@if [ -e "$(BPF_GEN_DIR)" ] && ! rm -rf "$(BPF_GEN_DIR)" 2>/dev/null; then \
+		echo ""; \
+		echo "WARNING: could not remove $(BPF_GEN_DIR), it is owned by another user"; \
+		echo "         (typically left by a prior 'sudo make'). Remove it with:"; \
+		echo ""; \
+		echo "             sudo rm -rf $(BPF_GEN_DIR)"; \
+		echo ""; \
+		echo "         Then re-run. (Newer 'make test-bpf-load' no longer runs the"; \
+		echo "         build under sudo, so this should not recur.)"; \
+		echo ""; \
+	fi
 
 deps:
 	$(GO) mod download
@@ -218,12 +230,18 @@ test-integration:
 test-bpf-load: $(BPF_OBJ)
 	@echo "Running BPF loader tests against the freshly built object..."
 	$(GO) test -count=1 ./internal/ebpf/loader/...
+	@echo "Compiling the kernel verifier load-test as $$(id -un)..."
+	@mkdir -p $(dir $(BPF_LOADTEST_BIN))
+	$(GO) test -c -count=1 -tags bpf_loadtest -o $(BPF_LOADTEST_BIN) ./internal/ebpf/loader/
 	@if [ "$$(id -u)" = "0" ]; then \
-		echo ">>> root detected: running kernel verifier load-test"; \
-		$(GO) test -count=1 -tags bpf_loadtest -run TestLoadPodtrace_KernelVerifierAccepts ./internal/ebpf/loader/...; \
+		echo ">>> root: running kernel verifier load-test"; \
+		./$(BPF_LOADTEST_BIN) -test.v -test.run TestLoadPodtrace_KernelVerifierAccepts; \
+	elif command -v sudo >/dev/null 2>&1; then \
+		echo ">>> running kernel verifier load-test under sudo (binary only; the build stays owned by $$(id -un))"; \
+		sudo ./$(BPF_LOADTEST_BIN) -test.v -test.run TestLoadPodtrace_KernelVerifierAccepts; \
 	else \
-		echo ">>> not root: skipping kernel verifier load-test"; \
-		echo ">>> to include it: sudo -E env \"PATH=\$$PATH\" make test-bpf-load"; \
+		echo ">>> sudo not available: skipping kernel verifier load-test"; \
+		echo ">>> to run it: sudo ./$(BPF_LOADTEST_BIN) -test.run TestLoadPodtrace_KernelVerifierAccepts"; \
 	fi
 
 test-bench:

--- a/bpf/cpu.c
+++ b/bpf/cpu.c
@@ -131,8 +131,6 @@ int tracepoint_sched_switch(void *ctx) {
 
 SEC("kprobe/do_futex")
 int kprobe_do_futex(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_FUTEX);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -204,8 +202,6 @@ int kretprobe_do_futex(struct pt_regs *ctx) {
 
 SEC("uprobe/pthread_mutex_lock")
 int uprobe_pthread_mutex_lock(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_PTHREAD_MUTEX);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);

--- a/bpf/filesystem.c
+++ b/bpf/filesystem.c
@@ -8,8 +8,6 @@
 
 SEC("kprobe/vfs_write")
 int kprobe_vfs_write(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_VFS_WRITE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -27,8 +25,6 @@ int kprobe_vfs_write(struct pt_regs *ctx) {
 
 SEC("kprobe/vfs_read")
 int kprobe_vfs_read(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_VFS_READ);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -148,8 +144,6 @@ int kretprobe_vfs_write(struct pt_regs *ctx) {
 
 SEC("kprobe/vfs_fsync")
 int kprobe_vfs_fsync(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_VFS_FSYNC);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);

--- a/bpf/kafka.c
+++ b/bpf/kafka.c
@@ -8,8 +8,6 @@
 SEC("uprobe/rd_kafka_topic_new")
 int uprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_KAFKA_TOPIC_NEW);
 
 	const char *topic = (const char *)PT_REGS_PARM2(ctx);
@@ -25,8 +23,6 @@ int uprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 SEC("uretprobe/rd_kafka_topic_new")
 int uretprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_KAFKA_TOPIC_NEW);
 
 	u64 topic_ptr = (u64)PT_REGS_RC(ctx);
@@ -46,8 +42,6 @@ int uretprobe_rd_kafka_topic_new(struct pt_regs *ctx)
 SEC("uprobe/rd_kafka_produce")
 int uprobe_rd_kafka_produce(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_KAFKA_PRODUCE);
 	u64 ts  = bpf_ktime_get_ns();
 
@@ -116,8 +110,6 @@ int uretprobe_rd_kafka_produce(struct pt_regs *ctx)
 SEC("uprobe/rd_kafka_consumer_poll")
 int uprobe_rd_kafka_consumer_poll(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_KAFKA_POLL);
 	u64 ts  = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);

--- a/bpf/memcached.c
+++ b/bpf/memcached.c
@@ -81,8 +81,6 @@ static __always_inline int mc_emit(struct pt_regs *ctx, u32 pid, u32 tid, int re
 SEC("uprobe/memcached_get")
 int uprobe_memcached_get(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;
@@ -101,8 +99,6 @@ int uretprobe_memcached_get(struct pt_regs *ctx)
 SEC("uprobe/memcached_set")
 int uprobe_memcached_set(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;
@@ -122,8 +118,6 @@ int uretprobe_memcached_set(struct pt_regs *ctx)
 SEC("uprobe/memcached_delete")
 int uprobe_memcached_delete(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_MEMCACHED);
 	const char *mc_key = (const char *)PT_REGS_PARM2(ctx);
 	if (!mc_key) return 0;

--- a/bpf/network.c
+++ b/bpf/network.c
@@ -222,8 +222,6 @@ int kretprobe_tcp_connect(struct pt_regs *ctx) {
 
 SEC("kprobe/tcp_sendmsg")
 int kprobe_tcp_sendmsg(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_TCP_SENDMSG);
 	u64 ts = bpf_ktime_get_ns();
 
@@ -309,8 +307,6 @@ int kretprobe_tcp_sendmsg(struct pt_regs *ctx) {
 
 SEC("kprobe/tcp_recvmsg")
 int kprobe_tcp_recvmsg(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_TCP_RECVMSG);
 	u64 ts = bpf_ktime_get_ns();
 
@@ -372,8 +368,6 @@ int kretprobe_tcp_recvmsg(struct pt_regs *ctx) {
 
 SEC("uprobe/getaddrinfo")
 int uprobe_getaddrinfo(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_GETADDRINFO);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -611,8 +605,6 @@ int tracepoint_net_dev_xmit(void *ctx) {
 
 SEC("kprobe/udp_sendmsg")
 int kprobe_udp_sendmsg(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_UDP_SENDMSG);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -659,8 +651,6 @@ int kretprobe_udp_sendmsg(struct pt_regs *ctx) {
 
 SEC("kprobe/udp_recvmsg")
 int kprobe_udp_recvmsg(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_UDP_RECVMSG);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -766,8 +756,6 @@ int uretprobe_http_request(struct pt_regs *ctx) {
 
 SEC("uprobe/http_response")
 int uprobe_http_response(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_HTTP_RESPONSE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -814,8 +802,6 @@ int uretprobe_http_response(struct pt_regs *ctx) {
 
 SEC("uprobe/PQexec")
 int uprobe_PQexec(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_PQEXEC);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -874,8 +860,6 @@ int uretprobe_PQexec(struct pt_regs *ctx) {
 
 SEC("uprobe/mysql_real_query")
 int uprobe_mysql_real_query(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_MYSQL_QUERY);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -933,8 +917,6 @@ int uretprobe_mysql_real_query(struct pt_regs *ctx) {
 }
 SEC("uprobe/SSL_connect")
 int uprobe_SSL_connect(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_SSL_CONNECT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -973,8 +955,6 @@ int uretprobe_SSL_connect(struct pt_regs *ctx) {
 
 SEC("uprobe/SSL_accept")
 int uprobe_SSL_accept(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_SSL_ACCEPT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -1013,8 +993,6 @@ int uretprobe_SSL_accept(struct pt_regs *ctx) {
 
 SEC("uprobe/SSL_do_handshake")
 int uprobe_SSL_do_handshake(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_SSL_DO_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -1053,8 +1031,6 @@ int uretprobe_SSL_do_handshake(struct pt_regs *ctx) {
 
 SEC("uprobe/gnutls_handshake")
 int uprobe_gnutls_handshake(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_GNUTLS_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -1093,8 +1069,6 @@ int uretprobe_gnutls_handshake(struct pt_regs *ctx) {
 
 SEC("uprobe/mbedtls_ssl_handshake")
 int uprobe_mbedtls_ssl_handshake(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_MBEDTLS_HANDSHAKE);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);

--- a/bpf/redis.c
+++ b/bpf/redis.c
@@ -65,8 +65,6 @@ static __always_inline int redis_emit(struct pt_regs *ctx, u32 pair, u32 pid, u3
 SEC("uprobe/redisCommand")
 int uprobe_redisCommand(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_REDIS_COMMAND);
 	u64 ts  = bpf_ktime_get_ns();
 
@@ -87,8 +85,6 @@ int uretprobe_redisCommand(struct pt_regs *ctx)
 SEC("uprobe/redisCommandArgv")
 int uprobe_redisCommandArgv(struct pt_regs *ctx)
 {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_REDIS_COMMAND_ARGV);
 	u64 ts  = bpf_ktime_get_ns();
 

--- a/bpf/syscalls.c
+++ b/bpf/syscalls.c
@@ -87,8 +87,6 @@ int tracepoint_sched_process_fork(void *ctx) {
 
 SEC("kprobe/do_sys_openat2")
 int kprobe_do_sys_openat2(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_OPENAT);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -146,8 +144,6 @@ int kretprobe_do_sys_openat2(struct pt_regs *ctx) {
 
 SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_VFS_UNLINK);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);
@@ -212,8 +208,6 @@ int kretprobe_vfs_unlink(struct pt_regs *ctx) {
 
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
-	u32 pid = bpf_get_current_pid_tgid() >> 32;
-	u32 tid = (u32)bpf_get_current_pid_tgid();
 	struct pair_key key = make_pair_key(PAIR_VFS_RENAME);
 	u64 ts = bpf_ktime_get_ns();
 	bpf_map_update_elem(&start_times, &key, &ts, BPF_ANY);


### PR DESCRIPTION
Entry and state-correlation probes computed pid/tid via bpf_get_current_pid_tgid() but never read them; the identity is already in the pair key and attributed by the return probes. Remove all 60 across 7 files. The helper is opaque to the compiler, so these were real redundant calls.

Add -Wall -Werror=unused-variable to BPF_CFLAGS so a future dead store fails the build (the missing warning gate).

Fix the sudo hygiene the load-test:
- test-bpf-load builds the object and test binary as the invoking user and runs only the pre-built binary with sudo, so sudo never writes root-owned files into the source tree.
- clean reports a clear message and 'sudo rm -rf bpf/.generated' when that dir was left root-owned by an older sudo build, instead of dying with a raw rm error.