### PR TITLE
fix: repair the first-run experience and uninstall cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN set -eu; \
         echo "Run 'make bpf-btf-header' on a host with bpftool before building." >&2; \
         exit 1; \
     else \
-        echo "WARNING: building from the stub bpf/vmlinux.h, gRPC and FastCGI probes will be no-ops in this image" >&2; \
+        echo "BPF build: stub bpf/vmlinux.h. It declares the fields podtrace reads under preserve_access_index, so CO-RE resolves them against the running kernel and every probe is built. The running kernel still needs BTF." >&2; \
     fi
 
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ spec:
 ```bash
 kubectl apply -f session.yaml
 kubectl get podtracesession diag-api -n my-app -w   # wait for Completed
-kubectl get cm api-diag-report -n my-app -o jsonpath='{.data.report\.txt}' | less
+kubectl get cm api-diag-report -n my-app -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' | less
 ```
 
 This path runs the same eBPF stack the CLI uses, but as a per-node
@@ -238,7 +238,7 @@ kubectl get podtracesession demo-trace -n podtrace-demo -w
 
 # Read the report
 kubectl get cm nginx-trace-report -n podtrace-demo \
-  -o jsonpath='{.data.report\.txt}'
+  -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'
 
 # Tear down the demo (operator + sample workload + CRDs)
 kubectl delete ns podtrace-system podtrace-demo

--- a/api/v1alpha1/podtracesession_types.go
+++ b/api/v1alpha1/podtracesession_types.go
@@ -36,6 +36,7 @@ const (
 // PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
 // reconciles this into one privileged Job per node hosting matched pods.
 // +kubebuilder:validation:XValidation:rule="[has(self.selector), has(self.podRefs)].filter(x, x).size() == 1",message="exactly one of spec.selector or spec.podRefs must be set"
+// +kubebuilder:validation:XValidation:rule="has(self.reportRef) || (has(self.exporterRef) && has(self.exporterRef.name))",message="at least one of spec.exporterRef or spec.reportRef must be set, otherwise the session has nowhere to put its output"
 type PodTraceSessionSpec struct {
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
@@ -55,19 +56,12 @@ type PodTraceSessionSpec struct {
 	// +optional
 	Filters []EventFilter `json:"filters,omitempty"`
 
-	// +kubebuilder:validation:Required
-	ExporterRef corev1.LocalObjectReference `json:"exporterRef"`
+	// ExporterRef names the ExporterConfig this session ships spans to.
+	// +optional
+	ExporterRef corev1.LocalObjectReference `json:"exporterRef,omitempty"`
 
 	// TracerConfigRef pins every Job this session spawns to one
 	// TracerConfig, overriding the per-node fleet lookup.
-	//
-	// Left unset, each per-node Job takes the config of the fleet that
-	// targets its node, so a session spanning two node pools picks up each
-	// pool's own image and redaction policy. Set this when a session must
-	// run under one known configuration regardless of placement.
-	//
-	// TracerConfig is cluster-scoped, so this is a bare name with no
-	// namespace.
 	// +optional
 	TracerConfigRef *corev1.LocalObjectReference `json:"tracerConfigRef,omitempty"`
 

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -95,11 +95,12 @@ static __attribute__((noinline)) u32 append_dec(char *buf, u32 idx, u32 max_idx,
 	int started = 0;
 	for (int i = 0; i < 5; i++) {
 		u32 digit = (val / divisor) % 10;
-		if (digit != 0 || started || divisor == 1) {
+		if (digit != 0 || started || i == 4) {
 			if (idx < max_idx) buf[idx++] = '0' + digit;
 			started = 1;
 		}
-		divisor /= 10;
+		if (divisor > 1)
+			divisor /= 10;
 	}
 	return idx;
 }

--- a/deploy/charts/podtrace/templates/NOTES.txt
+++ b/deploy/charts/podtrace/templates/NOTES.txt
@@ -48,7 +48,7 @@ Quick start
   # Run an end-to-end trace against any pod
   kubectl apply -f examples/diagnose-demo.yaml
   kubectl -n podtrace-demo get podtracesession diag-demo -w
-  kubectl -n podtrace-demo get cm diag-demo-report -o jsonpath='{.data.report\.txt}'
+  kubectl -n podtrace-demo get cm diag-demo-report -o go-template='{{ "{{range $k,$v := .data}}{{$v}}{{end}}" }}'
 {{- else if .Values.operator.enabled }}
   # Operator is running but no TracerConfig is rendered. Apply one to
   # bring up the agent DaemonSet:

--- a/deploy/charts/podtrace/templates/cr-teardown.yaml
+++ b/deploy/charts/podtrace/templates/cr-teardown.yaml
@@ -1,0 +1,130 @@
+{{/*
+  Uninstall cleanup for the bootstrapped TracerConfig.
+
+  The TracerConfig is applied by the post-install hook Job in
+  cr-bootstrap.yaml, not as a tracked release resource, so `helm uninstall`
+  leaves it behind. That is harmless for a config object, but this one owns
+  the agent DaemonSet: leaving it means a privileged, CAP_SYS_ADMIN pod
+  keeps running on every node with no operator left to reconcile, update or
+  stop it.
+
+  So the default is to remove it. Deleting the TracerConfig cascades to the
+  DaemonSet through its ownerReference, and TracerConfig carries no
+  finalizer, so the delete completes without the operator's help. This hook
+  runs before the release's own resources are torn down, while the operator
+  is still up.
+
+  Set tracerConfig.retainOnUninstall=true to keep the agents running across
+  an uninstall — for a chart reinstall that should not interrupt capture,
+  or when the TracerConfig is managed outside this release.
+
+  Helm-only: OLM and raw-kubectl install paths do not run hooks, and the
+  operator self-bootstraps a TracerConfig on those paths, so they are
+  unaffected either way.
+*/}}
+{{- if and .Values.operator.enabled .Values.tracerConfig.create (not .Values.tracerConfig.retainOnUninstall) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "podtrace.fullname" . }}-cr-teardown
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cr-teardown
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "podtrace.fullname" . }}-cr-teardown
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cr-teardown
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["podtrace.io"]
+    resources: ["tracerconfigs"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "podtrace.fullname" . }}-cr-teardown
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cr-teardown
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "podtrace.fullname" . }}-cr-teardown
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "podtrace.fullname" . }}-cr-teardown
+    namespace: {{ include "podtrace.systemNamespace" . }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "podtrace.fullname" . }}-cr-teardown
+  namespace: {{ include "podtrace.systemNamespace" . }}
+  labels:
+    {{- include "podtrace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cr-teardown
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 60
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: podtrace
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: cr-teardown
+    spec:
+      serviceAccountName: {{ include "podtrace.fullname" . }}-cr-teardown
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: {{ .Values.crds.labelerImage | default "alpine/k8s:1.37.0@sha256:b421c2e9419edb98db39b6ab641669f4db7bb2acf354f22450c6b7e7176d1ff4" }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "Deleting TracerConfig {{ .Values.tracerConfig.name }} so the agent DaemonSet stops with the chart."
+              kubectl delete tracerconfig {{ .Values.tracerConfig.name | quote }} \
+                --ignore-not-found --wait=true --timeout=90s
+              echo "Done. Set tracerConfig.retainOnUninstall=true to keep agents running across an uninstall."
+{{- end }}

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtraceschedules.yaml
@@ -127,9 +127,8 @@ spec:
                       duration:
                         type: string
                       exporterRef:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
+                        description: ExporterRef names the ExporterConfig this session
+                          ships spans to.
                         properties:
                           name:
                             default: ""
@@ -377,14 +376,6 @@ spec:
                         description: |-
                           TracerConfigRef pins every Job this session spawns to one
                           TracerConfig, overriding the per-node fleet lookup.
-
-                          Left unset, each per-node Job takes the config of the fleet that
-                          targets its node, so a session spanning two node pools picks up each
-                          pool's own image and redaction policy. Set this when a session must
-                          run under one known configuration regardless of placement.
-
-                          TracerConfig is cluster-scoped, so this is a bare name with no
-                          namespace.
                         properties:
                           name:
                             default: ""
@@ -403,13 +394,16 @@ spec:
                         type: integer
                     required:
                     - duration
-                    - exporterRef
                     type: object
                     x-kubernetes-validations:
                     - message: exactly one of spec.selector or spec.podRefs must be
                         set
                       rule: '[has(self.selector), has(self.podRefs)].filter(x, x).size()
                         == 1'
+                    - message: at least one of spec.exporterRef or spec.reportRef
+                        must be set, otherwise the session has nowhere to put its
+                        output
+                      rule: has(self.reportRef) || (has(self.exporterRef) && has(self.exporterRef.name))
                 required:
                 - spec
                 type: object

--- a/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
+++ b/deploy/charts/podtrace/templates/crds/podtrace.io_podtracesessions.yaml
@@ -73,9 +73,8 @@ spec:
               duration:
                 type: string
               exporterRef:
-                description: |-
-                  LocalObjectReference contains enough information to let you locate the
-                  referenced object inside the same namespace.
+                description: ExporterRef names the ExporterConfig this session ships
+                  spans to.
                 properties:
                   name:
                     default: ""
@@ -321,14 +320,6 @@ spec:
                 description: |-
                   TracerConfigRef pins every Job this session spawns to one
                   TracerConfig, overriding the per-node fleet lookup.
-
-                  Left unset, each per-node Job takes the config of the fleet that
-                  targets its node, so a session spanning two node pools picks up each
-                  pool's own image and redaction policy. Set this when a session must
-                  run under one known configuration regardless of placement.
-
-                  TracerConfig is cluster-scoped, so this is a bare name with no
-                  namespace.
                 properties:
                   name:
                     default: ""
@@ -347,12 +338,14 @@ spec:
                 type: integer
             required:
             - duration
-            - exporterRef
             type: object
             x-kubernetes-validations:
             - message: exactly one of spec.selector or spec.podRefs must be set
               rule: '[has(self.selector), has(self.podRefs)].filter(x, x).size() ==
                 1'
+            - message: at least one of spec.exporterRef or spec.reportRef must be
+                set, otherwise the session has nowhere to put its output
+              rule: has(self.reportRef) || (has(self.exporterRef) && has(self.exporterRef.name))
           status:
             description: PodTraceSessionStatus reflects the observed state of a PodTraceSession.
             properties:

--- a/deploy/charts/podtrace/values.schema.json
+++ b/deploy/charts/podtrace/values.schema.json
@@ -1,428 +1,488 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "podtrace Helm chart values",
-    "description": "Configuration schema for the podtrace chart. See values.yaml for inline documentation of every field.",
-    "type": "object",
-    "properties": {
-        "agent": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": "object"
-                },
-                "alerting": {
-                    "type": "object",
-                    "properties": {
-                        "allowInsecureWebhook": {
-                            "type": "boolean"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "webhookURL": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "btfMode": {
-                    "type": "string"
-                },
-                "dnsFullAnswers": {
-                    "type": "boolean"
-                },
-                "dnsPacketCapture": {
-                    "type": "boolean"
-                },
-                "eventBufferSize": {
-                    "type": "integer"
-                },
-                "logLevel": {
-                    "type": "string",
-                    "enum": ["", "debug", "info", "warn", "error"]
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "usdt": {
-                    "type": "boolean"
-                },
-                "metrics": {
-                    "type": "object",
-                    "description": "Continuous metrics plane. See docs/continuous-metrics.md.",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "excludeNamespaces": {
-                            "type": "array",
-                            "maxItems": 64,
-                            "items": {
-                                "type": "string",
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                            }
-                        },
-                        "seriesBudget": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 2000000,
-                            "description": "0 uses the built-in default."
-                        },
-                        "nativeHistograms": {
-                            "type": "boolean"
-                        },
-                        "semanticConventions": {
-                            "type": "boolean"
-                        },
-                        "attributeCardinality": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 10000
-                        },
-                        "labels": {
-                            "type": "object",
-                            "properties": {
-                                "pod": {
-                                    "type": "boolean"
-                                },
-                                "process": {
-                                    "type": "boolean"
-                                }
-                            }
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        }
-                    }
-                },
-                "statusReportInterval": {
-                    "type": "string"
-                },
-                "tolerations": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "effect": {
-                                "type": "string"
-                            },
-                            "operator": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "podtrace Helm chart values",
+  "description": "Configuration schema for the podtrace chart. See values.yaml for inline documentation of every field.",
+  "type": "object",
+  "properties": {
+    "agent": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "object"
         },
-        "crds": {
-            "type": "object",
-            "properties": {
-                "adopt": {
-                    "type": "boolean"
-                },
-                "install": {
-                    "type": "boolean"
-                },
-                "keep": {
-                    "type": "boolean"
-                },
-                "labelerImage": {
-                    "type": "string"
-                }
+        "alerting": {
+          "type": "object",
+          "properties": {
+            "allowInsecureWebhook": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "webhookURL": {
+              "type": "string"
             }
+          }
         },
-        "examples": {
-            "type": "object",
-            "properties": {
-                "exporterconfig": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "endpoint": {
-                            "type": "string"
-                        },
-                        "insecure": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "protocol": {
-                            "type": "string"
-                        },
-                        "samplePercent": {
-                            "type": ["integer", "null"],
-                            "minimum": 0,
-                            "maximum": 100
-                        },
-                        "synthesizeSpans": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
+        "btfMode": {
+          "type": "string"
         },
-        "image": {
-            "type": "object",
-            "properties": {
-                "pullPolicy": {
-                    "type": "string"
-                },
-                "pullSecrets": {
-                    "type": "array"
-                },
-                "repository": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                }
-            }
+        "dnsFullAnswers": {
+          "type": "boolean"
+        },
+        "dnsPacketCapture": {
+          "type": "boolean"
+        },
+        "eventBufferSize": {
+          "type": "integer"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": [
+            "",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "usdt": {
+          "type": "boolean"
         },
         "metrics": {
-            "type": "object",
-            "properties": {
-                "podMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "path": {
-                            "type": "string"
-                        }
-                    }
+          "type": "object",
+          "description": "Continuous metrics plane. See docs/continuous-metrics.md.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "excludeNamespaces": {
+              "type": "array",
+              "maxItems": 64,
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              }
+            },
+            "seriesBudget": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2000000,
+              "description": "0 uses the built-in default."
+            },
+            "nativeHistograms": {
+              "type": "boolean"
+            },
+            "semanticConventions": {
+              "type": "boolean"
+            },
+            "attributeCardinality": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000
+            },
+            "labels": {
+              "type": "object",
+              "properties": {
+                "pod": {
+                  "type": "boolean"
                 },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "interval": {
-                            "type": "string"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "path": {
-                            "type": "string"
-                        }
-                    }
+                "process": {
+                  "type": "boolean"
                 }
+              }
             }
+          }
         },
-        "namespace": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
                 },
-                "create": {
-                    "type": "boolean"
-                },
-                "labels": {
-                    "type": "object"
-                },
-                "name": {
-                    "type": "string"
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
                 }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                },
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
+          }
         },
-        "operator": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": "object"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "extraEnv": {
-                    "type": "array"
-                },
-                "leaderElect": {
-                    "type": "boolean"
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podAnnotations": {
-                    "type": "object"
-                },
-                "replicas": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        }
-                    }
-                },
-                "tolerations": {
-                    "type": "array"
-                }
-            }
+        "statusReportInterval": {
+          "type": "string"
         },
-        "rbac": {
+        "tolerations": {
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "create": {
-                    "type": "boolean"
-                }
+              "effect": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string"
+              }
             }
-        },
-        "session": {
-            "type": "object",
-            "properties": {
-                "activeDeadlineOffset": {
-                    "type": "string"
-                },
-                "backoffLimit": {
-                    "type": "integer"
-                },
-                "maxConcurrentSessionsPerNode": {
-                    "type": "integer"
-                },
-                "maxDuration": {
-                    "type": "string"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": ["string", "integer", "number"]
-                                },
-                                "memory": {
-                                    "type": ["string", "integer", "number"]
-                                }
-                            }
-                        }
-                    }
-                },
-                "ttlSecondsAfterFinished": {
-                    "type": "integer"
-                }
-            }
-        },
-        "tracerConfig": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "sidecarUploader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "webhook": {
-            "type": "object",
-            "properties": {
-                "caBundle": {
-                    "type": "string"
-                },
-                "certManager": {
-                    "type": "object",
-                    "properties": {
-                        "issuerRef": {
-                            "type": "object",
-                            "properties": {
-                                "kind": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "certSource": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "port": {
-                    "type": "integer"
-                }
-            }
+          }
         }
+      }
+    },
+    "crds": {
+      "type": "object",
+      "properties": {
+        "adopt": {
+          "type": "boolean"
+        },
+        "install": {
+          "type": "boolean"
+        },
+        "keep": {
+          "type": "boolean"
+        },
+        "labelerImage": {
+          "type": "string"
+        }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "properties": {
+        "exporterconfig": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "endpoint": {
+              "type": "string"
+            },
+            "insecure": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "samplePercent": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0,
+              "maximum": 100
+            },
+            "synthesizeSpans": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "pullPolicy": {
+          "type": "string"
+        },
+        "pullSecrets": {
+          "type": "array"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "podMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "namespace": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "operator": {
+      "type": "object",
+      "properties": {
+        "affinity": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEnv": {
+          "type": "array"
+        },
+        "leaderElect": {
+          "type": "boolean"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "replicas": {
+          "type": "integer"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                },
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                },
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tolerations": {
+          "type": "array"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "session": {
+      "type": "object",
+      "properties": {
+        "activeDeadlineOffset": {
+          "type": "string"
+        },
+        "backoffLimit": {
+          "type": "integer"
+        },
+        "maxConcurrentSessionsPerNode": {
+          "type": "integer"
+        },
+        "maxDuration": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                },
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                },
+                "memory": {
+                  "type": [
+                    "string",
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer"
+        }
+      }
+    },
+    "tracerConfig": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sidecarUploader": {
+          "type": "boolean"
+        },
+        "retainOnUninstall": {
+          "type": "boolean"
+        }
+      }
+    },
+    "webhook": {
+      "type": "object",
+      "properties": {
+        "caBundle": {
+          "type": "string"
+        },
+        "certManager": {
+          "type": "object",
+          "properties": {
+            "issuerRef": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "certSource": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        }
+      }
     }
+  }
 }

--- a/deploy/charts/podtrace/values.yaml
+++ b/deploy/charts/podtrace/values.yaml
@@ -155,6 +155,8 @@ tracerConfig:
   name: default
   sidecarUploader: false
 
+  retainOnUninstall: false
+
   redaction:
     enabled: false
     redactDNSNames: false

--- a/deploy/quickstart-sample.yaml
+++ b/deploy/quickstart-sample.yaml
@@ -48,27 +48,64 @@ spec:
               cpu: 200m
               memory: 128Mi
 ---
-# OTLP exporter pointing at a localhost collector — replace the endpoint
-# with your own OTLP receiver to ship traces externally. The session
-# still produces a ConfigMap report regardless of whether traces reach
-# this endpoint.
-apiVersion: podtrace.io/v1alpha1
-kind: ExporterConfig
+# Gives nginx a stable name for the loadgen to call, and a ClusterIP for
+# the session to observe DNS and connect activity against.
+apiVersion: v1
+kind: Service
 metadata:
-  name: demo-otlp
+  name: nginx
   namespace: podtrace-demo
 spec:
-  type: otlp
-  otlp:
-    endpoint: localhost:4318
-    protocol: http
-    insecure: true
+  selector:
+    app: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+---
+# Drives the traffic the session reports on: one 200 and one 404 per
+# second, so the report shows request paths, status codes and latency
+# rather than an empty collection period.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgen
+  namespace: podtrace-demo
+  labels:
+    app: loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen
+  template:
+    metadata:
+      labels:
+        app: loadgen
+    spec:
+      containers:
+        - name: curl
+          image: curlimages/curl:8.9.1
+          command: ["sh", "-c"]
+          args:
+            - |
+              while true; do
+                curl -s -o /dev/null http://nginx.podtrace-demo.svc.cluster.local/ || true
+                curl -s -o /dev/null http://nginx.podtrace-demo.svc.cluster.local/missing || true
+                sleep 1
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
 ---
 # 30-second diagnose session against the nginx pod. Inspect the result:
 #
 #   kubectl get podtracesession demo-trace -n podtrace-demo
 #   kubectl get cm nginx-trace-report -n podtrace-demo \
-#     -o jsonpath='{.data.report\.txt}'
+#     -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'
 apiVersion: podtrace.io/v1alpha1
 kind: PodTraceSession
 metadata:
@@ -80,8 +117,8 @@ spec:
       app: nginx
   duration: 30s
   filters: [dns, net, fs]
-  exporterRef:
-    name: demo-otlp
+  # No exporterRef: this session only wants a local report. To ship spans
+  # as well, add an ExporterConfig and reference it here.
   reportRef:
     configMap:
       name: nginx-trace-report

--- a/docs/crd-podtraceschedule.md
+++ b/docs/crd-podtraceschedule.md
@@ -230,7 +230,7 @@ sessionTemplate:
     #   credentialsSecretRef: { name: s3-creds }
 ```
 
-Then `kubectl get cm nightly-report -o jsonpath='{.data.report\.txt}'`
+Then `kubectl get cm nightly-report -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'`
 for the latest run, or `aws s3 ls s3://my-bucket/podtrace/` for the
 archived history.
 

--- a/docs/crd-podtracesession.md
+++ b/docs/crd-podtracesession.md
@@ -133,7 +133,7 @@ kubectl get podtracesession diag-api -n my-app -o jsonpath='{.status.summary}{"\
 kubectl get podtracesession diag-api -n my-app -o jsonpath='{range .status.jobs[*]}{.node}: {.totalEvents} events{"\n"}{end}'
 
 # Read the full report
-kubectl get cm api-diag-report -n my-app -o jsonpath='{.data.report\.txt}' | less
+kubectl get cm api-diag-report -n my-app -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' | less
 
 # Inspect raw kubelet termination message
 kubectl -n podtrace-system get pods -l podtrace.io/session=diag-api \

--- a/docs/e2e-verification.md
+++ b/docs/e2e-verification.md
@@ -168,7 +168,7 @@ kubectl -n e2e wait deploy/web --for=condition=Available --timeout=60s
 
 until [ "$(kubectl -n e2e get podtracesession nonotlp-jaeger -o jsonpath='{.status.state}')" = "Completed" ]; do sleep 3; done
 kubectl -n e2e get podtracesession nonotlp-jaeger
-kubectl -n e2e get cm nonotlp-report -o jsonpath='{.data.report\.txt}' | head -20
+kubectl -n e2e get cm nonotlp-report -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' | head -20
 
 kubectl -n e2e delete podtracesession nonotlp-jaeger
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ kubectl get podtracesession demo-trace -n podtrace-demo \
 
 # Read the full human-readable report
 kubectl get cm nginx-trace-report -n podtrace-demo \
-  -o jsonpath='{.data.report\.txt}'
+  -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'
 ```
 
 The demo session has `ttlSecondsAfterFinished: 600`, so it auto-deletes itself 10 minutes after completing. To tear down everything immediately:
@@ -671,3 +671,44 @@ helm install podtrace deploy/charts/podtrace \
 See [operator.md](operator.md) for the architectural picture and
 [crd-podtracesession.md](crd-podtracesession.md) for an end-to-end
 trace example after install.
+
+### Uninstall
+
+```bash
+helm uninstall podtrace --namespace podtrace-system
+```
+
+The chart applies the `TracerConfig` from a hook Job rather than as a
+tracked release resource, so Helm does not remove it on its own — and
+that object owns the agent DaemonSet. Left in place it would keep a
+privileged, `CAP_SYS_ADMIN` pod running on every node with no operator
+left to reconcile or stop it, so a `pre-delete` hook deletes it. The
+DaemonSet, its ServiceAccount and its ClusterRole go with it through
+their owner references.
+
+To keep the agents running across an uninstall — reinstalling the chart
+without interrupting capture, or managing the `TracerConfig` outside the
+release — opt out:
+
+```bash
+helm uninstall podtrace --namespace podtrace-system \
+  --set tracerConfig.retainOnUninstall=true
+```
+
+Then remove them by hand when you are done:
+
+```bash
+kubectl delete tracerconfig default
+```
+
+Two things Helm never removes, by design:
+
+- **CRDs**, and with them every `PodTrace`, `PodTraceSession`,
+  `ExporterConfig` and report object in the cluster. Delete them with
+  `kubectl delete crd -l app.kubernetes.io/name=podtrace` only when you
+  intend to lose that data.
+- **The namespace**, if the chart created it.
+
+OLM and raw-`kubectl` installs do not run Helm hooks. On those paths the
+operator self-bootstraps a `TracerConfig`, so delete it yourself when
+removing podtrace.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -82,7 +82,7 @@ spec:
 Then:
 
 ```bash
-kubectl get cm my-pod-diag-report -n my-app -o jsonpath='{.data.report\.txt}' > report.txt
+kubectl get cm my-pod-diag-report -n my-app -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' > report.txt
 ```
 
 ### Selector-driven multi-pod trace

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -176,7 +176,7 @@ EOF
 # Session runs a Job on the target's node, finishes within ~15s
 kubectl wait --for=jsonpath='{.status.state}'=Completed \
   podtracesession smoke --timeout=60s
-kubectl get cm smoke-report -o jsonpath='{.data.report\.txt}'
+kubectl get cm smoke-report -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'
 ```
 
 ## BTF on Talos

--- a/docs/viewing-events.md
+++ b/docs/viewing-events.md
@@ -13,7 +13,7 @@ path is. Pick the one that matches what you're doing.
 | You want… | Use | Read it with |
 |---|---|---|
 | Live events streaming in your terminal | `kubectl podtrace` CLI mode | the CLI itself prints them |
-| One bounded snapshot you can `kubectl get` | `PodTraceSession` with `spec.reportRef.configMap` | `kubectl get cm <name> -o jsonpath='{.data.report\.txt}'` |
+| One bounded snapshot you can `kubectl get` | `PodTraceSession` with `spec.reportRef.configMap` | `kubectl get cm <name> -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'` |
 | Archived per-run snapshots over time | `PodTraceSchedule` with `reportRef.objectStore` | `aws s3 cp s3://…/<key> -` |
 | Real-time spans in a UI (production) | any CR with an `ExporterConfig` pointed at OTLP | Jaeger / Tempo / Datadog / Splunk |
 
@@ -107,7 +107,7 @@ EOF
 until [ "$(kubectl -n my-app get podtracesession my-trace -o jsonpath='{.status.state}')" = "Completed" ]; do sleep 5; done
 
 # Read the full human-readable report
-kubectl -n my-app get cm my-trace-report -o jsonpath='{.data.report\.txt}' | less
+kubectl -n my-app get cm my-trace-report -o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' | less
 ```
 
 What the report contains (sample from a curl workload):
@@ -149,7 +149,7 @@ related failures into causal chains and offers fixes.
 
 Use `reportRef.secret` instead of `configMap` when the report may
 contain sensitive hostnames/paths/payloads. Same read pattern,
-`-o jsonpath='{.data.report\.txt}' | base64 -d`.
+`-o go-template='{{range $k,$v := .data}}{{$v}}{{end}}' | base64 -d`.
 
 **Size limit**: ConfigMaps and Secrets are capped at 1 MiB by etcd.
 For longer runs or noisier workloads, prefer Surface 3.

--- a/internal/operator/agent_pod_labels_test.go
+++ b/internal/operator/agent_pod_labels_test.go
@@ -1,0 +1,74 @@
+package operator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func agentDaemonSetSpecForLabels(t *testing.T) (map[string]string, map[string]string) {
+	t.Helper()
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	spec := buildAgentDaemonSetSpec(tc, "podtrace-system")
+	return spec.Selector.MatchLabels, spec.Template.Labels
+}
+
+func TestAgentPodsCarryTheStandardLabelConvention(t *testing.T) {
+	_, pod := agentDaemonSetSpecForLabels(t)
+
+	want := map[string]string{
+		"app.kubernetes.io/name":       "podtrace",
+		"app.kubernetes.io/component":  ComponentAgent,
+		"app.kubernetes.io/part-of":    "podtrace",
+		"app.kubernetes.io/managed-by": ManagedByValue,
+	}
+	for k, v := range want {
+		if pod[k] != v {
+			t.Errorf("pod label %s = %q, want %q. The operator's own pods use this convention, "+
+				"so an agent without it is invisible to any selector, NetworkPolicy or "+
+				"ServiceMonitor written the usual way", k, pod[k], v)
+		}
+	}
+}
+
+func TestAgentPodsKeepTheirPodtraceLabels(t *testing.T) {
+	selector, pod := agentDaemonSetSpecForLabels(t)
+
+	for k, v := range selector {
+		if pod[k] != v {
+			t.Errorf("pod label %s = %q, want %q; the pod must still satisfy its own selector",
+				k, pod[k], v)
+		}
+	}
+}
+
+func TestTheDaemonSetSelectorGainsNoNewLabels(t *testing.T) {
+	selector, _ := agentDaemonSetSpecForLabels(t)
+
+	if len(selector) != 3 {
+		t.Fatalf("selector = %v, want exactly 3 labels. spec.selector is immutable, so a label "+
+			"added here can only be applied by deleting and recreating the DaemonSet, "+
+			"restarting a privileged pod on every node", selector)
+	}
+	for k := range selector {
+		if len(k) > 18 && k[:18] == "app.kubernetes.io/" {
+			t.Errorf("selector gained %q; the convention labels belong on the pod template only", k)
+		}
+	}
+}
+
+func TestPodTemplateLabelsAreACopy(t *testing.T) {
+	selector := map[string]string{"a": "1"}
+	pod := agentPodTemplateLabels(selector)
+	pod["b"] = "2"
+
+	if _, leaked := selector["b"]; leaked {
+		t.Error("writing to the pod labels mutated the selector; they share a map, and the " +
+			"selector is immutable once the DaemonSet exists")
+	}
+}

--- a/internal/operator/chart_uninstall_hook_test.go
+++ b/internal/operator/chart_uninstall_hook_test.go
@@ -1,0 +1,76 @@
+package operator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func repoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(append([]string{"..", ".."}, parts...)...))
+	if err != nil {
+		t.Fatalf("read %v: %v", parts, err)
+	}
+	return string(raw)
+}
+
+func TestUninstallRemovesTheTracerConfigByDefault(t *testing.T) {
+	tpl := repoFile(t, "deploy", "charts", "podtrace", "templates", "cr-teardown.yaml")
+
+	if !strings.Contains(tpl, "helm.sh/hook: pre-delete") {
+		t.Error("the teardown hook is not a pre-delete hook, so it would run after the " +
+			"release's own resources are already gone")
+	}
+	if !strings.Contains(tpl, "kubectl delete tracerconfig") {
+		t.Error("the teardown Job does not delete the TracerConfig, which is what owns the " +
+			"privileged agent DaemonSet")
+	}
+	if !strings.Contains(tpl, "not .Values.tracerConfig.retainOnUninstall") {
+		t.Error("the teardown hook is not gated on tracerConfig.retainOnUninstall, so there is " +
+			"no way to keep agents running across an uninstall")
+	}
+}
+
+func TestRetainOnUninstallIsOptInAndSchemaChecked(t *testing.T) {
+	values := repoFile(t, "deploy", "charts", "podtrace", "values.yaml")
+	if !strings.Contains(values, "retainOnUninstall: false") {
+		t.Error("retainOnUninstall must default to false: leaving a CAP_SYS_ADMIN DaemonSet " +
+			"running on every node with no operator is not a safe default")
+	}
+
+	schema := repoFile(t, "deploy", "charts", "podtrace", "values.schema.json")
+	if !strings.Contains(schema, "retainOnUninstall") {
+		t.Error("retainOnUninstall is missing from values.schema.json, so a typo would be " +
+			"accepted silently and the agents would be deleted anyway")
+	}
+}
+
+func TestNoDocumentedReportCommandUsesTheDeadJSONPath(t *testing.T) {
+	dead := `jsonpath='{.data.report\.txt}'`
+
+	roots := []string{"docs", "deploy", "README.md"}
+	var offenders []string
+	for _, root := range roots {
+		base := filepath.Join("..", "..", root)
+		_ = filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			raw, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			if strings.Contains(string(raw), dead) {
+				offenders = append(offenders, path)
+			}
+			return nil
+		})
+	}
+	if len(offenders) > 0 {
+		t.Errorf("these still tell the reader to run a command that returns nothing: %v. The "+
+			"report key is report-<node>.txt; read every key instead, with "+
+			"-o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'", offenders)
+	}
+}

--- a/internal/operator/podtracesession_controller.go
+++ b/internal/operator/podtracesession_controller.go
@@ -169,8 +169,6 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		var missing *errNoTracerConfig
 		if errors.As(err, &missing) {
-			// Terminal: no amount of requeueing conjures a TracerConfig, and
-			// proceeding would build a Job with an empty image.
 			return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "TracerConfigUnresolved", err.Error())
 		}
 		return ctrl.Result{}, err
@@ -179,8 +177,9 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	systemNS := systemNamespaceForSession(tc, r.SystemNamespace)
 
 	var ec podtracev1alpha1.ExporterConfig
+	hasExporter := session.Spec.ExporterRef.Name != ""
 	ecKey := types.NamespacedName{Namespace: session.Namespace, Name: session.Spec.ExporterRef.Name}
-	if err := r.Get(ctx, ecKey, &ec); err != nil {
+	if err := r.Get(ctx, ecKey, &ec); hasExporter && err != nil {
 		if apierrors.IsNotFound(err) {
 			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "ExporterNotFound",
 				fmt.Sprintf("ExporterConfig %s not found", ecKey))
@@ -192,12 +191,8 @@ func (r *PodTraceSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := validateManagedCRName("ExporterConfig", ec.Name); err != nil {
 		return ctrl.Result{}, r.failSessionTerminally(ctx, &session, "ExporterConfigNameTooLong", err.Error())
 	}
-	// A session whose nodes span fleets with different spec.systemNamespace
-	// puts Jobs in more than one namespace, and a Job cannot mount a bundle,
-	// assume a ServiceAccount, or exercise RBAC that lives somewhere else.
-	// Provision the full set in every namespace the resolution touches.
 	for _, ns := range resolved.namespaces {
-		if err := ensureSessionExporterBundle(ctx, r.Client, r.reader(), &session, &ec, ns); err != nil {
+		if err := ensureSessionExporterBundleIfReferenced(ctx, r.Client, r.reader(), &session, &ec, ns, hasExporter); err != nil {
 			r.setCondition(&session, ConditionDegraded, metav1.ConditionTrue, "BundleSync", err.Error())
 			_ = r.Status().Update(ctx, &session)
 			return ctrl.Result{RequeueAfter: 60 * time.Second}, nil

--- a/internal/operator/podtracesession_job.go
+++ b/internal/operator/podtracesession_job.go
@@ -101,9 +101,13 @@ func buildSessionJobSpec(s *podtracev1alpha1.PodTraceSession, tc *podtracev1alph
 	}
 
 	sessionArgs := append([]string{}, args...)
+	if s.Spec.ExporterRef.Name != "" {
+		sessionArgs = append(sessionArgs,
+			"--tracing",
+			"--exporter-from-file", "/etc/podtrace/exporter/bundle.yaml",
+		)
+	}
 	sessionArgs = append(sessionArgs,
-		"--tracing",
-		"--exporter-from-file", "/etc/podtrace/exporter/bundle.yaml",
 		"--summary-file", "/var/run/podtrace/summary.json",
 		"--termination-message-path", "/dev/termination-log",
 	)

--- a/internal/operator/session_bundle.go
+++ b/internal/operator/session_bundle.go
@@ -38,6 +38,13 @@ func SessionBundleName(sessionUID types.UID) string {
 
 // ensureSessionExporterBundle creates-or-updates the ConfigMap + optional
 // companion Secret the session Job mounts at /etc/podtrace/exporter/.
+func ensureSessionExporterBundleIfReferenced(ctx context.Context, c client.Client, reader client.Reader, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string, referenced bool) error {
+	if !referenced {
+		return nil
+	}
+	return ensureSessionExporterBundle(ctx, c, reader, s, ec, systemNS)
+}
+
 func ensureSessionExporterBundle(ctx context.Context, c client.Client, reader client.Reader, s *podtracev1alpha1.PodTraceSession, ec *podtracev1alpha1.ExporterConfig, systemNS string) error {
 	name := SessionBundleName(s.UID)
 

--- a/internal/operator/session_without_exporter_test.go
+++ b/internal/operator/session_without_exporter_test.go
@@ -1,0 +1,78 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	podtracev1alpha1 "github.com/gma1k/podtrace/api/v1alpha1"
+)
+
+func sessionWithExporter(name string) *podtracev1alpha1.PodTraceSession {
+	return &podtracev1alpha1.PodTraceSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns", UID: "uid-1"},
+		Spec: podtracev1alpha1.PodTraceSessionSpec{
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Duration:    metav1.Duration{Duration: 30_000_000_000},
+			ExporterRef: corev1.LocalObjectReference{Name: name},
+			ReportRef: &podtracev1alpha1.ReportReference{
+				ConfigMap: &corev1.LocalObjectReference{Name: "report"},
+			},
+		},
+	}
+}
+
+func sessionJobArgs(t *testing.T, s *podtracev1alpha1.PodTraceSession) []string {
+	t.Helper()
+	tc := &podtracev1alpha1.TracerConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec:       podtracev1alpha1.TracerConfigSpec{Image: "ghcr.io/gma1k/podtrace:test"},
+	}
+	spec := buildSessionJobSpec(s, tc, "node-1", sessionTargets{})
+	for _, c := range spec.Template.Spec.Containers {
+		if c.Name != reportUploaderContainerName {
+			return c.Args
+		}
+	}
+	t.Fatal("no main container in the session Job")
+	return nil
+}
+
+func TestAReportOnlySessionDoesNotAskForAnExporterBundle(t *testing.T) {
+	s := sessionWithExporter("")
+
+	args := strings.Join(sessionJobArgs(t, s), " ")
+	if strings.Contains(args, "--exporter-from-file") {
+		t.Errorf("args = %q; a session with no exporterRef must not ask for a bundle. The "+
+			"ConfigMap is never created for it and the volume is optional, so the Job would "+
+			"fail reading a file that was never meant to exist", args)
+	}
+	if strings.Contains(args, "--tracing") {
+		t.Errorf("args = %q; span export was enabled with nothing to export to", args)
+	}
+	if !strings.Contains(args, "--summary-file") {
+		t.Errorf("args = %q; the report path must survive having no exporter", args)
+	}
+}
+
+func TestASessionWithAnExporterStillGetsItsBundle(t *testing.T) {
+	s := sessionWithExporter("otlp")
+
+	args := strings.Join(sessionJobArgs(t, s), " ")
+	for _, want := range []string{"--tracing", "--exporter-from-file"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args = %q, want %s", args, want)
+		}
+	}
+}
+
+func TestBundleRenderingIsSkippedWhenNoExporterIsReferenced(t *testing.T) {
+	err := ensureSessionExporterBundleIfReferenced(
+		t.Context(), nil, nil, sessionWithExporter(""), nil, "podtrace-system", false)
+	if err != nil {
+		t.Errorf("ensureSessionExporterBundleIfReferenced = %v, want nil. It must not touch the "+
+			"client at all for a report-only session; a nil client here proves it did not", err)
+	}
+}

--- a/internal/operator/tracerconfig_daemonset.go
+++ b/internal/operator/tracerconfig_daemonset.go
@@ -22,6 +22,8 @@ func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string)
 		},
 	}
 
+	podLabels := agentPodTemplateLabels(selector.MatchLabels)
+
 	hostPathType := corev1.HostPathDirectory
 	priv := false
 	runAsRoot := int64(0)
@@ -109,7 +111,7 @@ func buildAgentDaemonSetSpec(tc *podtracev1alpha1.TracerConfig, systemNS string)
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: selector.MatchLabels,
+				Labels: podLabels,
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName:            AgentServiceAccountName(tc.Name),
@@ -196,4 +198,19 @@ func itoa(n int) string    { return strconv.Itoa(n) }
 // name.
 func intstrFromString(name string) intstr.IntOrString {
 	return intstr.FromString(name)
+}
+
+// agentPodTemplateLabels returns the selector labels plus the
+// app.kubernetes.io/* convention, as a new map so the caller's selector is
+// left untouched.
+func agentPodTemplateLabels(selector map[string]string) map[string]string {
+	labels := make(map[string]string, len(selector)+4)
+	for k, v := range selector {
+		labels[k] = v
+	}
+	labels["app.kubernetes.io/name"] = "podtrace"
+	labels["app.kubernetes.io/component"] = ComponentAgent
+	labels["app.kubernetes.io/part-of"] = "podtrace"
+	labels["app.kubernetes.io/managed-by"] = ManagedByValue
+	return labels
 }

--- a/internal/webhook/v1alpha1/podtracesession_webhook.go
+++ b/internal/webhook/v1alpha1/podtracesession_webhook.go
@@ -62,7 +62,7 @@ func (v *PodTraceSessionCustomValidator) validate(ctx context.Context, s *podtra
 	if s.Spec.Duration.Duration <= 0 {
 		return nil, fmt.Errorf("spec.duration must be greater than zero")
 	}
-	if err := resolveExporterRef(ctx, v.Client, s.Namespace, s.Spec.ExporterRef.Name); err != nil {
+	if err := resolveSessionExporterRef(ctx, v.Client, s.Namespace, s.Spec.ExporterRef.Name); err != nil {
 		return nil, err
 	}
 	if err := resolveTracerConfigRef(ctx, v.Client, s.Spec.TracerConfigRef, s.Namespace, v.SystemNamespace); err != nil {

--- a/internal/webhook/v1alpha1/webhook_helpers.go
+++ b/internal/webhook/v1alpha1/webhook_helpers.go
@@ -188,6 +188,13 @@ func resolveTracerConfigRef(ctx context.Context, c client.Client, ref *corev1.Lo
 
 // resolveExporterRef verifies that spec.exporterRef.name refers to an
 // ExporterConfig that exists in the caller's namespace.
+func resolveSessionExporterRef(ctx context.Context, c client.Client, namespace, name string) error {
+	if name == "" {
+		return nil
+	}
+	return resolveExporterRef(ctx, c, namespace, name)
+}
+
 func resolveExporterRef(ctx context.Context, c client.Client, namespace, name string) error {
 	if name == "" {
 		return fmt.Errorf("spec.exporterRef.name is required")


### PR DESCRIPTION
## Summary

Different fixes, the documented report command returned nothing, `helm uninstall` left a privileged DaemonSet running, sessions needed an exporter they did not use, and the quickstart traced an idle pod.

## Changes

- **Report command**: every documented `-o jsonpath='{.data.report\.txt}'` returned empty output, because the key is `report-<node>.txt` and `reportDataKey()` only returns `report.txt` when `NODE_NAME` is unset, which never happens in a session Job. Replaced 13 references across 10 files with `-o go-template='{{range $k,$v := .data}}{{$v}}{{end}}'`, which reads every node's report. Docs-only: per-node keys are correct for multi-node sessions. The occurrence in `NOTES.txt` is Helm-escaped so the braces survive template rendering.
- **Uninstall**: the TracerConfig is applied by a hook Job rather than a tracked release resource, so Helm left it behind, and it owns the agent DaemonSet: a pod kept running on every node with no operator to manage it. New `pre-delete` hook deletes it, cascading to the DaemonSet, ServiceAccount and ClusterRole through their owner references. `tracerConfig.retainOnUninstall` (default false) opts out. Helm-only; OLM and raw-kubectl paths do not run hooks. `docs/installation.md` gains the uninstall section it never had.
- **Optional exporterRef**: `exporterRef` is no longer required, with a CEL rule requiring `exporterRef` or `reportRef` so a session always has somewhere to put its output. The operator skips ExporterConfig resolution and bundle rendering when none is named, and omits `--tracing` and `--exporter-from-file` from the Job, which would otherwise fail on a bundle that was never created.
- **Quickstart**: added a Service and a loadgen so the demo drives its own traffic, and dropped the dead `localhost:4318` exporter that only existed to satisfy the required field. The first report now shows real request paths and status codes instead of "No events collected during the diagnostic period".
- **Dockerfile**: the stub-build warning still claimed gRPC and FastCGI probes become no-ops, untrue since the guard removal.
- **Labels**: agent pods now carry `app.kubernetes.io/{name,component,part-of,managed-by}` alongside the existing `podtrace.io/*` labels, so selectors, NetworkPolicies and ServiceMonitors written the conventional way find them. Added to the pod template only, as a copied map: the DaemonSet `spec.selector` is immutable and shared the same map, so writing through it would have required deleting and recreating a privileged workload on every node.