### PR TITLE
chore: update go to 1.27.0 and golangci-lint to 2.13.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,7 +105,7 @@
       "allowedVersions": "<4.2.1 || >4.2.1"
     },
     {
-      "description": "The go.mod language directive gates golangci-lint: it refuses to lint a module targeting a newer Go than the release binary was built with, and staticcheck (honnef.co/go/tools v0.7.0, vendored by golangci-lint v2.12.2) panics on Go 1.27 stdlib source.",
+      "description": "The Go version also lives in the Dockerfile, the Makefile lint pin and the docs, and golangci-lint must be built with it first. Bump the directive deliberately via the dashboard; patch bumps stay automatic.",
       "matchManagers": [
         "gomod"
       ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,19 +142,19 @@ them locally and you will not be surprised by CI.
 
 ### Go
 
-`make lint` runs **golangci-lint v2.12.2** — the same version CI pins — against
+`make lint` runs **golangci-lint v2.13.0** — the same version CI pins — against
 [`.golangci.yml`](.golangci.yml), which selects the v2 `standard` linter set:
 `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`. Because both the
 version and the linter set are pinned in-repo, a clean `make lint` locally means
 a clean lint job in CI.
 
-> **Do not install golangci-lint with `go install`.** golangci-lint v2.12.2
-> declares `go 1.25.0`, so `go install` builds it with a Go 1.25 toolchain, and
+> **Do not install golangci-lint with `go install`.** golangci-lint v2.13.0
+> declares `go 1.26.0`, so `go install` builds it with a Go 1.26 toolchain, and
 > the resulting binary refuses to run against this module:
-> `the Go language version (go1.25) used to build golangci-lint is lower than
-> the targeted Go version (1.26.5)`. It fails with or without a config file.
+> `the Go language version (go1.26) used to build golangci-lint is lower than
+> the targeted Go version (1.27.0)`. It fails with or without a config file.
 > `make lint` avoids this by downloading the official prebuilt release binary
-> (built with Go 1.26) into `bin/`, checksum-verified against the release's
+> (built with Go 1.27) into `bin/`, checksum-verified against the release's
 > `checksums.txt`.
 
 Formatting is plain `gofmt` — `make fmt` is `go fmt ./...`. It is deliberately

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@
 # The same image serves the CLI, the agent DaemonSet, the operator
 # Deployment, and per-session Jobs, one binary, multiple subcommands.
 
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.27.0
 ARG DEBIAN_RELEASE=trixie
-ARG GO_IMAGE_DIGEST=sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7
+ARG GO_IMAGE_DIGEST=sha256:6212da3924947f4b6a939df02ea627c13f338f1a41d6c3fcb0dd9d076eef46c4
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_RELEASE}@${GO_IMAGE_DIGEST} AS builder
 

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ envtest:
 	  $(GO) test -tags=envtest -count=1 -timeout 300s \
 	    ./api/v1alpha1/... ./internal/operator/... ./internal/agent/...
 
-GOLANGCI_LINT_VERSION ?= 2.12.2
+GOLANGCI_LINT_VERSION ?= 2.13.0
 GOLANGCI_LINT ?= bin/golangci-lint
 
 $(GOLANGCI_LINT):

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ to CRs, see [docs/migration.md](docs/migration.md).
 ## Prerequisites
 
 - Linux kernel 5.8+ with BTF support
-- Go 1.26+ (or any earlier 1.x with `GOTOOLCHAIN=auto`)
+- Go 1.27+ (or any earlier 1.x with `GOTOOLCHAIN=auto`)
 - Kubernetes cluster access
 
 ## Building

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,7 @@ podtrace/
 
 ### Prerequisites
 
-- Go 1.26+ (or any earlier 1.x with `GOTOOLCHAIN=auto`, which downloads
+- Go 1.27+ (or any earlier 1.x with `GOTOOLCHAIN=auto`, which downloads
   the toolchain version declared in `go.mod` automatically)
 - Clang and LLVM
 - Linux kernel 5.8+ with BTF (full L7 tracing needs the `bpf_loop` helper,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -394,8 +394,8 @@ You should see usage information.
 - Verify clang is installed: `clang --version`
 
 **Error: "Go version too old"**
-- Upgrade Go to 1.26+, or set `GOTOOLCHAIN=auto` so `go` downloads the
-  exact toolchain (`go 1.26.0` per `go.mod`) on demand.
+- Upgrade Go to 1.27+, or set `GOTOOLCHAIN=auto` so `go` downloads the
+  exact toolchain (`go 1.27.0` per `go.mod`) on demand.
 - The Makefile will show upgrade instructions
 
 **Error: "permission denied" when attaching probes**

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gma1k/podtrace
 
-go 1.26.7
+go 1.27.0
 
 require (
 	cloud.google.com/go/auth v0.23.1


### PR DESCRIPTION
## Summary

golangci-lint v2.13.0 is the first release built with go1.27.0, so the Go 1.27 toolchain bump that previously broke CI is now safe. Bump the go.mod directive, the golang base image, and the local lint pin together.

## Changes

- `go.mod`: `go 1.26.7` to `1.27.0` - `Dockerfile`: `GO_VERSION` `1.26.6` to `1.27.0`, with `GO_IMAGE_DIGEST`
  re-pinned to `golang:1.27.0-trixie` (Docker resolves `name:tag@digest` by digest, so a stale digest would silently keep building on 1.26.6).
- `Makefile`: `GOLANGCI_LINT_VERSION` `2.12.2` to `2.13.0`. #445 bumped only the workflow, so `make lint` was still fetching a go1.26-built binary that refuses to run against a 1.27 module, CONTRIBUTING.md's claim that the two
  pins match was already false.
- Docs: `Go 1.26+` → `Go 1.27+` in README, `docs/development.md`, `docs/installation.md`; CONTRIBUTING.md's `go install` warning updated to v2.13.0 / go1.26 / 1.27.0.