### PR TITLE
docs: define API versioning and CRD graduation policy

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -9,6 +9,7 @@ on:
       - "go.sum"
       - "cmd/**"
       - "internal/**"
+      - "deploy/charts/podtrace/templates/crds/**"
       - "Makefile"
       - ".github/workflows/go-ci.yml"
   pull_request:
@@ -19,6 +20,7 @@ on:
       - "go.sum"
       - "cmd/**"
       - "internal/**"
+      - "deploy/charts/podtrace/templates/crds/**"
       - "Makefile"
       - ".github/workflows/go-ci.yml"
   workflow_dispatch:
@@ -262,3 +264,77 @@ jobs:
             echo "::error::Generated manifests are stale. Run 'make manifests generate' and commit the result." >&2
             exit 1
           fi
+
+  crd-schema-compat:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Materialize the base revision's CRD manifests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/crd-base
+          crd_dir=deploy/charts/podtrace/templates/crds
+          # A CRD added by this PR has no base revision; absence is not a break.
+          git ls-tree --name-only -z "${BASE_SHA}" "${crd_dir}/" \
+            | while IFS= read -r -d '' path; do
+                git show "${BASE_SHA}:${path}" > "/tmp/crd-base/$(basename "${path}")"
+              done
+
+      - name: Compare served schemas
+        id: compare
+        run: |
+          set +e
+          output=$(go run ./hack/crdcompat \
+            -base /tmp/crd-base \
+            -head deploy/charts/podtrace/templates/crds 2>&1)
+          status=$?
+          set -e
+          echo "${output}"
+          {
+            echo "report<<CRDCOMPAT"
+            echo "${output}"
+            echo "CRDCOMPAT"
+          } >> "$GITHUB_OUTPUT"
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          if [ "${status}" -gt 1 ]; then
+            echo "::error::crdcompat failed to run" >&2
+            exit 1
+          fi
+
+      - name: Require a recorded break
+        if: steps.compare.outputs.status == '1'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPORT: ${{ steps.compare.outputs.report }}
+        run: |
+          set -euo pipefail
+          if git log --format=%B "${BASE_SHA}..${HEAD_SHA}" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            echo "::notice::Breaking CRD schema change, declared by a BREAKING CHANGE footer."
+            echo "${REPORT}"
+            echo
+            echo "Record it in the history table in docs/api-versioning.md before merging."
+            exit 0
+          fi
+          echo "::error::This PR removes or retypes a field in a served CRD version:" >&2
+          echo "${REPORT}" >&2
+          echo >&2
+          echo "Served versions are a compatibility promise — see docs/api-versioning.md." >&2
+          echo "If the change is intended, add a BREAKING CHANGE footer to a commit in" >&2
+          echo "this PR and add a row to the history table in docs/api-versioning.md." >&2
+          exit 1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,18 +33,26 @@ Full support matrix, including which probes need BTF, is in
 
 Small, well-defined work that unblocks the larger items below.
 
-1. **Reconcile the CRD inventory.** [STABILITY.md](STABILITY.md) describes
-   four CRDs. There are six: `PodTrace`, `PodTraceSession`,
-   `PodTraceSchedule`, `ExporterConfig`, `TracerConfig`, and
-   `ApplicationTrace`. The `v1.0.0` criteria inherit the same undercount and
-   need the same correction.
-
-2. **Publish a per-CRD `v1beta1` readiness table.** The three graduation
+1. **Publish a per-CRD `v1beta1` readiness table.** The three graduation
    gates already exist in [STABILITY.md](STABILITY.md). What is missing is an
    honest assessment of each CRD against them, so adopters can see which
    parts of the API are close to stable and which are still moving.
 
-3. **Finish the supply-chain baseline.** OpenSSF Scorecard now runs and
+2. **Use the `v1alpha1` cleanup window.** Alpha versions can drop and rename
+   fields with no notice owed; `v1beta1` cannot, and anything graduated is
+   carried until `v1`. So awkward field names and shapes get fixed now or
+   they get fixed never. Reviewing the six schemas with that deadline in
+   mind is the highest-value API work available, and the least likely to be
+   possible later. Rationale in
+   [docs/api-versioning.md](docs/api-versioning.md).
+
+3. **Build the graduation machinery.** The procedure is decided; the tooling
+   for it does not exist. Storage migration to move stored objects to a new
+   version, a schema-identity check across served versions, and a chainsaw
+   scenario that proves round-tripping against a live API server in both the
+   read and the write direction.
+
+4. **Finish the supply-chain baseline.** OpenSSF Scorecard now runs and
    publishes. Remaining: SLSA provenance attached to releases, and an
    [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec)
    manifest that states the inherent risk of a privileged kernel-level agent
@@ -52,39 +60,33 @@ Small, well-defined work that unblocks the larger items below.
 
 ## Next
 
-4. **A formal API deprecation policy.** [STABILITY.md](STABILITY.md) lists
-   this as a condition for `v1.0.0` but does not yet define it. It needs to
-   say how long a deprecated field or CRD version is served, how deprecation
-   is announced, and what an adopter is entitled to rely on.
+5. **Graduate the CRDs that clear their gates to `v1beta1`.** Graduation is
+   per-CRD and spans two releases — add the new version and migrate stored
+   objects, then retire the old one — so this lands incrementally rather
+   than as one event. The first graduation is also the test of whether the
+   procedure in [docs/api-versioning.md](docs/api-versioning.md) survives
+   contact with a real cluster, so it should be a small CRD rather than
+   `PodTrace`.
 
-5. **Graduate the CRDs that clear their gates to `v1beta1`,** served
-   alongside `v1alpha1` during transition. Graduation is per-CRD, so this
-   lands incrementally rather than as one event.
-
-6. **Decide the conversion story.** Today podtrace ships no conversion
-   webhooks and expects adopters to edit manifests by hand. Serving
-   `v1alpha1` and `v1beta1` simultaneously makes that choice load-bearing, so
-   it needs to be either committed to explicitly or replaced with conversion.
-
-7. **Make the Go API usable from outside.** `api/v1alpha1` and `pkg/client`
+6. **Make the Go API usable from outside.** `api/v1alpha1` and `pkg/client`
    are importable, which means anyone can build a controller or integration
    against podtrace CRs. Runnable godoc examples are the cheapest way to make
    that real, and `go test` keeps them from rotting.
 
 ## Later
 
-8. **`v1.0.0`,** once the four conditions in [STABILITY.md](STABILITY.md)
+7. **`v1.0.0`,** once the four conditions in [STABILITY.md](STABILITY.md)
    hold. This is downstream of everything above and is not near.
 
-9. **State platform support in tiers.** [docs/compatibility.md](docs/compatibility.md)
+8. **State platform support in tiers.** [docs/compatibility.md](docs/compatibility.md)
    already documents what is required. The gap is a clear statement of what
    is CI-verified against what is best-effort, particularly for kernels
    without BTF, where a meaningful subset of probes is unavailable.
 
-10. **Project sustainability.** Podtrace has one maintainer. That is the
-    single largest risk to anyone adopting it, more than any individual
-    feature, and it is worth naming plainly rather than leaving implicit. A
-    second maintainer with real review authority is the goal.
+9. **Project sustainability.** Podtrace has one maintainer. That is the
+   single largest risk to anyone adopting it, more than any individual
+   feature, and it is worth naming plainly rather than leaving implicit. A
+   second maintainer with real review authority is the goal.
 
 ## Non-goals
 
@@ -114,5 +116,7 @@ list, especially from anyone running podtrace against real traffic.
 - [CHANGELOG.md](CHANGELOG.md), what already shipped
 - [GOVERNANCE.md](GOVERNANCE.md), how decisions get made
 - [CONTRIBUTING.md](CONTRIBUTING.md), how to work on any of the above
+- [docs/api-versioning.md](docs/api-versioning.md), the CRD graduation
+  contract, deprecation policy, and cutover procedure
 - [docs/compatibility.md](docs/compatibility.md), kernel, Kubernetes, and
   architecture support

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -26,8 +26,12 @@ podtrace specifically:
 
 - **Schemas may change** between minor releases. Field renames, removals,
   and semantic changes are allowed.
-- **No conversion webhooks** are provided. You upgrade by editing your
-  manifests, not by relying on automatic conversion.
+- **No conversion webhooks**, by design rather than by omission. Versions
+  are graduated as identical schemas, so `conversion.strategy: None` is
+  correct and there is nothing for a webhook to convert. Shape changes
+  happen while a CRD is at `v1alpha1`, never at a version boundary. The
+  contract and the cutover procedure are in
+  [docs/api-versioning.md](docs/api-versioning.md).
 - **Best-effort backward compatibility within a minor release line.** A
   patch release (e.g. `v0.11.0` → `v0.11.1`) will not break existing
   manifests. Minor releases (`v0.11.0` → `v0.12.0`) may.
@@ -84,15 +88,23 @@ After `v1.0.0`, the standard semver rules apply: `feat:` bumps minor,
 A CRD graduates from `v1alpha1` to `v1beta1` when **all** of the following
 hold for that CRD:
 
-1. Schema has been stable across at least 2 consecutive minor releases.
-2. Conversion is documented (manual or webhook-based) for any past
-   breaking change.
+1. The CRD's generated schema has not changed in the last 3 releases.
+   Verifiable from the committed CRD manifests, not from judgement.
+2. Every past breaking change for that CRD is recorded in the history
+   table in [docs/api-versioning.md](docs/api-versioning.md), with what
+   an adopter had to do.
 3. The control plane reconciler for the CRD has end-to-end test coverage
    in the [chainsaw e2e suite](.github/workflows/chainsaw.yml).
 
 A `v1beta1` graduation can land for one CRD without graduating the
-others. CRDs at `v1beta1` and `v1alpha1` will be served simultaneously
-during transition.
+others.
+
+Graduation copies the schema unchanged — a `v1beta1` that differs from its
+`v1alpha1` is not a graduation, it is a breaking change wearing a new
+label. Both versions are served during the transition, which spans two
+releases while stored objects are migrated, and the older version is then
+removed. The procedure and the reasoning are in
+[docs/api-versioning.md](docs/api-versioning.md).
 
 ### Path to `v1.0.0`
 
@@ -102,7 +114,11 @@ The repository tags `v1.0.0` when:
    months.
 2. CLI flag surface has been stable for ≥6 months.
 3. Helm chart values have been stable for ≥6 months.
-4. A formal API deprecation policy is in place.
+4. A formal API deprecation policy is in place. Satisfied by
+   [docs/api-versioning.md](docs/api-versioning.md), which adopts the
+   upstream [Kubernetes deprecation
+   policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+   rather than defining a competing scheme.
 
 Until then, expect `v0.x` cadence with the rules above.
 
@@ -112,6 +128,9 @@ Until then, expect `v0.x` cadence with the rules above.
   every breaking change.
 - [docs/compatibility.md](docs/compatibility.md) — kernel, Kubernetes,
   architecture, and distro support matrix.
+- [docs/api-versioning.md](docs/api-versioning.md) — the graduation
+  contract, the deprecation policy, the version cutover procedure, and the
+  breaking-change history.
 - [docs/migration.md](docs/migration.md) — how to move between the CLI and
   CRD models. Not the same as schema migration.
 - [docs/crd-podtrace.md](docs/crd-podtrace.md),

--- a/deploy/charts/podtrace/templates/validating-webhook.yaml
+++ b/deploy/charts/podtrace/templates/validating-webhook.yaml
@@ -10,7 +10,7 @@
 # Validating admission webhook for podtrace.io/v1alpha1.
 #
 # The paths below are authoritative: they match the kubebuilder markers on
-# the Go webhook types in api/v1alpha1/*_webhook.go. `make manifests`
+# the webhook handlers in internal/webhook/v1alpha1/. `make manifests`
 # regenerates hack/reference/ from those markers, and the manifests-drift CI
 # job fails if the committed reference is stale. Keep this hand-authored
 # template in sync with hack/reference/ (a manual diff — CI does not compare

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Welcome to the `Podtrace` documentation. This directory contains comprehensive g
 ### Operator (CRD-driven workflows)
 - **[Operator](operator.md)** - Operator + agent architecture, helm install, key invariants
 - **[Migration](migration.md)** - CLI binary → CR walkthrough with a translation table
+- **[API Versioning](api-versioning.md)** - CRD graduation contract, deprecation policy, version cutover procedure, breaking-change history
 - **[PodTrace CR](crd-podtrace.md)** - Continuous tracing via a Custom Resource
 - **[PodTraceSession CR](crd-podtracesession.md)** - Bounded diagnose with a report artifact
 - **[PodTraceSchedule CR](crd-podtraceschedule.md)** - Recurring diagnose on a cron schedule

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,182 @@
+# API Versioning and CRD Graduation
+
+How podtrace's CRD versions move forward, what changes are allowed at each
+stage, and the procedure for graduating a CRD from one version to the next.
+
+This is about **schema** migration. For moving from the CLI binary to the
+CR-driven model, see [migration.md](migration.md), a different thing that
+happens to share the word. For what each version promises, see
+[STABILITY.md](../STABILITY.md).
+
+## The graduation contract
+
+**Graduation introduces no schema change.**
+
+A CRD graduates `v1alpha1` to `v1beta1` as an identical schema. The new
+version is a copy: same fields, same types, same validation. Storage moves
+to the new version, existing objects are migrated, and the old version is
+retired.
+
+API changes happen **before** graduation or **after** it. They never happen
+at the version boundary.
+
+The consequence is that podtrace serves multiple versions with
+`conversion.strategy: None` and needs no conversion webhook, not because
+webhooks were judged too expensive, but because there is nothing to convert.
+
+### Why the boundary is the wrong place to change shape
+
+Kubernetes offers two conversion strategies for CRDs: `None`, where the API
+server relabels `apiVersion` and prunes the object against the requested
+version's schema, and `Webhook`, where it calls an endpoint you run.
+Declarative in-process conversion was proposed as
+[KEP-3945](https://github.com/kubernetes/enhancements/issues/3945) and
+closed as not planned, so there is no third option.
+
+Under `strategy: None`, reads are safe: a client asking for a version that
+lacks a field simply does not see it. **Writes are not.** If the served
+versions differ in shape, a write through the older version discards
+whatever that version's schema does not describe:
+
+| Write path through the older version | Field only in the storage version |
+|---|---|
+| `kubectl apply` (client-side) | lost |
+| read-modify-write via a typed client | lost |
+| `kubectl apply --server-side`, non-owning field manager | preserved |
+| `kubectl apply --server-side --force-conflicts` | lost |
+
+Two of those are what GitOps controllers do on a normal sync. So an
+"additive-only" superset is not sufficient to make `strategy: None` safe,
+it makes reads safe and leaves writes lossy.
+
+If the schemas are **identical**, the failure mode cannot occur, and
+Kubernetes deprecation policy rule, "API objects must be able to
+round-trip between API versions in a given release without information
+loss", holds by construction rather than by promise.
+
+`strategy: Webhook` was considered and rejected separately. A conversion
+webhook sits in the **read** path of the CRs, including the operator's own
+reconcile reads. When it is unavailable, existing traces stop reconciling.
+For a diagnostic tool, being unavailable during an incident is the specific
+failure this project cannot accept.
+
+## Where API change is allowed
+
+Podtrace follows the [Kubernetes deprecation
+policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+rather than defining its own. The three rules that matter here:
+
+- **Rule #1** — once an element exists at a version, it can never be removed
+  from that version, nor have its behavior significantly changed.
+- **Rule #2** — objects must round-trip between served versions without
+  information loss.
+- **Rule #4a** — alpha versions may be removed in any release with no prior
+  deprecation notice. Beta versions must be served for 9 months or 3 minor
+  releases after deprecation, whichever is longer.
+
+Applied to podtrace:
+
+| Stage | What is allowed |
+|---|---|
+| While at `v1alpha1` | Rename, retype, restructure, remove. No notice owed. Record it in [CHANGELOG.md](../CHANGELOG.md) with a `BREAKING CHANGE` footer and in the history below. |
+| At graduation | Nothing. The schema is copied unchanged. |
+| At `v1beta1` and later | Add optional fields. Deprecate fields, but never remove them from that version. |
+
+Rule #1 is the reason graduation is a deadline and not a milestone: every
+awkward field that reaches `v1beta1` is carried until `v1`. A rename after
+graduation means adding the new field and keeping the old one indefinitely.
+
+**So the cleanup window is now, while the CRDs are at `v1alpha1`.** If a
+field name or shape is wrong, that is the time to say so.
+
+## The cutover procedure
+
+A single-step swap is not possible. The API server pins a version in
+`spec.versions` for as long as it appears in `status.storedVersions`:
+
+```
+status.storedVersions[0]: Invalid value: "v1alpha1": missing from
+spec.versions; v1alpha1 was previously a storage version, and must remain in
+spec.versions until a storage migration ensures no data remains persisted in
+v1alpha1 and removes v1alpha1 from status.storedVersions
+```
+
+So there is always an overlap window. Graduation spans two releases.
+
+### Release N — add the new version and migrate storage
+
+1. **Add `v1beta1` with an identical schema.** A new `api/v1beta1` package
+   carrying the same types, with `+kubebuilder:storageversion` moved to it.
+   Both versions `served: true`; `storage: true` on `v1beta1` only.
+2. **Migrate storage.** Write every existing object once so it re-persists
+   in the new version. Any no-op write does it — the operation must be
+   idempotent and safe to re-run.
+3. **Patch `status.storedVersions`** to list only the new version, which
+   unpins the old one.
+
+At this point both versions are served, the schemas are identical, and no
+client can lose data whichever version it writes through.
+
+### Release N+1 — retire the old version
+
+4. **Remove `v1alpha1` from `spec.versions`.** Existing objects are
+   untouched; clients pinned to the old version get a `NotFound` for the
+   resource and must update `apiVersion`.
+
+For adopters, migration is editing one line. That is the whole of it,
+because the schemas were identical.
+
+### During the overlap
+
+Both versions work for reads and writes. Prefer the newer version in
+manifests so there is nothing to change at step 4.
+
+## Enforcement
+
+Stating the contract is not enough to hold it — the previous version of this
+policy was a disclaimer with nothing behind it.
+
+- `make manifests` regenerates the CRDs, and the `manifests-drift` CI job
+  fails on stale output.
+- A CI check fails any PR whose generated CRD diff removes or renames a
+  field unless the commit carries a `BREAKING CHANGE` footer. This is what
+  keeps the history below complete.
+- Once a CRD serves two versions, a schema-identity check asserts that the
+  served versions are the same shape, and a chainsaw scenario proves it
+  against a live API server in both the read and the write direction.
+
+## Breaking change history
+
+Every schema or behavioral break, and what an adopter had to do. Graduation
+gate 2 in [STABILITY.md](../STABILITY.md) depends on this list being
+complete.
+
+| Release | CRD | Change | What adopters had to do |
+|---|---|---|---|
+| v0.11.10 | PodTraceSession | `.status.phase` renamed to `.status.state`; the `SessionPhase` values became `SessionState` with the same names | Update anything reading `.status.phase` — `kubectl` output columns, scripts, dashboards. No manifest change: the field is status-only. |
+| v0.13.10 | PodTrace, PodTraceSession, PodTraceSchedule | Cross-namespace targeting requires the target namespace to opt in with the `podtrace.io/allow-tracing-from` annotation | Annotate target namespaces. Without it, existing cross-namespace CRs silently narrow to their own namespace. See [cross-namespace-cr-targeting.md](cross-namespace-cr-targeting.md). |
+
+Two things about this list are worth stating plainly rather than leaving to
+be discovered.
+
+The `v0.11.10` rename shipped in a **patch** release, which the pre-1.0 rules
+in [STABILITY.md](../STABILITY.md) say will not break existing CRDs, and it
+was not recorded under a `BREAKING` heading at the time. The rule was right
+and the release did not follow it. The CI check described under
+[Enforcement](#enforcement) exists because a policy that depends on
+remembering is not a policy.
+
+Neither change would have been solved by a conversion webhook. The first is a
+status field, written by the operator and never round-tripped from a
+manifest; the second is behavioral, and conversion only addresses shape. The
+argument for skipping conversion does not rest on this list being short — it
+rests on the graduation contract above.
+
+## Related documents
+
+- [STABILITY.md](../STABILITY.md) — what each version promises, and the
+  graduation gates
+- [ROADMAP.md](../ROADMAP.md) — which CRDs are being worked toward
+  graduation
+- [CHANGELOG.md](../CHANGELOG.md) — release-by-release record
+- [migration.md](migration.md) — CLI binary to CR-driven workflows

--- a/hack/crdcompat/compat.go
+++ b/hack/crdcompat/compat.go
@@ -1,0 +1,230 @@
+// Command crdcompat compares two sets of generated CRD manifests and reports
+// schema changes that break existing objects: a field that disappears from a
+// served version, or one whose type changes.
+//
+// It exists because the graduation contract in docs/api-versioning.md depends
+// on such changes being deliberate and recorded. A policy that relies on
+// remembering is not a policy — the v0.11.10 rename of
+// PodTraceSession.status.phase shipped in a patch release without a BREAKING
+// CHANGE footer, which is exactly what this catches.
+//
+// The tool only reports. Whether a report is a failure is decided by the
+// caller, so that a commit carrying a BREAKING CHANGE footer can proceed.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Change is one breaking schema difference between two revisions of a CRD.
+type Change struct {
+	CRD     string
+	Version string
+	Path    string
+	Kind    ChangeKind
+	Detail  string
+}
+
+// ChangeKind distinguishes why a change breaks existing objects.
+type ChangeKind string
+
+const (
+	FieldRemoved   ChangeKind = "field removed"
+	TypeChanged    ChangeKind = "type changed"
+	VersionRemoved ChangeKind = "served version removed"
+)
+
+func (c Change) String() string {
+	if c.Detail == "" {
+		return fmt.Sprintf("%s: %s %s: %s", c.CRD, c.Version, c.Kind, c.Path)
+	}
+	return fmt.Sprintf("%s: %s %s: %s (%s)", c.CRD, c.Version, c.Kind, c.Path, c.Detail)
+}
+
+// crd is the subset of a CustomResourceDefinition this tool reads.
+type crd struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Versions []struct {
+			Name   string `json:"name"`
+			Served bool   `json:"served"`
+			Schema struct {
+				OpenAPIV3Schema map[string]any `json:"openAPIV3Schema"`
+			} `json:"schema"`
+		} `json:"versions"`
+	} `json:"spec"`
+}
+
+// field is a leaf or branch of a schema, keyed by its dotted path.
+type field struct {
+	openAPIType string
+}
+
+// Compare reports the breaking differences between the old and new revision of
+// a single CRD manifest. Additions are not breaking and are not reported.
+func Compare(oldYAML, newYAML []byte) ([]Change, error) {
+	oldCRD, err := parse(oldYAML)
+	if err != nil {
+		return nil, fmt.Errorf("parsing previous revision: %w", err)
+	}
+	newCRD, err := parse(newYAML)
+	if err != nil {
+		return nil, fmt.Errorf("parsing new revision: %w", err)
+	}
+
+	name := newCRD.Metadata.Name
+	if name == "" {
+		name = oldCRD.Metadata.Name
+	}
+
+	var changes []Change
+	newVersions := servedSchemas(newCRD)
+	for version, oldFields := range servedSchemas(oldCRD) {
+		newFields, ok := newVersions[version]
+		if !ok {
+			changes = append(changes, Change{
+				CRD:     name,
+				Version: version,
+				Kind:    VersionRemoved,
+				Path:    version,
+				Detail:  "requires a storage migration first",
+			})
+			continue
+		}
+		changes = append(changes, compareFields(name, version, oldFields, newFields)...)
+	}
+
+	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].Version != changes[j].Version {
+			return changes[i].Version < changes[j].Version
+		}
+		return changes[i].Path < changes[j].Path
+	})
+	return changes, nil
+}
+
+func compareFields(crdName, version string, oldFields, newFields map[string]field) []Change {
+	var changes []Change
+	for path, oldField := range oldFields {
+		newField, ok := newFields[path]
+		if !ok {
+			changes = append(changes, Change{
+				CRD:     crdName,
+				Version: version,
+				Kind:    FieldRemoved,
+				Path:    path,
+			})
+			continue
+		}
+		if oldField.openAPIType != "" && newField.openAPIType != "" &&
+			oldField.openAPIType != newField.openAPIType {
+			changes = append(changes, Change{
+				CRD:     crdName,
+				Version: version,
+				Kind:    TypeChanged,
+				Path:    path,
+				Detail:  oldField.openAPIType + " -> " + newField.openAPIType,
+			})
+		}
+	}
+	return changes
+}
+
+func parse(data []byte) (*crd, error) {
+	var c crd
+	if err := yaml.Unmarshal(stripTemplateLines(data), &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// stripTemplateLines drops the Helm control lines that
+// hack/inject-crd-annotations.sh wraps around each generated manifest, so the
+// committed chart templates can be parsed as plain YAML.
+func stripTemplateLines(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "{{") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return []byte(strings.Join(kept, "\n"))
+}
+
+// servedSchemas flattens each served version's schema into dotted field paths.
+// Unserved versions are skipped: nothing reads them, so changing them breaks
+// nobody.
+func servedSchemas(c *crd) map[string]map[string]field {
+	out := map[string]map[string]field{}
+	for _, v := range c.Spec.Versions {
+		if !v.Served {
+			continue
+		}
+		fields := map[string]field{}
+		walk("", v.Schema.OpenAPIV3Schema, fields)
+		out[v.Name] = fields
+	}
+	return out
+}
+
+// walk descends a structural schema, recording one entry per addressable
+// field. Array element schemas are recorded under the array's own path with a
+// "[]" suffix so that a type change inside a list is still visible.
+func walk(prefix string, schema map[string]any, out map[string]field) {
+	if schema == nil {
+		return
+	}
+
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		for name, raw := range properties {
+			child, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			path := name
+			if prefix != "" {
+				path = prefix + "." + name
+			}
+			out[path] = field{openAPIType: stringValue(child, "type")}
+			walk(path, child, out)
+		}
+	}
+
+	if items, ok := schema["items"].(map[string]any); ok && prefix != "" {
+		path := prefix + "[]"
+		out[path] = field{openAPIType: stringValue(items, "type")}
+		walk(path, items, out)
+	}
+
+	if additional, ok := schema["additionalProperties"].(map[string]any); ok && prefix != "" {
+		path := prefix + "{}"
+		out[path] = field{openAPIType: stringValue(additional, "type")}
+		walk(path, additional, out)
+	}
+}
+
+func stringValue(m map[string]any, key string) string {
+	if s, ok := m[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// Report renders changes as a newline-terminated block, most significant
+// first, suitable for a CI annotation.
+func Report(changes []Change) string {
+	var b strings.Builder
+	for _, c := range changes {
+		b.WriteString(c.String())
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/hack/crdcompat/compat_test.go
+++ b/hack/crdcompat/compat_test.go
@@ -1,0 +1,444 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func crdYAML(versions string) []byte {
+	return []byte(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podtracesessions.podtrace.io
+spec:
+  group: podtrace.io
+  versions:
+` + versions)
+}
+
+func oneVersion(name string, served bool, properties string) string {
+	servedValue := "false"
+	if served {
+		servedValue = "true"
+	}
+	return `  - name: ` + name + `
+    served: ` + servedValue + `
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+` + properties
+}
+
+func changePaths(changes []Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, string(c.Kind)+" "+c.Path)
+	}
+	return out
+}
+
+func requireChanges(t *testing.T, changes []Change, want ...string) {
+	t.Helper()
+	got := changePaths(changes)
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAddingAnOptionalFieldIsNotBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+              maxEventsPerSecond: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes)
+}
+
+func TestRemovingAFieldIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+              paused: {type: boolean}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "field removed spec.paused")
+}
+
+func TestRenameIsReportedAsRemovalOfTheOldPath(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          status:
+            type: object
+            properties:
+              phase: {type: string}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          status:
+            type: object
+            properties:
+              state: {type: string}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "field removed status.phase")
+}
+
+func TestRestructuringAFieldIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              sampling:
+                type: object
+                properties:
+                  percent: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "field removed spec.samplePercent")
+}
+
+func TestChangingAFieldTypeIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: string}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "type changed spec.samplePercent")
+	if changes[0].Detail != "integer -> string" {
+		t.Fatalf("detail = %q", changes[0].Detail)
+	}
+}
+
+func TestRemovingAServedVersionIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`) + oneVersion("v1beta1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	after := crdYAML(oneVersion("v1beta1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "served version removed v1alpha1")
+}
+
+func TestUnservedVersionsAreIgnored(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", false, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+              paused: {type: boolean}
+`))
+	after := crdYAML(oneVersion("v1alpha1", false, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes)
+}
+
+func TestIdenticalSchemasAcrossTwoServedVersionsPass(t *testing.T) {
+	identical := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`) + oneVersion("v1beta1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+
+	changes, err := Compare(identical, identical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes)
+}
+
+func TestNestedFieldRemovalReportsTheFullPath(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              exporterRef:
+                type: object
+                properties:
+                  name: {type: string}
+                  namespace: {type: string}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              exporterRef:
+                type: object
+                properties:
+                  name: {type: string}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "field removed spec.exporterRef.namespace")
+}
+
+func TestListElementTypeChangeIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              filters:
+                type: array
+                items: {type: string}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              filters:
+                type: array
+                items: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "type changed spec.filters[]")
+}
+
+func TestMapValueTypeChangeIsBreaking(t *testing.T) {
+	before := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              labels:
+                type: object
+                additionalProperties: {type: string}
+`))
+	after := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              labels:
+                type: object
+                additionalProperties: {type: integer}
+`))
+
+	changes, err := Compare(before, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "type changed spec.labels{}")
+}
+
+func TestMalformedManifestIsAnError(t *testing.T) {
+	_, err := Compare([]byte("this: [is: not: valid"), crdYAML(oneVersion("v1alpha1", true, "")))
+	if err == nil {
+		t.Fatal("expected an error for a malformed manifest")
+	}
+}
+
+func TestRunComparesEveryManifestInTheDirectory(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+
+	unchanged := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	regressed := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+              paused: {type: boolean}
+`))
+
+	write := func(dir, name string, body []byte) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(baseDir, "podtrace.io_podtraces.yaml", regressed)
+	write(headDir, "podtrace.io_podtraces.yaml", unchanged)
+	write(baseDir, "podtrace.io_exporterconfigs.yaml", unchanged)
+	write(headDir, "podtrace.io_exporterconfigs.yaml", unchanged)
+
+	changes, err := run(baseDir, headDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "field removed spec.paused")
+}
+
+func TestRunFlagsADeletedManifest(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+
+	body := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	if err := os.WriteFile(filepath.Join(baseDir, "podtrace.io_podtraces.yaml"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := run(baseDir, headDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes, "served version removed podtrace.io_podtraces.yaml")
+}
+
+func TestNewManifestsAreNotBreaking(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+
+	body := crdYAML(oneVersion("v1alpha1", true, `          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+`))
+	if err := os.WriteFile(filepath.Join(headDir, "podtrace.io_applicationtraces.yaml"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := run(baseDir, headDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireChanges(t, changes)
+}
+
+func TestCommittedChartTemplatesAreParseable(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "deploy", "charts", "podtrace", "templates", "crds", "*.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no committed CRD manifests found")
+	}
+
+	for _, path := range paths {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsed, err := parse(body)
+		if err != nil {
+			t.Fatalf("%s: %v", filepath.Base(path), err)
+		}
+		if parsed.Metadata.Name == "" {
+			t.Fatalf("%s: no metadata.name", filepath.Base(path))
+		}
+		served := servedSchemas(parsed)
+		if len(served) == 0 {
+			t.Fatalf("%s: no served versions", filepath.Base(path))
+		}
+		for version, fields := range served {
+			if len(fields) == 0 {
+				t.Fatalf("%s: %s has no fields", filepath.Base(path), version)
+			}
+		}
+	}
+}
+
+func TestHelmControlLinesAreStripped(t *testing.T) {
+	body := []byte(`{{- if .Values.crds.install }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- if .Values.crds.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+  name: podtraces.podtrace.io
+spec:
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              samplePercent: {type: integer}
+{{- end }}
+`)
+
+	parsed, err := parse(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Metadata.Name != "podtraces.podtrace.io" {
+		t.Fatalf("name = %q", parsed.Metadata.Name)
+	}
+	if _, ok := servedSchemas(parsed)["v1alpha1"]["spec.samplePercent"]; !ok {
+		t.Fatal("spec.samplePercent not found")
+	}
+}

--- a/hack/crdcompat/main.go
+++ b/hack/crdcompat/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+)
+
+func main() {
+	base := flag.String("base", "", "directory holding the previous revision of the CRD manifests")
+	head := flag.String("head", "", "directory holding the new revision of the CRD manifests")
+	flag.Parse()
+
+	if *base == "" || *head == "" {
+		fmt.Fprintln(os.Stderr, "usage: crdcompat -base <dir> -head <dir>")
+		os.Exit(2)
+	}
+
+	changes, err := run(*base, *head)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "crdcompat: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(changes) == 0 {
+		fmt.Println("No breaking CRD schema changes.")
+		return
+	}
+
+	fmt.Print(Report(changes))
+	os.Exit(1)
+}
+
+// run compares every manifest in baseDir against its namesake in headDir.
+func run(baseDir, headDir string) ([]Change, error) {
+	baseRoot, err := os.OpenRoot(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = baseRoot.Close() }()
+
+	headRoot, err := os.OpenRoot(headDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = headRoot.Close() }()
+
+	baseNames, err := manifestNames(baseRoot)
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", baseDir, err)
+	}
+	headNames, err := manifestNames(headRoot)
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", headDir, err)
+	}
+
+	var all []Change
+	for _, name := range baseNames {
+		if !headNames.has(name) {
+			all = append(all, Change{
+				CRD:    name,
+				Kind:   VersionRemoved,
+				Path:   name,
+				Detail: "manifest no longer generated",
+			})
+			continue
+		}
+
+		oldYAML, err := baseRoot.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+		newYAML, err := headRoot.ReadFile(name)
+		if err != nil {
+			return nil, err
+		}
+
+		changes, err := Compare(oldYAML, newYAML)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		all = append(all, changes...)
+	}
+	return all, nil
+}
+
+// nameSet is the set of manifest names found in one directory.
+type nameSet []string
+
+func (s nameSet) has(name string) bool {
+	for _, candidate := range s {
+		if candidate == name {
+			return true
+		}
+	}
+	return false
+}
+
+// manifestNames lists the YAML files directly inside root, sorted, so that a
+// report is ordered the same way on every run.
+func manifestNames(root *os.Root) (nameSet, error) {
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		return nil, err
+	}
+
+	names := make(nameSet, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}


### PR DESCRIPTION
## Summary

`STABILITY.md` said "No conversion webhooks are provided" as a disclaimer, and ROADMAP item 6 left the choice open. This commits to it: graduation introduces no schema change, so `conversion.strategy: None` is correct and there is nothing to convert. Shape changes happen while a CRD is at `v1alpha1` or additively afterwards, never at a version boundary.

## Changes

- New `docs/api-versioning.md`: graduation contract, two-release cutover procedure, deprecation policy, breaking-change history.
- `STABILITY.md`: conversion bullet becomes a decision; gate 1 is now observable ("no schema change in the last 3 releases"); gate 2 points at the history table; `v1.0.0` condition 4 satisfied.
- `ROADMAP.md`: items 1, 4 and 6 resolved and removed.
- New `hack/crdcompat` + `crd-schema-compat` CI job: fails a PR that removes or retypes a field in a served CRD version without a `BREAKING CHANGE` footer.
- Fixes a stale comment pointing at `api/v1alpha1/*_webhook.go`.